### PR TITLE
Data panel improvements

### DIFF
--- a/public/viewer/AusGlobeViewer.css
+++ b/public/viewer/AusGlobeViewer.css
@@ -418,7 +418,7 @@ a.ausglobe-title-menuItem:hover {
 
 .ausglobe-accordion-item-content-visible {
     visibility: visible;
-    max-height: 400px; /* TODO: set this dynamically based on number of accordion items */
+    max-height: none;
 
     -webkit-transition: max-height 0.25s;
     -moz-transition: max-height 0.25s;

--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -190,11 +190,11 @@ GeoDataCollection.prototype.remove = function(id) {
 *
 */
 GeoDataCollection.prototype.show = function(layer, val) {
-    layer.show = val;
     if (layer === undefined) {
-        console.log('ERROR: layer not found:', id);
+        console.log('ERROR: layer not found.');
         return;
     }
+    layer.show = val;
     if (layer.dataSource) {
         if (val) {
             this.dataSourceCollection.add(layer.dataSource);

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -341,13 +341,17 @@ var GeoDataBrowserViewModel = function(options) {
 
     this.userContent = komapping.fromJS([], this._collectionListMapping);
 
-    function getDescription(item) {
-        return item.description;
-    }
-
     var nowViewingMapping = {
         create : function(options) {
-            var viewModel = komapping.fromJS(options.data.description);
+            var description = options.data.description;
+            if (!defined(description)) {
+                description = {
+                    Title : options.data.name,
+                    base_url : options.data.url,
+                    type : options.data.type
+                };
+            }
+            var viewModel = komapping.fromJS(description);
             viewModel.show = knockout.observable(options.data.show);
             viewModel.layer = options.data;
             return viewModel;


### PR DESCRIPTION
- Fix a problem I introduced yesterday where the content of an accordion button was cut off after 400 pixels.  This change also breaks the animated expand/collapse because CSS is hard.  It seems it's not possible to use CSS transitions to animate to/from a non-constant height.  At some point I'll do the animation in javascript, but it's not a priority at the moment.
- Make data that is drag/dropped or selected via the "Browse and select a file to upload" button show up correctly in the Now Viewing panel.
- Fix jshint warnings.
