### PR TITLE
data.gov.au ckan catalog

### DIFF
--- a/public/init_geelong.json
+++ b/public/init_geelong.json
@@ -6,10 +6,10 @@
         "programs.communications.gov.au"
     ],
     "camera": {
-        "west": 105,
-        "south": -45,
-        "east": 155,
-        "north": -5
+        "west": 144.3,
+        "south": -38.3,
+        "east": 144.5,
+        "north": -38.0
     },
     "services": [],
     "catalog": [

--- a/public/init_geelong.json
+++ b/public/init_geelong.json
@@ -1,0 +1,28 @@
+{
+    "corsDomains" : [
+        "data.gov.au",
+        "ga.gov.au",
+        "corsproxy.com",
+        "programs.communications.gov.au"
+    ],
+    "camera": {
+        "west": 105,
+        "south": -45,
+        "east": 155,
+        "north": -5
+    },
+    "services": [],
+    "catalog": [
+        {
+            "name": "Geelong Open Data",
+            "type": "ckan",
+            "url": "http://www.data.gov.au",
+            "filterQuery": ["fq=organization%3acity-of-greater-geelong"],
+            "filterByWmsGetCapabilities": false,
+            "minimumMaxScaleDenominator": 1e10,
+            "blacklist": {
+                "Rainforests (EVC_2005)": true
+            }
+        }
+    ]
+}

--- a/public/init_nm.json
+++ b/public/init_nm.json
@@ -2456,6 +2456,17 @@
             ]
         },
         {
+            "name": "Data.gov.au",
+            "type": "ckan",
+            "url": "http://www.data.gov.au",
+            "filterQuery": ["fq=res_format%3awms"],
+            "filterByWmsGetCapabilities": false,
+            "minimumMaxScaleDenominator": 1e10,
+            "blacklist": {
+                "Rainforests (EVC_2005)": true
+            }
+        },
+        {
             "name": "Data Providers",
             "type": "group",
             "items": [
@@ -2478,12 +2489,6 @@
                     "description": "[Licence](http://creativecommons.org/licenses/by/2.5/au/)",
                     "dataCustodian": "[Australian Bureau of Statistics](http://www.abs.gov.au/)",
                     "url": "http://geoserver-nm.nicta.com.au/admin_bnds_abs/ows",
-                    "type": "wms-getCapabilities"
-                },
-                {
-                    "name": "data.gov.au",
-                    "dataCustodian": "[data.gov.au](http://www.data.gov.au/)",
-                    "url": "http://data.gov.au/geoserver/ows",
                     "type": "wms-getCapabilities"
                 },
                 {

--- a/src/Models/CkanCatalogGroup.js
+++ b/src/Models/CkanCatalogGroup.js
@@ -391,6 +391,10 @@ function populateGroupFromResults(ckanGroup, json) {
             var params = uri.search(true);
             var layerName = params.LAYERS || params.layers || params.typeName;
 
+            if (!defined(layerName)) {
+                continue;
+            }
+
             // Remove the query portion of the WMS URL.
             uri.search('');
             var url = uri.toString();
@@ -420,12 +424,15 @@ function populateGroupFromResults(ckanGroup, json) {
 
             //if no groups then use organization
             var groups = item.groups;
-            if (!defined(groups) || groups.length === 0) {
+            if (!defined(groups) || groups.length === 0 || dataGovCkan) {
                 groups = [item.organization];
             }
             for (var groupIndex = 0; groupIndex < groups.length; ++groupIndex) {
                 var group = groups[groupIndex];
                 var groupName = group.display_name || group.title;
+                if (groupName.indexOf(',') !== -1) {
+                    groupName = groupName.substring(0, groupName.indexOf(','));
+                }
 
                 if (ckanGroup.blacklist && ckanGroup.blacklist[groupName]) {
                     continue;

--- a/src/Models/CkanCatalogGroup.js
+++ b/src/Models/CkanCatalogGroup.js
@@ -222,6 +222,7 @@ sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@
 // The "format" field of CKAN resources must match this regular expression to be considered a WMS resource.
 var wmsFormatRegex = /^wms$/i;
 var esriRestFormatRegex = /^esri rest$/i;
+var jsonFormatRegex = /^JSON$/i;
 
 function filterResultsByGetCapabilities(ckanGroup, json) {
     var wmsServers = {};
@@ -359,12 +360,22 @@ function populateGroupFromResults(ckanGroup, json) {
             }
         }
 
+        var dataGovCkan = (ckanGroup.url === 'http://www.data.gov.au');  //data.gov.au hack
+
         // Currently, we support WMS and Esri REST layers.
         var resources = item.resources;
         for (var resourceIndex = 0; resourceIndex < resources.length; ++resourceIndex) {
             var resource = resources[resourceIndex];
-            if (resource.__filtered || (!resource.format.match(wmsFormatRegex) && !resource.format.match(esriRestFormatRegex))) {
-                continue;
+                //TODO: make the resource types a parameter in the init file
+            if (dataGovCkan) {
+                if (resource.__filtered || (!resource.format.match(jsonFormatRegex))) {
+                    continue;
+                }
+            }
+            else {
+                if (resource.__filtered || (!resource.format.match(wmsFormatRegex) && !resource.format.match(esriRestFormatRegex))) {
+                    continue;
+                }
             }
 
             var wmsUrl = resource.wms_url;
@@ -375,14 +386,15 @@ function populateGroupFromResults(ckanGroup, json) {
                 }
             }
 
-            // Extract the layer name from the WMS URL.
+            // Extract the layer name from the URL.
             var uri = new URI(wmsUrl);
             var params = uri.search(true);
-            var layerName = params.LAYERS || params.layers;
+            var layerName = params.LAYERS || params.layers || params.typeName;
 
             // Remove the query portion of the WMS URL.
             uri.search('');
             var url = uri.toString();
+            url = url.replace('wfs', 'wms');  //data.gov.au hack
 
             var newItem;
             if (resource.format.match(esriRestFormatRegex)) {
@@ -406,18 +418,23 @@ function populateGroupFromResults(ckanGroup, json) {
                 newItem.dataCustodian = item.organization.description || item.organization.title;
             }
 
+            //if no groups then use organization
             var groups = item.groups;
+            if (!defined(groups) || groups.length === 0) {
+                groups = [item.organization];
+            }
             for (var groupIndex = 0; groupIndex < groups.length; ++groupIndex) {
                 var group = groups[groupIndex];
+                var groupName = group.display_name || group.title;
 
-                if (ckanGroup.blacklist && ckanGroup.blacklist[group.display_name]) {
+                if (ckanGroup.blacklist && ckanGroup.blacklist[groupName]) {
                     continue;
                 }
 
-                var existingGroup = ckanGroup.findFirstItemByName(group.display_name);
+                var existingGroup = ckanGroup.findFirstItemByName(groupName);
                 if (!defined(existingGroup)) {
                     existingGroup = new CatalogGroup(ckanGroup.application);
-                    existingGroup.name = group.display_name;
+                    existingGroup.name = groupName;
                     ckanGroup.add(existingGroup);
                 }
 


### PR DESCRIPTION
This uses ckan to create the catalog for data.gov.au.  Like vic ckan it's rather specific to the limitations of how they've implemented their server so this will change as they change things.  It also does not pull all the items available on the data.gov.au wms server since the ckan records do not all contain the layer name in the JSON resource (where we look since none of the wms or wfs records have the layer name). 

So a starting point for this, but still worth having live for better organization/metadata and to hopefully spur on improvements in the data records.

It also updates the extent when the wms layer is turned on by automatically doing the metadata call.  I think the auto update is good, and don't see any downside to automatically doing the getFeatureInfo call.  If that is OK, then we may be able to use the getFeatureInfo for all wms extents and get rid of rectangle in the init file for wms items.
