### PR TITLE
Leaflet cache

### DIFF
--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -1016,6 +1016,7 @@ these extensions in order for National Map to know how to load it.'
                         transparent: true,
                         exceptions: 'application/vnd.ogc.se_xml'
                     });
+                    that._viewer.map.addLayer(provider);
                 }
                 else {
                     var wmsOptions = {
@@ -1125,7 +1126,11 @@ these extensions in order for National Map to know how to load it.'
 
                 for (var y = nw.y; y <= se.y; ++y) {
                     for (var x = nw.x; x <= se.x; ++x) {
-                        console.log('tile', x, y, level);
+                        var coords = new L.Point(x, y);
+                        coords.z = level;
+
+                        var str = request.provider.getTileUrl(coords);
+                        console.log(str);
 //                        if (!defined(request.provider.requestImage(x, y, level))) {
 //                            console.log('too many requests in flight');
 //                        }

--- a/src/viewer/GeoDataBrowserViewModel.js
+++ b/src/viewer/GeoDataBrowserViewModel.js
@@ -1009,48 +1009,58 @@ these extensions in order for National Map to know how to load it.'
                     proxy = undefined;
                 }
 
-                var wmsOptions = {
-                    url: url,
-                    layers : item.Name(),
-                    parameters: {
+                if (!defined(that._viewer.viewer)) {
+                    provider = new L.tileLayer.wms(url, {
+                        layers: item.Name(),
                         format: 'image/png',
                         transparent: true,
-                        styles: '',
                         exceptions: 'application/vnd.ogc.se_xml'
-                    },
-                    proxy: proxy
-                };
-
-                var crs;
-                if (defined(item.CRS)) {
-                    crs = item.CRS();
-                } else if (defined(item.SRS)) {
-                    crs = item.SRS();
-                } else {
-                    crs = undefined;
+                    });
                 }
-                if (defined(crs)) {
-                    if (crsIsMatch(crs, 'EPSG:4326')) {
-                        // Standard Geographic
-                    } else if (crsIsMatch(crs, 'CRS:84')) {
-                        // Another name for EPSG:4326
-                        wmsOptions.parameters.srs = 'CRS:84';
-                    } else if (crsIsMatch(crs, 'EPSG:4283')) {
-                        // Australian system that is equivalent to EPSG:4326.
-                        wmsOptions.parameters.srs = 'EPSG:4283';
-                    } else if (crsIsMatch(crs, 'EPSG:3857')) {
-                        // Standard Web Mercator
-                        wmsOptions.tilingScheme = new WebMercatorTilingScheme();
-                    } else if (crsIsMatch(crs, 'EPSG:900913')) {
-                        // Older code for Web Mercator
-                        wmsOptions.tilingScheme = new WebMercatorTilingScheme();
-                        wmsOptions.parameters.srs = 'EPSG:900913';
+                else {
+                    var wmsOptions = {
+                        url: url,
+                        layers : item.Name(),
+                        parameters: {
+                            format: 'image/png',
+                            transparent: true,
+                            styles: '',
+                            exceptions: 'application/vnd.ogc.se_xml'
+                        },
+                        proxy: proxy
+                    };
+
+                    var crs;
+                    if (defined(item.CRS)) {
+                        crs = item.CRS();
+                    } else if (defined(item.SRS)) {
+                        crs = item.SRS();
                     } else {
-                        // No known supported CRS listed.  Try the default, EPSG:4326, and hope for the best.
+                        crs = undefined;
                     }
-                }
+                    if (defined(crs)) {
+                        if (crsIsMatch(crs, 'EPSG:4326')) {
+                            // Standard Geographic
+                        } else if (crsIsMatch(crs, 'CRS:84')) {
+                            // Another name for EPSG:4326
+                            wmsOptions.parameters.srs = 'CRS:84';
+                        } else if (crsIsMatch(crs, 'EPSG:4283')) {
+                            // Australian system that is equivalent to EPSG:4326.
+                            wmsOptions.parameters.srs = 'EPSG:4283';
+                        } else if (crsIsMatch(crs, 'EPSG:3857')) {
+                            // Standard Web Mercator
+                            wmsOptions.tilingScheme = new WebMercatorTilingScheme();
+                        } else if (crsIsMatch(crs, 'EPSG:900913')) {
+                            // Older code for Web Mercator
+                            wmsOptions.tilingScheme = new WebMercatorTilingScheme();
+                            wmsOptions.parameters.srs = 'EPSG:900913';
+                        } else {
+                            // No known supported CRS listed.  Try the default, EPSG:4326, and hope for the best.
+                        }
+                    }
 
-                var provider = new WebMapServiceImageryProvider(wmsOptions);
+                    var provider = new WebMapServiceImageryProvider(wmsOptions);
+                }
                 requests.push({
                     item : item,
                     provider : provider
@@ -1100,7 +1110,8 @@ these extensions in order for National Map to know how to load it.'
             var request = requests[i];
             var bareItem = komapping.toJS(request.item);
             var extent = getOGCLayerExtent(bareItem);
-            var tilingScheme = request.provider.tilingScheme;
+//            var tilingScheme = request.provider.tilingScheme;
+            var tilingScheme = new WebMercatorTilingScheme();
 
             name = bareItem.Title;
 
@@ -1114,13 +1125,16 @@ these extensions in order for National Map to know how to load it.'
 
                 for (var y = nw.y; y <= se.y; ++y) {
                     for (var x = nw.x; x <= se.x; ++x) {
-                        if (!defined(request.provider.requestImage(x, y, level))) {
-                            console.log('too many requests in flight');
-                        }
+                        console.log('tile', x, y, level);
+//                        if (!defined(request.provider.requestImage(x, y, level))) {
+//                            console.log('too many requests in flight');
+//                        }
                     }
                 }
             }
         }
+
+        return;
 
         loadImage.createImage = loadImage.defaultCreateImage;
         throttleRequestByServer.maximumRequestsPerServer = oldMax;


### PR DESCRIPTION
Put in the leaflet equivalent for populate-cache.  Since the provider has a getTileUrl method the additions were pretty minimal.

Can you check this quickly there and post to production if OK?  It appears to work fine locally, but I'm having vpn issues here that kept me from testing on the stage site.  
