### PR TITLE
Height query improvements

### DIFF
--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -605,11 +605,13 @@ AusGlobeViewer.prototype._createCesiumViewer = function(container) {
 
     // Show mouse position and height if terrain on
     inputHandler.setInputAction( function (movement) {
+
         var pickRay = camera.getPickRay(movement.endPosition);
 
         var globe = scene.globe;
         var pickedTriangle = globe.pickTriangle(pickRay, scene);
         if (defined(pickedTriangle)) {
+            // Get a fast, accurate-ish height every time the mouse moves.
             var ellipsoid = globe.ellipsoid;
             
             var v0 = ellipsoid.cartesianToCartographic(pickedTriangle.v0);
@@ -630,7 +632,11 @@ AusGlobeViewer.prototype._createCesiumViewer = function(container) {
                 intersection.height = height;
             }
 
-            document.getElementById('ausglobe-title-middle').innerHTML = cartographicToDegreeString(scene, intersection);
+            var errorBar = globe.terrainProvider.getLevelMaximumGeometricError(pickedTriangle.tile.level);
+
+            document.getElementById('ausglobe-title-middle').innerHTML = cartographicToDegreeString(intersection, errorBar);
+
+            debounceSampleAccurateHeight(globe, intersection);
         } else {
             document.getElementById('ausglobe-title-middle').innerHTML = '';
         }
@@ -719,6 +725,70 @@ AusGlobeViewer.prototype._createCesiumViewer = function(container) {
 
     return viewer;
 };
+
+var lastHeightSamplePosition = new Cartographic();
+var accurateHeightTimer;
+var tileRequestInFlight;
+var accurateSamplingDebounceTime = 250;
+
+function debounceSampleAccurateHeight(globe, position) {
+    // After a delay with no mouse movement, get a more accurate height.
+    Cartographic.clone(position, lastHeightSamplePosition);
+
+    var terrainProvider = globe.terrainProvider;
+    if (terrainProvider instanceof CesiumTerrainProvider) {
+        clearTimeout(accurateHeightTimer);
+        accurateHeightTimer = setTimeout(function() {
+            sampleAccurateHeight(terrainProvider, position);
+        }, accurateSamplingDebounceTime);
+    }
+}
+
+function sampleAccurateHeight(terrainProvider, position) {
+    accurateHeightTimer = undefined;
+    if (tileRequestInFlight) {
+        // A tile request is already in flight, so reschedule for later.
+        accurateHeightTimer = setTimeout(sampleAccurateHeight, accurateSamplingDebounceTime);
+        return;
+    }
+
+    // Find the most detailed available tile at the last mouse position.
+    var tilingScheme = terrainProvider.tilingScheme;
+    var tiles = terrainProvider._availableTiles;
+    var foundTileID;
+    var foundLevel;
+
+    for (var level = tiles.length - 1; !foundTileID && level >= 0; --level) {
+        var levelTiles = tiles[level];
+        var tileID = tilingScheme.positionToTileXY(position, level);
+        var yTiles = tilingScheme.getNumberOfYTilesAtLevel(level);
+        var tmsY = yTiles - tileID.y - 1;
+
+        // Is this tile ID available from the terrain provider?
+        for (var i = 0, len = levelTiles.length; !foundTileID && i < len; ++i) {
+            var range = levelTiles[i];
+            if (tileID.x >= range.startX && tileID.x <= range.endX && tmsY >= range.startY && tmsY <= range.endY) {
+                foundLevel = level;
+                foundTileID = tileID;
+            }
+        }
+    }
+
+    if (foundTileID) {
+        // This tile has our most accurate available height, so go get it.
+        tileRequestInFlight = when(terrainProvider.requestTileGeometry(foundTileID.x, foundTileID.y, foundLevel, false), function(terrainData) {
+            tileRequestInFlight = undefined;
+            if (Cartographic.equals(position, lastHeightSamplePosition)) {
+                position.height = terrainData.interpolateHeight(tilingScheme.tileXYToRectangle(foundTileID.x, foundTileID.y, foundLevel), position.longitude, position.latitude);
+                document.getElementById('ausglobe-title-middle').innerHTML = cartographicToDegreeString(position);
+            } else {
+                // Mouse moved since we started this request, so the result isn't useful.  Try again next time.
+            }
+        }, function() {
+            tileRequestInFlight = undefined;
+        });
+    }
+}
 
 AusGlobeViewer.prototype.isCesium = function() {
     return defined(this.viewer);
@@ -994,13 +1064,18 @@ function setCurrentDataset(layer, that) {
 // -------------------------------------------
 // Text Formatting
 // -------------------------------------------
-function cartographicToDegreeString(scene, cartographic) {
+function cartographicToDegreeString(cartographic, errorBar) {
     var strNS = cartographic.latitude < 0 ? 'S' : 'N';
     var strWE = cartographic.longitude < 0 ? 'W' : 'E';
     var text = 'Lat: ' + Math.abs(CesiumMath.toDegrees(cartographic.latitude)).toFixed(3) + '&deg; ' + strNS +
         ' | Lon: ' + Math.abs(CesiumMath.toDegrees(cartographic.longitude)).toFixed(3) + '&deg; ' + strWE;
     if (defined(cartographic.height)) {
-        text += ' | Elev: ' + cartographic.height.toFixed(1) + ' m';
+        text += ' | Elev: ' + cartographic.height.toFixed(1);
+        if (defined(errorBar)) {
+            text += "±" + errorBar.toFixed(1);
+        }
+
+        text += ' m';
     }
     return text;
 }

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -31,6 +31,7 @@ var CesiumEvent = Cesium.Event;
 var Rectangle = Cesium.Rectangle;
 var Fullscreen = Cesium.Fullscreen;
 var InfoBox = Cesium.InfoBox;
+var Intersections2D = Cesium.Intersections2D;
 var JulianDate = Cesium.JulianDate;
 var KeyboardEventModifier = Cesium.KeyboardEventModifier;
 var loadJson = Cesium.loadJson;
@@ -604,33 +605,34 @@ AusGlobeViewer.prototype._createCesiumViewer = function(container) {
 
     // Show mouse position and height if terrain on
     inputHandler.setInputAction( function (movement) {
-        var terrainProvider = scene.globe.terrainProvider;
-        var cartesian = camera.pickEllipsoid(movement.endPosition, ellipsoid);
-        if (cartesian) {
-            if (terrainProvider instanceof EllipsoidTerrainProvider) {
-                //flat earth
-                document.getElementById('ausglobe-title-middle').innerHTML = cartesianToDegreeString(scene, cartesian);
+        var pickRay = camera.getPickRay(movement.endPosition);
+
+        var globe = scene.globe;
+        var pickedTriangle = globe.pickTriangle(pickRay, scene);
+        if (defined(pickedTriangle)) {
+            var ellipsoid = globe.ellipsoid;
+            
+            var v0 = ellipsoid.cartesianToCartographic(pickedTriangle.v0);
+            var v1 = ellipsoid.cartesianToCartographic(pickedTriangle.v1);
+            var v2 = ellipsoid.cartesianToCartographic(pickedTriangle.v2);
+            var intersection = ellipsoid.cartesianToCartographic(pickedTriangle.intersection);
+
+            var barycentric = Intersections2D.computeBarycentricCoordinates(
+                intersection.longitude, intersection.latitude,
+                v0.longitude, v0.latitude,
+                v1.longitude, v1.latitude,
+                v2.longitude, v2.latitude);
+
+            if (barycentric.x >= -1e-15 && barycentric.y >= -1e-15 && barycentric.z >= -1e-15) {
+                var height = barycentric.x * v0.height +
+                             barycentric.y * v1.height +
+                             barycentric.z * v2.height;
+                intersection.height = height;
             }
-            else {
-                var cartographic = ellipsoid.cartesianToCartographic(cartesian);
-                var terrainPos = [cartographic];
-                
-                //TODO: vary tile level based based on camera height
-                var tileLevel = 7;
-                try {
-                    when(sampleTerrain(terrainProvider, tileLevel, terrainPos), function() {
-                        if (scene.isDestroyed()) {
-                            return;
-                        }
-                        var text = cartesianToDegreeString(scene, cartesian);
-                        text += ' | Elev: ' + terrainPos[0].height.toFixed(1) + ' m';
-                        document.getElementById('ausglobe-title-middle').innerHTML = text;
-                    });
-                } catch (e) {}
-            }
-        }
-        else {
-            document.getElementById('ausglobe-title-middle').innerHTML = "";
+
+            document.getElementById('ausglobe-title-middle').innerHTML = cartographicToDegreeString(scene, intersection);
+        } else {
+            document.getElementById('ausglobe-title-middle').innerHTML = '';
         }
     }, ScreenSpaceEventType.MOUSE_MOVE);
 
@@ -997,21 +999,9 @@ function cartographicToDegreeString(scene, cartographic) {
     var strWE = cartographic.longitude < 0 ? 'W' : 'E';
     var text = 'Lat: ' + Math.abs(CesiumMath.toDegrees(cartographic.latitude)).toFixed(3) + '&deg; ' + strNS +
         ' | Lon: ' + Math.abs(CesiumMath.toDegrees(cartographic.longitude)).toFixed(3) + '&deg; ' + strWE;
-    return text;
-}
-
-function cartesianToDegreeString(scene, cartesian) {
-    var globe = scene.globe;
-    var ellipsoid = globe.ellipsoid;
-    var cartographic = ellipsoid.cartesianToCartographic(cartesian);
-    return cartographicToDegreeString(scene, cartographic);
-}
-
-function rectangleToDegreeString(scene, rect) {
-    var nw = new Cartographic(rect.west, rect.north);
-    var se = new Cartographic(rect.east, rect.south);
-    var text = 'NW: ' + cartographicToDegreeString(scene, nw);
-    text += ', SE: ' + cartographicToDegreeString(scene, se);
+    if (defined(cartographic.height)) {
+        text += ' | Elev: ' + cartographic.height.toFixed(1) + ' m';
+    }
     return text;
 }
 


### PR DESCRIPTION
This also greatly improves lat/lon accuracy because it now finds the terrain position - not ellipsoid position - that the mouse cursor is over.

When moving the mouse, an approximate height is shown with an error bar.  The error can be pretty large when zoomed out:

![image](https://cloud.githubusercontent.com/assets/924374/3729679/a4821f88-16c1-11e4-89ea-162b811f8af1.png)

When you get in close, the error is much more reasonable:

![image](https://cloud.githubusercontent.com/assets/924374/3729685/b7f850aa-16c1-11e4-8f94-cf7faf959f10.png)

When the mouse stops moving for 250 milliseconds, we query the most detailed tile available for the position the mouse cursor is over, and display that height (without an error bar).

![image](https://cloud.githubusercontent.com/assets/924374/3729768/f5571bc4-16c2-11e4-8ccd-c6b0673f2383.png)

Heights are still referenced to WGS84, not mean sea level.  It will take me a little time to fix that because I'll need a mean sea level surface representation, like [EGM96](http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm96/egm96.html), on the client.

I think this is an improvement, but feedback welcome.  Lon/lat is hands-down better.  Height while moving the mouse is no longer misleading, at least, even if it's not especially useful when zoomed out.  Height after the mouse stops is the most accurate our terrain data lets us provide.  It should be a performance improvement as well.
