### PR TITLE
Nicta proxy cache

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,6 @@
 {
     "proxyDomains" : [
+        "research.nicta.com.au",
         "gov.au",
         "arcgis.com"
     ]

--- a/public/init_nm.json
+++ b/public/init_nm.json
@@ -1,6 +1,5 @@
 {
     "corsDomains" : [
-        "research.nicta.com.au",
         "data.gov.au",
         "ga.gov.au",
         "corsproxy.com"

--- a/src/viewer/main.js
+++ b/src/viewer/main.js
@@ -84,7 +84,7 @@ if (start) {
         if (defined(hash) && hash.length > 0) {
             if (hash.indexOf('start=') === 0) {
                 startData = JSON.parse(decodeURIComponent(hash.substring(6)));
-            } else {
+            } else if (hash.toLowerCase() !== 'populate-cache') {
                 application.initSources.push('init_' + hash + ".json");
             }
         }


### PR DESCRIPTION
Moved research.nicta.com.au to proxy so we cache tiles for it.  We can maybe look at a varnish cache down the road for the geoservers.
