### PR TITLE
Add ntlis.nt.gov.au to the proxy whitelist.

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -5,7 +5,8 @@
         "bom.gov.au",
         "ga.gov.au",
         "communications.gov.au",
-        "tas.gov.au"
+        "tas.gov.au",
+        "ntlis.nt.gov.au"
     ],
  "corsDomains" : [
         "research.nicta.com.au",


### PR DESCRIPTION
Fixes #245.
