### PR TITLE
esri health code

### DIFF
--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -398,6 +398,11 @@ GeoDataCollection.prototype.checkServerHealth = function(layer, succeed, fail) {
             succeed(layer);
         }
     }, function(err) {
+            //ESRI exception case - accept 400 status as well as 200
+        if (err.statusCode === 400) {
+            succeed(layer);
+            return;
+        }
         if (defined(fail)) {
             fail(layer);
         }

--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -400,7 +400,9 @@ GeoDataCollection.prototype.checkServerHealth = function(layer, succeed, fail) {
     }, function(err) {
             //ESRI exception case - accept 400 status as well as 200
         if (err.statusCode === 400) {
-            succeed(layer);
+            if (defined(succeed)) {
+                succeed(layer);
+            }
             return;
         }
         if (defined(fail)) {


### PR DESCRIPTION
fixes #381

handles esri response code different from geoserver/mapserver/etc.  still avoiding getCapabilities since these can be quite a lot of overhead, especially on esri wms servers.  Can look at this further in the refactor.
