### PR TITLE
Use promises to manage loading, instead of ad hoc insanity

### DIFF
--- a/public/init_vic.json
+++ b/public/init_vic.json
@@ -10,7 +10,7 @@
         {
             "name": "Victorian Government",
             "type": "ckan",
-            "url": "http://www.dataa.vic.gov.au/data",
+            "url": "http://www.data.vic.gov.au/data",
             "filterQuery": "res_format:wms",
             "filterByWmsGetCapabilities": true,
             "minimumMaxScaleDenominator": 1e10,

--- a/public/init_vic.json
+++ b/public/init_vic.json
@@ -10,7 +10,7 @@
         {
             "name": "Victorian Government",
             "type": "ckan",
-            "url": "http://www.data.vic.gov.au/data",
+            "url": "http://www.dataa.vic.gov.au/data",
             "filterQuery": "res_format:wms",
             "filterByWmsGetCapabilities": true,
             "minimumMaxScaleDenominator": 1e10,

--- a/public/test/init_test.json
+++ b/public/test/init_test.json
@@ -14,7 +14,7 @@
                             "url": "test/cemeteries.geojson"
                         },
                         {
-                            "name": "Bike Racks (GeoJSON:reproj",
+                            "name": "Bike Racks (GeoJSON:reproj)",
                             "type": "geojson",
                             "url": "test/bike_racks.geojson"
                         },

--- a/src/Core/arraysAreEqual.js
+++ b/src/Core/arraysAreEqual.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var defined = require('../../third_party/cesium/Source/Core/defined');
+
+function arraysAreEqual(left, right) {
+    if (left === right) {
+        return true;
+    }
+
+    if (!defined(left) || !defined(right) || left.length !== right.length) {
+        return false;
+    }
+
+    for (var i = 0; i < left.length; ++i) {
+        if (left[i] !== right[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+module.exports = arraysAreEqual;

--- a/src/Core/runLater.js
+++ b/src/Core/runLater.js
@@ -2,8 +2,14 @@
 
 /*global require*/
 
+var when = require('../../third_party/cesium/Source/ThirdParty/when');
+
 var runLater = function(functionToRunLater) {
-    setTimeout(functionToRunLater, 0);
+    var deferred = when.defer();
+    setTimeout(function() {
+        deferred.resolve(functionToRunLater());
+    }, 0);
+    return deferred.promise;
 };
 
 module.exports = runLater;

--- a/src/ViewModels/CatalogGroupViewModel.js
+++ b/src/ViewModels/CatalogGroupViewModel.js
@@ -33,7 +33,7 @@ var CatalogGroupViewModel = function(application) {
     CatalogMemberViewModel.call(this, application);
 
     this._loadingPromise = undefined;
-    this._loadInfluencingValues = undefined;
+    this._lastLoadInfluencingValues = undefined;
 
     /**
      * Gets or sets a value indicating whether the group is currently expanded and showing
@@ -265,6 +265,7 @@ CatalogGroupViewModel.prototype.load = function() {
 
         return that._load();
     }).then(function() {
+        that._loadingPromise = undefined;
         that.isLoading = false;
     }).otherwise(function(e) {
         that._lastLoadInfluencingValues = undefined;
@@ -284,6 +285,7 @@ CatalogGroupViewModel.prototype.load = function() {
  * @protected
  */
 CatalogGroupViewModel.prototype._load = function() {
+    return when();
 };
 
 var emptyArray = freezeObject([]);

--- a/src/ViewModels/CatalogGroupViewModel.js
+++ b/src/ViewModels/CatalogGroupViewModel.js
@@ -9,11 +9,14 @@ var defineProperties = require('../../third_party/cesium/Source/Core/definePrope
 var freezeObject = require('../../third_party/cesium/Source/Core/freezeObject');
 var knockout = require('../../third_party/cesium/Source/ThirdParty/knockout');
 var RuntimeError = require('../../third_party/cesium/Source/Core/RuntimeError');
+var when = require('../../third_party/cesium/Source/ThirdParty/when');
 
+var arraysAreEqual = require('../Core/arraysAreEqual');
 var createCatalogMemberFromType = require('./createCatalogMemberFromType');
 var CatalogMemberViewModel = require('./CatalogMemberViewModel');
 var inherit = require('../Core/inherit');
-var runWhenDoneLoading = require('./runWhenDoneLoading');
+var raiseErrorOnRejectedPromise = require('./raiseErrorOnRejectedPromise');
+var runLater = require('../Core/runLater');
 
 /**
  * A group of data items and other groups in the {@link CatalogViewModel}.  A group can contain
@@ -28,6 +31,9 @@ var runWhenDoneLoading = require('./runWhenDoneLoading');
  */
 var CatalogGroupViewModel = function(application) {
     CatalogMemberViewModel.call(this, application);
+
+    this._loadingPromise = undefined;
+    this._loadInfluencingValues = undefined;
 
     /**
      * Gets or sets a value indicating whether the group is currently expanded and showing
@@ -56,7 +62,7 @@ var CatalogGroupViewModel = function(application) {
     knockout.getObservable(this, 'isOpen').subscribe(function(newValue) {
         // Load this group's items (if we haven't already) when it is opened.
         if (newValue) {
-            that.load();
+            raiseErrorOnRejectedPromise(that.application, that.load());
         }
     });
 
@@ -66,7 +72,7 @@ var CatalogGroupViewModel = function(application) {
         // If this spins you into a stack overflow, verify that your derived-class load method only
         // loads when it actually needs to do so!
         if (newValue === false && that.isOpen) {
-            that.load();
+            raiseErrorOnRejectedPromise(that.application, that.load());
         }
     });
 };
@@ -145,13 +151,10 @@ defineProperties(CatalogGroupViewModel.prototype, {
 CatalogGroupViewModel.defaultUpdaters = clone(CatalogMemberViewModel.defaultUpdaters);
 
 CatalogGroupViewModel.defaultUpdaters.items = function(viewModel, json, propertyName, options) {
-    if (!defined(json.items)) {
-        return;
-    }
+    // Let the group finish loading first.  Otherwise, these changes could get clobbered by the load.
+    return when(viewModel.load(), function() {
+        var promises = [];
 
-    // If the group is still loading, delay this operation until the loading is complete.
-    // Otherwise, these changes could get clobbered by the load.
-    runWhenDoneLoading(viewModel, function(viewModel) {
         // TODO: allow JSON to update the order of items as well.
 
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -177,8 +180,10 @@ CatalogGroupViewModel.defaultUpdaters.items = function(viewModel, json, property
                 viewModel.add(existingItem);
             }
 
-            existingItem.updateFromJson(item, options);
+            promises.push(existingItem.updateFromJson(item, options));
         }
+
+        return when.all(promises);
     });
 };
 
@@ -220,12 +225,78 @@ CatalogGroupViewModel.defaultPropertiesForSharing.push('isOpened');
 freezeObject(CatalogGroupViewModel.defaultPropertiesForSharing);
 
 /**
- * When implemented in a derived class, loads the contents of this group, if the contents are not already loaded.  It is safe to
+ * Loads the contents of this group, if the contents are not already loaded.  It is safe to
  * call this method multiple times.  The {@link CatalogGroupViewModel#isLoading} flag will be set while the load is in progress.
- * This base-class implementation of this method does nothing because {@link CatalogGroupViewModel} does not do an lazy loading
- * of its content.
+ * Derived classes should implement {@link CatalogGroupViewModel#_load} to perform the actual loading for the group.
+ * Derived classes may optionally implement {@link CatalogGroupViewModel#_getValuesThatInfluenceLoad} to provide an array containing
+ * the current value of all properties that influence this group's load process.  Each time that {@link CatalogGroupViewModel#load}
+ * is invoked, these values are checked against the list of values returned last time, and {@link CatalogGroupViewModel#_load} is
+ * invoked again if they are different.  If {@link CatalogGroupViewModel#_getValuesThatInfluenceLoad} is undefined or returns an
+ * empty array, {@link CatalogGroupViewModel#_load} will only be invoked once, no matter how many times
+ * {@link CatalogGroupViewModel#load} is invoked.
+ *
+ * @returns {Promise} A promise that resolves when the load is complete, or undefined if the group is already loaded.
+ * 
  */
 CatalogGroupViewModel.prototype.load = function() {
+    if (defined(this._loadingPromise)) {
+        // Load already in progress.
+        return this._loadingPromise;
+    }
+
+    var loadInfluencingValues = [];
+    if (defined(this._getValuesThatInfluenceLoad)) {
+        loadInfluencingValues = this._getValuesThatInfluenceLoad();
+    }
+
+    if (arraysAreEqual(loadInfluencingValues, this._lastLoadInfluencingValues)) {
+        // Already loaded, and nothing has changed to force a re-load.
+        return undefined;
+    }
+
+    this.isLoading = true;
+
+    var that = this;
+    this._loadingPromise = runLater(function() {
+        that._lastLoadInfluencingValues = [];
+        if (defined(that._getValuesThatInfluenceLoad)) {
+            that._lastLoadInfluencingValues = that._getValuesThatInfluenceLoad();
+        }
+
+        return that._load();
+    }).then(function() {
+        that.isLoading = false;
+    }).otherwise(function(e) {
+        that._lastLoadInfluencingValues = undefined;
+        that._loadingPromise = undefined;
+        that.isOpen = false;
+        that.isLoading = false;
+        throw e;
+    });
+
+    return this._loadingPromise;
+};
+
+/**
+ * When implemented in a derived class, this method loads the group.  The base class implementation does nothing.
+ * This method should not be called directly; call {@link CatalogGroupViewModel#load} instead.
+ * @return {Promise} A promise that resolves when the load is complete.
+ * @protected
+ */
+CatalogGroupViewModel.prototype._load = function() {
+};
+
+var emptyArray = freezeObject([]);
+
+/**
+ * When implemented in a derived class, gets an array containing the current value of all properties that
+ * influence this group's load process.  See {@link CatalogGroupViewModel#load} for more information on when and
+ * how this is used.  The base class implementation returns an empty array.
+ * @return {Array} The array of values that influence the load process.
+ * @protected
+ */
+CatalogGroupViewModel.prototype._getValuesThatInfluenceLoad = function() {
+    return emptyArray;
 };
 
 /**

--- a/src/ViewModels/CatalogItemViewModel.js
+++ b/src/ViewModels/CatalogItemViewModel.js
@@ -715,11 +715,14 @@ function isEnabledChanged(viewModel) {
                 if (viewModel.isEnabled) {
                     viewModel._enable();
                 }
-            }).always(function() {
+            });
+
+            raiseErrorOnRejectedPromise(viewModel.application, loadPromise);
+
+            loadPromise.always(function() {
                 resolvedOrRejected = true;
                 viewModel._loadForEnablePromise = undefined;
             });
-            raiseErrorOnRejectedPromise(viewModel.application, loadPromise);
 
             // Make sure we know about it when the promise already resolved/rejected.
             viewModel._loadForEnablePromise = resolvedOrRejected ? undefined : loadPromise;

--- a/src/ViewModels/CatalogItemViewModel.js
+++ b/src/ViewModels/CatalogItemViewModel.js
@@ -389,6 +389,9 @@ var emptyArray = freezeObject([]);
  * @protected
  */
 CatalogItemViewModel.prototype._getValuesThatInfluenceLoad = function() {
+    // In the future, we can implement auto-reloading when any of these properties change.  Just create a knockout
+    // computed property that calls this method and subscribe to change notifications on that computed property.
+    // (Will need to use the rateLimit extender, presumably).
     return emptyArray;
 };
 

--- a/src/ViewModels/CatalogItemViewModel.js
+++ b/src/ViewModels/CatalogItemViewModel.js
@@ -15,10 +15,12 @@ var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
 var Scene = require('../../third_party/cesium/Source/Scene/Scene');
 var when = require('../../third_party/cesium/Source/ThirdParty/when');
 
+var arraysAreEqual = require('../Core/arraysAreEqual');
 var MetadataViewModel = require('./MetadataViewModel');
 var CatalogMemberViewModel = require('./CatalogMemberViewModel');
 var inherit = require('../Core/inherit');
 var NowViewingViewModel = require('./NowViewingViewModel');
+var raiseErrorOnRejectedPromise = require('./raiseErrorOnRejectedPromise');
 var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
 var runLater = require('../Core/runLater');
 var runWhenDoneLoading = require('./runWhenDoneLoading');
@@ -38,8 +40,9 @@ var CatalogItemViewModel = function(application) {
 
     this._enabledDate = undefined;
     this._shownDate = undefined;
-    this._callToEnableIsPending = false;
-    this._callToShowIsPending = false;
+    this._loadForEnablePromise = undefined;
+    this._loadingPromise = undefined;
+    this._lastLoadInfluencingValues = undefined;
 
     /**
      * The index of the item in the Now Viewing list.  Setting this property does not automatically change the order.
@@ -313,12 +316,80 @@ CatalogItemViewModel.defaultPropertiesForSharing.push('nowViewingIndex');
 freezeObject(CatalogItemViewModel.defaultPropertiesForSharing);
 
 /**
- * When implemented in a derived class, loads this data item it is not already loaded.  It is safe to
+ * Loads this catalog item, if it's not already loaded.  It is safe to
  * call this method multiple times.  The {@link CatalogItemViewModel#isLoading} flag will be set while the load is in progress.
- * This method may do nothing if the data item does not do an lazy loading of its data.  If the load happens asynchronously,
- * this method should return a Promise that resolves when the load is complete.
+ * Derived classes should implement {@link CatalogItemViewModel#_load} to perform the actual loading for the item.
+ * Derived classes may optionally implement {@link CatalogItemViewModel#_getValuesThatInfluenceLoad} to provide an array containing
+ * the current value of all properties that influence this item's load process.  Each time that {@link CatalogItemViewModel#load}
+ * is invoked, these values are checked against the list of values returned last time, and {@link CatalogItemViewModel#_load} is
+ * invoked again if they are different.  If {@link CatalogItemViewModel#_getValuesThatInfluenceLoad} is undefined or returns an
+ * empty array, {@link CatalogItemViewModel#_load} will only be invoked once, no matter how many times
+ * {@link CatalogItemViewModel#load} is invoked.
+ *
+ * @returns {Promise} A promise that resolves when the load is complete, or undefined if the item is already loaded.
+ * 
  */
 CatalogItemViewModel.prototype.load = function() {
+    if (defined(this._loadingPromise)) {
+        // Load already in progress.
+        return this._loadingPromise;
+    }
+
+    var loadInfluencingValues = [];
+    if (defined(this._getValuesThatInfluenceLoad)) {
+        loadInfluencingValues = this._getValuesThatInfluenceLoad();
+    }
+
+    if (arraysAreEqual(loadInfluencingValues, this._lastLoadInfluencingValues)) {
+        // Already loaded, and nothing has changed to force a re-load.
+        return undefined;
+    }
+
+    this.isLoading = true;
+
+    var that = this;
+    this._loadingPromise = runLater(function() {
+        that._lastLoadInfluencingValues = [];
+        if (defined(that._getValuesThatInfluenceLoad)) {
+            that._lastLoadInfluencingValues = that._getValuesThatInfluenceLoad();
+        }
+
+        return that._load();
+    }).then(function() {
+        that._loadingPromise = undefined;
+        that.isLoading = false;
+    }).otherwise(function(e) {
+        that._lastLoadInfluencingValues = undefined;
+        that._loadingPromise = undefined;
+        that.isEnabled = false;
+        that.isLoading = false;
+        throw e;
+    });
+
+    return this._loadingPromise;
+};
+
+/**
+ * When implemented in a derived class, this method loads the item.  The base class implementation does nothing.
+ * This method should not be called directly; call {@link CatalogItemViewModel#load} instead.
+ * @return {Promise} A promise that resolves when the load is complete.
+ * @protected
+ */
+CatalogItemViewModel.prototype._load = function() {
+    return when();
+};
+
+var emptyArray = freezeObject([]);
+
+/**
+ * When implemented in a derived class, gets an array containing the current value of all properties that
+ * influence this item's load process.  See {@link CatalogItemViewModel#load} for more information on when and
+ * how this is used.  The base class implementation returns an empty array.
+ * @return {Array} The array of values that influence the load process.
+ * @protected
+ */
+CatalogItemViewModel.prototype._getValuesThatInfluenceLoad = function() {
+    return emptyArray;
 };
 
 /**
@@ -638,12 +709,20 @@ function isEnabledChanged(viewModel) {
         // Be careful not to call _enable multiple times or to call _enable
         // after the item has already been disabled.
         if (!defined(viewModel._loadForEnablePromise)) {
-            viewModel._loadForEnablePromise = when(viewModel.load(), function() {
-                viewModel._loadForEnablePromise = undefined;
+            var resolvedOrRejected = false;
+
+            var loadPromise = when(viewModel.load(), function() {
                 if (viewModel.isEnabled) {
                     viewModel._enable();
                 }
+            }).always(function() {
+                resolvedOrRejected = true;
+                viewModel._loadForEnablePromise = undefined;
             });
+            raiseErrorOnRejectedPromise(viewModel.application, loadPromise);
+
+            // Make sure we know about it when the promise already resolved/rejected.
+            viewModel._loadForEnablePromise = resolvedOrRejected ? undefined : loadPromise;
         }
 
         viewModel.isShown = true;

--- a/src/ViewModels/CkanGroupViewModel.js
+++ b/src/ViewModels/CkanGroupViewModel.js
@@ -24,7 +24,6 @@ var CatalogGroupViewModel = require('./CatalogGroupViewModel');
 var inherit = require('../Core/inherit');
 var PopupMessage = require('../viewer/PopupMessage');
 var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
-var runLater = require('../Core/runLater');
 var WebMapServiceItemViewModel = require('./WebMapServiceItemViewModel');
 
 /**

--- a/src/ViewModels/CkanGroupViewModel.js
+++ b/src/ViewModels/CkanGroupViewModel.js
@@ -39,13 +39,6 @@ var WebMapServiceItemViewModel = require('./WebMapServiceItemViewModel');
 var CkanGroupViewModel = function(application) {
     CatalogGroupViewModel.call(this, application, 'ckan');
 
-    this._loadedUrl = undefined;
-    this._loadedFilterQuery = undefined;
-    this._loadedBlacklist = undefined;
-    this._loadedFilterByWmsGetCapabilities = undefined;
-    this._loadedMinimumMaxScaleDenominator = undefined;
-    this._loadingPromise = undefined;
-
     /**
      * Gets or sets the URL of the CKAN server.  This property is observable.
      * @type {String}
@@ -167,14 +160,9 @@ CkanGroupViewModel.defaultSerializers.isLoading = function(viewModel, json, prop
 freezeObject(CkanGroupViewModel.defaultSerializers);
 
 CkanGroupViewModel.prototype._getValuesThatInfluenceLoad = function() {
-    return [this.url, this.filterQuery, this.blacklist, this.filterByWmsGetCapabilities];
+    return [this.url, this.filterQuery, this.blacklist, this.filterByWmsGetCapabilities, this.minimumMaxScaleDenominator];
 };
 
-/**
- * Loads the items in this group by invoking the GetCapabilities service on the WMS server.
- * Each layer in the response becomes an item in the group.  The {@link CatalogGroupViewModel#isLoading} flag will
- * be set while the load is in progress.
- */
 CkanGroupViewModel.prototype._load = function() {
     if (!defined(this.url) || this.url.length === 0) {
         return undefined;

--- a/src/ViewModels/CsvItemViewModel.js
+++ b/src/ViewModels/CsvItemViewModel.js
@@ -49,7 +49,6 @@ var CsvItemViewModel = function(application, url) {
     CatalogItemViewModel.call(this, application);
 
     this._tableDataSource = undefined;
-    this._loadingPromise = undefined;
 
     /**
      * Gets or sets the URL from which to retrieve CSV data.  This property is ignored if

--- a/src/ViewModels/CsvItemViewModel.js
+++ b/src/ViewModels/CsvItemViewModel.js
@@ -29,7 +29,6 @@ var CatalogItemViewModel = require('./CatalogItemViewModel');
 var inherit = require('../Core/inherit');
 var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
 var readText = require('../Core/readText');
-var runLater = require('../Core/runLater');
 
 var WebMapServiceImageryProvider = require('../../third_party/cesium/Source/Scene/WebMapServiceImageryProvider');
 var WebMapServiceItemViewModel = require('./WebMapServiceItemViewModel');

--- a/src/ViewModels/CsvItemViewModel.js
+++ b/src/ViewModels/CsvItemViewModel.js
@@ -49,6 +49,7 @@ var CsvItemViewModel = function(application, url) {
     CatalogItemViewModel.call(this, application);
 
     this._tableDataSource = undefined;
+    this._loadingPromise = undefined;
 
     /**
      * Gets or sets the URL from which to retrieve CSV data.  This property is ignored if
@@ -136,7 +137,7 @@ CsvItemViewModel.prototype.load = function() {
     this._tableDataSource = new TableDataSource();
 
     var that = this;
-    runLater(function() {
+    this._loadingPromise = runLater(function() {
         that._loadedUrl = that.url;
         that._loadedData = that.data;
 
@@ -160,6 +161,7 @@ CsvItemViewModel.prototype.load = function() {
                     }));
                 }
             }).otherwise(function() {
+                that._loadingPromise = undefined;
                 that.isLoading = false;
             });
         } else if (defined(that.url)) {
@@ -173,12 +175,14 @@ CsvItemViewModel.prototype.load = function() {
                     message: '\
 An error occurred while retrieving CSV data from the provided link.'
                 }));
+                that._loadingPromise = undefined;
                 that.isEnabled = false;
                 that._loadedUrl = undefined;
                 that._loadedData = undefined;
             });
         }
     });
+    return this._loadingPromise;
 };
 
 CsvItemViewModel.prototype._enableInCesium = function() {
@@ -382,6 +386,7 @@ a region mapping column.'
         viewModel.clock = viewModel._tableDataSource.clock;
         viewModel.rectangle = viewModel._tableDataSource.dataset.getExtent();
 
+        viewModel._loadingPromise = undefined;
         viewModel.isLoading = false;
     }
 }

--- a/src/ViewModels/CzmlItemViewModel.js
+++ b/src/ViewModels/CzmlItemViewModel.js
@@ -183,8 +183,6 @@ function proxyUrl(application, url) {
 
 function doneLoading(viewModel) {
     viewModel.clock = viewModel._czmlDataSource.clock;
-    viewModel._loadingPromise = undefined;
-    viewModel.isLoading = false;
 }
 
 function errorLoading(viewModel) {

--- a/src/ViewModels/CzmlItemViewModel.js
+++ b/src/ViewModels/CzmlItemViewModel.js
@@ -46,6 +46,7 @@ var CzmlItemViewModel = function(application, url) {
     this._czmlDataSource = undefined;
     this._loadedUrl = undefined;
     this._loadedData = undefined;
+    this._loadingPromise = undefined;
 
     /**
      * Gets or sets the URL from which to retrieve CZML data.  This property is ignored if
@@ -129,7 +130,7 @@ CzmlItemViewModel.prototype.load = function() {
     this._czmlDataSource = dataSource;
 
     var that = this;
-    runLater(function() {
+    this._loadingPromise = runLater(function() {
         that._loadedUrl = that.url;
         that._loadedData = that.data;
 
@@ -157,6 +158,7 @@ CzmlItemViewModel.prototype.load = function() {
             });
         }
     });
+    return this._loadingPromise;
 };
 
 CzmlItemViewModel.prototype._enable = function() {
@@ -201,6 +203,7 @@ function proxyUrl(application, url) {
 
 function doneLoading(viewModel) {
     viewModel.clock = viewModel._czmlDataSource.clock;
+    viewModel._loadingPromise = undefined;
     viewModel.isLoading = false;
 }
 
@@ -216,6 +219,7 @@ at <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.a
 
     viewModel._loadedUrl = undefined;
     viewModel._loadedData = undefined;
+    viewModel._loadingPromise = undefined;
     viewModel.isEnabled = false;
     viewModel.isLoading = false;
     viewModel._czmlDataSource = undefined;

--- a/src/ViewModels/CzmlItemViewModel.js
+++ b/src/ViewModels/CzmlItemViewModel.js
@@ -106,6 +106,10 @@ defineProperties(CzmlItemViewModel.prototype, {
     }
 });
 
+CzmlItemViewModel.prototype._getValuesThatInfluenceLoad = function() {
+    return [this.url, this.data];
+};
+
 CzmlItemViewModel.prototype._load = function() {
     var dataSource = new CzmlDataSource();
     this._czmlDataSource = dataSource;

--- a/src/ViewModels/CzmlItemViewModel.js
+++ b/src/ViewModels/CzmlItemViewModel.js
@@ -15,7 +15,6 @@ var defineProperties = require('../../third_party/cesium/Source/Core/definePrope
 var DeveloperError = require('../../third_party/cesium/Source/Core/DeveloperError');
 var knockout = require('../../third_party/cesium/Source/ThirdParty/knockout');
 var loadJson = require('../../third_party/cesium/Source/Core/loadJson');
-var loadXML = require('../../third_party/cesium/Source/Core/loadXML');
 var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
 var when = require('../../third_party/cesium/Source/ThirdParty/when');
 
@@ -24,11 +23,8 @@ var MetadataViewModel = require('./MetadataViewModel');
 var MetadataItemViewModel = require('./MetadataItemViewModel');
 var ViewModelError = require('./ViewModelError');
 var CatalogItemViewModel = require('./CatalogItemViewModel');
-var ImageryLayerItemViewModel = require('./ImageryLayerItemViewModel');
 var inherit = require('../Core/inherit');
-var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
 var readJson = require('../Core/readJson');
-var runLater = require('../Core/runLater');
 
 /**
  * A {@link CatalogItemViewModel} representing Cesium Language (CZML) data.
@@ -44,9 +40,6 @@ var CzmlItemViewModel = function(application, url) {
     CatalogItemViewModel.call(this, application);
 
     this._czmlDataSource = undefined;
-    this._loadedUrl = undefined;
-    this._loadedData = undefined;
-    this._loadingPromise = undefined;
 
     /**
      * Gets or sets the URL from which to retrieve CZML data.  This property is ignored if
@@ -113,52 +106,35 @@ defineProperties(CzmlItemViewModel.prototype, {
     }
 });
 
-/**
- * Processes the CZML data supplied via the {@link CzmlItemViewModel#data} property.  If
- * {@link CzmlItemViewModel#data} is undefined, this method downloads CZML data from 
- * {@link CzmlItemViewModel#url} and processes that.  It is safe to call this method multiple times.
- * It is called automatically when the data source is enabled.
- */
-CzmlItemViewModel.prototype.load = function() {
-    if ((this.url === this._loadedUrl && this.data === this._loadedData) || this.isLoading === true) {
-        return;
-    }
-
-    this.isLoading = true;
-
+CzmlItemViewModel.prototype._load = function() {
     var dataSource = new CzmlDataSource();
     this._czmlDataSource = dataSource;
 
     var that = this;
-    this._loadingPromise = runLater(function() {
-        that._loadedUrl = that.url;
-        that._loadedData = that.data;
 
-        if (defined(that.data)) {
-            when(that.data, function(data) {
-                if (data instanceof Blob) {
-                    readJson(data).then(function(data) {
-                        dataSource.load(data, proxyUrl(that, that.dataSourceUrl));
-                        doneLoading(that);
-                    }).otherwise(function() {
-                        errorLoading(that);
-                    });
-                } else {
+    if (defined(that.data)) {
+        return when(that.data, function(data) {
+            if (data instanceof Blob) {
+                return readJson(data).then(function(data) {
                     dataSource.load(data, proxyUrl(that, that.dataSourceUrl));
                     doneLoading(that);
-                }
-            }).otherwise(function() {
-                errorLoading(that);
-            });
-        } else {
-            dataSource.loadUrl(proxyUrl(that, that.url)).then(function() {
+                }).otherwise(function() {
+                    errorLoading(that);
+                });
+            } else {
+                dataSource.load(data, proxyUrl(that, that.dataSourceUrl));
                 doneLoading(that);
-            }).otherwise(function() {
-                errorLoading(that);
-            });
-        }
-    });
-    return this._loadingPromise;
+            }
+        }).otherwise(function() {
+            errorLoading(that);
+        });
+    } else {
+        return dataSource.loadUrl(proxyUrl(that, that.url)).then(function() {
+            doneLoading(that);
+        }).otherwise(function() {
+            errorLoading(that);
+        });
+    }
 };
 
 CzmlItemViewModel.prototype._enable = function() {
@@ -208,21 +184,14 @@ function doneLoading(viewModel) {
 }
 
 function errorLoading(viewModel) {
-    viewModel.application.error.raiseEvent(new ViewModelError({
+    throw new ViewModelError({
         sender: viewModel,
         title: 'Error loading CZML',
         message: '\
 An error occurred while loading a CZML file.  This may indicate that the file is invalid or that it \
 is not supported by National Map.  If you would like assistance or further information, please email us \
 at <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.au</a>.'
-    }));
-
-    viewModel._loadedUrl = undefined;
-    viewModel._loadedData = undefined;
-    viewModel._loadingPromise = undefined;
-    viewModel.isEnabled = false;
-    viewModel.isLoading = false;
-    viewModel._czmlDataSource = undefined;
+    });
 }
 
 module.exports = CzmlItemViewModel;

--- a/src/ViewModels/GeoJsonItemViewModel.js
+++ b/src/ViewModels/GeoJsonItemViewModel.js
@@ -29,7 +29,6 @@ var ImageryLayerItemViewModel = require('./ImageryLayerItemViewModel');
 var inherit = require('../Core/inherit');
 var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
 var readJson = require('../Core/readJson');
-var runLater = require('../Core/runLater');
 
 var lineAndFillPalette = {
     minimumRed : 0.4,

--- a/src/ViewModels/GeoJsonItemViewModel.js
+++ b/src/ViewModels/GeoJsonItemViewModel.js
@@ -68,6 +68,7 @@ var GeoJsonItemViewModel = function(application, url) {
 
     this._loadedUrl = undefined;
     this._loadedData = undefined;
+    this._loadingPromise = undefined;
     
     this._readyData = undefined;
 
@@ -151,7 +152,7 @@ GeoJsonItemViewModel.prototype.load = function() {
     this.isLoading = true;
 
     var that = this;
-    runLater(function() {
+    this._loadingPromise = runLater(function() {
         that._loadedUrl = that.url;
         that._loadedData = that.data;
 
@@ -168,9 +169,11 @@ GeoJsonItemViewModel.prototype.load = function() {
                     that.data = json;
                     updateViewModelFromData(that, json);
                     that.isLoading = false;
+                    that._loadingPromise = undefined;
                 });
             }).otherwise(function() {
                 that.isLoading = false;
+                that._loadingPromise = undefined;
             });
         } else {
             loadJson(that.url).then(function(json) {
@@ -197,9 +200,11 @@ sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@
                 that.isEnabled = false;
                 that._loadedUrl = undefined;
                 that._loadedData = undefined;
+                that._loadingPromise = undefined;
             });
         }
     });
+    return this._loadingPromise;
 };
 
 GeoJsonItemViewModel.prototype._enable = function() {

--- a/src/ViewModels/GpxItemViewModel.js
+++ b/src/ViewModels/GpxItemViewModel.js
@@ -18,7 +18,6 @@ var ViewModelError = require('./ViewModelError');
 var CatalogItemViewModel = require('./CatalogItemViewModel');
 var inherit = require('../Core/inherit');
 var readXml = require('../Core/readXml');
-var runLater = require('../Core/runLater');
 
 var GeoJsonItemViewModel = require('./GeoJsonItemViewModel');
 var readText = require('../Core/readText');

--- a/src/ViewModels/GpxItemViewModel.js
+++ b/src/ViewModels/GpxItemViewModel.js
@@ -41,6 +41,7 @@ var GpxItemViewModel = function(application, url) {
     this._geoJsonViewModel = undefined;
     this._loadedUrl = undefined;
     this._loadedData = undefined;
+    this._loadingPromise = undefined;
 
     /**
      * Gets or sets the URL from which to retrieve GPX data.  This property is ignored if
@@ -122,7 +123,7 @@ GpxItemViewModel.prototype.load = function() {
     this._geoJsonViewModel = new GeoJsonItemViewModel(this.application);
 
     var that = this;
-    runLater(function() {
+    this._loadingPromise = runLater(function() {
         that._loadedUrl = that.url;
         that._loadedData = that.data;
 
@@ -147,6 +148,7 @@ GpxItemViewModel.prototype.load = function() {
             });
         }
     });
+    return this._loadingPromise;
 };
 
 GpxItemViewModel.prototype._enable = function() {
@@ -194,6 +196,7 @@ function loadGpxText(viewModel, text) {
             subscription.dispose();
             viewModel.rectangle = viewModel._geoJsonViewModel.rectangle;
             viewModel.isLoading = false;
+            viewModel._loadingPromise = undefined;
         }
     });
 
@@ -215,6 +218,7 @@ at <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.a
     viewModel.isEnabled = false;
     viewModel.isLoading = false;
     viewModel._geoJsonViewModel = undefined;
+    viewModel._loadingPromise = undefined;
 }
 
 module.exports = GpxItemViewModel;

--- a/src/ViewModels/GpxItemViewModel.js
+++ b/src/ViewModels/GpxItemViewModel.js
@@ -39,9 +39,6 @@ var GpxItemViewModel = function(application, url) {
     CatalogItemViewModel.call(this, application);
 
     this._geoJsonViewModel = undefined;
-    this._loadedUrl = undefined;
-    this._loadedData = undefined;
-    this._loadingPromise = undefined;
 
     /**
      * Gets or sets the URL from which to retrieve GPX data.  This property is ignored if
@@ -108,47 +105,35 @@ defineProperties(GpxItemViewModel.prototype, {
     }
 });
 
-/**
- * Processes the Gpx data supplied via the {@link GpxItemViewModel#data} property.  If
- * {@link GpxItemViewModel#data} is undefined, this method downloads GPX data from 
- * {@link GpxItemViewModel#url} and processes that.  It is safe to call this method multiple times.
- * It is called automatically when the data source is enabled.
- */
-GpxItemViewModel.prototype.load = function() {
-    if ((this.url === this._loadedUrl && this.data === this._loadedData) || this.isLoading === true) {
-        return;
-    }
+GpxItemViewModel.prototype._getValuesThatInfluenceLoad = function() {
+    return [this.url, this.data];
+};
 
-    this.isLoading = true;
+GpxItemViewModel.prototype._load = function() {
     this._geoJsonViewModel = new GeoJsonItemViewModel(this.application);
 
     var that = this;
-    this._loadingPromise = runLater(function() {
-        that._loadedUrl = that.url;
-        that._loadedData = that.data;
 
-        if (defined(that.data)) {
-            when(that.data, function(data) {
-                var promise;
-                if (data instanceof Blob) {
-                    promise = readText(data);
-                } else {
-                    promise = data;
-                }
+    if (defined(that.data)) {
+        return when(that.data, function(data) {
+            var promise;
+            if (data instanceof Blob) {
+                promise = readText(data);
+            } else {
+                promise = data;
+            }
 
-                when(promise, function(text) {
-                    loadGpxText(that, text);
-                });
+            return when(promise, function(text) {
+                return loadGpxText(that, text);
             });
-        } else {
-            loadText(proxyUrl(that, that.url)).then(function(text) {
-                loadGpxText(that, text);
-            }).otherwise(function() {
-                errorLoading(that);
-            });
-        }
-    });
-    return this._loadingPromise;
+        });
+    } else {
+        return loadText(proxyUrl(that, that.url)).then(function(text) {
+            return loadGpxText(that, text);
+        }).otherwise(function() {
+            errorLoading(that);
+        });
+    }
 };
 
 GpxItemViewModel.prototype._enable = function() {
@@ -191,34 +176,21 @@ function loadGpxText(viewModel, text) {
 
     viewModel._geoJsonViewModel.data = geojson;
 
-    var subscription = knockout.getObservable(viewModel._geoJsonViewModel, 'isLoading').subscribe(function(newValue) {
-        if (newValue === false) {
-            subscription.dispose();
-            viewModel.rectangle = viewModel._geoJsonViewModel.rectangle;
-            viewModel.isLoading = false;
-            viewModel._loadingPromise = undefined;
-        }
+    return viewModel._geoJsonViewModel.load().then(function() {
+        viewModel.rectangle = viewModel._geoJsonViewModel.rectangle;
+        viewModel.clock = viewModel._geoJsonViewModel.clock;
     });
-
-    viewModel._geoJsonViewModel.load();
 }
 
 function errorLoading(viewModel) {
-    viewModel.application.error.raiseEvent(new ViewModelError({
+    throw new ViewModelError({
         sender: viewModel,
         title: 'Error loading GPX',
         message: '\
 An error occurred while loading a GPX file.  This may indicate that the file is invalid or that it \
 is not supported by National Map.  If you would like assistance or further information, please email us \
 at <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.au</a>.'
-    }));
-
-    viewModel._loadedUrl = undefined;
-    viewModel._loadedData = undefined;
-    viewModel.isEnabled = false;
-    viewModel.isLoading = false;
-    viewModel._geoJsonViewModel = undefined;
-    viewModel._loadingPromise = undefined;
+    });
 }
 
 module.exports = GpxItemViewModel;

--- a/src/ViewModels/KmlItemViewModel.js
+++ b/src/ViewModels/KmlItemViewModel.js
@@ -28,7 +28,6 @@ var ImageryLayerItemViewModel = require('./ImageryLayerItemViewModel');
 var inherit = require('../Core/inherit');
 var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
 var readXml = require('../Core/readXml');
-var runLater = require('../Core/runLater');
 
 /**
  * A {@link CatalogItemViewModel} representing KML or KMZ feature data.

--- a/src/ViewModels/KmlItemViewModel.js
+++ b/src/ViewModels/KmlItemViewModel.js
@@ -46,6 +46,7 @@ var KmlItemViewModel = function(application, url) {
     this._kmlDataSource = undefined;
     this._loadedUrl = undefined;
     this._loadedData = undefined;
+    this._loadingPromise = undefined;
 
     /**
      * Gets or sets the URL from which to retrieve KML or KMZ data.  This property is ignored if
@@ -131,7 +132,7 @@ KmlItemViewModel.prototype.load = function() {
     this._kmlDataSource = dataSource;
 
     var that = this;
-    runLater(function() {
+    this._loadingPromise = runLater(function() {
         that._loadedUrl = that.url;
         that._loadedData = that.data;
 
@@ -179,6 +180,7 @@ KmlItemViewModel.prototype.load = function() {
             });
         }
     });
+    return this._loadingPromise;
 };
 
 KmlItemViewModel.prototype._enable = function() {

--- a/src/ViewModels/KmlItemViewModel.js
+++ b/src/ViewModels/KmlItemViewModel.js
@@ -44,9 +44,6 @@ var KmlItemViewModel = function(application, url) {
     CatalogItemViewModel.call(this, application);
 
     this._kmlDataSource = undefined;
-    this._loadedUrl = undefined;
-    this._loadedData = undefined;
-    this._loadingPromise = undefined;
 
     /**
      * Gets or sets the URL from which to retrieve KML or KMZ data.  This property is ignored if
@@ -113,74 +110,61 @@ defineProperties(KmlItemViewModel.prototype, {
     }
 });
 
+KmlItemViewModel.prototype._getValuesThatInfluenceLoad = function() {
+    return [this.url, this.data];
+};
+
 var kmzRegex = /\.kmz$/i;
 
-/**
- * Processes the KML or KMZ data supplied via the {@link KmlItemViewModel#data} property.  If
- * {@link KmlItemViewModel#data} is undefined, this method downloads KML or KMZ data from 
- * {@link KmlItemViewModel#url} and processes that.  It is safe to call this method multiple times.
- * It is called automatically when the data source is enabled.
- */
-KmlItemViewModel.prototype.load = function() {
-    if ((this.url === this._loadedUrl && this.data === this._loadedData) || this.isLoading === true) {
-        return;
-    }
-
-    this.isLoading = true;
-
+KmlItemViewModel.prototype._load = function() {
     var dataSource = new KmlDataSource();
     this._kmlDataSource = dataSource;
 
     var that = this;
-    this._loadingPromise = runLater(function() {
-        that._loadedUrl = that.url;
-        that._loadedData = that.data;
 
-        if (defined(that.data)) {
-            when(that.data, function(data) {
-                if (data instanceof Document) {
-                    dataSource.load(data, proxyUrl(that, that.dataSourceUrl)).then(function() {
+    if (defined(that.data)) {
+        return when(that.data, function(data) {
+            if (data instanceof Document) {
+                return dataSource.load(data, proxyUrl(that, that.dataSourceUrl)).then(function() {
+                    doneLoading(that);
+                }).otherwise(function() {
+                    errorLoading(that);
+                });
+            } else if (data instanceof Blob) {
+                if (that.dataSourceUrl && that.dataSourceUrl.match(kmzRegex)) {
+                    return dataSource.loadKmz(data, proxyUrl(that, that.dataSourceUrl)).then(function() {
                         doneLoading(that);
                     }).otherwise(function() {
                         errorLoading(that);
                     });
-                } else if (data instanceof Blob) {
-                    if (that.dataSourceUrl && that.dataSourceUrl.match(kmzRegex)) {
-                        dataSource.loadKmz(data, proxyUrl(that, that.dataSourceUrl)).then(function() {
+                } else {
+                    return readXml(data).then(function(xml) {
+                        return dataSource.load(xml, proxyUrl(that, that.dataSourceUrl)).then(function() {
                             doneLoading(that);
                         }).otherwise(function() {
                             errorLoading(that);
                         });
-                    } else {
-                        readXml(data).then(function(xml) {
-                            dataSource.load(xml, proxyUrl(that, that.dataSourceUrl)).then(function() {
-                                doneLoading(that);
-                            }).otherwise(function() {
-                                errorLoading(that);
-                            });
-                        });
-                    }
-                } else {
-                    that.application.error.raiseEvent(new ViewModelError({
-                        sender: that,
-                        title: 'Unexpected type of KML data',
-                        message: '\
-    KmlItemViewModel.data is expected to be an XML Document, Blob, or File, but it was none of these. \
-    This may indicate a bug in National Map or incorrect use of the National Map API. \
-    If you believe it is a bug in National Map, please report it by emailing \
-    <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.au</a>.'
-                    }));
+                    });
                 }
-            });
-        } else {
-            dataSource.loadUrl(proxyUrl(that, that.url)).then(function() {
-                doneLoading(that);
-            }).otherwise(function() {
-                errorLoading(that);
-            });
-        }
-    });
-    return this._loadingPromise;
+            } else {
+                throw new ViewModelError({
+                    sender: that,
+                    title: 'Unexpected type of KML data',
+                    message: '\
+KmlItemViewModel.data is expected to be an XML Document, Blob, or File, but it was none of these. \
+This may indicate a bug in National Map or incorrect use of the National Map API. \
+If you believe it is a bug in National Map, please report it by emailing \
+<a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.au</a>.'
+                });
+            }
+        });
+    } else {
+        return dataSource.loadUrl(proxyUrl(that, that.url)).then(function() {
+            doneLoading(that);
+        }).otherwise(function() {
+            errorLoading(that);
+        });
+    }
 };
 
 KmlItemViewModel.prototype._enable = function() {
@@ -225,24 +209,17 @@ function proxyUrl(application, url) {
 
 function doneLoading(viewModel) {
     viewModel.clock = viewModel._kmlDataSource.clock;
-    viewModel.isLoading = false;
 }
 
 function errorLoading(viewModel) {
-    viewModel.application.error.raiseEvent(new ViewModelError({
+    throw new ViewModelError({
         sender: viewModel,
         title: 'Error loading KML or KMZ',
         message: '\
 An error occurred while loading a KML or KMZ file.  This may indicate that the file is invalid or that it \
 is not supported by National Map.  If you would like assistance or further information, please email us \
 at <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.au</a>.'
-    }));
-
-    viewModel._loadedUrl = undefined;
-    viewModel._loadedData = undefined;
-    viewModel.isEnabled = false;
-    viewModel.isLoading = false;
-    viewModel._kmlDataSource = undefined;
+    });
 }
 
 module.exports = KmlItemViewModel;

--- a/src/ViewModels/WebFeatureServiceGroupViewModel.js
+++ b/src/ViewModels/WebFeatureServiceGroupViewModel.js
@@ -23,7 +23,6 @@ var CatalogGroupViewModel = require('./CatalogGroupViewModel');
 var inherit = require('../Core/inherit');
 var PopupMessage = require('../viewer/PopupMessage');
 var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
-var runLater = require('../Core/runLater');
 var unionRectangles = require('../Map/unionRectangles');
 var WebFeatureServiceItemViewModel = require('./WebFeatureServiceItemViewModel');
 

--- a/src/ViewModels/WebFeatureServiceGroupViewModel.js
+++ b/src/ViewModels/WebFeatureServiceGroupViewModel.js
@@ -39,8 +39,6 @@ var WebFeatureServiceItemViewModel = require('./WebFeatureServiceItemViewModel')
 var WebFeatureServiceGroupViewModel = function(application) {
     CatalogGroupViewModel.call(this, application, 'wfs-getCapabilities');
 
-    this._loadedUrl = undefined;
-
     /**
      * Gets or sets the URL of the WFS server.  This property is observable.
      * @type {String}
@@ -127,31 +125,15 @@ WebFeatureServiceGroupViewModel.defaultSerializers.isLoading = function(viewMode
 
 freezeObject(WebFeatureServiceGroupViewModel.defaultSerializers);
 
-/**
- * Loads the items in this group by invoking the GetCapabilities service on the WFS server.
- * Each layer in the response becomes an item in the group.  The {@link CatalogGroupViewModel#isLoading} flag will
- * be set while the load is in progress.
- */
-WebFeatureServiceGroupViewModel.prototype.load = function() {
-    if (this.url === this._loadedUrl || this.isLoading) {
-        return;
-    }
-
-    this.isLoading = true;
-
-    var that = this;
-    runLater(function() {
-        that._loadedUrl = that.url;
-        getCapabilities(that).always(function() {
-            that.isLoading = false;
-        });
-    });
+WebFeatureServiceGroupViewModel.prototype._getValuesThatInfluenceLoad = function() {
+    return [this.url];
 };
 
-function getCapabilities(viewModel) {
-    var url = cleanAndProxyUrl(viewModel.application, viewModel.url) + '?service=WFS&version=1.1.0&request=GetCapabilities';
+WebFeatureServiceGroupViewModel.prototype._load = function() {
+    var url = cleanAndProxyUrl(this.application, this.url) + '?service=WFS&version=1.1.0&request=GetCapabilities';
 
-    return when(loadXML(url), function(xml) {
+    var that = this;
+    return loadXML(url).then(function(xml) {
         var json = $.xml2json(xml);
 
         var supportsJsonGetFeature = false;
@@ -168,7 +150,7 @@ function getCapabilities(viewModel) {
             }
         }
 
-        var dataCustodian = viewModel.dataCustodian;
+        var dataCustodian = that.dataCustodian;
         if (!defined(dataCustodian) && defined(json.ServiceProvider) && defined(json.ServiceProvider.ProviderName)) {
             dataCustodian = json.ServiceProvider.ProviderName;
 
@@ -183,10 +165,10 @@ function getCapabilities(viewModel) {
         }
 
         if (defined(json.FeatureTypeList)) {
-            addFeatureTypes(viewModel, json.FeatureTypeList.FeatureType, viewModel.items, undefined, supportsJsonGetFeature, dataCustodian);
+            addFeatureTypes(that, json.FeatureTypeList.FeatureType, that.items, undefined, supportsJsonGetFeature, dataCustodian);
         }
-    }, function(e) {
-        viewModel.application.error.raiseEvent(new ViewModelError({
+    }).otherwise(function(e) {
+        throw new ViewModelError({
             title: 'Group is not available',
             message: '\
 An error occurred while invoking GetCapabilities on the WFS server.  \
@@ -200,12 +182,9 @@ National Map itself.</p>\
 <p>If you did not enter this link manually, this error may indicate that the group you opened is temporarily unavailable or there is a \
 problem with your internet connection.  Try opening the group again, and if the problem persists, please report it by \
 sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.au</a>.</p>'
-        }));
-
-        viewModel.isOpen = false;
-        viewModel._loadedUrl = undefined;
+        });
     });
-}
+};
 
 function findElementByName(list, name) {
     if (!defined(list)) {

--- a/src/ViewModels/WebFeatureServiceItemViewModel.js
+++ b/src/ViewModels/WebFeatureServiceItemViewModel.js
@@ -40,13 +40,10 @@ var gmlToGeoJson = require('../Map/gmlToGeoJson');
 var WebFeatureServiceItemViewModel = function(application) {
     CatalogItemViewModel.call(this, application);
 
-    this._metadata = undefined;
     this._dataUrl = undefined;
     this._dataUrlType = undefined;
     this._metadataUrl = undefined;
     this._geoJsonViewModel = undefined;
-    this._loadedUrl = undefined;
-    this._loadedTypeNames = undefined;
 
     /**
      * Gets or sets the URL of the WFS server.  This property is observable.
@@ -155,20 +152,6 @@ defineProperties(WebFeatureServiceItemViewModel.prototype, {
     },
 
     /**
-     * Gets the metadata associated with this data source and the server that provided it, if applicable.
-     * @memberOf WebFeatureServiceItemViewModel.prototype
-     * @type {MetadataViewModel}
-     */
-    /*metadata : {
-        get : function() {
-            if (!defined(this._metadata)) {
-                this._metadata = requestMetadata(this);
-            }
-            return this._metadata;
-        }
-    },*/
-
-    /**
      * Gets the set of functions used to update individual properties in {@link CatalogMemberViewModel#updateFromJson}.
      * When a property name in the returned object literal matches the name of a property on this instance, the value
      * will be called as a function and passed a reference to this instance, a reference to the source JSON object
@@ -214,46 +197,28 @@ WebFeatureServiceItemViewModel.defaultSerializers.metadataUrl = function(viewMod
 };
 freezeObject(WebFeatureServiceItemViewModel.defaultSerializers);
 
-/**
- * Processes the feature data supplied via the {@link GeoJsonItemViewModel#data} property.  If
- * {@link GeoJsonItemViewModel#data} is undefined, this method downloads GeoJSON data from 
- * {@link GeoJsonItemViewModel#url} and processes that.  It is safe to call this method multiple times.
- * It is called automatically when the data source is enabled.
- */
-WebFeatureServiceItemViewModel.prototype.load = function() {
-    if ((this.url === this._loadedUrl && this.typeNames === this._loadedTypeNames) || this.isLoading === true) {
+WebFeatureServiceItemViewModel.prototype._getValuesThatInfluenceLoad = function() {
+    return [this.url, this.typeNames, this.requestGeoJson, this.requestGml];
+};
+
+WebFeatureServiceItemViewModel.prototype._load = function() {
+    this._geoJsonViewModel = new GeoJsonItemViewModel(this.application);
+
+
+    var promise;
+    if (this.requestGeoJson) {
+        promise = loadGeoJson(this);
+    } else if (this.requestGml) {
+        promise = loadGml(this);
+    } else {
         return;
     }
 
-    this.isLoading = true;
-    this._geoJsonViewModel = new GeoJsonItemViewModel(this.application);
+    this._geoJsonViewModel.data = promise;
 
     var that = this;
-    runLater(function() {
-        that._loadedUrl = that.url;
-        that._loadedTypeNames = that.typeNames;
-
-        var promise;
-        if (that.requestGeoJson) {
-            promise = loadGeoJson(that);
-        } else if (that.requestGml) {
-            promise = loadGml(that);
-        } else {
-            that.isLoading = false;
-            return;
-        }
-
-        that._geoJsonViewModel.data = promise;
-
-        var subscription = knockout.getObservable(that._geoJsonViewModel, 'isLoading').subscribe(function(newValue) {
-            if (newValue === false) {
-                subscription.dispose();
-                that.rectangle = that._geoJsonViewModel.rectangle;
-                that.isLoading = false;
-            }
-        });
-
-        that._geoJsonViewModel.load();
+    return that._geoJsonViewModel.load().then(function() {
+        that.rectangle = that._geoJsonViewModel.rectangle;
     });
 };
 

--- a/src/ViewModels/WebFeatureServiceItemViewModel.js
+++ b/src/ViewModels/WebFeatureServiceItemViewModel.js
@@ -25,7 +25,6 @@ var MetadataItemViewModel = require('./MetadataItemViewModel');
 var CatalogItemViewModel = require('./CatalogItemViewModel');
 var inherit = require('../Core/inherit');
 var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
-var runLater = require('../Core/runLater');
 var gmlToGeoJson = require('../Map/gmlToGeoJson');
 
 /**

--- a/src/ViewModels/WebMapServiceGroupViewModel.js
+++ b/src/ViewModels/WebMapServiceGroupViewModel.js
@@ -24,7 +24,6 @@ var CatalogGroupViewModel = require('./CatalogGroupViewModel');
 var inherit = require('../Core/inherit');
 var PopupMessage = require('../viewer/PopupMessage');
 var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
-var runLater = require('../Core/runLater');
 var WebMapServiceItemViewModel = require('./WebMapServiceItemViewModel');
 
 /**

--- a/src/ViewModels/raiseErrorOnRejectedPromise.js
+++ b/src/ViewModels/raiseErrorOnRejectedPromise.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/*global require*/
+
+var defined = require('../../third_party/cesium/Source/Core/defined');
+
+var ViewModelError = require('./ViewModelError');
+
+var raiseErrorOnRejectedPromise = function(application, promise) {
+    if (defined(promise)) {
+        promise.otherwise(function(e) {
+            if (e instanceof ViewModelError) {
+                application.error.raiseEvent(e);
+            } else {
+                application.error.raiseEvent(new ViewModelError({
+                    sender: undefined,
+                    title: 'An unknown error occurred',
+                    message: '\
+<p>National Map experienced an unknown error.  Please report this by emailing <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.au</a>.  \
+Details of the error are below.</p>\
+<p><pre>' + e.toString() + '</pre></p>'
+                }));
+            }
+        });
+    }
+};
+
+module.exports = raiseErrorOnRejectedPromise;

--- a/src/viewer/main.js
+++ b/src/viewer/main.js
@@ -135,6 +135,8 @@ if (start) {
             var alwaysUseProxy = (FeatureDetection.isInternetExplorer() && FeatureDetection.internetExplorerVersion()[0] < 10);
             corsProxy.setProxyList(config.proxyDomains, corsDomains, alwaysUseProxy);
 
+            var promises = [];
+
             // Make another pass over the init sources to update the catalog and load services.
             for (i = 0; i < initSources.length; ++i) {
                 initSource = initSources[i];
@@ -153,10 +155,10 @@ if (start) {
                     }
 
                     try {
-                        application.catalog.updateFromJson(initSource.catalog, {
+                        promises.push(application.catalog.updateFromJson(initSource.catalog, {
                             onlyUpdateExistingItems: initSource.catalogOnlyUpdatesExistingItems,
                             isUserSupplied: isUserSupplied
-                        });
+                        }));
                     } catch(e) {
                         var message = new PopupMessage({
                             container: document.body,
@@ -171,11 +173,13 @@ if (start) {
                 }
             }
 
-            application.catalog.isLoading = false;
+            when.all(promises, function() {
+                application.catalog.isLoading = false;
 
-            var viewer = new AusGlobeViewer(application, camera);
+                var viewer = new AusGlobeViewer(application, camera);
 
-            document.getElementById('loadingIndicator').style.display = 'none';
+                document.getElementById('loadingIndicator').style.display = 'none';
+            });
         });
     });
 }


### PR DESCRIPTION
This pull request makes the `load` method of our various catalog groups and items much simpler and less error prone.  Instead of managing the `isLoading` flag and various other bits of state as they were before, items and groups now override a protected `_load` method that does nothing other than actually load.  It returns a Promise that resolves when the load is complete.

In addition to making it easier to write and understand view-model loading, this change also improves catalog item composability.  For example, it is now much more straightforward for `WebFeatureServiceItemViewModel` to aggregate `GeoJsonViewModel`.

Plus National Map is 5 lines of code shorter than before. :)
