### PR TITLE
Improve test of WebGL support.

### DIFF
--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -877,7 +877,14 @@ function supportsWebgl() {
         return false;
     }
     var canvas = document.createElement( 'canvas' );
-    var gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+
+    var webglOptions = {
+        alpha : false,
+        stencil : false,
+        failIfMajorPerformanceCaveat : true
+    };
+
+    var gl = canvas.getContext("webgl", webglOptions) || canvas.getContext("experimental-webgl", webglOptions);
     if (!gl) {
         // Browser could not initialize WebGL. User probably needs to
         // update their drivers or get a new browser. Present a link to


### PR DESCRIPTION
Use the same options for WebGL context creation that Cesium itself uses.
This avoids the potential for National Map's test to succeed only for
Cesium's actual creation to fail.
