### PR TITLE
Fix state issue with viewerMode causing problems for devices without 3d

### DIFF
--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -307,6 +307,9 @@ If you\'re on a desktop or laptop, consider increasing the size of your window.'
     });
 
     this.selectViewer(this.webGlSupported);
+    if(!this.webGlSupported) {
+        this.application.viewerMode = ViewerMode.Leaflet;
+    }
 
     knockout.getObservable(this.application, 'viewerMode').subscribe(function() {
         changeViewer(this);


### PR DESCRIPTION
Viewer was switching to leaflet when device didn't support WebGL, but viewerMode was left with default value causing issues if changeViewer was called.
