### PR TITLE
Only allow the legend of one data source at a time to be visible

### DIFF
--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -103,6 +103,16 @@ var GeoDataBrowserViewModel = function(options) {
 
     this._openLegend = createCommand(function(item) {
         item.legendIsOpen(!item.legendIsOpen());
+
+        if (item.legendIsOpen()) {
+            // Close the other legends.
+            var nowViewing = that.nowViewing();
+            for (var i = 0; i < nowViewing.length; ++i) {
+                if (nowViewing[i] !== item) {
+                    nowViewing[i].legendIsOpen(false);
+                }
+            }
+        }
     });
 
     this._toggleCategoryOpen = createCommand(function(item) {


### PR DESCRIPTION
Clicking on the name of one data source now collapses all other legends.
