### PR TITLE
UI improvements

### DIFF
--- a/public/datasets/csv_service.json
+++ b/public/datasets/csv_service.json
@@ -1,8 +1,8 @@
 {"name":"CSV Example", "Layer": [
   {"name":"Geolocated Tables","proxy":false,"type":"CSV","queryable":"0","Layer": [
-    {"Name": "NSW Incidents", "Abstract": "Simulated data from NSW", "url":"./datasets/incidents.csv","BoundingBox":{"west":147.3154707,"south":-36.78012603,"east":153.5498186,"north":-28.2198794}},
-    {"Name": "Pacific Earthquakes", "Abstract": "Earthquake events collected from SOSUS", "url":"./datasets/earthquakes.csv","BoundingBox":{"west":-130.998,"south":40.01,"east":-121.398,"north":50.993}},
-    {"Name": "Axial Site Earthquakes", "Abstract": "Earthquake storm from Axial site on Juan de Fuca plate", "url":"./datasets/axial.csv","BoundingBox":{"west":-130.0612,"south":45.811,"east":-129.955,"north":46.0031}}
+    {"Name": "NSW Incidents", "Title": "NSW Incidents", "Abstract": "Simulated data from NSW", "url":"./datasets/incidents.csv","BoundingBox":{"west":147.3154707,"south":-36.78012603,"east":153.5498186,"north":-28.2198794}},
+    {"Name": "Pacific Earthquakes", "Title": "Pacific Earthquakes", "Abstract": "Earthquake events collected from SOSUS", "url":"./datasets/earthquakes.csv","BoundingBox":{"west":-130.998,"south":40.01,"east":-121.398,"north":50.993}},
+    {"Name": "Axial Site Earthquakes", "Title": "Axial Site Earthquakes", "Abstract": "Earthquake storm from Axial site on Juan de Fuca plate", "url":"./datasets/axial.csv","BoundingBox":{"west":-130.0612,"south":45.811,"east":-129.955,"north":46.0031}}
   ]}
 ]}
 

