### PR TITLE
Services api

### DIFF
--- a/public/data_collection.json
+++ b/public/data_collection.json
@@ -1,4 +1,4 @@
-{"name":"National Map Collections", "Layer": [
+{"name":"National Map Collections", "nm_ext_type": "collections", "Layer": [
   {"name":"Land","base_url":"http://www.ga.gov.au/gis/services/topography/Australian_Topography_WM/MapServer/WMSServer","proxy":true,"type":"WMS","queryable":"0","Layer": [
 
     {"Name":"0","Title":"Gravity Image","base_url":"http://www.ga.gov.au/gis/services/earth_observation/Gravity_Image_WM/MapServer/WMSServer","BoundingBox":{"west":"105.930454436693","east":"162.097118856693","south":"-43.74050960205765","north":"-7.92768801894694"},"queryable":"1"},
@@ -119,11 +119,17 @@
     {"Name":"admin_bnds:UCL_2011_AUST","Title":"Urban Centre and Locality","BoundingBox":{"west":"96.816941408","east":"159.109219008","south":"-43.740509602057614","north":"-9.142175976703609"},"queryable":"1"},
 
     {"Name":"admin_bnds:RA_2011_AUST","Title":"Remoteness Area","BoundingBox":{"west":"96.816941408","east":"159.109219008","south":"-43.740509602057614","north":"-9.142175976703609"},"queryable":"1"}
-    ]},
+  ]},
 
-  {"name":"Places","base_url":"http://www.ga.gov.au/gazetteer-australia-wfsg-gws/wfs","proxy":true,"type":"WFS","queryable":"0","Layer": [
+  {"name":"Experimental","base_url":"","proxy":false,"type":"DATA","queryable":"0","Layer": [
+  
+    {"Name": "Traffic Incidents", "Title": "Traffic Incidents", "Abstract": "Simulated data showing traffic incidents over time", "url":"http://localhost/datasets/incidents.csv","BoundingBox":{"west":147.3154707,"south":-36.78012603,"east":153.5498186,"north":-28.2198794}},
+    
+    {"Name": "Pacific Earthquakes", "Title": "Pacific Earthquakes", "Abstract": "Earthquake events collected from SOSUS", "url":"http://localhost/datasets/earthquakes.csv","BoundingBox":{"west":-130.998,"south":40.01,"east":-121.398,"north":50.993}},
+    
+    {"Name": "Axial Site Earthquakes", "Title": "Axial Site Earthquakes", "Abstract": "Earthquake storm from Axial site on Juan de Fuca plate", "url":"http://localhost/datasets/axial.csv","BoundingBox":{"west":-130.0612,"south":45.811,"east":-129.955,"north":46.0031}},
 
-    {"Name":"iso19112:SI_LocationInstance","Title":"GA Gazetteer Example (slow)","count": "1400", "queryable":"1"}
+    {"Name": "CentreLink Sites", "Title": "CentreLink Sites via GME", "Abstract": "CentreLink Sites - Google Maps Engine Example","type":"GME", "BoundingBox":{"west":127.3154707,"south":-41.78012603,"east":153.5498186,"north":-10.2198794}, "url": "https://www.googleapis.com/mapsengine/v1/tables/12421761926155747447-06672618218968397709/features?maxResults=500&version=published&key=AIzaSyBZIS_uRrKShArQfvQtURFZasUpXyAaGDk"}
   ]}
 
 ]}

--- a/public/data_sources.json
+++ b/public/data_sources.json
@@ -1,4 +1,4 @@
-{"name":"National Map Data Sources", "Layer": [
+{"name":"National Map Data Sources", "nm_ext_type": "sources", "Layer": [
   { "name": "Maps", "Layer": [
     { "name": "Boundaries (ABS)", "base_url": "http://geoserver.research.nicta.com.au/admin_bnds_abs/ows", "type": "WMS", "proxy": false },
     { "name": "Boundaries (PSMA)", "base_url": "http://geoserver.research.nicta.com.au/admin_bnds_psma/ows", "type": "WMS", "proxy": false },
@@ -13,10 +13,6 @@
     { "name": "Water (BOM Geofabric)", "base_url": "http://geofabric.bom.gov.au/simplefeatures/ows", "type": "WFS", "proxy": true },
     { "name": "data.gov.au", "base_url": "http://data.gov.au/geoserver/ows", "type": "WFS", "proxy": false },
     { "name": "Western Australia", "base_url": "http://www2.landgate.wa.gov.au/ows/wfspublic_4326/wfs", "type": "WFS", "proxy": true }
-  ]},
-  { "name": "Other", "Layer": [
-    { "name": "GME Example", "base_url": "./datasets/gme_service.json", "type": "GME", "proxy": false },
-    { "name": "Sample GeoData", "base_url": "./datasets/csv_service.json", "type": "CSV", "proxy": false }
   ]}
 ]}
 

--- a/public/datasets/csv_service.json
+++ b/public/datasets/csv_service.json
@@ -1,8 +1,0 @@
-{"name":"CSV Example", "Layer": [
-  {"name":"Geolocated Tables","proxy":false,"type":"CSV","queryable":"0","Layer": [
-    {"Name": "NSW Incidents", "Title": "NSW Incidents", "Abstract": "Simulated data from NSW", "url":"./datasets/incidents.csv","BoundingBox":{"west":147.3154707,"south":-36.78012603,"east":153.5498186,"north":-28.2198794}},
-    {"Name": "Pacific Earthquakes", "Title": "Pacific Earthquakes", "Abstract": "Earthquake events collected from SOSUS", "url":"./datasets/earthquakes.csv","BoundingBox":{"west":-130.998,"south":40.01,"east":-121.398,"north":50.993}},
-    {"Name": "Axial Site Earthquakes", "Title": "Axial Site Earthquakes", "Abstract": "Earthquake storm from Axial site on Juan de Fuca plate", "url":"./datasets/axial.csv","BoundingBox":{"west":-130.0612,"south":45.811,"east":-129.955,"north":46.0031}}
-  ]}
-]}
-

--- a/public/datasets/gme_service.json
+++ b/public/datasets/gme_service.json
@@ -1,6 +1,0 @@
-{"name":"GME Example", "Layer": [
-  {"name":"Health Data","proxy":false,"type":"GME","queryable":"0","Layer": [
-    {"Name": "CentreLink Sites", "Title": "CentreLink Sites", "Abstract": "CentreLink Sites Example", "BoundingBox":{"west":127.3154707,"south":-41.78012603,"east":153.5498186,"north":-10.2198794}, "url": "https://www.googleapis.com/mapsengine/v1/tables/12421761926155747447-06672618218968397709/features?maxResults=500&version=published&key=AIzaSyBZIS_uRrKShArQfvQtURFZasUpXyAaGDk"}
-  ]}
-]}
-

--- a/public/nm_services.json
+++ b/public/nm_services.json
@@ -1,4 +1,4 @@
-{"name":"National Map Services", "services": [
+{"name":"National Map Services", "nm_ext_type": "services", "services": [
     { "name": "GeoSpace", "description": "A service provided by NICTA for sharing visualizations made in National Map", "url": "http://geospace.research.nicta.com.au/upload", "request": "POST"},
     { "name": "Your Service", "description": "Something you built"}
 ]}

--- a/public/nm_test_services.json
+++ b/public/nm_test_services.json
@@ -1,4 +1,4 @@
-{"name":"National Map Services", "services": [
+{"name":"National Map Services", "nm_ext_type": "services", "services": [
     { "name": "Local GeoSpace", "description": "A local instance to GeoSpace for testing", "url": "http://localhost:3000/upload", "request": "POST"},
     { "name": "NM Service 1", "description": "A service returning bike racks on the Gold Coast", "url": "http://localhost:3000/nm_service_1", "request": "POST"}
 ]}

--- a/public/nm_test_services.json
+++ b/public/nm_test_services.json
@@ -1,0 +1,5 @@
+{"name":"National Map Services", "services": [
+    { "name": "Local GeoSpace", "description": "A local instance to GeoSpace for testing", "url": "http://localhost:3000/upload", "request": "POST"},
+    { "name": "NM Service 1", "description": "A service returning bike racks on the Gold Coast", "url": "http://localhost:3000/nm_service_1", "request": "POST"}
+]}
+

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -189,7 +189,7 @@ var AusGlobeViewer = function(geoDataManager) {
         }
     });
 
-    this.geoDataManager.loadUrl(window.location);
+    this.geoDataManager.loadInitialUrl(window.location);
 
 };
 

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -119,12 +119,12 @@ var GeoDataBrowser = function(options) {
                 <div class="ausglobe-accordion-category">\
                     <div class="ausglobe-add-data-message">\
                         Add data by dragging and dropping it onto the map, or\
-                        <span class="ausglobe-upload-file-button" data-bind="click: selectFileToUpload">Browse and select a file to upload</span>.\
+                        <span class="ausglobe-upload-file-button" data-bind="click: selectFileToUpload">Browse and select a file to load</span>.\
                         <input type="file" style="display: none;" id="uploadFile" data-bind="event: { change: addUploadedFile }"/>\
                     </div>\
-                    <form class="ausglobe-user-service-form" data-bind="submit: addWfsService">\
+                    <form class="ausglobe-user-service-form" data-bind="submit: addDataOrService">\
                         <label>\
-                            <div>Add a Web Feature Service URL (advanced):</div>\
+                            <div>Enter a web link to add a data file or WMS/WFS service (advanced):</div>\
                             <input class="ausglobe-wfs-url-input" type="text" data-bind="value: wfsServiceUrl" />\
                         </label>\
                         <div>\

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -407,11 +407,11 @@ var GeoDataBrowserViewModel = function(options) {
             }
 
             var collections;
-            if (json.name === 'National Map Data Sources') {
+            if (json.nm_ext_type === 'sources') {
                 collections = json.Layer;
-            } else if (json.name === 'National Map Collections') {
+            } else if (json.nm_ext_type === 'collections') {
                 collections = [json];
-            } else if (json.name === 'National Map Services') {
+            } else if (json.nm_ext_type === 'services') {
                 that._dataManager.addServices(json.services);
             }
             

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -116,19 +116,29 @@ var GeoDataBrowserViewModel = function(options) {
         });
     });
 
-    this._addWfsService = createCommand(function() {
-        var item = createCategory({
-            data : {
-                name : that.wfsServiceUrl,
-                base_url : that.wfsServiceUrl,
-                type : 'WFS',
-                proxy : true
+    this._addDataOrService = createCommand(function() {
+        if (that._viewer.geoDataManager.formatSupported(that.wfsServiceUrl)) {
+            that._viewer.geoDataManager.loadUrl(that.wfsServiceUrl);
+        }
+        else {
+                //TODO: set type based on user confirmation - need real UI
+            var ret = window.confirm("Dumb UI to cover for now.  Click OK for a WFS service and cancel for a WMS service.");
+            var type = 'WFS';
+            if (ret === false) {
+                type = 'WMS';
             }
-        });
-        that.userContent.push(item);
+            var item = createCategory({
+                data : {
+                    name : that.wfsServiceUrl,
+                    base_url : that.wfsServiceUrl,
+                    type : type,
+                    proxy : true
+                }
+            });
+            that.userContent.push(item);
 
-        item.isOpen(true);
-
+            item.isOpen(true);
+        }
         that.wfsServiceUrl = '';
     });
 
@@ -433,7 +443,7 @@ var GeoDataBrowserViewModel = function(options) {
         var files = evt.dataTransfer.files;
         for (var i = 0; i < files.length; ++i) {
             var file = files[i];
-            if (file.name.indexOf('.json') === -1) {
+            if (file.name.toUpperCase().indexOf('.JSON') === -1) {
                 continue;
             }
 
@@ -556,9 +566,9 @@ defineProperties(GeoDataBrowserViewModel.prototype, {
         }
     },
 
-    addWfsService : {
+    addDataOrService : {
         get : function() {
-            return this._addWfsService;
+            return this._addDataOrService;
         }
     },
 

--- a/src/viewer/GeoDataWidget.js
+++ b/src/viewer/GeoDataWidget.js
@@ -52,27 +52,7 @@ var GeoDataWidget = function(geoDataManager, setCurrentDataset) {
             </form>';
     document.body.appendChild(div);
 
-    // -----------------------------
-    // Handle mouse click on display object
-    // -----------------------------
-/*    var handler = new ScreenSpaceEventHandler(this.scene.canvas);
-    handler.setInputAction(
-        function (movement) {
-            var pickedObject = that.scene.pick(movement.position);
-            if (pickedObject !== undefined) {
-                pickedObject = pickedObject.primitive;
-            }
-            if (pickedObject) {
-                //show picking dialog
-                var dlg_text = 'Item ' + pickedObject._index;
-                var dlg_title = 'Info';
-                showHTMLTextDialog(dlg_title, dlg_text, false);
-            }
-        },
-        ScreenSpaceEventType.LEFT_CLICK);
-*/
-
-    //Drag and drop support
+    //Data drag and drop support
     document.addEventListener("dragenter", noopHandler, false);
     document.addEventListener("dragexit", noopHandler, false);
     document.addEventListener("dragover", noopHandler, false);
@@ -142,29 +122,41 @@ function dropHandler(evt, that) {
 }
 
 //Simple html dialog
-function showHTMLTextDialog(title_text, display_text, b_modal, close_function) {
+GeoDataWidget.prototype.showHTMLTextDialog = function(title_text, display_text, b_modal, url) {
+    var that = this;
+    
     if (b_modal === undefined) {
         b_modal = true;
     }
-    if (close_function === undefined) {
-        close_function = function() {};
-    }
     $('#dialogInfo').html(display_text);
-    $('#dialogInfo').dialog({
-        close: close_function,
+    var dlg_props = {
         title: title_text,
         modal: b_modal,
         width: 400,
+        height: 400,
         position: {
             my: "middle center",
             at: "middle center",
             offset: "20 0",
             of: window
         }
-    });
-}
+    };
+    if (url !== undefined) {
+        dlg_props.buttons = {
+            "Load": function () {
+                if (url) {
+                    that.geoDataManager.loadUrl(url);
+                }
+                $(this).dialog('close');
+            }
+        };
+    }
+    $('#dialogInfo').dialog(dlg_props);
+};
 
-function postToService(service, request) {
+GeoDataWidget.prototype.postToService = function(service, request) {
+    var that = this;
+    
     var formData = new FormData();
     for (var fld in request) {
         if (request.hasOwnProperty(fld)) {
@@ -175,20 +167,26 @@ function postToService(service, request) {
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function () {
         if (xhr.readyState === 4) {
-            var str;
+            var str, url;
             if (xhr.status !== 200) {
                 str = 'Error ' + xhr.status + ': ' + xhr.responseText;
             }
             else {
                 var res = JSON.parse(xhr.responseText);
                 str = res.displayHtml;
-           }
-           showHTMLTextDialog(service.name + ' responded with', str, true);
+                url = res.dataUrl;
+                if (url !== undefined) {
+                    str += '<h3>Data Links:</h3>';
+                    str += '<i> - You can click load or copy and paste this url into Add Data</i><br>';
+                    str += url;
+                }
+            }
+            that.showHTMLTextDialog(service.name + ' responded with', str, true, url);
         }
     };
     xhr.open('POST', service.url);
     xhr.send(formData);
-}
+};
 
 // Pick layer dialog
 GeoDataWidget.prototype.showServicesDialog = function (request) {
@@ -196,11 +194,11 @@ GeoDataWidget.prototype.showServicesDialog = function (request) {
     
     var services = that.geoDataManager.getServices();
 
-    $('#list1').height('50px');
+    $('#list1').height('150px');
     $("#dialogServices").dialog({
         title: 'Aditional Services (Experimental)',
         width: 300,
-        height: 300,
+        height: 400,
         modal: false,
         position: {
             my: "left top",
@@ -213,7 +211,7 @@ GeoDataWidget.prototype.showServicesDialog = function (request) {
                 var item = $('#list1 .ui-selected');
                 if (item !== undefined) {
                     var id = item[0].id;
-                    postToService(services[id], request);
+                    that.postToService(services[id], request);
                 }
                 $(this).dialog('close');
             },
@@ -284,7 +282,7 @@ GeoDataWidget.prototype.showShareDialog = function (request) {
             'Embed': function () {
                 var str = '&lt;iframe style="width: 720px; height: 405px; border: none;" src="' + url;
                 str += '" allowFullScreen mozAllowFullScreen webkitAllowFullScreen&gt;&lt;/iframe&gt;';
-                showHTMLTextDialog("Copy this code to embed National Map in an HTML page", str, true);
+                that.showHTMLTextDialog("Copy this code to embed National Map in an HTML page", str, true);
                 $(this).dialog('close');
             },
             'Services': function () {


### PR DESCRIPTION
I don't think this is quite done, but it tries clean up the sources, collections to be more consistent.  So now:
- Sources (have catalogs of data items): These are WMS/WFS/REST/GME and Data Collections (removed other random service placeholders
- Data item have types: WMS, WFS/REST/GME (returns geojson) and DATA (data files) 
- CSV type is gone
  - DATA items: type is generated from the extension, but probably will need be settable by the user
  - All data items can be equally invoked by drag-drop, file open, url, or services via a returned url (delta kmz) 
  - A data source collection, a data collection, or a service can be added to NM by drag-drop.
  - Services return a JSON object with html text and a url that the user can choose to add to their environment.
