### PR TITLE
Update Cesium and adjust for its breaking changes.

### DIFF
--- a/src/TableDataSource.js
+++ b/src/TableDataSource.js
@@ -179,6 +179,8 @@ TableDataSource.prototype.setCurrentVariable = function (varname) {
     });
 };
 
+var startScratch = new JulianDate();
+var endScratch = new JulianDate();
 
 /**
 * Replaceable visualizer function
@@ -209,8 +211,8 @@ TableDataSource.prototype.czmlRecFromPoint = function (point) {
         rec.position.cartographicDegrees[p] = point.pos[p];
     }
 
-    var start = JulianDate.addMinutes(point.time, -this.leadTimeMin);
-    var finish = JulianDate.addMinutes(point.time, this.trailTimeMin);
+    var start = JulianDate.addMinutes(point.time, -this.leadTimeMin, startScratch);
+    var finish = JulianDate.addMinutes(point.time, this.trailTimeMin, endScratch);
     rec.billboard.show[0].interval = JulianDate.toIso8601(start) + '/' + JulianDate.toIso8601(finish);
     return rec;
 };

--- a/src/Variable.js
+++ b/src/Variable.js
@@ -93,8 +93,8 @@ Variable.prototype.processTimeVar = function () {
     }
     function time_excel(v) {   // 40544.4533
         var date = JulianDate.fromDate(new Date('January 1, 1970 0:00:00'));
-        date = JulianDate.addDays(date, Math.floor(v) - 25569.0); //account for offset to 1900
-        date = JulianDate.addSeconds(date, (v - Math.floor(v)) * 60 * 60 * 24);
+        date = JulianDate.addDays(date, Math.floor(v) - 25569.0, date); //account for offset to 1900
+        date = JulianDate.addSeconds(date, (v - Math.floor(v)) * 60 * 60 * 24, date);
         return date;
     }
     function time_utc(v) {   //12321231414434
@@ -110,7 +110,7 @@ Variable.prototype.processTimeVar = function () {
         var d = new Date();
         d.setUTCFullYear(year);
         d.setUTCHours(date_str.substring(7, 9), date_str.substring(9, 11), date_str.substring(11, 13));
-        var date = JulianDate.addDays(JulianDate.fromDate(d), dayofyear);
+        var date = JulianDate.addDays(JulianDate.fromDate(d), dayofyear, new JulianDate());
         return date;
     }
     //create new Cessium time variable to attach to the variable

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -816,9 +816,6 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
 
             this.scene.primitives.removeAll();
 
-            // Hack to prevent the viewer from destroying our DataSourceCollection.
-            this.viewer._dataSourceCollection = new DataSourceCollection();
-
             this.viewer.destroy();
             this.viewer = undefined;
         }
@@ -1104,13 +1101,13 @@ function flyToPosition(scene, position, durationMilliseconds) {
     var controller = scene.screenSpaceCameraController;
     controller.enableInputs = false;
 
-    scene.animations.add({
-        duration : durationMilliseconds,
+    scene.tweens.add({
+        duration : durationMilliseconds / 1000.0,
         easingFunction : Tween.Easing.Sinusoidal.InOut,
-        startValue : {
+        startObject : {
             time: 0.0
         },
-        stopValue : {
+        stopObject : {
             time : 1.0
         },
         onUpdate : function(value) {
@@ -1192,11 +1189,11 @@ AusGlobeViewer.prototype.updateCameraFromRect = function(rect_in, flightTimeMill
         rect.south -= epsilon/2.0;
     }
     if (scene !== undefined && !scene.isDestroyed()) {
-        var flight = CameraFlightPath.createAnimationRectangle(scene, {
+        var flight = CameraFlightPath.createTweenRectangle(scene, {
             destination : rect,
-            duration: flightTimeMilliseconds
+            duration: flightTimeMilliseconds / 1000.0
         });
-        scene.animations.add(flight);
+        scene.tweens.add(flight);
     }
     else if (map !== undefined) {
         var bnds = [[CesiumMath.toDegrees(rect.south), CesiumMath.toDegrees(rect.west)],

--- a/src/viewer/NavigationWidget.js
+++ b/src/viewer/NavigationWidget.js
@@ -125,28 +125,28 @@ function animateToTilt(scene, targetTiltDegrees, durationMilliseconds) {
     var controller = scene.screenSpaceCameraController;
     controller.enableInputs = false;
 
-    scene.animations.add({
-        duration : durationMilliseconds,
+    scene.tweens.add({
+        duration : durationMilliseconds / 1000.0,
         easingFunction : Tween.Easing.Sinusoidal.InOut,
-        startValue : {
+        startObject : {
             time: 0.0
         },
-        stopValue : {
+        stopObject : {
             time : 1.0
         },
-        onUpdate : function(value) {
+        update : function(value) {
             if (scene.isDestroyed()) {
                 return;
             }
             scene.camera.tilt = CesiumMath.lerp(startTilt, endTilt, value.time);
         },
-        onComplete : function() {
+        complete : function() {
             if (controller.isDestroyed()) {
                 return;
             }
             controller.enableInputs = true;
         },
-        onCancel: function() {
+        cancel: function() {
             if (controller.isDestroyed()) {
                 return;
             }
@@ -177,16 +177,16 @@ function flyToPosition(scene, position, durationMilliseconds) {
     var controller = scene.screenSpaceCameraController;
     controller.enableInputs = false;
 
-    scene.animations.add({
-        duration : durationMilliseconds,
+    scene.tweens.add({
+        duration : durationMilliseconds / 1000.0,
         easingFunction : Tween.Easing.Sinusoidal.InOut,
-        startValue : {
+        startObject : {
             time: 0.0
         },
-        stopValue : {
+        stopObject : {
             time : 1.0
         },
-        onUpdate : function(value) {
+        update : function(value) {
             if (scene.isDestroyed()) {
                 return;
             }
@@ -194,13 +194,13 @@ function flyToPosition(scene, position, durationMilliseconds) {
             scene.camera.position.y = CesiumMath.lerp(startPosition.y, endPosition.y, value.time);
             scene.camera.position.z = CesiumMath.lerp(startPosition.z, endPosition.z, value.time);
         },
-        onComplete : function() {
+        complete : function() {
             if (controller.isDestroyed()) {
                 return;
             }
             controller.enableInputs = true;
         },
-        onCancel: function() {
+        cancel: function() {
             if (controller.isDestroyed()) {
                 return;
             }

--- a/src/viewer/SearchWidgetViewModel.js
+++ b/src/viewer/SearchWidgetViewModel.js
@@ -267,8 +267,8 @@ function geocode(viewModel) {
 
             var options = {
                 destination: position,
-                duration: viewModel._flightDuration,
-                onComplete: function () {
+                duration: viewModel._flightDuration / 1000.0,
+                complete: function () {
                     var screenSpaceCameraController = viewModel._viewer.scene.screenSpaceCameraController;
                     screenSpaceCameraController.ellipsoid = viewModel._ellipsoid;
                 },
@@ -276,8 +276,8 @@ function geocode(viewModel) {
                 convert: false
             };
 
-            var flight = CameraFlightPath.createAnimation(viewModel._viewer.scene, options);
-            viewModel._viewer.scene.animations.add(flight);
+            var flight = CameraFlightPath.createTween(viewModel._viewer.scene, options);
+            viewModel._viewer.scene.tweens.add(flight);
         } else {
             // Leaflet
             viewModel._viewer.map.fitBounds([[south, west], [north, east]]);


### PR DESCRIPTION
The updated version of Cesium no longer destroys our DataSourceCollection
when the Viewer is destroyed, so I was able to remove a workaround from
our code.

However, Cesium has a number of breaking changes as a result of the ongoing 1.0 push.  Better to stay in sync than deal with it all at once, I'd say.
