### PR TITLE
Fix GeoJSON loading, and more.

### DIFF
--- a/public/third_party/proj4_epsg.js
+++ b/public/third_party/proj4_epsg.js
@@ -10,7 +10,7 @@ proj4_epsg = {
     'EPSG:900913' : 'EPSG:900913',
     'EPSG:102113' : 'EPSG:102113',
         //AusGlobe entries
-    'EPGS:4283' : '+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs',
+    'EPSG:4283' : '+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs',
     'EPSG:3577' : '+proj=aea +lat_1=-18 +lat_2=-36 +lat_0=0 +lon_0=132 +x_0=0 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
     'EPSG:3112' : '+proj=lcc +lat_1=-18 +lat_2=-36 +lat_0=0 +lon_0=134 +x_0=0 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',
     'EPSG:28349' : '+proj=utm +zone=49 +south +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs',

--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -1577,8 +1577,26 @@ GeoDataCollection.prototype.addGeoJsonLayer = function(geojson, layer) {
         layer.style.polygon.fillcolor = layer.style.line.color;
         layer.style.polygon.fillcolor.alpha = 0.75;
     }
-    
-    var newDataSource = new GeoJsonDataSource();
+
+    // If this GeoJSON is an object literal with a single property, treat that
+    // property as the name of the data source, and the property's value as the
+    // actual GeoJSON.
+    var numProperties = 0;
+    var propertyName;
+    for (propertyName in geojson) {
+        if (geojson.hasOwnProperty(propertyName)) {
+            ++numProperties;
+            if (numProperties > 1) {
+                break; // no need to count past 2 properties.
+            }
+        }
+    }
+
+    var name;
+    if (numProperties === 1) {
+        name = propertyName;
+        geojson = geojson[propertyName];
+    }
     
    //Reprojection and downsampling
     var crs_code = getCrsCode(geojson);
@@ -1601,7 +1619,9 @@ GeoDataCollection.prototype.addGeoJsonLayer = function(geojson, layer) {
     }
     
     if (this.map === undefined) {
-            //create the object
+        //create the object
+        var newDataSource = new GeoJsonDataSource(name);
+
         newDataSource.load(geojson).then(function() {
             var entities = newDataSource.entities.entities;
 

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -1362,7 +1362,7 @@ function selectFeatures(promises, viewer) {
             }
 
             function describe(properties) {
-                var html = '<table class="cesium-geoJsonDataSourceTable">';
+                var html = '<table class="cesium-infoBox-defaultTable">';
                 for ( var key in properties) {
                     if (properties.hasOwnProperty(key)) {
                         var value = properties[key];


### PR DESCRIPTION
And more:
- Support GeoJSON with a CRS of type 'name' instead of type 'EPSG'.
- Treat EPSG:4283 as equivalent to 4326.
- Support the GeoJSON variation from South Australia with an extra "envelope" around the normal GeoJSON we're used to seeing.
- Use Cesium's tweaked styling for the feature info panel (different style for
  alternating rows).
