### PR TITLE
Improvements for Tuesday demo

### DIFF
--- a/public/viewer/AusGlobeViewer.css
+++ b/public/viewer/AusGlobeViewer.css
@@ -543,3 +543,56 @@ a.ausglobe-title-menuItem:hover {
 .ausglobe-search-button:hover {
     background-color: #48b;
 }
+
+.ausglobe-info-container {
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    background-color: rgba(0,0,0,0.8);
+}
+
+.ausglobe-info {
+    display: inline-block;
+    width: 600px;
+    height: 500px;
+    background-color: white;
+    margin: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+}
+
+.ausglobe-info-close-button {
+    position: absolute;
+    right: 0;
+    top: 0;
+    cursor: pointer;
+    padding: 10px;
+    font-size: 18pt;
+    font-weight: bold;
+}
+
+.ausglobe-info h1 {
+    font-size: 12pt;
+    padding: 10px;
+    font-weight: bold;
+}
+
+.ausglobe-info h2 {
+    font-size: 10pt;
+    padding-left: 10px;
+    padding-top: 10px;
+    padding-right: 10px;
+    padding-bottom: 2px;
+    font-weight: bold;
+}
+
+.ausglobe-info-field {
+    position: relative;
+    left: 10px;
+    right: 10px;
+}

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -938,6 +938,9 @@ AusGlobeViewer.prototype._createCesiumViewer = function(container) {
                 var cartographic = ellipsoid.cartesianToCartographic(cartesian);
                 var terrainPos = [cartographic];
                 function sampleTerrainSuccess() {
+                    if (scene.isDestroyed()) {
+                        return;
+                    }
                     var text = cartesianToDegreeString(scene, cartesian);
                     text += ' | Elev: ' + terrainPos[0].height.toFixed(1) + ' m';
                     document.getElementById('position').innerHTML = text;
@@ -997,8 +1000,9 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
     if (!bCesium) {
 
         //create leaflet viewer
-        map = L.map('cesiumContainer', { zoomControl: false }).setView([-28.5, 135], 5);
-        new L.Control.Zoom({ position: 'topright' }).addTo(map);
+        map = L.map('cesiumContainer', {
+            zoomControl: false
+        }).setView([-28.5, 135], 5);
 
         map.on("boxzoomend", function(e) {
             console.log(e.boxZoomBounds);
@@ -1017,7 +1021,7 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
         map.addLayer(layer);
 
         //document.getElementById('controls').style.visibility = 'hidden';
-        this._navigationWidget.show = false;
+        this._navigationWidget.showTilt = false;
         document.getElementById('position').style.visibility = 'hidden';
 
         //redisplay data
@@ -1091,7 +1095,7 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
         this._enableSelectExtent(true);
         stopTimeline(this.viewer);
 
-        this._navigationWidget.show = true;
+        this._navigationWidget.showTilt = true;
         document.getElementById('position').style.visibility = 'visible';
         /*
          var esri = new ArcGisMapServerImageryProvider({

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -759,14 +759,12 @@ var updateLegend = function(datavis) {
 // Timeline display on selection
 //------------------------------------
 function showTimeline(viewer) {
-    viewer.timeline.show = true;
-    viewer.animation.show = true;
+    viewer.showTimeControls = true;
 }
 
 function hideTimeline(viewer) {
     if (defined(viewer)) {
-        viewer.timeline.show = false;
-        viewer.animation.show = false;
+        viewer.showTimeControls = false;
     }
 }
 
@@ -887,7 +885,8 @@ AusGlobeViewer.prototype._createCesiumViewer = function(container) {
         }),
         terrainProvider : new CesiumTerrainProvider({
             url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
-        })
+        }),
+        timeControlsInitiallyVisible : false
     };
 
     //create CesiumViewer

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -38,6 +38,7 @@ var Tween = Cesium.Tween;
 var Transforms = Cesium.Transforms;
 var Matrix3 = Cesium.Matrix3;
 var Matrix4 = Cesium.Matrix4;
+var viewerDynamicObjectMixin = Cesium.viewerDynamicObjectMixin;
 
 var knockout = require('knockout');
 var komapping = require('knockout.mapping');
@@ -891,6 +892,19 @@ AusGlobeViewer.prototype._createCesiumViewer = function(container) {
 
     //create CesiumViewer
     var viewer = new Viewer(container, options);
+    viewer.extend(viewerDynamicObjectMixin);
+
+    var lastHeight = 0;
+    viewer.scene.preRender.addEventListener(function(scene, time) {
+        var container = viewer._container;
+        var height = container.clientHeight;
+
+        if (height !== lastHeight) {
+            viewer.infoBox.viewModel.maxHeight = Math.max(height - 300, 100);
+            lastHeight = height;
+        }
+    });
+
 
     var scene = viewer.scene;
     var canvas = scene.canvas;

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -59,7 +59,7 @@ var GeoDataBrowser = function(options) {
                             <img class="ausglobe-accordion-category-item-checkbox" src="images/Check_tick.svg" data-bind="click: $root.toggleItemEnabled, visible: isEnabled()" />\
                             <img class="ausglobe-accordion-category-item-checkbox" src="images/Check_box.svg" data-bind="click: $root.toggleItemEnabled, visible: !isEnabled()" />\
                             <div class="ausglobe-accordion-category-item-label" data-bind="text: Title, click: $root.zoomToItem"></div>\
-                            <div class="ausglobe-accordion-category-item-infoButton">info</div>\
+                            <div class="ausglobe-accordion-category-item-infoButton" data-bind="click: $root.showInfoForItem">info</div>\
                         </div>\
                     </div>\
                 </div>\

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -13,6 +13,7 @@ var Rectangle = Cesium.Rectangle;
 var createCommand = Cesium.createCommand;
 
 var GeoData = require('../GeoData');
+var GeoDataInfoPopup = require('./GeoDataInfoPopup');
 var knockout = require('knockout');
 var komapping = require('knockout.mapping');
 var knockoutES5 = require('../../public/third_party/knockout-es5.js');
@@ -81,6 +82,13 @@ var GeoDataBrowserViewModel = function(options) {
             return;
         }
         that._viewer.updateCameraFromRect(item.layer.extent, 1000);
+    });
+
+    this._showInfoForItem = createCommand(function(item) {
+        new GeoDataInfoPopup({
+            container : document.body,
+            viewModel : item
+        });
     });
 
     function removeBaseLayer() {
@@ -208,6 +216,12 @@ defineProperties(GeoDataBrowserViewModel.prototype, {
     zoomToItem : {
         get : function() {
             return this._zoomToItem;
+        }
+    },
+
+    showInfoForItem : {
+        get : function() {
+            return this._showInfoForItem;
         }
     },
 

--- a/src/viewer/GeoDataInfoPopup.js
+++ b/src/viewer/GeoDataInfoPopup.js
@@ -1,0 +1,42 @@
+"use strict";
+
+/*global require,Cesium*/
+var getElement = Cesium.getElement;
+
+var knockout = require('knockout');
+
+var GeoDataInfoPopup = function(options) {
+    var container = getElement(options.container);
+
+    var wrapper = document.createElement('div');
+    wrapper.className = 'ausglobe-info-container';
+    wrapper.setAttribute('data-bind', 'click: close');
+    container.appendChild(wrapper);
+
+    var info = document.createElement('div');
+    info.className = 'ausglobe-info';
+    info.setAttribute('data-bind', 'click: function(viewModel, e) { e.stopPropagation(); }');
+    info.innerHTML = '\
+        <div class="ausglobe-info-close-button" data-bind="click: close">&times;</div>\
+        <h1 data-bind="text: info.Title"></h1>\
+        <h2>Type</h2>\
+        <div class="ausglobe-info-field" data-bind="text: info.type"></div>\
+        <h2>URL</h2>\
+        <div class="ausglobe-info-field" data-bind="text: info.base_url"></div>\
+        <h2 data-bind="visible: info.Name() !== \'REST\'">Layer Name</h2>\
+        <div class="ausglobe-info-field" data-bind="visible: info.Name() !== \'REST\', text: info.Name"></div>\
+        </div>\
+    ';
+    wrapper.appendChild(info);
+
+    this._viewModel = {
+        info : options.viewModel,
+        close : function() {
+            container.removeChild(wrapper);
+        }
+    };
+
+    knockout.applyBindings(this._viewModel, wrapper);
+};
+
+module.exports = GeoDataInfoPopup;

--- a/src/viewer/NavigationWidget.js
+++ b/src/viewer/NavigationWidget.js
@@ -16,6 +16,7 @@ var IntersectionTests = Cesium.IntersectionTests;
 var defined = Cesium.defined;
 var Tween = Cesium.Tween;
 var defaultValue = Cesium.defaultValue;
+var defineProperties = Cesium.defineProperties;
 
 var knockout = require('knockout');
 
@@ -23,40 +24,57 @@ var NavigationWidget = function(viewer, container) {
     container = getElement(container);
 
     this._viewer = viewer;
+    this._showTilt = true;
 
     var element = document.createElement('div');
     element.className = 'navigation-controls';
     container.appendChild(element);
 
+    this._element = element;
+
     element.innerHTML = '\
         <img src="images/plus.svg" class="navigation-control" data-bind="click: zoomIn" title="Zoom In"></div>\
         <img src="images/minus.svg" class="navigation-control" data-bind="click: zoomOut" title="Zoom Out"></div>\
-        <img src="images/tilt_none.svg" class="navigation-control" data-bind="click: tilt, visible: isTiltExtreme" title="Tilt"></div>\
-        <img src="images/tilt_moderate.svg" class="navigation-control" data-bind="click: tilt, visible: isTiltNone" title="Tilt"></div>\
-        <img src="images/tilt_extreme.svg" class="navigation-control" data-bind="click: tilt, visible: isTiltModerate" title="Tilt"></div>\
+        <img src="images/tilt_none.svg" class="navigation-control" data-bind="click: tilt, visible: showTilt && isTiltExtreme" title="Tilt"></div>\
+        <img src="images/tilt_moderate.svg" class="navigation-control" data-bind="click: tilt, visible: showTilt && isTiltNone" title="Tilt"></div>\
+        <img src="images/tilt_extreme.svg" class="navigation-control" data-bind="click: tilt, visible: showTilt && isTiltModerate" title="Tilt"></div>\
     ';
 
     var that = this;
     this._viewModel = {
         zoomIn : createCommand(function() {
-            var scene = that._viewer.scene
-            var camera = scene.camera;
-            var focus = getCameraFocus(scene);
-            var direction = Cartesian3.subtract(focus, camera.position);
-            var movementVector = Cartesian3.multiplyByScalar(direction, 2.0 / 3.0);
-            var endPosition = Cartesian3.add(camera.position, movementVector);
+            if (that._viewer.map) {
+                // Leaflet
+                that._viewer.map.zoomIn(1);
+                return;
+            } else {
+                // Cesium
+                var scene = that._viewer.scene
+                var camera = scene.camera;
+                var focus = getCameraFocus(scene);
+                var direction = Cartesian3.subtract(focus, camera.position);
+                var movementVector = Cartesian3.multiplyByScalar(direction, 2.0 / 3.0);
+                var endPosition = Cartesian3.add(camera.position, movementVector);
 
-            flyToPosition(scene, endPosition);
+                flyToPosition(scene, endPosition);
+            }
         }),
         zoomOut : createCommand(function() {
-            var scene = that._viewer.scene
-            var camera = scene.camera;
-            var focus = getCameraFocus(scene);
-            var direction = Cartesian3.subtract(focus, camera.position);
-            var movementVector = Cartesian3.multiplyByScalar(direction, -2.0);
-            var endPosition = Cartesian3.add(camera.position, movementVector);
+            if (that._viewer.map) {
+                // Leaflet
+                that._viewer.map.zoomOut(1);
+                return;
+            } else {
+                // Cesium
+                var scene = that._viewer.scene
+                var camera = scene.camera;
+                var focus = getCameraFocus(scene);
+                var direction = Cartesian3.subtract(focus, camera.position);
+                var movementVector = Cartesian3.multiplyByScalar(direction, -2.0);
+                var endPosition = Cartesian3.add(camera.position, movementVector);
 
-            flyToPosition(scene, endPosition);
+                flyToPosition(scene, endPosition);
+            }
         }),
         tilt : createCommand(function() {
             if (that._viewModel.isTiltNone) {
@@ -73,15 +91,27 @@ var NavigationWidget = function(viewer, container) {
                 animateToTilt(that._viewer.scene, 90.0);
             }
         }),
+        showTilt : true,
         isTiltNone : true,
         isTiltModerate : false,
         isTiltExtreme : false
     };
 
-    knockout.track(this._viewModel, ['isTiltNone', 'isTiltModerate', 'isTiltExtreme']);
+    knockout.track(this._viewModel, ['showTilt', 'isTiltNone', 'isTiltModerate', 'isTiltExtreme']);
 
     knockout.applyBindings(this._viewModel, element);
 };
+
+defineProperties(NavigationWidget.prototype, {
+    showTilt : {
+        get : function() {
+            return this._viewModel.showTilt;
+        },
+        set : function(value) {
+            this._viewModel.showTilt = value;
+        }
+    }
+});
 
 function animateToTilt(scene, targetTiltDegrees, durationMilliseconds) {
     durationMilliseconds = defaultValue(durationMilliseconds, 200);
@@ -102,12 +132,21 @@ function animateToTilt(scene, targetTiltDegrees, durationMilliseconds) {
             time : 1.0
         },
         onUpdate : function(value) {
+            if (scene.isDestroyed()) {
+                return;
+            }
             scene.camera.tilt = CesiumMath.lerp(startTilt, endTilt, value.time);
         },
         onComplete : function() {
+            if (controller.isDestroyed()) {
+                return;
+            }
             controller.enableInputs = true;
         },
         onCancel: function() {
+            if (controller.isDestroyed()) {
+                return;
+            }
             controller.enableInputs = true;
         }
     });
@@ -145,14 +184,23 @@ function flyToPosition(scene, position, durationMilliseconds) {
             time : 1.0
         },
         onUpdate : function(value) {
+            if (scene.isDestroyed()) {
+                return;
+            }
             scene.camera.position.x = CesiumMath.lerp(startPosition.x, endPosition.x, value.time);
             scene.camera.position.y = CesiumMath.lerp(startPosition.y, endPosition.y, value.time);
             scene.camera.position.z = CesiumMath.lerp(startPosition.z, endPosition.z, value.time);
         },
         onComplete : function() {
+            if (controller.isDestroyed()) {
+                return;
+            }
             controller.enableInputs = true;
         },
         onCancel: function() {
+            if (controller.isDestroyed()) {
+                return;
+            }
             controller.enableInputs = true;
         }
     });


### PR DESCRIPTION
- Fixes the crash when tilting (I had a hard time reproducing this consistently, but I'm fairly certain this fixes it).
- Removes the redundant zoom controls in 2D.  The NM-styled ones in the lower right work in both modes.
- Adds a data source info popup with basic information: name, type, URL, layer name.
- Display info about features on click.  It doesn't work for raster maps, only vector features.  I just activated a built-in Cesium capability.  Try out Other->GME Examples->CentreLink Sites or Features->data.gov.au->Buildings.  3D only at the moment.

Don't forget to run git submodule update after pulling this change, because part of it is in the Cesium submodule.
