### PR TITLE
Derive error bounds from the min/max tile heights.

### DIFF
--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -633,6 +633,11 @@ AusGlobeViewer.prototype._createCesiumViewer = function(container) {
             }
 
             var errorBar = globe.terrainProvider.getLevelMaximumGeometricError(pickedTriangle.tile.level);
+            var approximateHeight = intersection.height;
+            var minHeight = pickedTriangle.tile.data.minimumHeight;
+            var maxHeight = pickedTriangle.tile.data.maximumHeight;
+            var maxDiff = Math.max(approximateHeight - minHeight, maxHeight - approximateHeight);
+            errorBar = Math.min(errorBar, maxDiff);
 
             document.getElementById('ausglobe-title-middle').innerHTML = cartographicToDegreeString(intersection, errorBar);
 


### PR DESCRIPTION
If they're tighter than the tile max geometric error.  When zoomed out this makes the error bar a little more sane.

This is Keith's suggestion from #262.

I wonder if it would look better to show a range of heights rather than `random number±big number`...
