### PR TITLE
Use Cesium in IE11.

### DIFF
--- a/public/viewer/AusGlobeViewer.css
+++ b/public/viewer/AusGlobeViewer.css
@@ -670,6 +670,10 @@ a.ausglobe-title-menuItem:hover {
     text-decoration: none;
 }
 
+#cesiumContainer .cesium-widget-credits a:link {
+    color: white;
+}
+
 #cesiumContainer .cesium-widget-credits a:visited {
     color: white;
 }

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -733,7 +733,7 @@ function supportsWebgl() {
         return false;
     }
     var canvas = document.createElement( 'canvas' );
-    var gl = canvas.getContext("webgl");
+    var gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
     if (!gl) {
         // Browser could not initialize WebGL. User probably needs to
         // update their drivers or get a new browser. Present a link to


### PR DESCRIPTION
IE11 exposes only the `experimental-webgl` context.

Also make non-visited links to cesiumjs.org and www.bing.com in the credits white instead of blue.

Fixes #42.
