### PR TITLE
Remove ETag from proxied responses, and add CORS header.

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ function filterHeaders(req, headers) {
     }
 
     result['Cache-Control'] = 'public; max-age=315360000';
+    result['Access-Control-Allow-Origin'] ='*';
 
     return result;
 }

--- a/server.js
+++ b/server.js
@@ -34,6 +34,8 @@ function filterHeaders(req, headers) {
         result['Authorization'] = 'Basic d21zOndtcw==';
     }
 
+    result['Cache-Control'] = 'public; max-age=315360000';
+
     return result;
 }
 
@@ -128,6 +130,7 @@ if (cluster.isMaster) {
 
     var app = express();
     app.use(compression());
+    app.disable('etag');
     app.use(express.static(path.join(__dirname, 'public')));
 
     var upstreamProxy = argv['upstream-proxy'];


### PR DESCRIPTION
Removing the ETag drastically improves performance when proxying/caching for WMS servers that add it and then take just as long to revalidate the ETag as to send a full response (I'm looking at you, Esri).

Adding `Access-Control-Allow-Origin` allows our proxy to be used in cross-origin requests, which means we can use the production proxy when testing on localhost, for example.
