### PR TITLE
*.gov.au proxy

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,16 +1,11 @@
 { "proxyDomains" : [
-        "services.arcgisonline.com",
         "spatialreference.org",
-        "landgate.wa.gov.au",
-        "bom.gov.au",
-        "ga.gov.au",
-        "communications.gov.au",
-        "tas.gov.au",
-        "ntlis.nt.gov.au"
+        "gov.au"
     ],
  "corsDomains" : [
         "research.nicta.com.au",
-        "data.gov.au"
+        "data.gov.au",
+        "corsproxy.com"
     ]
 }
 

--- a/src/corsProxy.js
+++ b/src/corsProxy.js
@@ -22,23 +22,24 @@ corsProxy.shouldUseProxy = function(url) {
 
     var uri = new URI(url);
     var host = uri.host();
-    var proxyAvail = proxyAllowedHost(host);
-    console.log(host);
+    var proxyAvail = proxyAllowedHost(host, corsProxy.proxyDomains);
+    var corsAvail = proxyAllowedHost(host, corsProxy.corsDomains);
 
-    if (proxyAvail) {
+    if (proxyAvail && !corsAvail) {
+//        console.log('PROXY:', host);
         return true;
     }
+//    console.log('CORS:', host);
     return false;
 };
 
 
 //Non CORS hosts we proxy to
-function proxyAllowedHost(host) {
+function proxyAllowedHost(host, domains) {
     host = host.toLowerCase();
-    var proxyDomains = corsProxy.proxyDomains;
     //check that host is from one of these domains
-    for (var i = 0; i < proxyDomains.length; i++) {
-        if (host.indexOf(proxyDomains[i], host.length - proxyDomains[i].length) !== -1) {
+    for (var i = 0; i < domains.length; i++) {
+        if (host.indexOf(domains[i], host.length - domains[i].length) !== -1) {
             return true;
         }
     }
@@ -46,8 +47,13 @@ function proxyAllowedHost(host) {
 }
 
 
-corsProxy.setProxyList = function(proxyDomains) {
+corsProxy.setProxyList = function(proxyDomains, corsDomains, alwaysUseProxy) {
     corsProxy.proxyDomains = proxyDomains;
+    corsProxy.corsDomains = corsDomains;
+    if (alwaysUseProxy) {
+        proxyDomains.concat(corsDomains);
+        corsDomains = [];
+    }
 };
 
 

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -310,11 +310,9 @@ Your web browser does not appear to support WebGL, so you will see a limited, \
     //get the server config to know how to handle urls and load initial one
     Cesium.loadJson('config.json').then( function(obj) {
         var proxyDomains = obj.proxyDomains;
+        var corsDomains = obj.corsDomains;
         //workaround for non-CORS browsers (i.e. IE9)
-        if (that._alwaysUseProxy) {
-            proxyDomains.concat(obj.corsDomains);
-        }
-        corsProxy.setProxyList(proxyDomains);
+        corsProxy.setProxyList(obj.proxyDomains, obj.corsDomains, that._alwaysUseProxy);
         
         that.geoDataManager.loadInitialUrl(url);
     });


### PR DESCRIPTION
A bit trickier than I thought, since data.gov.au is in *.gov.au, but we want to remember it's cors.

Added corsproxy.com and will look into removing spatialreference.org down the road.
