### PR TITLE
Keep the globe from disappearing when using Norton Identity Safe.

### DIFF
--- a/public/css/AusGlobeViewer.css
+++ b/public/css/AusGlobeViewer.css
@@ -1,3 +1,7 @@
+html {
+    height: 100%;
+}
+
 body {
     height: 100%;
     width: 100%;


### PR DESCRIPTION
It does sketchy things with the style of the body tag in order to display a banner at the top.