--- a/public/viewer/AusGlobeViewer.css
+++ b/public/viewer/AusGlobeViewer.css
@@ -502,14 +502,15 @@ a.ausglobe-title-menuItem:hover {
 
 .ausglobe-search-form .ausglobe-search-input {
     border: solid 1px #444;
-    background-color: rgba(40, 40, 40, 0.7);
-    color: white;
+    background-color: white;
+    color: black;
     display: inline-block;
     vertical-align: middle;
     width: 250px;
     height: 32px;
     margin: 0;
-    padding: 0 32px 0 0;
+    padding: 5px;
+    padding-right: 32px;
     border-radius: 0;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -521,8 +522,6 @@ a.ausglobe-title-menuItem:hover {
 }
 
 .ausglobe-search-form .ausglobe-search-input:focus {
-    border-color: #ea4;
-    background-color: rgba(15, 15, 15, 0.9);
     box-shadow: none;
     outline: none;
 }

--- a/public/viewer/AusGlobeViewer.css
+++ b/public/viewer/AusGlobeViewer.css
@@ -275,7 +275,7 @@ a.ausglobe-title-menuItem:hover {
     position: absolute;
     left: 0;
     width: 300px;
-    top: 50px;
+    top: 100px;
     bottom: 80px;
     pointer-events: none;
 }
@@ -490,4 +490,56 @@ a.ausglobe-title-menuItem:hover {
 
 .ausglobe-imagery-label {
     text-align: center;
+}
+
+.ausglobe-search-form {
+    position: absolute;
+    display: inline-block;
+    margin: 0 3px;
+    top: 50px;
+    left: 5px;
+}
+
+.ausglobe-search-form .ausglobe-search-input {
+    border: solid 1px #444;
+    background-color: rgba(40, 40, 40, 0.7);
+    color: white;
+    display: inline-block;
+    vertical-align: middle;
+    width: 250px;
+    height: 32px;
+    margin: 0;
+    padding: 0 32px 0 0;
+    border-radius: 0;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+.ausglobe-search-form:hover .ausglobe-search-input {
+    border-color: #aef;
+    box-shadow: 0 0 8px #fff;
+}
+
+.ausglobe-search-form .ausglobe-search-input:focus {
+    border-color: #ea4;
+    background-color: rgba(15, 15, 15, 0.9);
+    box-shadow: none;
+    outline: none;
+}
+
+.ausglobe-search-button {
+    background-color: #303336;
+    display: inline-block;
+    position: absolute;
+    cursor: pointer;
+    width: 32px;
+    top: 1px;
+    right: 1px;
+    height: 30px;
+    vertical-align: middle;
+    fill: #edffff;
+}
+
+.ausglobe-search-button:hover {
+    background-color: #48b;
 }

--- a/public/viewer/AusGlobeViewer.css
+++ b/public/viewer/AusGlobeViewer.css
@@ -454,6 +454,7 @@ a.ausglobe-title-menuItem:hover {
 
 .ausglobe-accordion-category-item-enabled {
     background-color: #CCDDD8;
+    cursor: pointer;
 }
 
 .ausglobe-accordion-category-item-checkbox {

--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -32,11 +32,6 @@ var GeoDataCollection = function() {
     this.GeoDataRemoved = new Cesium.Event();
     this.ViewerChanged = new Cesium.Event();
     this.ShareRequest = new Cesium.Event();
-    
-    //load list of available services for GeoDataCollection
-    Cesium.loadJson('./data_sources.json').then(function (obj) {
-        that.serviceList = obj;
-    });
 }
 
 

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -349,10 +349,14 @@ function zoomIn(scene, pos) { zoomCamera(scene, 2.0/3.0, pos); };
 function zoomOut(scene, pos) { zoomCamera(scene, -3.0/2.0, pos); };
 
 // Move camera to Rectangle
-function updateCameraFromRect(scene, map, rect_in, ms) {
+AusGlobeViewer.prototype.updateCameraFromRect = function(rect_in, flightTimeMilliseconds) {
     if (rect_in === undefined) {
         return;
     }
+
+    var scene = this.scene;
+    var map = this.map;
+
     //check that we're not too close
     var epsilon = CesiumMath.EPSILON3;
     var rect = rect_in.clone();
@@ -367,7 +371,7 @@ function updateCameraFromRect(scene, map, rect_in, ms) {
     if (scene !== undefined && !scene.isDestroyed()) {
         var flight = CameraFlightPath.createAnimationRectangle(scene, {
             destination : rect,
-            duration: ms
+            duration: flightTimeMilliseconds
         });
         scene.animations.add(flight);
     }
@@ -376,7 +380,7 @@ function updateCameraFromRect(scene, map, rect_in, ms) {
             [CesiumMath.toDegrees(rect.north), CesiumMath.toDegrees(rect.east)]];
         map.fitBounds(bnds);
     }
-}
+};
 
 
 // -------------------------------------------
@@ -580,7 +584,7 @@ AusGlobeViewer.prototype._enableSelectExtent = function(bActive) {
             }
             that.geoDataWidget.setExtent(ext);
             if (ext) {
-                updateCameraFromRect(that.scene, that.map, ext, 1000);
+                that.updateCameraFromRect(ext, 1000);
                 // Display polyline based on ext
                 var east = ext.east, west = ext.west, north = ext.north, south = ext.south;
                 var ellipsoid = Ellipsoid.WGS84;
@@ -695,10 +699,6 @@ var setCurrentDataset = function(layer, that) {
     }
     updateTimeline(that.viewer, start, finish);
     updateLegend(tableData);
-
-    if (layer.extent !== undefined) {
-        updateCameraFromRect(that.scene, that.map, layer.extent, 1000);
-    }
 }
 
 
@@ -709,7 +709,7 @@ AusGlobeViewer.prototype._showSettingsDialog = function() {
         title: 'Settings',
         width: 250,
         height: 250,
-        modal: false,
+        modal: false
     });
 
     var list = $('#list4');
@@ -726,12 +726,12 @@ AusGlobeViewer.prototype._showSettingsDialog = function() {
         {
             text: '3D',
             getState: function() { return that._cesiumViewerActive(); },
-            setState: function(val) { that.selectViewer(val); },
+            setState: function(val) { that.selectViewer(val); }
         },
         {
             text: 'Water Mask',
             getState: function() { return true; },
-            setState: function(val) { alert('NYI'); },
+            setState: function(val) { alert('NYI'); }
         }
 
     ];
@@ -959,7 +959,12 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
         if (this.map !== undefined) {
             var bnds = this.map.getBounds()
             var rect = Rectangle.fromDegrees(bnds.getWest(), bnds.getSouth(), bnds.getEast(), bnds.getNorth());
-            updateCameraFromRect(this.scene, undefined, rect, 0);
+
+            //remove existing map viewer
+            this.map.remove();
+            this.map = undefined;
+
+            this.updateCameraFromRect(rect, 0);
         }
 
         this.geoDataManager.setViewer({scene: this.scene, map: undefined});
@@ -977,12 +982,6 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
          });
          this.scene.globe.imageryLayers.addImageryProvider(esri);
          */
-        //remove existing map viewer
-        if (this.map !== undefined) {
-            this.map.remove();
-            this.map = undefined;
-        }
-
     }
 };
 

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -170,7 +170,7 @@ var AusGlobeViewer = function(geoDataManager) {
                 var parent = komapping.toJS(options.parent);
                 var data = combine(options.data, parent);
 
-                var layerViewModel = komapping.fromJS(data);
+                var layerViewModel = komapping.fromJS(data, categoryMapping);
                 layerViewModel.isEnabled = knockout.observable(false);
 
                 return layerViewModel;
@@ -207,7 +207,15 @@ var AusGlobeViewer = function(geoDataManager) {
 
                                 var layers = remapped.Layer();
                                 for (var i = 0; i < layers.length; ++i) {
-                                    layer.push(layers[i]);
+                                    // TODO: handle hierarchy better
+                                    if (defined(layers[i].Layer)) {
+                                        var subLayers = layers[i].Layer();
+                                        for (var j = 0; j < subLayers.length; ++j) {
+                                            layer.push(subLayers[j]);
+                                        }
+                                    } else {
+                                        layer.push(layers[i]);
+                                    }
                                 }
 
                                 version(version() + 1);

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -183,6 +183,7 @@ var AusGlobeViewer = function(geoDataManager) {
             create : function(options) {
                 var layerViewModel = komapping.fromJS(options.data, categoryMapping);
                 layerViewModel.isOpen = knockout.observable(false);
+                layerViewModel.isLoading = knockout.observable(false);
 
                 if (!defined(layerViewModel.Layer)) {
                     var layer = undefined;
@@ -202,6 +203,7 @@ var AusGlobeViewer = function(geoDataManager) {
 
                         // Don't request capabilities until the layer is opened.
                         if (layerViewModel.isOpen()) {
+                            layerViewModel.isLoading(true);
                             that.geoDataManager.getCapabilities(options.data, function(description) {
                                 var remapped = komapping.fromJS(description, categoryMapping);
 
@@ -219,6 +221,7 @@ var AusGlobeViewer = function(geoDataManager) {
                                 }
 
                                 version(version() + 1);
+                                layerViewModel.isLoading(false);
                             });
 
                             layerRequested = true;

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -41,6 +41,7 @@ var GeoDataBrowser = require('./GeoDataBrowser');
 var GeoDataWidget = require('./GeoDataWidget');
 var TitleWidget = require('./TitleWidget');
 var NavigationWidget = require('./NavigationWidget');
+var SearchWidget = require('./SearchWidget');
 
 //Initialize the selected viewer - Cesium or Leaflet
 var AusGlobeViewer = function(geoDataManager) {
@@ -85,6 +86,11 @@ var AusGlobeViewer = function(geoDataManager) {
     this._titleWidget = titleWidget;
 
     this._navigationWidget = new NavigationWidget(this, document.body);
+
+    this._searchWidget = new SearchWidget({
+        container : document.body,
+        viewer : this
+    });
 
 //    var div = document.createElement('div');
 //    div.id = 'controls';

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -53,6 +53,7 @@ var GeoDataBrowser = function(options) {
                         <img class="ausglobe-accordion-category-header-arrow" src="images/full_arrow_down.svg" data-bind="visible: !isOpen()" />\
                         <div class="ausglobe-accordion-category-header-label" data-bind="text: name"></div>\
                     </div>\
+                    <div class="ausglobe-accordion-category-loading" data-bind="visible: isLoading">Loading</div>\
                     <div class="ausglobe-accordion-category-content" data-bind="foreach: Layer, css: { \'ausglobe-accordion-category-content-visible\': isOpen }">\
                         <div class="ausglobe-accordion-category-item" data-bind="css: { \'ausglobe-accordion-category-item-enabled\': isEnabled() }">\
                             <img class="ausglobe-accordion-category-item-checkbox" src="images/Check_tick.svg" data-bind="click: $root.toggleItemEnabled, visible: isEnabled()" />\

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -57,7 +57,7 @@ var GeoDataBrowser = function(options) {
                         <div class="ausglobe-accordion-category-item" data-bind="css: { \'ausglobe-accordion-category-item-enabled\': isEnabled() }">\
                             <img class="ausglobe-accordion-category-item-checkbox" src="images/Check_tick.svg" data-bind="click: $root.toggleItemEnabled, visible: isEnabled()" />\
                             <img class="ausglobe-accordion-category-item-checkbox" src="images/Check_box.svg" data-bind="click: $root.toggleItemEnabled, visible: !isEnabled()" />\
-                            <div class="ausglobe-accordion-category-item-label" data-bind="text: Title"></div>\
+                            <div class="ausglobe-accordion-category-item-label" data-bind="text: Title, click: $root.zoomToItem"></div>\
                             <div class="ausglobe-accordion-category-item-infoButton">info</div>\
                         </div>\
                     </div>\

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -76,6 +76,13 @@ var GeoDataBrowserViewModel = function(options) {
         }
     });
 
+    this._zoomToItem = createCommand(function(item) {
+        if (!defined(item.layer) || !defined(item.layer.extent)) {
+            return;
+        }
+        that._viewer.updateCameraFromRect(item.layer.extent, 1000);
+    });
+
     function removeBaseLayer() {
         if (!defined(that._viewer.viewer)) {
             var message = 'Base layer selection is not yet implemented for Leaflet.';
@@ -195,6 +202,12 @@ defineProperties(GeoDataBrowserViewModel.prototype, {
     toggleItemEnabled : {
         get : function() {
             return this._toggleItemEnabled;
+        }
+    },
+
+    zoomToItem : {
+        get : function() {
+            return this._zoomToItem;
         }
     },
 

--- a/src/viewer/SearchWidget.js
+++ b/src/viewer/SearchWidget.js
@@ -1,0 +1,149 @@
+"use strict";
+
+/*global require,Cesium*/
+var getElement = Cesium.getElement;
+var defined = Cesium.defined;
+var defineProperties = Cesium.defineProperties;
+var SvgPathBindingHandler = Cesium.SvgPathBindingHandler;
+
+var knockout = require('knockout');
+var SearchWidgetViewModel = require('./SearchWidgetViewModel');
+
+SvgPathBindingHandler.register(knockout);
+
+var startSearchPath = 'M29.772,26.433l-7.126-7.126c0.96-1.583,1.523-3.435,1.524-5.421C24.169,8.093,19.478,3.401,13.688,3.399C7.897,3.401,3.204,8.093,3.204,13.885c0,5.789,4.693,10.481,10.484,10.481c1.987,0,3.839-0.563,5.422-1.523l7.128,7.127L29.772,26.433zM7.203,13.885c0.006-3.582,2.903-6.478,6.484-6.486c3.579,0.008,6.478,2.904,6.484,6.486c-0.007,3.58-2.905,6.476-6.484,6.484C10.106,20.361,7.209,17.465,7.203,13.885z';
+var stopSearchPath = 'M24.778,21.419 19.276,15.917 24.777,10.415 21.949,7.585 16.447,13.087 10.945,7.585 8.117,10.415 13.618,15.917 8.116,21.419 10.946,24.248 16.447,18.746 21.948,24.248z';
+
+/**
+ * A widget for finding addresses and landmarks, and flying the camera to them.  Geocoding is
+ * performed using the {@link http://msdn.microsoft.com/en-us/library/ff701715.aspx|Bing Maps Locations API}.
+ *
+ * @alias SearchWidget
+ * @constructor
+ *
+ * @param {Element|String} options.container The DOM element or ID that will contain the widget.
+ * @param {Scene} options.scene The Scene instance to use.
+ * @param {String} [options.url='//dev.virtualearth.net'] The base URL of the Bing Maps API.
+ * @param {String} [options.key] The Bing Maps key for your application, which can be
+ *        created at {@link https://www.bingmapsportal.com}.
+ *        If this parameter is not provided, {@link BingMapsApi.defaultKey} is used.
+ *        If {@link BingMapsApi.defaultKey} is undefined as well, a message is
+ *        written to the console reminding you that you must create and supply a Bing Maps
+ *        key as soon as possible.  Please do not deploy an application that uses
+ *        this widget without creating a separate key for your application.
+ * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The Scene's primary ellipsoid.
+ * @param {Number} [options.flightDuration=1500] The duration of the camera flight to an entered location, in milliseconds.
+ */
+var SearchWidget = function(options) {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(options) || !defined(options.container)) {
+        throw new DeveloperError('options.container is required.');
+    }
+    //>>includeEnd('debug');
+
+    var container = getElement(options.container);
+    var viewModel = new SearchWidgetViewModel(options);
+
+    viewModel._startSearchPath = startSearchPath;
+    viewModel._stopSearchPath = stopSearchPath;
+
+    var form = document.createElement('form');
+    form.className = 'ausglobe-search-form';
+    form.setAttribute('data-bind', 'submit: search');
+
+    var textBox = document.createElement('input');
+    textBox.type = 'search';
+    textBox.className = 'ausglobe-search-input';
+    textBox.setAttribute('placeholder', 'Enter an address or landmark...');
+    textBox.setAttribute('data-bind', '\
+value: searchText,\
+valueUpdate: "afterkeydown"');
+    form.appendChild(textBox);
+
+    var searchButton = document.createElement('span');
+    searchButton.className = 'ausglobe-search-button';
+    searchButton.setAttribute('data-bind', '\
+click: search,\
+cesiumSvgPath: { path: isSearchInProgress ? _stopSearchPath : _startSearchPath, width: 32, height: 32 }');
+    form.appendChild(searchButton);
+
+    container.appendChild(form);
+
+    knockout.applyBindings(viewModel, form);
+
+    this._container = container;
+    this._viewModel = viewModel;
+    this._form = form;
+
+    this._onInputBegin = function(e) {
+        if (!container.contains(e.target)) {
+            textBox.blur();
+        }
+    };
+
+    this._onInputEnd = function(e) {
+        if (container.contains(e.target)) {
+            textBox.focus();
+        }
+    };
+
+    //We subscribe to both begin and end events in order to give the text box
+    //focus no matter where on the widget is clicked.
+    document.addEventListener('mousedown', this._onInputBegin, true);
+    document.addEventListener('mouseup', this._onInputEnd, true);
+    document.addEventListener('touchstart', this._onInputBegin, true);
+    document.addEventListener('touchend', this._onInputEnd, true);
+};
+
+defineProperties(SearchWidget.prototype, {
+    /**
+     * Gets the parent container.
+     * @memberof SearchWidget.prototype
+     *
+     * @type {Element}
+     */
+    container : {
+        get : function() {
+            return this._container;
+        }
+    },
+
+    /**
+     * Gets the view model.
+     * @memberof SearchWidget.prototype
+     *
+     * @type {SearchWidgetViewModel}
+     */
+    viewModel : {
+        get : function() {
+            return this._viewModel;
+        }
+    }
+});
+
+/**
+ * @memberof SearchWidget
+ * @returns {Boolean} true if the object has been destroyed, false otherwise.
+ */
+SearchWidget.prototype.isDestroyed = function() {
+    return false;
+};
+
+/**
+ * Destroys the widget.  Should be called if permanently
+ * removing the widget from layout.
+ * @memberof SearchWidget
+ */
+SearchWidget.prototype.destroy = function() {
+    document.removeEventListener('mousedown', this._onInputBegin, true);
+    document.removeEventListener('mouseup', this._onInputEnd, true);
+    document.removeEventListener('touchstart', this._onInputBegin, true);
+    document.removeEventListener('touchend', this._onInputEnd, true);
+
+    knockout.cleanNode(this._form);
+    this._container.removeChild(this._form);
+
+    return destroyObject(this);
+};
+
+module.exports = SearchWidget;

--- a/src/viewer/SearchWidgetViewModel.js
+++ b/src/viewer/SearchWidgetViewModel.js
@@ -1,0 +1,348 @@
+"use strict";
+
+/*global require,Cesium*/
+var BingMapsApi = Cesium.BingMapsApi;
+var defaultValue = Cesium.defaultValue;
+var defined = Cesium.defined;
+var defineProperties = Cesium.defineProperties;
+var DeveloperError = Cesium.DeveloperError;
+var Ellipsoid = Cesium.Ellipsoid;
+var jsonp = Cesium.jsonp;
+var CesiumMath = Cesium.Math;
+var Matrix4 = Cesium.Matrix4;
+var Rectangle = Cesium.Rectangle;
+var CameraFlightPath = Cesium.CameraFlightPath;
+var SceneMode = Cesium.SceneMode;
+var when = Cesium.when;
+var createCommand = Cesium.createCommand;
+
+var knockout = require('knockout');
+
+/**
+ * The view model for the {@link Geocoder} widget.
+ * @alias SearchWidgetViewModel
+ * @constructor
+ *
+ * @param {Scene} options.scene The Scene instance to use.
+ * @param {String} [options.url='//dev.virtualearth.net'] The base URL of the Bing Maps API.
+ * @param {String} [options.key] The Bing Maps key for your application, which can be
+ *        created at {@link https://www.bingmapsportal.com}.
+ *        If this parameter is not provided, {@link BingMapsApi.defaultKey} is used.
+ *        If {@link BingMapsApi.defaultKey} is undefined as well, a message is
+ *        written to the console reminding you that you must create and supply a Bing Maps
+ *        key as soon as possible.  Please do not deploy an application that uses
+ *        this widget without creating a separate key for your application.
+ * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The Scene's primary ellipsoid.
+ * @param {Number} [options.flightDuration=1500] The duration of the camera flight to an entered location, in milliseconds.
+ */
+var SearchWidgetViewModel = function(options) {
+    //>>includeStart('debug', pragmas.debug);
+    if (!defined(options) || !defined(options.viewer)) {
+        throw new DeveloperError('options.scene is required.');
+    }
+    //>>includeEnd('debug');
+
+    this._url = defaultValue(options.url, '//dev.virtualearth.net/');
+    if (this._url.length > 0 && this._url[this._url.length - 1] !== '/') {
+        this._url += '/';
+    }
+
+    this._key = BingMapsApi.getKey(options.key);
+    this._viewer = options.viewer;
+    this._ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
+    this._flightDuration = defaultValue(options.flightDuration, 1500);
+    this._searchText = '';
+    this._isSearchInProgress = false;
+    this._geocodeInProgress = undefined;
+
+    var that = this;
+    this._searchCommand = createCommand(function() {
+        if (that.isSearchInProgress) {
+            cancelGeocode(that);
+        } else {
+            geocode(that);
+        }
+    });
+
+    knockout.track(this, ['_searchText', '_isSearchInProgress']);
+
+    /**
+     * Gets a value indicating whether a search is currently in progress.  This property is observable.
+     *
+     * @type {Boolean}
+     */
+    this.isSearchInProgress = undefined;
+    knockout.defineProperty(this, 'isSearchInProgress', {
+        get : function() {
+            return this._isSearchInProgress;
+        }
+    });
+
+    /**
+     * Gets or sets the text to search for.
+     *
+     * @type {String}
+     */
+    this.searchText = undefined;
+    knockout.defineProperty(this, 'searchText', {
+        get : function() {
+            if (this.isSearchInProgress) {
+                return 'Searching...';
+            }
+            return this._searchText;
+        },
+        set : function(value) {
+            //>>includeStart('debug', pragmas.debug);
+            if (typeof value !== 'string') {
+                throw new DeveloperError('value must be a valid string.');
+            }
+            //>>includeEnd('debug');
+
+            this._searchText = value;
+        }
+    });
+
+    /**
+     * Gets or sets the the duration of the camera flight in milliseconds.
+     * A value of zero causes the camera to instantly switch to the geocoding location.
+     *
+     * @type {Number}
+     * @default 1500
+     */
+    this.flightDuration = undefined;
+    knockout.defineProperty(this, 'flightDuration', {
+        get : function() {
+            return this._flightDuration;
+        },
+        set : function(value) {
+            //>>includeStart('debug', pragmas.debug);
+            if (value < 0) {
+                throw new DeveloperError('value must be positive.');
+            }
+            //>>includeEnd('debug');
+
+            this._flightDuration = value;
+        }
+    });
+};
+
+defineProperties(SearchWidgetViewModel.prototype, {
+    /**
+     * Gets the Bing maps url.
+     * @memberof SearchWidgetViewModel.prototype
+     *
+     * @type {String}
+     */
+    url : {
+        get : function() {
+            return this._url;
+        }
+    },
+
+    /**
+     * Gets the Bing maps key.
+     * @memberof SearchWidgetViewModel.prototype
+     *
+     * @type {String}
+     */
+    key : {
+        get : function() {
+            return this._key;
+        }
+    },
+
+    /**
+     * Gets the scene to control.
+     * @memberof SearchWidgetViewModel.prototype
+     *
+     * @type {Scene}
+     */
+    viewer : {
+        get : function() {
+            return this._viewer;
+        }
+    },
+
+    /**
+     * Gets the ellipsoid to be viewed.
+     * @memberof SearchWidgetViewModel.prototype
+     *
+     * @type {Ellipsoid}
+     */
+    ellipsoid : {
+        get : function() {
+            return this._ellipsoid;
+        }
+    },
+
+    /**
+     * Gets the Command that is executed when the button is clicked.
+     * @memberof SearchWidgetViewModel.prototype
+     *
+     * @type {Command}
+     */
+    search : {
+        get : function() {
+            return this._searchCommand;
+        }
+    }
+});
+
+function geocode(viewModel) {
+    var query = viewModel.searchText;
+
+    if (/^\s*$/.test(query)) {
+        //whitespace string
+        return;
+    }
+
+    viewModel._isSearchInProgress = true;
+
+    var cameraPosition = viewModel._viewer.scene.camera.positionWC;
+    var cameraPositionCartographic = Ellipsoid.WGS84.cartesianToCartographic(cameraPosition);
+
+    var x = {
+        "authenticationResultCode": "ValidCredentials",
+        "brandLogoUri": "http:\/\/dev.virtualearth.net\/Branding\/logo_powered_by.png",
+        "copyright": "Copyright © 2014 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.",
+        "resourceSets": [
+            {
+                "estimatedTotal": 2,
+                "resources": [
+                    {
+                        "__type": "Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1",
+                        "bbox": [59.998630523681641, -136.48089599609375, 79.00848388671875, -102],
+                        "name": "Northwest Territories",
+                        "point": {
+                            "type": "Point",
+                            "coordinates": [67.2751235961914, -118.86355590820312]
+                        },
+                        "address": {
+                            "adminDistrict": "NT",
+                            "countryRegion": "Canada",
+                            "formattedAddress": "Northwest Territories"
+                        },
+                        "confidence": "High",
+                        "entityType": "AdminDivision1",
+                        "geocodePoints": [
+                            {
+                                "type": "Point",
+                                "coordinates": [67.2751235961914, -118.86355590820312],
+                                "calculationMethod": "Rooftop",
+                                "usageTypes": ["Display"]
+                            }
+                        ],
+                        "matchCodes": ["Good"]
+                    },
+                    {
+                        "__type": "Location:http:\/\/schemas.microsoft.com\/search\/local\/ws\/rest\/v1",
+                        "bbox": [-26.006711959838867, 122.29334259033203, -10.855688095092773, 138.00273132324219],
+                        "name": "Northern Territory",
+                        "point": {
+                            "type": "Point",
+                            "coordinates": [-19.48194694519043, 133.3697509765625]
+                        },
+                        "address": {
+                            "adminDistrict": "NT",
+                            "countryRegion": "Australia",
+                            "formattedAddress": "Northern Territory"
+                        },
+                        "confidence": "High",
+                        "entityType": "AdminDivision1",
+                        "geocodePoints": [
+                            {
+                                "type": "Point",
+                                "coordinates": [-19.48194694519043, 133.3697509765625],
+                                "calculationMethod": "Rooftop",
+                                "usageTypes": ["Display"]
+                            }
+                        ],
+                        "matchCodes": ["Good"]
+                    }
+                ]
+            }
+        ], "statusCode": 200, "statusDescription": "OK", "traceId": "81ab9583ed6742668d6621d88e60ba7e|BN20130532|02.00.151.2000|BN2SCH020180822, BN2SCH020201635"};
+
+    var promise = jsonp(viewModel._url + 'REST/v1/Locations?userLocation=' + CesiumMath.toDegrees(cameraPositionCartographic.latitude) + ',' + CesiumMath.toDegrees(cameraPositionCartographic.longitude) , {
+        parameters : {
+            query : query,
+            key : viewModel._key
+        },
+        callbackParameterName : 'jsonp'
+    });
+
+    var geocodeInProgress = viewModel._geocodeInProgress = when(promise, function(result) {
+        if (geocodeInProgress.cancel) {
+            return;
+        }
+        viewModel._isSearchInProgress = false;
+
+        if (result.resourceSets.length === 0) {
+            viewModel.searchText = viewModel._searchText + ' (not found)';
+            return;
+        }
+
+        var resourceSet = result.resourceSets[0];
+        if (resourceSet.resources.length === 0) {
+            viewModel.searchText = viewModel._searchText + ' (not found)';
+            return;
+        }
+
+        var resource = resourceSet.resources[0];
+
+        // Prefer the resource that is in Australia, if any.
+        for (var i = 0; i < resourceSet.resources.length; ++i) {
+            var resource = resourceSet.resources[i];
+            if (defined(resource.address) && resource.address.countryRegion === 'Australia') {
+                resource = resourceSet.resources[i];
+                break;
+            }
+        }
+
+        viewModel._searchText = resource.name;
+        var bbox = resource.bbox;
+        var south = bbox[0];
+        var west = bbox[1];
+        var north = bbox[2];
+        var east = bbox[3];
+        var rectangle = Rectangle.fromDegrees(west, south, east, north);
+
+        var camera = viewModel._viewer.scene.camera;
+        var position = camera.getRectangleCameraCoordinates(rectangle);
+        if (!defined(position)) {
+            // This can happen during a scene mode transition.
+            return;
+        }
+
+        var options = {
+            destination : position,
+            duration : viewModel._flightDuration,
+            onComplete : function() {
+                var screenSpaceCameraController = viewModel._viewer.scene.screenSpaceCameraController;
+                screenSpaceCameraController.ellipsoid = viewModel._ellipsoid;
+            },
+            endReferenceFrame : Matrix4.IDENTITY,
+            convert : false
+        };
+
+        var flight = CameraFlightPath.createAnimation(viewModel._viewer.scene, options);
+        viewModel._viewer.scene.animations.add(flight);
+    }, function() {
+        if (geocodeInProgress.cancel) {
+            return;
+        }
+
+        viewModel._isSearchInProgress = false;
+        viewModel.searchText = viewModel._searchText + ' (error)';
+    });
+}
+
+function cancelGeocode(viewModel) {
+    viewModel._isSearchInProgress = false;
+    if (defined(viewModel._geocodeInProgress)) {
+        viewModel._geocodeInProgress.cancel = true;
+        viewModel._geocodeInProgress = undefined;
+    }
+}
+
+module.exports = SearchWidgetViewModel;


### PR DESCRIPTION
- Adds the "Other Data" to the browser.  `getCapabilities` is done asynchronsouly when the category is opened, so it might take a second for the list of layers to appear (I'll add a spinner soon to make this more obvious).
- Adds a search box.  It's using the Bing geocoder, but I tried to make it a bit more Australia-oriented than the one built into Cesium.  First, it passes the camera's coordinates to the service request, so in theory Bing should return more location-relevant results.  Second, when geocoding returns multiple results, we zoom to the first one that lists its country as Australia.  The end result is that entering "NT" zooms to Northern Territory rather than flying off to Canada.
- Enabling a layer no longer automatically zooms there.  To zoom, click on the label of an enabled layer.
