### PR TITLE
Use Geoserver legends for Broadband items.

### DIFF
--- a/public/init_nm.json
+++ b/public/init_nm.json
@@ -41,7 +41,6 @@
                         {
                             "name": "Broadband Availability",
                             "description": "[Licence](http://creativecommons.org/licenses/by/3.0/au/)<br/>[More Info](https://www.mybroadband.communications.gov.au)",
-                            "legendUrl": "https://programs.communications.gov.au/NBNBSL/images/mybroadband/availability.png",
                             "dataCustodian": "[Department of Communications](http://www.communications.gov.au/)",
                             "rectangle": [
                                 "112.93529999999998",
@@ -59,7 +58,6 @@
                         {
                             "name": "Broadband Availabilty no Borders",
                             "description": "[Licence](http://creativecommons.org/licenses/by/3.0/au/)<br/>[More Info](https://www.mybroadband.communications.gov.au)",
-                            "legendUrl": "https://programs.communications.gov.au/NBNBSL/images/mybroadband/availability.png",
                             "dataCustodian": "[Department of Communications](http://www.communications.gov.au/)",
                             "rectangle": [
                                 "112.93529999999998",
@@ -77,7 +75,6 @@
                         {
                             "name": "Broadband Quality",
                             "description": "[Licence](http://creativecommons.org/licenses/by/3.0/au/)<br/>[More Info](https://www.mybroadband.communications.gov.au)",
-                            "legendUrl": "https://programs.communications.gov.au/NBNBSL/images/mybroadband/quality.png",
                             "dataCustodian": "[Department of Communications](http://www.communications.gov.au/)",
                             "rectangle": [
                                 "112.93529999999998",
@@ -95,7 +92,6 @@
                         {
                             "name": "Broadband ADSL Quality",
                             "description": "[Licence](http://creativecommons.org/licenses/by/3.0/au/)<br/>[More Info](https://www.mybroadband.communications.gov.au)",
-                            "legendUrl": "https://programs.communications.gov.au/NBNBSL/images/mybroadband/adsl_quality.png",
                             "dataCustodian": "[Department of Communications](http://www.communications.gov.au/)",
                             "rectangle": [
                                 "112.93529999999998",
@@ -113,7 +109,6 @@
                         {
                             "name": "Broadband ADSL Quality no Borders",
                             "description": "[Licence](http://creativecommons.org/licenses/by/3.0/au/)<br/>[More Info](https://www.mybroadband.communications.gov.au)",
-                            "legendUrl": "https://programs.communications.gov.au/NBNBSL/images/mybroadband/adsl_quality.png",
                             "dataCustodian": "[Department of Communications](http://www.communications.gov.au/)",
                             "rectangle": [
                                 "112.93529999999998",


### PR DESCRIPTION
This is a pull request into Production.

It updates the Broadband data items to use the Geoserver-generated legend instead of the direct URLs we were using before.  This is at the request of Brendan Gordon at the Department of Communications.

After this is merged into Production, I'll update the server and then merge this change into master.
