### PR TITLE
Fixes for CSV support.

### DIFF
--- a/src/TableDataSource.js
+++ b/src/TableDataSource.js
@@ -12,6 +12,7 @@ And writes a czml file for it to display
 //TODO: DOCUMENT using model in GeoJsonDataSource
 
 var defaultValue = require('../third_party/cesium/Source/Core/defaultValue');
+var defined = require('../third_party/cesium/Source/Core/defined');
 var CzmlDataSource = require('../third_party/cesium/Source/DataSources/CzmlDataSource');
 var Color = require('../third_party/cesium/Source/Core/Color');
 var defineProperties = require('../third_party/cesium/Source/Core/defineProperties');
@@ -268,7 +269,7 @@ TableDataSource.prototype._getNormalizedPoint = function (pt_val) {
 TableDataSource.prototype._mapValue2Scale = function (pt_val) {
     var scale = this.scale;
     var normPoint = this._getNormalizedPoint(pt_val);
-    if (normPoint !== undefined) {
+    if (defined(normPoint) && normPoint === normPoint) {
         scale *= (this.scale_by_val ? 1.0 * normPoint + 0.5 : 1.0);
     }
     return scale;

--- a/src/Variable.js
+++ b/src/Variable.js
@@ -185,7 +185,7 @@ Variable.prototype.processEnumVar = function () {
         this.vals[i] = parseFloat(n);
     }
     this.enum_list = enum_list;
-    this.calculateVarMinMax();
+    this._calculateVarMinMax();
 };
 
 


### PR DESCRIPTION
- Fix incorrect reference to `calculateVarMinMax` in Variable.js.
- Don't set the Scale to NaN when a column has a mix of numbers and strings.
