### PR TITLE
merged our 3 NM init formats into one

### DIFF
--- a/public/bom_collection.json
+++ b/public/bom_collection.json
@@ -1,4 +1,5 @@
-{"name":"Topics","nm_ext_type":"collections","Layer":[
+{"name":"Data Collection", "Layer": [
+  {"name":"BOM","Layer":[
     {"name":"ahgf_gwc","base_url":"http://geofabric.bom.gov.au/simplefeatures/ows","proxy":true,"type":"WMS","querable":0,"Layer":[
         {"Name":"AHGFAquiferContour","Title":"AHGFAquiferContour","BoundingBox":{"west":"130.9294316820001","east":"151.640955901","south":"-41.24101109706462","north":"-12.157000677611002"},
 		"queryable":1},
@@ -155,4 +156,5 @@
 		{"Name":"AHGFWaterbody","Title":"AHGFWaterbody","BoundingBox":{"west":"112.99395000000004","east":"153.6130200000001","south":"-43.6060489990578","north":"-8.933328999710083"},
 		"queryable":1}
 	]}
+  ]} 
 ]} 

--- a/public/data_sources.json
+++ b/public/data_sources.json
@@ -1,4 +1,4 @@
-{"name":"Data Collections", "nm_ext_type": "sources", "Layer": [
+{"name":"Data Collections", "Layer": [
   { "name": "Data Providers", "Layer": [
     { "name": "Topography (Geoscience Australia)", "base_url": "http://geoserver.research.nicta.com.au/geotopo_250k/ows", "type": "WMS", "proxy": true, "wfsAvailable": true },
     { "name": "Water (Bureau of Meteorology Geofabric)", "base_url": "http://geofabric.bom.gov.au/simplefeatures/ows", "type": "WMS", "proxy": true, "wfsAvailable": true },

--- a/public/demo_collection.json
+++ b/public/demo_collection.json
@@ -1,4 +1,5 @@
-{"name":"Further Demos", "nm_ext_type": "collections", "Layer": [
+{"name":"Data Collection", "Layer": [
+  {"name":"Further Demos", "Layer": [
     {"name":"Time Based Data","base_url":"","proxy":false,"type":"DATA","queryable":"0","Layer": [
         {"Name": "Traffic Incidents", "Title": "Traffic Incidents", "Abstract": "Simulated data showing traffic incidents over time", "url":"./datasets/incidents.csv","BoundingBox":{"west":147.3154707,"south":-36.78012603,"east":153.5498186,"north":-28.2198794}},
         {"Name": "Pacific Earthquakes", "Title": "Pacific Earthquakes", "Abstract": "Earthquake events collected from SOSUS", "url":"./datasets/earthquakes.csv","BoundingBox":{"west":-130.998,"south":40.01,"east":-121.398,"north":50.993}},
@@ -7,5 +8,6 @@
     {"name":"Google Maps Engine","base_url":"","proxy":false,"type":"GME","queryable":"0","Layer": [
         {"Name": "CentreLink Sites", "Title": "CentreLink Sites via GME", "Abstract": "CentreLink Sites - Google Maps Engine Example","type":"GME", "BoundingBox":{"west":127.3154707,"south":-41.78012603,"east":153.5498186,"north":-10.2198794}, "url": "https://www.googleapis.com/mapsengine/v1/tables/12421761926155747447-06672618218968397709/features?maxResults=500&version=published&key=AIzaSyBZIS_uRrKShArQfvQtURFZasUpXyAaGDk"}
     ]}
+  ]}
 ]}
 

--- a/public/demo_sources.json
+++ b/public/demo_sources.json
@@ -1,4 +1,4 @@
-{"name":"Data Providers", "nm_ext_type": "sources", "Layer": [
+{"name":"Data Providers", "Layer": [
   { "name": "Demo Providers", "Layer": [
     { "name": "Topography (GA)", "base_url": "http://www.ga.gov.au/gis/services/topography/Australian_Topography/MapServer/WFSServer", "type": "WFS", "proxy": true },
     { "name": "Topography (GA REST)", "base_url": "http://www.ga.gov.au/gis/rest/services/topography/Australian_Topography/MapServer", "type": "REST", "proxy": true },

--- a/public/geotopo_collection.json
+++ b/public/geotopo_collection.json
@@ -1,4 +1,5 @@
-{"name":"Topics","nm_ext_type":"collections","Layer":[
+{"name":"Data Collection", "Layer": [
+  {"name":"GeoTopo 250K","Layer":[
    	{"name":"Landuse","base_url":"http://geoserver.research.nicta.com.au/geotopo_250k/ows","proxy":false,"type":"WMS","querable":0,"Layer":[
 		{"Name":"DLCDv1_Class","Title":"DLCDv1_Class","BoundingBox":{"west":"110.0000005","east":"155.0091895","south":"-45.004797499999995","north":"-9.999999500000008"},
 "queryable":1},
@@ -203,4 +204,5 @@
 		{"Name":"powerlines","Title":"powerlines","BoundingBox":{"west":"114.63228","east":"153.49785","south":"-43.16291999905861","north":"-12.458869999601996"},
 "queryable":1}
 	]}
+  ]}
 ]}

--- a/public/init_nm_merged.json
+++ b/public/init_nm_merged.json
@@ -336,5 +336,17 @@
 
         {"Name":"admin_bnds:RA_2011_AUST","Title":"Remoteness Area","BoundingBox":{"west":"96.816941408","east":"159.109219008","south":"-43.740509602057614","north":"-9.142175976703609"},"queryable":"1"}
     ]}
+  ]},
+  { "name": "Data Providers", "Layer": [
+    { "name": "Topography (Geoscience Australia)", "base_url": "http://geoserver.research.nicta.com.au/geotopo_250k/ows", "type": "WMS", "proxy": true, "wfsAvailable": true },
+    { "name": "Water (Bureau of Meteorology Geofabric)", "base_url": "http://geofabric.bom.gov.au/simplefeatures/ows", "type": "WMS", "proxy": true, "wfsAvailable": true },
+    { "name": "Boundaries (Australia Bureau of Statistics)", "base_url": "http://geoserver.research.nicta.com.au/admin_bnds_abs/ows", "type": "WMS", "proxy": false, "wfsAvailable": true },
+    { "name": "data.gov.au", "base_url": "http://data.gov.au/geoserver/ows", "type": "WMS", "proxy": false, "wfsAvailable": true }
   ]}
-]}
+  ],
+  "NMServices": [
+    { "name": "GeoSpace", "description": "A service provided by NICTA for sharing visualizations made in National Map", "url": "http://geospace.research.nicta.com.au/upload", "request": "POST"},
+    { "name": "NM Sample Service", "description": "A service returning bike racks on the Gold Coast", "url": "http://geospace.research.nicta.com.au/nm_service_1", "request": "POST"}
+  ]
+
+}

--- a/public/nm_services.json
+++ b/public/nm_services.json
@@ -1,5 +1,7 @@
-{"name":"National Map Services", "nm_ext_type": "services", "services": [
+{"name":"National Map Services", 
+  "NMServices": [
     { "name": "GeoSpace", "description": "A service provided by NICTA for sharing visualizations made in National Map", "url": "http://geospace.research.nicta.com.au/upload", "request": "POST"},
     { "name": "NM Sample Service", "description": "A service returning bike racks on the Gold Coast", "url": "http://geospace.research.nicta.com.au/nm_service_1", "request": "POST"}
-]}
+  ]
+}
 

--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -967,7 +967,7 @@ GeoDataCollection.prototype.getOGCFeatureURL = function(description) {
 
 //Utility function to derive a collection from a service
 function _getCollectionFromServiceLayers(layers) {
-    var obj = {"name":"Topics", "nm_ext_type": "collections", "Layer": []};
+    var obj = {"name":"Topics", "Layer": []};
     for (var i = 0; i < layers.length; i++) {
         var layer = layers[i];
         var name = layer.Name;
@@ -1004,7 +1004,8 @@ function _getCollectionFromServiceLayers(layers) {
         };
         topic.Layer.push(dataset);
     }
-    console.log(JSON.stringify(obj));
+    var collection = {"name":"Data Collection", "Layer": [ obj ] };
+    console.log(JSON.stringify(collection));
 }
 
 function _recurseLayerList(layer_src, layers) {

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -350,10 +350,12 @@ var GeoDataBrowserViewModel = function(options) {
 
     var dataCollectionsPromise = loadJson('./data_collection.json');
     var otherSourcesPromise = loadJson('./data_sources.json');
+    var servicesObjPromise = loadJson('./nm_services.json');
+//    var initNMPromise = loadJson('./init_nm_merged.json');
 
-    when.all([dataCollectionsPromise, otherSourcesPromise], function(sources) {
+    when.all([dataCollectionsPromise, otherSourcesPromise, servicesObjPromise], function(sources) {
         var browserContent = [];
-        browserContent.push(sources[0]);
+        browserContent.push(sources[0].Layer[0]);
 
         var otherSources = sources[1].Layer;
         for (var i = 0; i < otherSources.length; ++i) {
@@ -361,12 +363,8 @@ var GeoDataBrowserViewModel = function(options) {
         }
 
         komapping.fromJS(browserContent, that._collectionListMapping, browserContentViewModel);
-    });
-
-    Cesium.loadJson('./nm_services.json').then(function (obj) {
-        if (obj !== undefined) {
-            that._dataManager.addServices(obj.services);
-        }
+        
+        that._dataManager.addServices(sources[2].NMServices);
     });
 
     this.userContent = komapping.fromJS([], this._collectionListMapping);
@@ -421,18 +419,13 @@ var GeoDataBrowserViewModel = function(options) {
         evt.preventDefault();
 
         function loadCollection(json) {
-            if (!defined(json) || !defined(json.name)) {
+            if (!defined(json)) {
                 return;
             }
 
-            var collections;
-            if (json.nm_ext_type === 'sources') {
-                collections = json.Layer;
-            } else if (json.nm_ext_type === 'collections') {
-                collections = [json];
-            } else if (json.nm_ext_type === 'services') {
-                that._dataManager.addServices(json.services);
-            }
+            that._dataManager.addServices(json.NMServices);
+            
+            var collections = json.Layer;
             
             var existingCollection;
 


### PR DESCRIPTION
Normally I wouldn't mess with initialization file formats the day before going live, but I it ended up being not that big a change and I'd rather break our team before we go live rather than everyone after.  This addresses #135 .

Breaking change: data_collection files now need another object wrapper (see data_collections.json).  

I updated everything in public and added a merged version (init_nm_merged.json) that works in drag-drop.
