### PR TITLE
Smaller WMS sharing

### DIFF
--- a/src/ViewModels/CatalogMemberViewModel.js
+++ b/src/ViewModels/CatalogMemberViewModel.js
@@ -212,11 +212,13 @@ CatalogMemberViewModel.prototype.updateFromJson = function(json, options) {
 CatalogMemberViewModel.prototype.serializeToJson = function(options) {
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
+    var enabledItemsOnly = defaultValue(options.enabledItemsOnly, false);
+
     if (defaultValue(options.userSuppliedOnly, false) && !this.isUserSupplied) {
         return undefined;
     }
 
-    if (defaultValue(options.enabledItemsOnly, false) && this.isEnabled === false) {
+    if (enabledItemsOnly && this.isEnabled === false) {
         if (defined(options.itemsSkippedBecauseTheyAreNotEnabled)) {
             options.itemsSkippedBecauseTheyAreNotEnabled.push(this);
         }
@@ -253,7 +255,7 @@ CatalogMemberViewModel.prototype.serializeToJson = function(options) {
     }
 
     // Only serialize a group if the group has items in it.
-    if (defined(this.items) && (!defined(result.items) || result.items.length === 0)) {
+    if (enabledItemsOnly && defined(this.items) && (!defined(result.items) || result.items.length === 0)) {
         return undefined;
     }
 

--- a/src/ViewModels/CkanGroupViewModel.js
+++ b/src/ViewModels/CkanGroupViewModel.js
@@ -124,7 +124,7 @@ defineProperties(CkanGroupViewModel.prototype, {
      * When a property name on the view-model matches the name of a property in the serializers object lieral,
      * the value will be called as a function and passed a reference to the view-model, a reference to the destination
      * JSON object literal, and the name of the property.
-     * @memberOf CatalogGroupViewModel.prototype
+     * @memberOf CkanGroupViewModel.prototype
      * @type {Object}
      */
     serializers : {

--- a/src/ViewModels/WebFeatureServiceGroupViewModel.js
+++ b/src/ViewModels/WebFeatureServiceGroupViewModel.js
@@ -93,7 +93,7 @@ defineProperties(WebFeatureServiceGroupViewModel.prototype, {
      */
     serializers : {
         get : function() {
-            return WebMapServiceGroupViewModel.defaultSerializers;
+            return WebFeatureServiceGroupViewModel.defaultSerializers;
         }
     }
 });

--- a/src/ViewModels/WebMapServiceGroupViewModel.js
+++ b/src/ViewModels/WebMapServiceGroupViewModel.js
@@ -9,6 +9,7 @@ var defaultValue = require('../../third_party/cesium/Source/Core/defaultValue');
 var defined = require('../../third_party/cesium/Source/Core/defined');
 var defineProperties = require('../../third_party/cesium/Source/Core/defineProperties');
 var DeveloperError = require('../../third_party/cesium/Source/Core/DeveloperError');
+var freezeObject = require('../../third_party/cesium/Source/Core/freezeObject');
 var ImageryLayer = require('../../third_party/cesium/Source/Scene/ImageryLayer');
 var knockout = require('../../third_party/cesium/Source/ThirdParty/knockout');
 var loadXML = require('../../third_party/cesium/Source/Core/loadXML');
@@ -80,8 +81,51 @@ defineProperties(WebMapServiceGroupViewModel.prototype, {
         get : function() {
             return 'Web Map Service (WMS) Group';
         }
+    },
+
+    /**
+     * Gets the set of functions used to serialize individual properties in {@link CatalogMemberViewModel#serializeToJson}.
+     * When a property name on the view-model matches the name of a property in the serializers object lieral,
+     * the value will be called as a function and passed a reference to the view-model, a reference to the destination
+     * JSON object literal, and the name of the property.
+     * @memberOf WebMapServiceGroupViewModel.prototype
+     * @type {Object}
+     */
+    serializers : {
+        get : function() {
+            return WebMapServiceGroupViewModel.defaultSerializers;
+        }
     }
 });
+
+/**
+ * Gets or sets the set of default serializer functions to use in {@link CatalogMemberViewModel#serializeToJson}.  Types derived from this type
+ * should expose this instance - cloned and modified if necesary - through their {@link CatalogMemberViewModel#serializers} property.
+ * @type {Object}
+ */
+WebMapServiceGroupViewModel.defaultSerializers = clone(CatalogGroupViewModel.defaultSerializers);
+
+WebMapServiceGroupViewModel.defaultSerializers.items = function(viewModel, json, propertyName, options) {
+    // Only serialize minimal properties in contained items, because other properties are loaded from GetCapabilities.
+    var previousSerializeForSharing = options.serializeForSharing;
+    options.serializeForSharing = true;
+
+    // Only serlize enabled items as well.  This isn't quite right - ideally we'd serialize any
+    // property of any item if the property's value is changed from what was loaded from GetCapabilities -
+    // but this gives us reasonable results for sharing and is a lot less work than the ideal
+    // solution.
+    var previousEnabledItemsOnly = options.enabledItemsOnly;
+    options.enabledItemsOnly = true;
+
+    CatalogGroupViewModel.defaultSerializers.items(viewModel, json, propertyName, options);
+
+    options.enabledItemsOnly = previousEnabledItemsOnly;
+    options.serializeForSharing = previousSerializeForSharing;
+};
+
+WebMapServiceGroupViewModel.defaultSerializers.isLoading = function(viewModel, json, propertyName, options) {};
+
+freezeObject(WebMapServiceGroupViewModel.defaultSerializers);
 
 /**
  * Loads the items in this group by invoking the GetCapabilities service on the WMS server.


### PR DESCRIPTION
Previously, when sharing a user-added WMS group (GetCapabilities), we would include all of the (unnecessary) details of each layer.  Now only the group details plus opened/enabled/etc flags are serialized.
