### PR TITLE
Fix clean build problem

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,8 +2,9 @@
 
 /*global require*/
 
+var fs = require('fs');
 var gulp = require('gulp');
-var browserify = require('gulp-browserify');
+var browserify = require('browserify');
 var concat = require('gulp-concat');
 var jshint = require('gulp-jshint');
 var jsdoc = require('gulp-jsdoc');
@@ -12,13 +13,18 @@ var jasmine = require('gulp-jasmine');
 var exec = require('child_process').exec;
 var sourcemaps = require('gulp-sourcemaps');
 var exorcist = require('exorcist');
+var buffer = require('vinyl-buffer');
 var transform = require('vinyl-transform');
+var source = require('vinyl-source-stream');
+
+fs.mkdirSync('public/build');
 
 function build(minify) {
     // Combine main.js and its dependencies into a single file.
     // The poorly-named "debug: true" causes Browserify to generate a source map.
-    var result = gulp.src(['src/viewer/main.js'])
-        .pipe(browserify({ debug: true }));
+    var result = browserify('./src/viewer/main.js').bundle({ debug: true })
+        .pipe(source('ausglobe.js'))
+        .pipe(buffer());
 
     if (minify) {
         // Minify the combined source.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,9 @@ var buffer = require('vinyl-buffer');
 var transform = require('vinyl-transform');
 var source = require('vinyl-source-stream');
 
-fs.mkdirSync('public/build');
+if (!fs.existsSync('public/build')) {
+    fs.mkdirSync('public/build');
+}
 
 function build(minify) {
     // Combine main.js and its dependencies into a single file.

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "yargs": "1.2.6"
   },
   "devDependencies": {
+    "browserify": "^4.2.3",
     "exorcist": "^0.1.6",
     "gulp": "^3.8.0",
-    "gulp-browserify": "~0.5.0",
     "gulp-concat": "~2.2.0",
     "gulp-jasmine": "~0.2.0",
     "gulp-jsdoc": "^0.1.4",
@@ -24,6 +24,9 @@
     "gulp-sourcemaps": "^1.1.0",
     "gulp-uglify": "~0.3.0",
     "gulp-watch": "~0.6.5",
+    "intern": "^2.0.1",
+    "vinyl-buffer": "0.0.0",
+    "vinyl-source-stream": "^0.1.1",
     "vinyl-transform": "0.0.1"
   },
   "scripts": {


### PR DESCRIPTION
...by creating the `build` directory if it does not yet exist, because browserify flips out if the directory that might contain the source map doesn't exist.  It's fine if the source map itself doesn't exist, but the directory better be there!

Also removed dependency on gulp-browserify and instead used browserify
directly, because that lets us use a newer version of browserify (which I
had hoped would eliminate the need to manually create the directory, but
no) and because smart people on the internet say gulp-browserify isn't
good.
