### PR TITLE
Authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ausglobe",
   "version": "0.0.1",
   "dependencies": {
+    "compression": "1.0.8",
     "connect": "^3.0.0",
     "express": "^4.4.3",
     "cors": "~2.3.1",
@@ -9,7 +10,8 @@
     "knockout.mapping": "^2.4.2",
     "request": "*",
     "supervisor": "^0.4.1",
-    "weakmap": "0.0.6"
+    "weakmap": "0.0.6",
+    "yargs": "1.2.6"
   },
   "devDependencies": {
     "gulp": "^3.8.0",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,34 @@
 "use strict";
 
+var url = require('url');
+
+function getRemoteUrlFromParam(req) {
+    var remoteUrl = req.params[0];
+    if (remoteUrl) {
+        // add http:// to the URL if no protocol is present
+        if (!/^https?:\/\//.test(remoteUrl)) {
+            remoteUrl = 'http://' + remoteUrl;
+        }
+        remoteUrl = url.parse(remoteUrl);
+        // copy query string
+        remoteUrl.search = url.parse(req.url).search;
+    }
+    return remoteUrl;
+}
+
+var dontProxyHeaderRegex = /^(?:Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade)$/i;
+
+function filterHeaders(req, headers) {
+    var result = {};
+    // filter out headers that are listed in the regex above
+    Object.keys(headers).forEach(function(name) {
+        if (!dontProxyHeaderRegex.test(name)) {
+            result[name] = headers[name];
+        }
+    });
+    return result;
+}
+
 // Include the cluster module
 var cluster = require('cluster');
 
@@ -30,52 +59,104 @@ if (cluster.isMaster) {
 // Code to run if we're in a worker process
 } else {
 
-    /*global require,__dirname*/
+    /*global console,require,__dirname*/
     /*jshint es3:false*/
-    var path = require('path');
-    var express = require('express');
-    var url = require('url');
-    var cors = require('cors');
 
+    var express = require('express');
+    var compression = require('compression');
+    var request = require('request');
+    var path = require('path');
+
+    var yargs = require('yargs').options({
+        'port' : {
+            'default' : 3001,
+            'description' : 'Port to listen on.'
+        },
+        'public' : {
+            'type' : 'boolean',
+            'default' : true,
+            'description' : 'Run a public server that listens on all interfaces.'
+        },
+        'upstream-proxy' : {
+            'description' : 'A standard proxy server that will be used to retrieve data.  Specify a URL including port, e.g. "http://proxy:8000".'
+        },
+        'bypass-upstream-proxy-hosts' : {
+            'description' : 'A comma separated list of hosts that will bypass the specified upstream_proxy, e.g. "lanhost1,lanhost2"'
+        },
+        'help' : {
+            'alias' : 'h',
+            'type' : 'boolean',
+            'description' : 'Show this help.'
+        }
+    });
+    var argv = yargs.argv;
+
+    if (argv.help) {
+        return yargs.showHelp();
+    }
+
+    // eventually this mime type configuration will need to change
+    // https://github.com/visionmedia/send/commit/d2cb54658ce65948b0ed6e5fb5de69d022bef941
     var mime = express.static.mime;
     mime.define({
-        'application/json' : ['czml']
+        'application/json' : ['czml', 'json', 'geojson'],
+        'text/plain' : ['glsl']
     });
-
-    var url = require('url');
-    var request = require('request');
-
-    var dir = path.join(__dirname, 'public');
 
     var app = express();
-    app.use(cors());
-    //app.use(express.compress());
-    app.use(express.static(dir));
+    app.use(compression());
+    app.use(express.static(path.join(__dirname, 'public')));
 
-    var proxyAllowedHosts = {
-        'services.arcgisonline.com' : true,
-        'spatialreference.org' : true,
-        'www2.landgate.wa.gov.au' : true,
-        'geofabric.bom.gov.au' : true,
-        'www.ga.gov.au' : true,
-        'www.googleapis.com' : true,
-        'data.gov.au' : true
-    };
+    var upstreamProxy = argv['upstream-proxy'];
+    var bypassUpstreamProxyHosts = {};
+    if (argv['bypass-upstream-proxy-hosts']) {
+        argv['bypass-upstream-proxy-hosts'].split(',').forEach(function(host) {
+            bypassUpstreamProxyHosts[host.toLowerCase()] = true;
+        });
+    }
 
-    app.get(/^\/proxy\/(.+)$/, function(req, res) {
-        var remoteUrl = req.params[0];
-        if (remoteUrl.indexOf('http') !== 0) {
-            remoteUrl = 'http://' + remoteUrl;
+    app.get('/proxy/*', function(req, res, next) {
+        // look for request like http://localhost:8080/proxy/http://example.com/file?query=1
+        var remoteUrl = getRemoteUrlFromParam(req);
+        if (!remoteUrl) {
+            // look for request like http://localhost:8080/proxy/?http%3A%2F%2Fexample.com%2Ffile%3Fquery%3D1
+            remoteUrl = Object.keys(req.query)[0];
+            if (remoteUrl) {
+                remoteUrl = url.parse(remoteUrl);
+            }
         }
 
-        var url = req.url;
-        var queryStartIndex = url.indexOf('?');
-        if (queryStartIndex >= 0) {
-            remoteUrl += url.substring(queryStartIndex);
+        if (!remoteUrl) {
+            return res.send(400, 'No url specified.');
         }
 
-        request.get(remoteUrl).pipe(res);
+        if (!remoteUrl.protocol) {
+            remoteUrl.protocol = 'http:';
+        }
+
+        var proxy;
+        if (upstreamProxy && !(remoteUrl.host in bypassUpstreamProxyHosts)) {
+            proxy = upstreamProxy;
+        }
+
+        // encoding : null means "body" passed to the callback will be raw bytes
+
+        request.get({
+            url : url.format(remoteUrl),
+            headers : filterHeaders(req, req.headers),
+            encoding : null,
+            proxy : proxy
+        }, function(error, response, body) {
+            var code = 500;
+
+            if (response) {
+                code = response.statusCode;
+                res.header(filterHeaders(req, response.headers));
+            }
+
+            res.send(code, body);
+        });
     });
 
-    app.listen(3001);
+    app.listen(argv.port, argv.public ? undefined : 'localhost');
 }

--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -1120,9 +1120,9 @@ GeoDataCollection.prototype.getCapabilities = function(description, callback) {
     if (description.proxy || this.shouldUseProxy(request)) {
         request = corsProxy.getURL(request);
     }
-    
+
     var that = this;
-    Cesium.when(Cesium.loadText(request), function(text) {
+    Cesium.when(Cesium.loadText(request, undefined, description.username, description.password), function(text) {
         that.handleCapabilitiesRequest(text, description);
         callback(description);
     });


### PR DESCRIPTION
- Update our Node server based on the new one that just went into Cesium.  The proxy in the new server passes authentication information through correctly, so when a service requires authentication, the browser will prompt the user for it (once) and everything works as expected.
- Add the ability to specify a service's username/password in the collection JSON file.

This is an update to Cesium, so run `gulp build-cesium`.  It also requires new node modules, so run `npm install`.
