### PR TITLE
Preserve opacity and layer order on sharing

### DIFF
--- a/src/Map/gmlToGeoJson.js
+++ b/src/Map/gmlToGeoJson.js
@@ -2,7 +2,7 @@
 
 /*global require,$*/
 
-function xmlToGeoJson(xml) {
+function gmlToGeoJson(xml) {
     var json = $.xml2json(xml);
 
     var newObj = {type: "FeatureCollection", crs: {"type":"EPSG","properties":{"code":"4326"}}, features: []};
@@ -67,4 +67,4 @@ function gml2coord(posList) {
     return coords;
 }
 
-module.exports = xmlToGeoJson;
+module.exports = gmlToGeoJson;

--- a/src/ViewModels/CatalogGroupViewModel.js
+++ b/src/ViewModels/CatalogGroupViewModel.js
@@ -122,6 +122,18 @@ defineProperties(CatalogGroupViewModel.prototype, {
         get : function() {
             return CatalogGroupViewModel.defaultSerializers;
         }
+    },
+
+    /**
+     * Gets the set of names of the properties to be serialized for this object when {@link CatalogMemberViewModel#serializeToJson} is called
+     * and the `serializeForSharing` flag is set in the options.
+     * @memberOf CatalogGroupViewModel.prototype
+     * @type {String[]}
+     */
+    propertiesForSharing : {
+        get : function() {
+            return CatalogGroupViewModel.defaultPropertiesForSharing;
+        }
     }
 });
 
@@ -195,6 +207,17 @@ CatalogGroupViewModel.defaultSerializers.items = function(viewModel, json, prope
 CatalogGroupViewModel.defaultSerializers.isLoading = function(viewModel, json, propertyName, options) {};
 
 freezeObject(CatalogGroupViewModel.defaultSerializers);
+
+/**
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItemViewModel}-derived object with the
+ * `serializeForSharing` flag set in the options.
+ * @type {String[]}
+ */
+CatalogGroupViewModel.defaultPropertiesForSharing = clone(CatalogMemberViewModel.defaultPropertiesForSharing);
+CatalogGroupViewModel.defaultPropertiesForSharing.push('items');
+CatalogGroupViewModel.defaultPropertiesForSharing.push('isOpened');
+
+freezeObject(CatalogGroupViewModel.defaultPropertiesForSharing);
 
 /**
  * When implemented in a derived class, loads the contents of this group, if the contents are not already loaded.  It is safe to

--- a/src/ViewModels/CatalogItemViewModel.js
+++ b/src/ViewModels/CatalogItemViewModel.js
@@ -236,6 +236,18 @@ defineProperties(CatalogItemViewModel.prototype, {
         get : function() {
             return CatalogItemViewModel.defaultSerializers;
         }
+    },
+
+    /**
+     * Gets the set of names of the properties to be serialized for this object when {@link CatalogMemberViewModel#serializeToJson} is called
+     * and the `serializeForSharing` flag is set in the options.
+     * @memberOf CatalogItemViewModel.prototype
+     * @type {String[]}
+     */
+    propertiesForSharing : {
+        get : function() {
+            return CatalogItemViewModel.defaultPropertiesForSharing;
+        }
     }
 });
 
@@ -285,6 +297,19 @@ CatalogItemViewModel.defaultSerializers.rectangle = function(viewModel, json, pr
 };
 
 freezeObject(CatalogItemViewModel.defaultSerializers);
+
+/**
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItemViewModel}-derived object with the
+ * `serializeForSharing` flag set in the options.
+ * @type {String[]}
+ */
+CatalogItemViewModel.defaultPropertiesForSharing = clone(CatalogMemberViewModel.defaultPropertiesForSharing);
+CatalogItemViewModel.defaultPropertiesForSharing.push('isEnabled');
+CatalogItemViewModel.defaultPropertiesForSharing.push('isShown');
+CatalogItemViewModel.defaultPropertiesForSharing.push('isLegendVisible');
+CatalogItemViewModel.defaultPropertiesForSharing.push('nowViewingIndex');
+
+freezeObject(CatalogItemViewModel.defaultPropertiesForSharing);
 
 /**
  * When implemented in a derived class, loads this data item it is not already loaded.  It is safe to

--- a/src/ViewModels/CatalogMemberViewModel.js
+++ b/src/ViewModels/CatalogMemberViewModel.js
@@ -110,6 +110,18 @@ defineProperties(CatalogMemberViewModel.prototype, {
         get : function() {
             return CatalogMemberViewModel.defaultSerializers;
         }
+    },
+
+    /**
+     * Gets the set of names of the properties to be serialized for this object when {@link CatalogMemberViewModel#serializeToJson} is called
+     * and the `serializeForSharing` flag is set in the options.
+     * @memberOf CatalogMemberViewModel.prototype
+     * @type {String[]}
+     */
+    propertiesForSharing : {
+        get : function() {
+            return CatalogMemberViewModel.defaultPropertiesForSharing;
+        }
     }
 });
 
