### PR TITLE
Populate cache

### DIFF
--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -1839,7 +1839,7 @@ function filterMaxScaleDenominatorLayers(getCapabilitiesUrl, layersInGroup, laye
     });
 }
 
-function filterAllLayers(getCapabilitiesUrl, layersIngroup, layersToFilter) {
+function filterAllLayers(getCapabilitiesUrl, layersInGroup, layersToFilter) {
     for (var i = 0; i < layersInGroup.length; ++i) {
         var layerInGroup = layersInGroup[i];
 

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -52,14 +52,14 @@ var GeoDataBrowser = function(options) {
 
     var populateOpenButton = document.createElement('div');
     populateOpenButton.className = 'ausglobe-panel-button';
-    populateOpenButton.title = 'Pop Open';
-    populateOpenButton.innerHTML = '<div class="ausglobe-panel-button-label">Pop Open</div>';
+    populateOpenButton.title = 'Populate cache for data sources that are in open data panel categories';
+    populateOpenButton.innerHTML = '<div class="ausglobe-panel-button-label">Populate</div>';
     populateOpenButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache(true); }');
     wrapper.appendChild(populateOpenButton);
 
     var populateAllButton = document.createElement('div');
     populateAllButton.className = 'ausglobe-panel-button';
-    populateAllButton.title = 'Pop All';
+    populateAllButton.title = 'Populate cache for all data sources';
     populateAllButton.innerHTML = '<div class="ausglobe-panel-button-label">Pop All</div>';
     populateAllButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache(false); }');
     wrapper.appendChild(populateAllButton);

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -50,6 +50,20 @@ var GeoDataBrowser = function(options) {
     legendButton.setAttribute('data-bind', 'visible: legendsExist(), click: toggleShowingLegendPanel, css { "ausglobe-panel-button-panel-visible": showingLegendPanel }');
     wrapper.appendChild(legendButton);
 
+    var populateOpenButton = document.createElement('div');
+    populateOpenButton.className = 'ausglobe-panel-button';
+    populateOpenButton.title = 'Pop Open';
+    populateOpenButton.innerHTML = '<div class="ausglobe-panel-button-label">Pop Open</div>';
+    populateOpenButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache(true); }');
+    wrapper.appendChild(populateOpenButton);
+
+    var populateAllButton = document.createElement('div');
+    populateAllButton.className = 'ausglobe-panel-button';
+    populateAllButton.title = 'Pop All';
+    populateAllButton.innerHTML = '<div class="ausglobe-panel-button-label">Pop All</div>';
+    populateAllButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache(false); }');
+    wrapper.appendChild(populateAllButton);
+
     var dataPanel = document.createElement('div');
     dataPanel.id = 'ausglobe-data-panel';
     dataPanel.className = 'ausglobe-panel';

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -54,28 +54,28 @@ var GeoDataBrowser = function(options) {
     populateEnabledButton.className = 'ausglobe-panel-button';
     populateEnabledButton.title = 'Populate cache for data sources that are enabled';
     populateEnabledButton.innerHTML = '<div class="ausglobe-panel-button-label">Enabled</div>';
-    populateEnabledButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache("enabled"); }');
+    populateEnabledButton.setAttribute('data-bind', 'visible: showPopulateCache(), click: function() { populateCache("enabled"); }');
     wrapper.appendChild(populateEnabledButton);
 
     var populateOpenButton = document.createElement('div');
     populateOpenButton.className = 'ausglobe-panel-button';
     populateOpenButton.title = 'Populate cache for data sources that are in open data panel categories';
     populateOpenButton.innerHTML = '<div class="ausglobe-panel-button-label">Open</div>';
-    populateOpenButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache("opened"); }');
+    populateOpenButton.setAttribute('data-bind', 'visible: showPopulateCache(), click: function() { populateCache("opened"); }');
     wrapper.appendChild(populateOpenButton);
 
     var populateAllButton = document.createElement('div');
     populateAllButton.className = 'ausglobe-panel-button';
     populateAllButton.title = 'Populate cache for all data sources';
     populateAllButton.innerHTML = '<div class="ausglobe-panel-button-label">All</div>';
-    populateAllButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache("all"); }');
+    populateAllButton.setAttribute('data-bind', 'visible: showPopulateCache(), click: function() { populateCache("all"); }');
     wrapper.appendChild(populateAllButton);
 
     var maxLevel = document.createElement('div');
     maxLevel.className = 'ausglobe-panel-button';
     maxLevel.title = 'Maximum tile level';
     maxLevel.innerHTML = '<input class="ausglobe-wfs-url-input" type="text" data-bind="value: maxLevel" />';
