### PR TITLE
Add the ability to adjust translucency.

### DIFF
--- a/public/css/AusGlobeViewer.css
+++ b/public/css/AusGlobeViewer.css
@@ -593,7 +593,7 @@ a.ausglobe-title-menuItem:hover {
 .ausglobe-info {
     display: inline-block;
     width: 80%;
-    height: 500px;
+    height: 520px;
     background-color: white;
     margin: auto;
     position: absolute;
@@ -602,6 +602,10 @@ a.ausglobe-title-menuItem:hover {
     bottom: 0;
     right: 0;
     font-family: "Open Sans", sans-serif;
+}
+
+.ausglobe-info-translucencySlider {
+    vertical-align: middle;
 }
 
 .ausglobe-share {

--- a/src/viewer/GeoDataInfoPopup.js
+++ b/src/viewer/GeoDataInfoPopup.js
@@ -66,6 +66,12 @@ var GeoDataInfoPopup = function(options) {
             <div class="ausglobe-info-section">\
                 <div class="asuglobe-info-description" data-bind="html: description"></div>\
             </div>\
+            <div class="ausglobe-info-section" data-bind="if: supportsTranslucency">\
+                <div class="asuglobe-info-description">\
+                    <span>Translucency:</span>\
+                    <input class="ausglobe-info-translucencySlider" type="range" min="0" max="100" data-bind="value: translucency, valueUpdate: \'input\'" />\
+                </div>\
+            </div>\
             <div class="ausglobe-info-section" data-bind="if: info.base_url">\
                 <h2><span data-bind="text: serviceType"></span> Base URL</h2>\
                 <input readonly type="text" data-bind="value: info.base_url" size="80" onclick="this.select();" />\
@@ -102,8 +108,30 @@ var GeoDataInfoPopup = function(options) {
         _arrowRightPath : 'M11.166,23.963L22.359,17.5c1.43-0.824,1.43-2.175,0-3L11.166,8.037c-1.429-0.826-2.598-0.15-2.598,1.5v12.926C8.568,24.113,9.737,24.789,11.166,23.963z'
     };
 
+    var primitive = options.viewModel.layer ? options.viewModel.layer.primitive : undefined;
+
     viewModel.isLoading = knockout.observable(true);
     viewModel.info = options.viewModel;
+    viewModel.supportsTranslucency = primitive && (defined(primitive.alpha) || defined(primitive.setOpacity));
+    viewModel.translucency = knockout.observable(0);
+
+    if (viewModel.supportsTranslucency) {
+        if (defined(primitive.alpha)) {
+            viewModel.translucency((1.0 - primitive.alpha) * 100.0);
+        } else if (defined(primitive.options) && defined(primitive.options.opacity)) {
+            viewModel.translucency((1.0 - primitive.options.opacity) * 100.0);
+        }
+    }
+
+    viewModel.translucency.subscribe(function() {
+        if (viewModel.supportsTranslucency) {
+            if (defined(primitive.alpha)) {
+                primitive.alpha = (100.0 - viewModel.translucency()) / 100.0;
+            } else if (defined(primitive.setOpacity)) {
+                primitive.setOpacity((100.0 - viewModel.translucency()) / 100.0);
+            }
+        }
+    });
 
     viewModel.description = knockout.computed(function() {
         var text;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/924374/3743052/f376d146-1771-11e4-8856-eccd0e9ba386.png)

![image](https://cloud.githubusercontent.com/assets/924374/3743043/d82904f4-1771-11e4-8b13-8be855804afa.png)

The usability here isn't great, because the info popup greys out the map, so you can't really see what you're doing while adjusting the translucency.  But it works (in both Cesium and Leaflet), and @hilarycinis and @Meeena can run with it from here.

One minor bug is that the translucency value is lost when switching between 2D and 3D.  It would be a hassle to fix right now, and some of the data source refactoring we have planned should fix it for free.
