### PR TITLE
Don't add services by default.

### DIFF
--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -350,7 +350,7 @@ var GeoDataBrowserViewModel = function(options) {
 
     var dataCollectionsPromise = loadJson('./data_collection.json');
     var otherSourcesPromise = loadJson('./data_sources.json');
-    var servicesObjPromise = loadJson('./nm_services.json');
+    var servicesObjPromise; // = loadJson('./nm_services.json');
 //    var initNMPromise = loadJson('./init_nm_merged.json');
 
     when.all([dataCollectionsPromise, otherSourcesPromise, servicesObjPromise], function(sources) {
@@ -364,7 +364,9 @@ var GeoDataBrowserViewModel = function(options) {
 
         komapping.fromJS(browserContent, that._collectionListMapping, browserContentViewModel);
         
-        that._dataManager.addServices(sources[2].NMServices);
+        if (sources[2]) {
+            that._dataManager.addServices(sources[2].NMServices);
+        }
     });
 
     this.userContent = komapping.fromJS([], this._collectionListMapping);

--- a/src/viewer/ServicesPanel.js
+++ b/src/viewer/ServicesPanel.js
@@ -26,22 +26,31 @@ var ServicesPanel = function(options) {
             <div class="ausglobe-info-close-button" data-bind="click: close">&times;</div>\
             <h1>Send to a Service (Advanced)</h1>\
         </div>\
-        <div class="ausglobe-info-content">\
-            <div class="ausglobe-share-label">\
-                Choose one service to use:\
-                <div class="ausglobe-service-list" data-bind="foreach: services">\
-                    <div><label><input type="radio" name="ausglobe-service" data-bind="value: $index, checked: $root.selectedService" /><span data-bind="text: name"></span></div>\
+        <div data-bind="if: services.length > 0">\
+            <div class="ausglobe-info-content">\
+                <div class="ausglobe-share-label">\
+                    Choose one service to use:\
+                    <div class="ausglobe-service-list" data-bind="foreach: services">\
+                        <div><label><input type="radio" name="ausglobe-service" data-bind="value: $index, checked: $root.selectedService" /><span data-bind="text: name"></span></div>\
+                    </div>\
+                </div>\
+                <div class="ausglobe-share-label">\
+                    <hr />\
+                </div>\
+                <div class="ausglobe-share-label">\
+                    <h2 data-bind="text: services[selectedService() | 0].name"></h2>\
+                    <div class="ausglobe-share-label" data-bind="text: services[selectedService() | 0].description"></div>\
+                </div>\
+                <div class="ausglobe-share-label" data-bind="visible: services.length > 0">\
+                    <input class="ausglobe-services-send-button" type="button" value="Send" data-bind="click: sendRequest" />\
                 </div>\
             </div>\
-            <div class="ausglobe-share-label">\
-                <hr />\
-            </div>\
-            <div class="ausglobe-share-label">\
-                <h2 data-bind="text: services[selectedService() | 0].name"></h2>\
-                <div class="ausglobe-share-label" data-bind="text: services[selectedService() | 0].description"></div>\
-            </div>\
-            <div class="ausglobe-share-label">\
-                <input class="ausglobe-services-send-button" type="button" value="Send" data-bind="click: sendRequest" />\
+        </div>\
+        <div data-bind="if: services.length === 0">\
+            <div class="ausglobe-info-content">\
+                <div class="ausglobe-share-label">\
+                    Sorry, no services are currently available.  Please check back later.\
+                </div>\
             </div>\
         </div>\
     ';


### PR DESCRIPTION
Fixes #133.

When no services are available, the services panel looks like this:
![image](https://cloud.githubusercontent.com/assets/924374/3476172/f5b0c920-02fa-11e4-9bb3-9c4055140549.png)

`nm_services.json` can be dragged onto the globe to add back the services we had before.
