### PR TITLE
handle the rendering loop stopping

### DIFF
--- a/src/Models/Cesium.js
+++ b/src/Models/Cesium.js
@@ -29,6 +29,14 @@ var Cesium = function(application, viewer) {
      */
     this.scene = viewer.scene;
 
+
+    /**
+     * Gets or sets whether the viewer has stopped rendering since startup or last set to false.
+     * @type {Scene}
+     */
+    this.stoppedRendering = false;
+
+
     this._lastClockTime = new JulianDate(0, 0.0);
     this._lastCameraViewMatrix = new Matrix4();
     this._lastCameraMoveTime = 0;
@@ -169,6 +177,7 @@ function postRender(cesium, date) {
     if (!cameraMovedInLastSecond && !tilesWaiting && !cesium.viewer.clock.shouldAnimate) {
         console.log('stopping rendering @ ' + getTimestamp());
         cesium.viewer.useDefaultRenderLoop = false;
+        cesium.stoppedRendering = true;
     }
 
     Matrix4.clone(scene.camera.viewMatrix, cesium._lastCameraViewMatrix);

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -489,29 +489,6 @@ us via email at nationalmap@lists.nicta.com.au.'
         },
         ScreenSpaceEventType.LEFT_DOUBLE_CLICK, KeyboardEventModifier.SHIFT);
 
-    //Simple monitor to start up and switch to 2D if seem to be stuck.
-     this.monitor = new FrameRateMonitor({ 
-         scene: scene, 
-         minimumFrameRateDuringWarmup: 0.5,
-         minimumFrameRateAfterWarmup: 0,
-         samplingWindow: 2
-     });
-     this.monitor.lowFrameRate.addEventListener( function() {
-         if (!defined(that.slow3DPerformanceMessageViewed)) {
-             PopupMessageViewModel.open('ui', {
-                 title : 'Unusually Slow Performance Detected',
-                 message : '\
- It appears that your system is capable of running National Map in 3D mode, but is having significant performance issues. \
- We are automatically switching to 2D mode to help resolve this issue.  If you want to switch back to 3D mode you can select \
- that option from the Maps button.'
-             });
-             that.slow3DPerformanceMessageViewed = true;
-             runLater(function() { 
-                 that.selectViewer(false); 
-             });
-         }
-     });
-
     return viewer;
 };
 
@@ -559,7 +536,10 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
             inputHandler.removeInputAction( ScreenSpaceEventType.LEFT_DOUBLE_CLICK );
             inputHandler.removeInputAction( ScreenSpaceEventType.LEFT_DOUBLE_CLICK, KeyboardEventModifier.SHIFT );
 
-            this.monitor.destroy();
+            if (defined(this.monitor)) {
+                this.monitor.destroy();
+                this.monitor = undefined;
+            }
             this.viewer.destroy();
             this.viewer = undefined;
         }
@@ -701,6 +681,32 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
         this._enableSelectExtent(true);
 
         Clock.clone(previousClock, this.viewer.clock);
+
+        //Simple monitor to start up and switch to 2D if seem to be stuck.
+        if (!defined(this.checkedStartupPerformance)) {
+            this.checkedStartupPerformance = true;
+            this.monitor = new FrameRateMonitor({ 
+                scene: this.scene, 
+                minimumFrameRateDuringWarmup: 1,
+                minimumFrameRateAfterWarmup: 0,
+                samplingWindow: 2
+            });
+            this.monitor.lowFrameRate.addEventListener( function() {
+                if (!that.application.cesium.stoppedRendering) {
+                    PopupMessageViewModel.open('ui', {
+                        title : 'Unusually Slow Performance Detected',
+                        message : '\
+        It appears that your system is capable of running National Map in 3D mode, but is having significant performance issues. \
+        We are automatically switching to 2D mode to help resolve this issue.  If you want to switch back to 3D mode you can select \
+        that option from the Maps button at the top of the screen.'
+                    });
+                    runLater(function() { 
+                        that.selectViewer(false); 
+                    });
+                }
+            });
+        }
+
     }
 
     this.application.afterViewerChanged.raiseEvent();


### PR DESCRIPTION
A fix for the performance monitor.  It now only runs the first time 3d mode is entered and checks if the rendering loop was halted which implies that everything is running fast enough.
