### PR TITLE
Make Search more Australia-oriented

### DIFF
--- a/src/viewer/SearchWidgetViewModel.js
+++ b/src/viewer/SearchWidgetViewModel.js
@@ -214,7 +214,7 @@ function geocode(viewModel) {
         latitudeDegrees = center.lat;
     }
 
-    var promise = jsonp(viewModel._url + 'REST/v1/Locations?userLocation=' + latitudeDegrees + ',' + longitudeDegrees , {
+    var promise = jsonp(viewModel._url + 'REST/v1/Locations?culture=en-AU&userLocation=' + latitudeDegrees + ',' + longitudeDegrees , {
         parameters : {
             query : query,
             key : viewModel._key


### PR DESCRIPTION
By specifying `culture=en-AU` in the Bing Maps search query, we get results that are more relevant to our users in Australia.  Specifically, searching for `victoria` now zooms to the Australia state.

Fixes #333 
