### PR TITLE
Varnish tuning for vic

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,6 +6,10 @@ var configSettings = require('./public/config.json');
 
 function getRemoteUrlFromParam(req) {
     var remoteUrl = req.params[0];
+    if (remoteUrl.indexOf('_') === 0) {
+        remoteUrl = remoteUrl.substring(remoteUrl.indexOf('/')+1);
+        console.log(remoteUrl);
+    }
     if (remoteUrl) {
         // add http:// to the URL if no protocol is present
         if (!/^https?:\/\//.test(remoteUrl)) {
@@ -27,7 +31,7 @@ function filterHeaders(req, headers) {
         if (!dontProxyHeaderRegex.test(name)) {
             result[name] = headers[name];
         }
-    });
+    }); 
 
     var remote = getRemoteUrlFromParam(req);
     if (remote.host === 'programs.communications.gov.au'){

--- a/server.js
+++ b/server.js
@@ -8,7 +8,6 @@ function getRemoteUrlFromParam(req) {
     var remoteUrl = req.params[0];
     if (remoteUrl.indexOf('_') === 0) {
         remoteUrl = remoteUrl.substring(remoteUrl.indexOf('/')+1);
-        console.log(remoteUrl);
     }
     if (remoteUrl) {
         // add http:// to the URL if no protocol is present

--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -1779,7 +1779,7 @@ GeoDataCollection.prototype.handleCapabilitiesRequest = function(text, descripti
             if (wmsServers.hasOwnProperty(wmsServer)) {
                 var getCapabilitiesUrl = wmsServer + '?service=WMS&request=GetCapabilities';
                 if (corsProxy.shouldUseProxy(getCapabilitiesUrl)) {
-                    getCapabilitiesUrl = corsProxy.getURL(getCapabilitiesUrl);
+                    getCapabilitiesUrl = corsProxy.getURL(getCapabilitiesUr, '1d');
                 }
 
                 promises.push(filterMaxScaleDenominatorLayers(getCapabilitiesUrl, wmsServers[wmsServer], layers));
@@ -1887,7 +1887,7 @@ GeoDataCollection.prototype.getCapabilities = function(description, callback) {
    
     console.log('CAPABILITIES REQUEST:',request);
     if (corsProxy.shouldUseProxy(request)) {
-        request = corsProxy.getURL(request);
+        request = corsProxy.getURL(request, '1d');
     }
 
     var that = this;

--- a/src/GeoDataCollection.js
+++ b/src/GeoDataCollection.js
@@ -1779,7 +1779,7 @@ GeoDataCollection.prototype.handleCapabilitiesRequest = function(text, descripti
             if (wmsServers.hasOwnProperty(wmsServer)) {
                 var getCapabilitiesUrl = wmsServer + '?service=WMS&request=GetCapabilities';
                 if (corsProxy.shouldUseProxy(getCapabilitiesUrl)) {
-                    getCapabilitiesUrl = corsProxy.getURL(getCapabilitiesUr, '1d');
+                    getCapabilitiesUrl = corsProxy.getURL(getCapabilitiesUrl,'1d');
                 }
 
                 promises.push(filterMaxScaleDenominatorLayers(getCapabilitiesUrl, wmsServers[wmsServer], layers));

--- a/src/corsProxy.js
+++ b/src/corsProxy.js
@@ -3,8 +3,9 @@
 /*global require,URI*/
 
 var corsProxy = {
-    getURL : function(resource) {
-        return '/proxy/' + resource;
+    getURL : function(resource, proxyFlag) {
+        var flag = (proxyFlag === undefined) ? '' : '_' + proxyFlag + '/';
+        return '/proxy/' + flag + resource;
     },
     proxyDomains : []
 };

--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -24,7 +24,11 @@ sub vcl_recv {
 
 sub vcl_fetch
 {
-    set beresp.ttl = 10000m;
+  if (req.url ~ "^/proxy/_"){
+    set beresp.ttl = 1d;
+  } else {
+    set beresp.ttl = 14d;
+  }
 }
 
 # 


### PR DESCRIPTION
OK this does a few things:
- Added a flag to the corsProxy obect.  If present it appends the flag to /proxy/... to create /proxy/_flag/... 
- This is called with a '1d' flag in GeoDataCollection when doing getCapabilities, so that we update the proxy cache every 24 hours.  Otherwise urls are cached for 2 weeks.
- Server.js peels off the flag from the remoteUrl.

The flag right now is just a placeholder (it can only set the ttl to 1d), but we can use this mechanism for more interesting proxy communication in the future if we want.