@@ -132,6 +144,17 @@ CatalogMemberViewModel.defaultSerializers = {
 };
 
 freezeObject(CatalogMemberViewModel.defaultSerializers);
+
+/**
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogMemberViewModel}-derived object with the
+ * `serializeForSharing` flag set in the options.
+ * @type {String[]}
+ */
+CatalogMemberViewModel.defaultPropertiesForSharing = [
+    'name'
+];
+
+freezeObject(CatalogMemberViewModel.defaultPropertiesForSharing);
 
 /**
  * Updates the catalog member from a JSON object-literal description of it.
@@ -176,9 +199,12 @@ CatalogMemberViewModel.prototype.updateFromJson = function(json, options) {
  * @param {CatalogMemberViewModel[]} [options.itemsSkippedBecauseTheyHaveLocalData] An array that, if provided, is populated on return
  *        with all of the data items that were not serialized because they have a serializable 'data' property.  The array will be empty
  *        if options.skipItemsWithLocalData is false.
- * @param {Boolean} [options.serializeTogglesOnly=false] true to only serialize toggle properties such as {@link CatalogGroupViewModel#isOpen}, and
- *                  {@link CatalogItemViewModel#isEnabled}, and {@link CatalogItemViewModel#isLegendVisible}, rather than serializing all properties needed to completely
- *                  recreate the catalog.
+ * @param {Boolean} [options.serializeForSharing=false] true to only serialize properties that are typically necessary for sharing this member
+ *                                                      with other users, such as {@link CatalogGroupViewModel#isOpen}, {@link CatalogItemViewModel#isEnabled},
+ *                                                      {@link CatalogItemViewModel#isLegendVisible}, and {@link ImageryLayerViewModel#opacity},
+ *                                                      rather than serializing all properties needed to completely recreate the catalog.  The set of properties
+ *                                                      that is serialized when this property is true is given by each view-model's
+ *                                                      {@link CatalogMemberViewModel#propertiesForSharing} property.
  * @param {Boolean} [options.userSuppliedOnly=false] true to only serialize catalog members (and their containing groups) that have been identified as having been
  *                  supplied by the user ({@link CatalogMemberViewModel#isUserSupplied} is true); false to serialize all catalog members.
  * @return {Object} The serialized JSON object-literal.
@@ -207,10 +233,10 @@ CatalogMemberViewModel.prototype.serializeToJson = function(options) {
     var result = {};
 
     var filterFunction = function() { return true; };
-    if (options.serializeTogglesOnly) {
+    if (options.serializeForSharing) {
+        var that = this;
         filterFunction = function(propertyName) {
-            return propertyName === 'name' || propertyName === 'items' || propertyName === 'isEnabled' ||
-                   propertyName === 'isOpen' || propertyName === 'isLegendVisible';
+            return that.propertiesForSharing.indexOf(propertyName) >= 0;
         };
     } else {
         result.type = this.type;

--- a/src/ViewModels/CatalogViewModel.js
+++ b/src/ViewModels/CatalogViewModel.js
@@ -149,9 +149,10 @@ CatalogViewModel.prototype.updateFromJson = function(json, options) {
  * @param {CatalogMemberViewModel[]} [options.itemsSkippedBecauseTheyHaveLocalData] An array that, if provided, is populated on return
  *        with all of the data items that were not serialized because they have a serializable 'data' property.  The array will be empty
  *        if options.skipItemsWithLocalData is false.
- * @param {Boolean} [options.serializeTogglesOnly=false] true to only serialize toggle properties such as {@link CatalogGroupViewModel#isOpen}, and
- *                  {@link CatalogItemViewModel#isEnabled}, and {@link CatalogItemViewModel#isLegendVisible}, rather than serializing all properties needed to completely
- *                  recreate the catalog.
+ * @param {Boolean} [options.serializeForSharing=false] true to only serialize properties that are typically necessary for sharing this member
+ *                                                      with other users, such as {@link CatalogGroupViewModel#isOpen}, {@link CatalogItemViewModel#isEnabled},
+ *                                                      {@link CatalogItemViewModel#isLegendVisible}, and {@link ImageryLayerViewModel#opacity},
+ *                                                      rather than serializing all properties needed to completely recreate the catalog.
  * @param {Boolean} [options.userSuppliedOnly=false] true to only serialize catalog members (and their containing groups) that have been identified as having been
  *                  supplied by the user ({@link CatalogMemberViewModel#isUserSupplied} is true); false to serialize all catalog members.
  * @return {Object} The serialized JSON object-literal.

--- a/src/ViewModels/CkanGroupViewModel.js
+++ b/src/ViewModels/CkanGroupViewModel.js
@@ -142,9 +142,9 @@ defineProperties(CkanGroupViewModel.prototype, {
 CkanGroupViewModel.defaultSerializers = clone(CatalogGroupViewModel.defaultSerializers);
 
 CkanGroupViewModel.defaultSerializers.items = function(viewModel, json, propertyName, options) {
-    // Only serialize toggles in contained items, because other properties are loaded from CKAN.
-    var previousSerializeTogglesOnly = options.serializeTogglesOnly;
-    options.serializeTogglesOnly = true;
+    // Only serialize minimal properties in contained items, because other properties are loaded from CKAN.
+    var previousSerializeForSharing = options.serializeForSharing;
+    options.serializeForSharing = true;
 
     // Only serlize enabled items as well.  This isn't quite right - ideally we'd serialize any
     // property of any item if the property's value is changed from what was loaded from CKAN -
@@ -156,7 +156,7 @@ CkanGroupViewModel.defaultSerializers.items = function(viewModel, json, property
     CatalogGroupViewModel.defaultSerializers.items(viewModel, json, propertyName, options);
 
     options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeTogglesOnly = previousSerializeTogglesOnly;
+    options.serializeForSharing = previousSerializeForSharing;
 };
 
 CkanGroupViewModel.defaultSerializers.isLoading = function(viewModel, json, propertyName, options) {};

--- a/src/ViewModels/ImageryLayerItemViewModel.js
+++ b/src/ViewModels/ImageryLayerItemViewModel.js
@@ -105,6 +105,18 @@ defineProperties(ImageryLayerItemViewModel.prototype, {
         get : function() {
             return ImageryLayerItemViewModel.defaultSerializers;
         }
+    },
+
+    /**
+     * Gets the set of names of the properties to be serialized for this object when {@link CatalogMemberViewModel#serializeToJson} is called
+     * and the `serializeForSharing` flag is set in the options.
+     * @memberOf ImageryLayerItemViewModel.prototype
+     * @type {String[]}
+     */
+    propertiesForSharing : {
+        get : function() {
+            return ImageryLayerItemViewModel.defaultPropertiesForSharing;
+        }
     }
 });
 