-    maxLevel.setAttribute('data-bind', 'visible: showPopulateCache');
+    maxLevel.setAttribute('data-bind', 'visible: showPopulateCache()');
     wrapper.appendChild(maxLevel);
 
     var dataPanel = document.createElement('div');

--- a/src/viewer/GeoDataBrowser.js
+++ b/src/viewer/GeoDataBrowser.js
@@ -50,19 +50,33 @@ var GeoDataBrowser = function(options) {
     legendButton.setAttribute('data-bind', 'visible: legendsExist(), click: toggleShowingLegendPanel, css { "ausglobe-panel-button-panel-visible": showingLegendPanel }');
     wrapper.appendChild(legendButton);
 
+    var populateEnabledButton = document.createElement('div');
+    populateEnabledButton.className = 'ausglobe-panel-button';
+    populateEnabledButton.title = 'Populate cache for data sources that are enabled';
+    populateEnabledButton.innerHTML = '<div class="ausglobe-panel-button-label">Enabled</div>';
+    populateEnabledButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache("enabled"); }');
+    wrapper.appendChild(populateEnabledButton);
+
     var populateOpenButton = document.createElement('div');
     populateOpenButton.className = 'ausglobe-panel-button';
     populateOpenButton.title = 'Populate cache for data sources that are in open data panel categories';
-    populateOpenButton.innerHTML = '<div class="ausglobe-panel-button-label">Populate</div>';
-    populateOpenButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache(true); }');
+    populateOpenButton.innerHTML = '<div class="ausglobe-panel-button-label">Open</div>';
+    populateOpenButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache("opened"); }');
     wrapper.appendChild(populateOpenButton);
 
     var populateAllButton = document.createElement('div');
     populateAllButton.className = 'ausglobe-panel-button';
     populateAllButton.title = 'Populate cache for all data sources';
-    populateAllButton.innerHTML = '<div class="ausglobe-panel-button-label">Pop All</div>';
-    populateAllButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache(false); }');
+    populateAllButton.innerHTML = '<div class="ausglobe-panel-button-label">All</div>';
+    populateAllButton.setAttribute('data-bind', 'visible: showPopulateCache, click: function() { populateCache("all"); }');
     wrapper.appendChild(populateAllButton);
+
+    var maxLevel = document.createElement('div');
+    maxLevel.className = 'ausglobe-panel-button';
+    maxLevel.title = 'Maximum tile level';
+    maxLevel.innerHTML = '<input class="ausglobe-wfs-url-input" type="text" data-bind="value: maxLevel" />';
+    maxLevel.setAttribute('data-bind', 'visible: showPopulateCache');
+    wrapper.appendChild(maxLevel);
 
     var dataPanel = document.createElement('div');
     dataPanel.id = 'ausglobe-data-panel';

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -1046,6 +1046,27 @@ these extensions in order for National Map to know how to load it.'
         }
     }
 
+    // From StackOverflow: http://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array
+    function shuffle(array) {
+        var currentIndex = array.length,
+            temporaryValue, randomIndex;
+
+        // While there remain elements to shuffle...
+        while (0 !== currentIndex) {
+
+            // Pick a remaining element...
+            randomIndex = Math.floor(Math.random() * currentIndex);
+            currentIndex -= 1;
+
+            // And swap it with the current element.
+            temporaryValue = array[currentIndex];
+            array[currentIndex] = array[randomIndex];
+            array[randomIndex] = temporaryValue;
+        }
+
+        return array;
+    }
+
     function requestTiles(requests, maxLevel) {
         var urls = [];
 
@@ -1085,6 +1106,10 @@ these extensions in order for National Map to know how to load it.'
         throttleRequestByServer.maximumRequestsPerServer = oldMax;
 
         console.log('Requesting ' + urls.length + ' URLs!');
+
+        // Do requests in random order for better performance; successive requests are
+        // less likely to be to the same server.
+        shuffle(urls);
 
         var maxRequests = 6;
         var nextRequestIndex = 0;


### PR DESCRIPTION
When `#populate-cache` is included in the URL, display two new buttons.  The first one, "Populate", will request tiles for levels 0-5 for all data sources that are in categories that are open on the data panel.  The second one, "Pop All" will request tiles for levels 0-5 for all data sources, by opening all categories and waiting for them to load.

Status/progress information is logged to the console.
