### PR TITLE
Allow reordering of items in the Now Viewing panel

### DIFF
--- a/public/images/Reorder.svg
+++ b/public/images/Reorder.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="12"
+   height="24"
+   id="svg2985">
+  <defs
+     id="defs2987">
+    <marker
+       refX="0"
+       refY="0"
+       orient="auto"
+       id="Arrow2Mend"
+       style="overflow:visible">
+      <path
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)"
+         id="path3796"
+         style="fill:#ffffff;stroke:#ffffff;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round" />
+    </marker>
+    <marker
+       refX="0"
+       refY="0"
+       orient="auto"
+       id="Arrow2Mstart"
+       style="overflow:visible">
+      <path
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(0.6,0.6)"
+         id="path3793"
+         style="fill:#ffffff;stroke:#ffffff;;fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,8)"
+     id="layer1">
+    <path
+       d="M 6,22 6,2"
+       transform="translate(0,-8)"
+       id="path6261"
+       style="fill:#ffffff;stroke:#ffffff;;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-start:url(#Arrow2Mstart);marker-end:url(#Arrow2Mend)" />
+  </g>
+</svg>

--- a/public/viewer/AusGlobeViewer.css
+++ b/public/viewer/AusGlobeViewer.css
@@ -423,6 +423,11 @@ a.ausglobe-title-menuItem:hover {
     display: inline-block;
 }
 
