### PR TITLE
Dockerize nationalmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# Docker image for the primary national map application server
+FROM node:0.10-onbuild
+MAINTAINER briely.marum@nicta.com.au
+RUN apt-get update && apt-get install -y gdal-bin
+EXPOSE 3001

--- a/config.js
+++ b/config.js
@@ -1,9 +1,28 @@
 'use strict';
 
-module.exports = {
- db: {
-   production: "mongodb://geospace:geospace@geospace.research.nicta.com.au:1234/geospace-prod",
-   development: "mongodb://localhost/geospace-dev",
-   test: "mongodb://localhost/geospace-test",
- }
-};
+// If we're running inside a docker container, we'll have our mongo
+// dependency provided in environment variables. In the case where we
+// are running inside the docker container, but using  an external
+// (non dockerized) mongo instance, these variables can still be set
+// on the docker command line with -e
+var mongoAddr = process.env['MONGODB_PORT_27017_TCP_ADDR'];
+var mongoPort = process.env['MONGODB_PORT_27017_TCP_PORT'];
+
+if (typeof mongoAddr !== 'undefined' && typeof mongoPort !== 'undefined') {
+  var connString = 'mongodb://'+mongoAddr+':'+mongoPort;
+  module.exports = {
+    db: {
+      production: connString + "/geospace-prod",
+      development: connString  + "/geospace-dev",
+      test: connString + "/geospace-test",
+    }
+  }
+} else {
+  module.exports = {
+   db: {
+     production: "mongodb://geospace:geospace@geospace.research.nicta.com.au:1234/geospace-prod",
+     development: "mongodb://localhost/geospace-dev",
+     test: "mongodb://localhost/geospace-test",
+   }
+  };
+}

--- a/varnish/Dockerfile
+++ b/varnish/Dockerfile
@@ -1,0 +1,13 @@
+# A docker image running varnish proxy and cache
+# configuration for a nationalmap production
+# deployment
+FROM ubuntu:14.04
+MAINTAINER briely.marum@nicta.com.au
+RUN apt-get update && apt-get install -y varnish
+VOLUME ["/mnt/cache/varnish"]
+EXPOSE 80
+ADD default.vcl /default.vcl
+ADD varnish /etc/default/varnish
+ADD boot_varnish.sh /boot_varnish.sh
+RUN chmod +x /boot_varnish.sh
+CMD ["/boot_varnish.sh"]

--- a/varnish/boot_varnish.sh
+++ b/varnish/boot_varnish.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Our entry point for the varnish proxy and cache docker container.
+# I'm trying to leave the varnish config that's checked into our nm
+# repo identical wheather it's running inside a docker container or
+# not, so I'm applying some last minute config changes to varnish
+# when the container boots up allowing us to have a dynamically
+# assigned address and port for our backend container.
+
+function abort() {
+	echo $1
+	exit $2
+}
+
+[ -z "$NM_PORT_3001_TCP_ADDR" ] && abort "Nationalmap backend address is not defined" 1
+[ -z "$NM_PORT_3001_TCP_PORT" ] && abort "Nationalmap backend port is not defined"
+
+sed -e "s/127.0.0.1/$NM_PORT_3001_TCP_ADDR/g" -e "s/3001/$NM_PORT_3001_TCP_PORT/g" < /default.vcl > /etc/varnish/default.vcl
+
+
+# The following are the important slivers from the varnish upstart script
+# shipped with the varnish deb package in ubuntu 14.04.
+
+# Include varnish defaults if available
+if [ -f /etc/default/varnish ] ; then
+    . /etc/default/varnish
+fi
+
+# Open files (usually 1024, which is way too small for varnish)
+ulimit -n ${NFILES:-131072}
+
+# Maxiumum locked memory size for shared memory log
+ulimit -l ${MEMLOCK:-82000}
+
+
+/usr/sbin/varnishd ${DAEMON_OPTS}
+
+# Haven't found a way to prevent varnish from detatching
+# FIXME :P
+while true
+do
+	sleep 36000
+done


### PR DESCRIPTION
This adds docker config for the node application server, and varnish. I've also updated config.js to interrogate the environment for config injected by the docker environment regarding mongo.

The application server image is build directly on top of a standardized node language stack image, with the addition of gdal-bin. The varnish image is hand rolled and contains a custom boot script in place of the upstart script provided by the package maintainers.

A quick howto:

``` bash
# From the nm repo root directory, with a working nm build.
# Build the application server image.
sudo docker build -t nationalmap/backend .

# Build the varnish image.
sudo docker build -t nationalmap/varnish varnish/

# Boot up the official mongodb image.
sudo docker run -d -p 27017:27017 --name mongodb dockerfile/mongodb

# Start the backend image you built.
sudo docker run --name nationalmap --link mongodb:mongodb nationalmap/backend

# Start the varnish image you built.
sudo docker run  -d -p 80:80 --name varnish --link nationalmap:nm nationalmap/varnish
```

I'll add a complete set of documentation to the wiki once the pr is accepted.
