### PR TITLE
Add the ability to specify a WFS URL explicitly.

### DIFF
--- a/public/data_collection.json
+++ b/public/data_collection.json
@@ -1,6 +1,6 @@
 {"name":"Data Collections", "Layer": [
   {"name":"Data Sets", "Layer": [
-  	{"name":"Broadband","base_url":"https://programs.communications.gov.au/WMS","proxy":true,"type":"WMS","queryable":"0","username":"wms","password":"wms"},
+  	{"name":"Broadband","base_url":"https://programs.communications.gov.au/WMS","proxy":true,"type":"WMS","queryable":"0","username":"wms","password":"wms", "wfsAvailable": false, "wfsUrl": "https://programs.communications.gov.au/WFS"},
     {"name":"Land","base_url":"http://www.ga.gov.au/gis/services/topography/Australian_Topography_WM/MapServer/WMSServer","proxy":true,"type":"WMS","queryable":"0","Layer": [
         {"Name":"0","Title":"Gravity Image","base_url":"http://www.ga.gov.au/gis/services/earth_observation/Gravity_Image_WM/MapServer/WMSServer","BoundingBox":{"west":"105.930454436693","east":"162.097118856693","south":"-43.74050960205765","north":"-7.92768801894694"},"queryable":"1"},
         {"Name":"0","Title":"Land Cover","base_url":"http://www.ga.gov.au/gis/services/earth_observation/Landcover_WM/MapServer/WMSServer","BoundingBox":{"west":"110","east":"155.00919","south":"-45.0047975","north":"-7.92768801894694"},"queryable":"1"},

--- a/public/init_nm_merged.json
+++ b/public/init_nm_merged.json
@@ -1,5 +1,6 @@
 {"name":"Data Collections", "Layer": [
   {"name":"Data Sets", "Layer": [
+	{"name":"Broadband","base_url":"https://programs.communications.gov.au/WMS","proxy":true,"type":"WMS","queryable":"0","username":"wms","password":"wms", "wfsAvailable": false, "wfsUrl": "https://programs.communications.gov.au/WFS"},
     {"name":"Land","base_url":"http://www.ga.gov.au/gis/services/topography/Australian_Topography_WM/MapServer/WMSServer","proxy":true,"type":"WMS","queryable":"0","Layer": [
         {"Name":"0","Title":"Gravity Image","base_url":"http://www.ga.gov.au/gis/services/earth_observation/Gravity_Image_WM/MapServer/WMSServer","BoundingBox":{"west":"105.930454436693","east":"162.097118856693","south":"-43.74050960205765","north":"-7.92768801894694"},"queryable":"1"},
         {"Name":"0","Title":"Land Cover","base_url":"http://www.ga.gov.au/gis/services/earth_observation/Landcover_WM/MapServer/WMSServer","BoundingBox":{"west":"110","east":"155.00919","south":"-45.0047975","north":"-7.92768801894694"},"queryable":"1"},

--- a/src/viewer/GeoDataInfoPopup.js
+++ b/src/viewer/GeoDataInfoPopup.js
@@ -231,10 +231,16 @@ var GeoDataInfoPopup = function(options) {
     });
 
     viewModel.getDataUrl = knockout.computed(function() {
-        if (!viewModel.info.base_url || !viewModel.info.base_url()) {
+        var baseUrl;
+        if (viewModel.info.wfsUrl && viewModel.info.wfsUrl()) {
+            baseUrl = viewModel.info.wfsUrl();
+        } else if (viewModel.info.base_url && viewModel.info.base_url()) {
+            baseUrl = viewModel.info.base_url();
+        } else {
             return '';
         }
-        return viewModel.info.base_url() + '?service=WFS&version=1.1.0&request=GetFeature&typeName=' + viewModel.info.Name() + '&srsName=EPSG%3A4326&maxFeatures=1000';
+
+        return baseUrl + '?service=WFS&version=1.1.0&request=GetFeature&typeName=' + viewModel.info.Name() + '&srsName=EPSG%3A4326&maxFeatures=1000';
     });
 
     var getMetadataUrl = viewModel.getMetadataUrl();


### PR DESCRIPTION
Allows you to specify the base URL of the equivalent WMS server using the `wfsUrl` property in the collection JSON.  This was intended to be used for the Broadband Data Set, but unfortunately that WFS server has no correspondence between WMS layers and WFS feature types, so it doesn't work the way we'd like.  So in this pull request, the URL is in the collection file, but it is not shown to users because `wfsAvailable` is set to false.