+.ausglobe-nowViewing-drop-target {
+    position: relative;
+    border: 1px dashed gray;
+}
+
 .ausglobe-accordion-category-item {
     padding-left: 10px;
     padding-right: 10px;
@@ -452,6 +457,12 @@ a.ausglobe-title-menuItem:hover {
 .ausglobe-accordion-category-item-enabled {
     background-color: rgba(128, 128, 128, 0.65);
     cursor: pointer;
+}
+
+.ausglobe-nowViewing-dragHandle {
+    cursor: move;
+    position: relative;
+    top: 4px;
 }
 
 .ausglobe-accordion-category-item-checkbox {

--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -143,6 +143,16 @@ GeoDataCollection.prototype.add = function(layer) {
         this.layers.splice(firstFeatureLayer, 0, layer);
     }
 
+    // Force Leaflet to display the layers in the intended order.
+    if (defined(this.map)) {
+        for (var layerIndex = 0; layerIndex < this.layers.length; ++layerIndex) {
+            var currentLayer = this.layers[layerIndex];
+            if (defined(currentLayer.primitive)) {
+                currentLayer.primitive.setZIndex(layerIndex + 100);
+            }
+        }
+    }
+
     this.GeoDataAdded.raiseEvent(this, layer);
     return layer;
 };
@@ -176,6 +186,9 @@ GeoDataCollection.prototype.moveUp = function(layer) {
         return;
     }
 
+    this.layers[currentIndex] = layerAbove;
+    this.layers[newIndex] = layer;
+
     if (!defined(this.map)) {
         var layerIndex = this.imageryLayersCollection.indexOf(layer.primitive);
         var aboveIndex = this.imageryLayersCollection.indexOf(layerAbove.primitive);
@@ -184,10 +197,15 @@ GeoDataCollection.prototype.moveUp = function(layer) {
             layerIndex = this.imageryLayersCollection.indexOf(layer.primitive);
             aboveIndex = this.imageryLayersCollection.indexOf(layerAbove.primitive);
         }
+    } else {
+        for (var i = 0; i < this.layers.length; ++i) {
+            var currentLayer = this.layers[i];
+            if (defined(currentLayer.primitive)) {
+                currentLayer.primitive.setZIndex(i + 100);
+            }
+        }
     }
 
-    this.layers[currentIndex] = layerAbove;
-    this.layers[newIndex] = layer;
     this.GeoDataReordered.raiseEvent(this);
 };
 
@@ -216,6 +234,9 @@ GeoDataCollection.prototype.moveDown = function(layer) {
         return;
     }
 
+    this.layers[currentIndex] = layerBelow;
+    this.layers[newIndex] = layer;
+
     if (!defined(this.map)) {
         var layerIndex = this.imageryLayersCollection.indexOf(layer.primitive);
         var belowIndex = this.imageryLayersCollection.indexOf(layerBelow.primitive);
@@ -224,10 +245,15 @@ GeoDataCollection.prototype.moveDown = function(layer) {
             layerIndex = this.imageryLayersCollection.indexOf(layer.primitive);
             belowIndex = this.imageryLayersCollection.indexOf(layerBelow.primitive);
         }
+    } else {
+        for (var i = 0; i < this.layers.length; ++i) {
+            var currentLayer = this.layers[i];
+            if (defined(currentLayer.primitive)) {
+                currentLayer.primitive.setZIndex(i + 100);
+            }
+        }
     }
 
-    this.layers[currentIndex] = layerBelow;
-    this.layers[newIndex] = layer;
     this.GeoDataReordered.raiseEvent(this);
 };
 

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -53,7 +53,7 @@ var GeoDataBrowser = function(options) {
             <div class="ausglobe-accordion-item-content" data-bind="css: { \'ausglobe-accordion-item-content-visible\': nowViewingIsOpen }">\
                 <div class="ausglobe-accordion-category">\
                     <div class="ausglobe-accordion-category-content ausglobe-accordion-category-content-visible" data-bind="visible: nowViewing().length > 0, foreach: nowViewing">\
-                        <div class="ausglobe-accordion-category-item" draggable="true" data-bind="attr : { title : Title }, css: { \'ausglobe-accordion-category-item-enabled\': show }, event : { dragstart: $root.startNowViewingDrag, dragenter: $root.nowViewingDragEnter, dragend: $root.endNowViewingDrag }">\
+                        <div class="ausglobe-accordion-category-item" draggable="true" data-bind="attr : { title : Title, nowViewingIndex : $index }, css: { \'ausglobe-accordion-category-item-enabled\': show }, event : { dragstart: $root.startNowViewingDrag, dragenter: $root.nowViewingDragEnter, dragend: $root.endNowViewingDrag }">\
                             <img class="ausglobe-nowViewing-dragHandle" draggable="false" src="images/Reorder.svg" width="12" height="24" alt="Drag to reorder data sources." />\
                             <div class="ausglobe-accordion-category-item-checkbox" data-bind="click: $root.toggleItemShown, visible: show, cesiumSvgPath: { path: $root._checkboxChecked, width: 32, height: 32 }"></div>\
                             <div class="ausglobe-accordion-category-item-checkbox" data-bind="click: $root.toggleItemShown, visible: !show(), cesiumSvgPath: { path: $root._checkboxUnchecked, width: 32, height: 32 }"></div>\

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -53,7 +53,8 @@ var GeoDataBrowser = function(options) {
             <div class="ausglobe-accordion-item-content" data-bind="css: { \'ausglobe-accordion-item-content-visible\': nowViewingIsOpen }">\
                 <div class="ausglobe-accordion-category">\
                     <div class="ausglobe-accordion-category-content ausglobe-accordion-category-content-visible" data-bind="visible: nowViewing().length > 0, foreach: nowViewing">\
-                        <div class="ausglobe-accordion-category-item" data-bind="css: { \'ausglobe-accordion-category-item-enabled\': show }">\
+                        <div class="ausglobe-accordion-category-item" draggable="true" data-bind="attr : { title : Title }, css: { \'ausglobe-accordion-category-item-enabled\': show }, event : { dragstart : $root.startNowViewingDrag, dragenter : $root.nowViewingDragEnter }">\
+                            <img class="ausglobe-nowViewing-dragHandle" draggable="false" src="images/Reorder.svg" width="12" height="24" alt="Drag to reorder data sources." />\
                             <div class="ausglobe-accordion-category-item-checkbox" data-bind="click: $root.toggleItemShown, visible: show, cesiumSvgPath: { path: $root._checkboxChecked, width: 32, height: 32 }"></div>\
                             <div class="ausglobe-accordion-category-item-checkbox" data-bind="click: $root.toggleItemShown, visible: !show(), cesiumSvgPath: { path: $root._checkboxUnchecked, width: 32, height: 32 }"></div>\
                             <div class="ausglobe-accordion-category-item-label" data-bind="text: Title, click: $root.zoomToItem"></div>\

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -53,7 +53,7 @@ var GeoDataBrowser = function(options) {
             <div class="ausglobe-accordion-item-content" data-bind="css: { \'ausglobe-accordion-item-content-visible\': nowViewingIsOpen }">\
                 <div class="ausglobe-accordion-category">\
                     <div class="ausglobe-accordion-category-content ausglobe-accordion-category-content-visible" data-bind="visible: nowViewing().length > 0, foreach: nowViewing">\
-                        <div class="ausglobe-accordion-category-item" draggable="true" data-bind="attr : { title : Title }, css: { \'ausglobe-accordion-category-item-enabled\': show }, event : { dragstart : $root.startNowViewingDrag, dragenter : $root.nowViewingDragEnter }">\
+                        <div class="ausglobe-accordion-category-item" draggable="true" data-bind="attr : { title : Title }, css: { \'ausglobe-accordion-category-item-enabled\': show }, event : { dragstart: $root.startNowViewingDrag, dragenter: $root.nowViewingDragEnter, dragend: $root.endNowViewingDrag }">\
                             <img class="ausglobe-nowViewing-dragHandle" draggable="false" src="images/Reorder.svg" width="12" height="24" alt="Drag to reorder data sources." />\
                             <div class="ausglobe-accordion-category-item-checkbox" data-bind="click: $root.toggleItemShown, visible: show, cesiumSvgPath: { path: $root._checkboxChecked, width: 32, height: 32 }"></div>\
                             <div class="ausglobe-accordion-category-item-checkbox" data-bind="click: $root.toggleItemShown, visible: !show(), cesiumSvgPath: { path: $root._checkboxUnchecked, width: 32, height: 32 }"></div>\

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -501,7 +501,6 @@ var GeoDataBrowserViewModel = function(options) {
     });
 
     this._endNowViewingDrag = createCommand(function(viewModel, e) {
-        console.log('end drag');
         if (defined(draggedNowViewingItem)) {
             draggedNowViewingItem.style.display = 'block';
         }

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -372,14 +372,20 @@ var GeoDataBrowserViewModel = function(options) {
         }
     };
 
-    this.nowViewing = komapping.fromJS(this._dataManager.layers, nowViewingMapping);
+    function getLayers() {
+        var layers = that._dataManager.layers.slice();
+        layers.reverse();
+        return layers;
+    }
+
+    this.nowViewing = komapping.fromJS(getLayers(), nowViewingMapping);
 
     this._removeGeoDataAddedListener = this._dataManager.GeoDataAdded.addEventListener(function() {
-        komapping.fromJS(that._dataManager.layers, nowViewingMapping, that.nowViewing);
+        komapping.fromJS(getLayers(), nowViewingMapping, that.nowViewing);
     });
 
     this._removeGeoDataRemovedListener = this._dataManager.GeoDataRemoved.addEventListener(function() {
-        komapping.fromJS(that._dataManager.layers, nowViewingMapping, that.nowViewing);
+        komapping.fromJS(getLayers(), nowViewingMapping, that.nowViewing);
     });
 
     function noopHandler(evt) {

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -456,10 +456,29 @@ var GeoDataBrowserViewModel = function(options) {
         dragPlaceholder = document.createElement('div');
         dragPlaceholder.className = 'ausglobe-nowViewing-drop-target';
         dragPlaceholder.style.height = draggedNowViewingItem.clientHeight + 'px';
+        dragPlaceholder.addEventListener('drop', function(e) {
+            draggedNowViewingItem.parentElement.removeChild(draggedNowViewingItem);
+            dragPlaceholder.parentElement.insertBefore(draggedNowViewingItem, dragPlaceholder);
+        }, false);
 
         e.originalEvent.dataTransfer.setData('text/plain', 'Dragging a Now View item.');
 
         return true;
+    });
+
+    this._endNowViewingDrag = createCommand(function(viewModel, e) {
+        console.log('end drag');
+
+        if (defined(draggedNowViewingItem)) {
+            draggedNowViewingItem.style.display = 'block';
+        }
+
+        if (defined(dragPlaceholder)) {
+            if (defined(dragPlaceholder.parentElement)) {
+                dragPlaceholder.parentElement.removeChild(dragPlaceholder);
+            }
+            dragPlaceholder = undefined;
+        }
     });
 
     this._nowViewingDragEnter = createCommand(function(viewModel, e) {
@@ -645,6 +664,12 @@ defineProperties(GeoDataBrowserViewModel.prototype, {
     nowViewingDragEnter : {
         get : function() {
             return this._nowViewingDragEnter;
+        }
+    },
+
+    endNowViewingDrag : {
+        get : function() {
+            return this._endNowViewingDrag;
         }
     }
 });

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -450,7 +450,6 @@ var GeoDataBrowserViewModel = function(options) {
     var dragPlaceholder;
 
     this._startNowViewingDrag = createCommand(function(viewModel, e) {
-        console.log('start');
         draggedNowViewingItem = e.target;
 
         dragPlaceholder = document.createElement('div');
@@ -461,14 +460,12 @@ var GeoDataBrowserViewModel = function(options) {
             dragPlaceholder.parentElement.insertBefore(draggedNowViewingItem, dragPlaceholder);
         }, false);
 
-        e.originalEvent.dataTransfer.setData('text/plain', 'Dragging a Now View item.');
+        e.originalEvent.dataTransfer.setData('text', 'Dragging a Now Viewing item.');
 
         return true;
     });
 
     this._endNowViewingDrag = createCommand(function(viewModel, e) {
-        console.log('end drag');
-
         if (defined(draggedNowViewingItem)) {
             draggedNowViewingItem.style.display = 'block';
         }
@@ -485,8 +482,6 @@ var GeoDataBrowserViewModel = function(options) {
         if (e.currentTarget === dragPlaceholder || !e.currentTarget.parentElement) {
             return;
         }
-
-        console.log('enter');
 
         e.originalEvent.dataTransfer.dropEffect = 'move';
 
@@ -514,15 +509,12 @@ var GeoDataBrowserViewModel = function(options) {
         }
 
         if (dragPlaceholder.parentElement) {
-            console.log('removing placeholder');
             dragPlaceholder.parentElement.removeChild(dragPlaceholder);
         }
 
         if (insertBefore) {
-            console.log('inserting before ' + e.currentTarget.title);
             e.currentTarget.parentElement.insertBefore(dragPlaceholder, e.currentTarget);
         } else {
-            console.log('inserting after ' + e.currentTarget.title);
             e.currentTarget.parentElement.insertBefore(dragPlaceholder, siblings[targetIndex + 1]);
         }
     });


### PR DESCRIPTION
Items have drag handles on their left side and can be reordered by dragging and dropping them.  Feature layers always stay above map layers, mostly because Cesium currently requires this.

![image](https://cloud.githubusercontent.com/assets/924374/3438578/c7c2b0ae-00cb-11e4-8d43-a806d9c8a469.png)
