### PR TITLE
Remove jqueryui, clean up jshint warnings.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,9 +11,7 @@
 
     <!-- jQuery -->
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js" ></script>
-    <link href="http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css"/>
     <link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">
-    <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js"></script>
     
     <!-- Third Party -->
     <script type="text/javascript" src="./third_party/jquery.csv-0.71.min.js"></script>

--- a/src/corsProxy.js
+++ b/src/corsProxy.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/*global require*/
+/*global require,URI*/
 
 var corsProxy = {
     getURL : function(resource) {
@@ -32,7 +32,7 @@ corsProxy.shouldUseProxy = function(url) {
 
 
 //Non CORS hosts we proxy to
-var proxyAllowedHost = function(host) {
+function proxyAllowedHost(host) {
     host = host.toLowerCase();
     var proxyDomains = corsProxy.proxyDomains;
     //check that host is from one of these domains
@@ -47,7 +47,7 @@ var proxyAllowedHost = function(host) {
 
 corsProxy.setProxyList = function(proxyDomains) {
     corsProxy.proxyDomains = proxyDomains;
-}
+};
 
 
 module.exports = corsProxy;

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -537,51 +537,6 @@ AusGlobeViewer.prototype._enableSelectExtent = function(bActive) {
     }
 };
 
-// Settings dialog
-AusGlobeViewer.prototype._showSettingsDialog = function() {
-
-    $("#dialogSettings").dialog({
-        title: 'Settings',
-        width: 250,
-        height: 250,
-        modal: false
-    });
-
-    var list = $('#list4');
-    list.selectable({
-        selected: function (event, ui) {
-            var item = $('#list4 .ui-selected');
-        }
-    });
-    list.html('');
-
-    var that = this;
-
-    var settings = [
-        {
-            text: '3D',
-            getState: function() { return that._cesiumViewerActive(); },
-            setState: function(val) { that.selectViewer(val); }
-        },
-        {
-            text: 'Water Mask',
-            getState: function() { return true; },
-            setState: function(val) { alert('NYI'); }
-        }
-
-    ];
-    for (var i = 0; i < settings.length; i++) {
-        var state = settings[i].getState() ? 'checked' : 'unchecked';
-        list.append('<input type="checkbox" name="' + settings[i].text + '" id=' + i + ' '+ state +'><label for=' + i + ' id=' + i + '>' + settings[i].text + '</label><br>');
-    }
-    //set state when clicked
-    $('#dialogSettings :checkbox').click(function() {
-        var $this = $(this);
-        var id = $this[0].id;
-        settings[id].setState($this.is(':checked'));
-    });
-};
-
 AusGlobeViewer.prototype._cesiumViewerActive = function() { return (this.viewer !== undefined); };
 
 AusGlobeViewer.prototype._createCesiumViewer = function(container) {

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -169,7 +169,7 @@ var GeoDataBrowserViewModel = function(options) {
                 data : {
                     name : that.wfsServiceUrl,
                     base_url : that.wfsServiceUrl,
-                    type : that.addType,
+                    type : that.addType
                 }
             });
             that.userContent.push(item);


### PR DESCRIPTION
We had already removed all uses of jqueryui, so this pull request just removes the `<script>` tag and CSS link.

Also cleans up a few jshint warnings.
