### PR TITLE
config additions

### DIFF
--- a/public/vic.json
+++ b/public/vic.json
@@ -9,6 +9,6 @@
         "data.vic.gov.au"
     ],
   "initialDataMenu" : "init_nm.json",
-  "initialCamera" : { "west": 105, "south": -45, "east": 155, "north": -5}
+  "initialCamera" : { "west": 140, "south": -39, "east": 150, "north": -34}
 }
 

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -31,7 +31,7 @@ var GeoDataBrowserViewModel = function(options) {
     this._viewer = options.viewer;
     this._dataManager = options.dataManager;
     this.map = options.map;
-    this.initUrl = options.initUrl || './init_nm.json';
+    this.initUrl = options.initUrl;
     this.mode3d = options.mode3d;
 
     this.showingPanel = false;


### PR DESCRIPTION
Added more flexibility in initial configuration.  This will probably need to change as we decide how vic national map will actually be deployed, but it should get us some of the way.
- At startup the viewer looks for config.json by default or whatever the config param in the url is set to.
- The config file now includes the initial extent and data menu url as well as the proxy lists.
- The data_menu url param can still be used to override the initial data menu url.
- This also now sets up the proxy before calling the menu url so that can live on non-cors sites.

I also added a vic.json file for a sample vic startup, so nationalmap....com.au?config=vic.json will startup in vic mode.
