### PR TITLE
Open up CORS proxy and implement browse/select data source

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,7 +42,6 @@ app.get(/^\/proxy\/(.+)$/, function(req, res) {
         remoteUrl += url.substring(queryStartIndex);
     }
 
-    console.log(remoteUrl);
     request.get(remoteUrl).pipe(res);
 });
 

--- a/server.js
+++ b/server.js
@@ -1,7 +1,10 @@
+"use strict";
+
 /*global require,__dirname*/
 /*jshint es3:false*/
 var path = require('path');
 var express = require('express');
+var url = require('url');
 
 var mime = express.static.mime;
 mime.define({
@@ -27,13 +30,19 @@ var proxyAllowedHosts = {
     'data.gov.au' : true
 };
 
-app.get('/proxy', function(req, res) {
-    var remoteUrl = Object.keys(req.query)[0];
-    if (!proxyAllowedHosts[url.parse(remoteUrl).hostname.toLowerCase()]) {
-        res.send(400, 'Host it not in list of allowed hosts.');
-        return;
+app.get(/^\/proxy\/(.+)$/, function(req, res) {
+    var remoteUrl = req.params[0];
+    if (remoteUrl.indexOf('http') !== 0) {
+        remoteUrl = 'http://' + remoteUrl;
     }
 
+    var url = req.url;
+    var queryStartIndex = url.indexOf('?');
+    if (queryStartIndex >= 0) {
+        remoteUrl += url.substring(queryStartIndex);
+    }
+
+    console.log(remoteUrl);
     request.get(remoteUrl).pipe(res);
 });
 

--- a/src/corsProxy.js
+++ b/src/corsProxy.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/*global require*/
+
+var corsProxy = {
+    getURL : function(resource) {
+        return '/proxy/' + resource;
+    }
+};
+
+module.exports = corsProxy;

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -46,6 +46,7 @@ var knockout = require('knockout');
 var komapping = require('knockout.mapping');
 var knockoutES5 = require('../../public/third_party/knockout-es5.js');
 
+var corsProxy = require('./corsProxy');
 var GeoDataBrowser = require('./GeoDataBrowser');
 var GeoDataWidget = require('./GeoDataWidget');
 var readJson = require('../readJson');
@@ -707,7 +708,7 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
         /*
          var esri = new ArcGisMapServerImageryProvider({
          url: 'http://www.ga.gov.au/gis/rest/services/topography/Australian_Topography/MapServer',
-         proxy: new DefaultProxy('/proxy/')
+         proxy: corsProxy
          });
          this.scene.globe.imageryLayers.addImageryProvider(esri);
          */

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -95,6 +95,7 @@ var GeoDataBrowser = function(options) {
                     <div>\
                         Add data by dragging and dropping it onto the map, or\
                         <span class="ausglobe-upload-file-button" data-bind="click: selectFileToUpload">Browse and select a file to upload</span>.\
+                        <input type="file" style="display: none;" id="uploadFile" data-bind="event: { change: addUploadedFile }"/>\
                     </div>\
                     <form class="ausglobe-user-service-form" data-bind="submit: addWfsService">\
                         <label>\

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -8,7 +8,6 @@ var BingMapsStyle = Cesium.BingMapsStyle;
 var CesiumTerrainProvider = Cesium.CesiumTerrainProvider;
 var combine = Cesium.combine;
 var createCommand = Cesium.createCommand;
-var DefaultProxy = Cesium.DefaultProxy;
 var defined = Cesium.defined;
 var defineProperties = Cesium.defineProperties;
 var EllipsoidTerrainProvider = Cesium.EllipsoidTerrainProvider;
@@ -17,6 +16,7 @@ var Rectangle = Cesium.Rectangle;
 var TileMapServiceImageryProvider = Cesium.TileMapServiceImageryProvider;
 var when = Cesium.when;
 
+var corsProxy = require('../corsProxy');
 var GeoData = require('../GeoData');
 var GeoDataInfoPopup = require('./GeoDataInfoPopup');
 var readJson = require('../readJson');
@@ -184,8 +184,21 @@ var GeoDataBrowserViewModel = function(options) {
         var imageryLayers = that._viewer.scene.globe.imageryLayers;
         imageryLayers.addImageryProvider(new ArcGisMapServerImageryProvider({
             url : 'http://www.ga.gov.au/gis/rest/services/topography/Australian_Topography_WM/MapServer',
-            proxy : new DefaultProxy('/proxy/')
+            proxy : corsProxy
         }), 0);
+    });
+
+    this._selectFileToUpload = createCommand(function() {
+        var element = document.getElementById('uploadFile');
+        element.click();
+    });
+
+    this._addUploadedFile = createCommand(function() {
+        var uploadFileElement = document.getElementById('uploadFile');
+        var files = uploadFileElement.files;
+        for (var i = 0; i < files.length; ++i) {
+            that._viewer.geoDataManager.addFile(files[i]);
+        }
     });
 
     // Subscribe to a change in the selected viewer (2D/3D) in order to actually switch the viewer.
@@ -472,9 +485,13 @@ defineProperties(GeoDataBrowserViewModel.prototype, {
 
     selectFileToUpload : {
         get : function() {
-            return function() {
-                alert('Sorry, not yet implemented.');
-            };
+            return this._selectFileToUpload;
+        }
+    },
+
+    addUploadedFile : {
+        get : function() {
+            return this._addUploadedFile;
         }
     }
 });

--- a/src/viewer/GeoDataWidget.js
+++ b/src/viewer/GeoDataWidget.js
@@ -201,23 +201,6 @@ function handleError(e) {
     alert('error loading data: ' + e.what);
 }
 
-function loadLocalFile(path) {
-    if (typeof path === 'undefined') {
-        throw new DeveloperError('path is required');
-    }
-    var reader = new FileReader();
-    reader.readAsText(path);
-    var deferred = when.defer();
-    reader.onload = function (event) {
-        var allText = event.target.result;
-        deferred.resolve(allText);
-    };
-    reader.onerror = function (e) {
-        deferred.reject(e);
-    };
-    return deferred.promise;
-};
-
 var dropHandler = function (evt, that) {
     evt.stopPropagation();
     evt.preventDefault();
@@ -230,46 +213,8 @@ var dropHandler = function (evt, that) {
     for (var ndx = 0; ndx < count; ndx++) {
         var file = files[ndx];
         console.log(' - File Name: ' + file.name);
-        if (that.geoDataManager.formatSupported(file.name)) {
-            when(loadLocalFile(file), function (text) {
-                that.geoDataManager.zoomTo = true;
-                that.geoDataManager.loadText(text, file.name);
-            });
-        }
-        else {
-            if (file.size > 1000000) {
-                alert('File is too large to send to conversion service.  Click here for alternative file conversion options.');
-            }
-            else if (false) {
-                    //TODO: check against list of support extensions
-                alert('File format is not supported by conversion service.  Click here for alternative file conversion options.');
-            }
-            else {
-                if (!confirm('No local format handler.  Click OK to convert via our web service.')) {
-                    return;
-                }
-                // generate form data to submit text for conversion
-                var formData = new FormData();
-                formData.append('input_file', file);
 
-                var xhr = new XMLHttpRequest;
-                xhr.onreadystatechange = function () {
-                    if (xhr.readyState == 4) {
-                        var response = xhr.responseText;
-                        if (response.substring(0,1) !== '{') {
-                            console.log(response);
-                            alert('Error trying to convert: ' + file.name);
-                        }
-                        else {
-                            that.geoDataManager.zoomTo = true;
-                            that.geoDataManager.loadText(response, file.name+'.geojson');
-                        }
-                    }
-                }
-                xhr.open('POST', that.geoDataManager.visStore + '/convert');
-                xhr.send(formData);
-            }
-        }
+        that.geoDataManager.addFile(file);
     }
 }
 


### PR DESCRIPTION
Sorry for the two totally unrelated changes here...

First, this changes our node-based CORS proxy to:
- Proxy requests to any host.
- Accept the remote URL in unencoded form (ex: http://localhost:3001/proxy/http://www.google.com), which should make it much easier to pass pre-proxied URLs to APIs that aren't aware of the proxying, like Leaflet.

Second, this makes the "Browse and select a file to upload" button on the Add Data panel work.  The added data still doesn't show up in the data browser, though.
