### PR TITLE
Build improvements

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,7 +105,7 @@ gulp.task('release-cesium', function(cb) {
 
 gulp.task('default', ['build', 'lint']);
 
-gulp.task('release', ['release-ausglobe', 'docs']);
+gulp.task('release', ['build', 'lint', 'docs']);
 
 gulp.task('watch', function() {
     gulp.watch(['public/cesium/Source/**', 'public/cesium/Specs/**'], ['build-cesium']);

--- a/package.json
+++ b/package.json
@@ -14,16 +14,17 @@
     "yargs": "1.2.6"
   },
   "devDependencies": {
+    "exorcist": "^0.1.6",
     "gulp": "^3.8.0",
     "gulp-browserify": "~0.5.0",
     "gulp-concat": "~2.2.0",
     "gulp-jasmine": "~0.2.0",
     "gulp-jsdoc": "^0.1.4",
     "gulp-jshint": "~1.6.1",
-    "gulp-rename": "~1.2.0",
+    "gulp-sourcemaps": "^1.1.0",
     "gulp-uglify": "~0.3.0",
     "gulp-watch": "~0.6.5",
-    "gulp-add-src": "~0.1.1"
+    "vinyl-transform": "0.0.1"
   },
   "scripts": {
     "start": "node_modules/.bin/supervisor server"

--- a/src/CopyrightModule.js
+++ b/src/CopyrightModule.js
@@ -1,4 +1,5 @@
-/*!
+/**
+ * @license
  * Copyright(c) 2012-2014 National ICT Australia Limited (NICTA).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,3 +15,5 @@
  * limitations under the License.
  *
  */
+module.exports = undefined;
+

--- a/src/viewer/main.js
+++ b/src/viewer/main.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /*global require,Cesium*/
-
+var copyright = require('../CopyrightModule');
 var SvgPathBindingHandler = Cesium.SvgPathBindingHandler;
 var knockout = require('knockout');
 
@@ -14,7 +14,6 @@ if (typeof window.console === 'undefined') {
 
 SvgPathBindingHandler.register(knockout);
 
-/*global require*/
 var GeoDataCollection = require('../GeoDataCollection');
 var AusGlobeViewer = require('./AusGlobeViewer');
 


### PR DESCRIPTION
The `build` task now generates a combined, minified version of National Map with a source map, so that when debugging in a modern browser (Chrome, Firefox, and IE11 all included) you'll see the individual files we wrote, without minification.  This is an improvement because it means we'll be testing the same code that we actually deploy to production, and the debugging experience is also better than it was before.

There's a new `build-debug` task that builds an unminified version of `ausglobe.js`.  The only time you'll want to use this is when you're debugging in an old browser whose debugger does not support source maps.

I had a lot of trouble adding the copyright header without breaking the source map.  Apparently no one else is doing that (the copyright header, that is; lots of people are doing source maps) because the internet was no help.  The solution in this pull request adds the copyright header prior to any of our code, but unfortunately not right at the top of the file.

I also changed the default task to run `lint` instead of `docs`.
