### PR TITLE
Perf monitor

### DIFF
--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -690,9 +690,13 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
         //Simple monitor to start up and switch to 2D if seem to be stuck.
         if (!defined(this.checkedStartupPerformance)) {
             this.checkedStartupPerformance = true;
+            var uri = new URI(window.location);
+            var params = uri.search(true);
+            var frameRate = (defined(params.fps)) ? params.fps : 5;
+
             this.monitor = new FrameRateMonitor({ 
                 scene: this.scene, 
-                minimumFrameRateDuringWarmup: 5,
+                minimumFrameRateDuringWarmup: frameRate,
                 minimumFrameRateAfterWarmup: 0,
                 samplingWindow: 2
             });

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -525,9 +525,14 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
             this.application.cesium.destroy();
 
             //get camera and timeline settings
-            rect = getCameraRect(this.scene);
-            bnds = [[CesiumMath.toDegrees(rect.south), CesiumMath.toDegrees(rect.west)],
-                [CesiumMath.toDegrees(rect.north), CesiumMath.toDegrees(rect.east)]];
+            try {
+                rect = getCameraRect(this.scene);
+                bnds = [[CesiumMath.toDegrees(rect.south), CesiumMath.toDegrees(rect.west)],
+                    [CesiumMath.toDegrees(rect.north), CesiumMath.toDegrees(rect.east)]];
+            } catch (e) {
+                console.log('Using default screen extent', e.message);
+                bnds = rectangleToLatLngBounds(this.application.initialBoundingBox);
+            }
 
             this._enableSelectExtent(false);
 
@@ -687,7 +692,7 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
             this.checkedStartupPerformance = true;
             this.monitor = new FrameRateMonitor({ 
                 scene: this.scene, 
-                minimumFrameRateDuringWarmup: 1,
+                minimumFrameRateDuringWarmup: 5,
                 minimumFrameRateAfterWarmup: 0,
                 samplingWindow: 2
             });


### PR DESCRIPTION
After testing on Jane's evil machine, some more tuning of startup performance handling.

Set default frame rate to 5 and left in a uri param option to simplify testing/tuning on other machines.
Catch the bnds on the switchover and catch if they have a problem unrolling.  If so, use default.