@@ -113,6 +125,16 @@ freezeObject(ImageryLayerItemViewModel.defaultUpdaters);
 
 ImageryLayerItemViewModel.defaultSerializers = clone(CatalogItemViewModel.defaultSerializers);
 freezeObject(ImageryLayerItemViewModel.defaultSerializers);
+
+/**
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItemViewModel}-derived object with the
+ * `serializeForSharing` flag set in the options.
+ * @type {String[]}
+ */
+ImageryLayerItemViewModel.defaultPropertiesForSharing = clone(CatalogItemViewModel.defaultPropertiesForSharing);
+ImageryLayerItemViewModel.defaultPropertiesForSharing.push('opacity');
+
+freezeObject(ImageryLayerItemViewModel.defaultPropertiesForSharing);
 
 ImageryLayerItemViewModel.prototype._showInCesium = function() {
     if (!defined(this._imageryLayer)) {

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -162,7 +162,7 @@ var AusGlobeViewer = function(application, initialCamera) {
                         var enabledAndOpenedCatalog = that.application.catalog.serializeToJson({
                             enabledItemsOnly: true,
                             skipItemsWithLocalData: true,
-                            serializeTogglesOnly: true,
+                            serializeForSharing: true,
                         });
                         if (enabledAndOpenedCatalog.length > 0) {
                             initSources.push({


### PR DESCRIPTION
The underlying problem was that the `opacity` and `nowViewingIndex` properties were not being serialized, but I also refactored things a bit so that the different view-models class can now declare which of their properties should be serialized for sharing.
