### PR TITLE
fix population/nexis server

### DIFF
--- a/public/init_nm.json
+++ b/public/init_nm.json
@@ -1185,8 +1185,8 @@
                                 "-11.05104999964455"
                             ],
                             "type": "wms",
-                            "url": "http://www.ga.gov.au/gis/services/hazards/NEXIS_2012_WMS/MapServer/WMSServer",
-                            "layers": "7",
+                            "url": "http://www.ga.gov.au/gis/services/hazards/NEXIS_National_Exposure_Information_System_Population_Density_Exposure/MapServer/WMSServer",
+                            "layers": "0,1,2,3,4",
                             "getFeatureInfoAsGeoJson": false
                         },
                         {
@@ -2484,13 +2484,6 @@
                     "name": "data.gov.au",
                     "dataCustodian": "[data.gov.au](http://www.data.gov.au/)",
                     "url": "http://data.gov.au/geoserver/ows",
-                    "type": "wms-getCapabilities"
-                },
-                {
-                    "name": "National Exposure Information System 2012",
-                    "description": "[Licence](http://www.ga.gov.au/copyright)",
-                    "dataCustodian": "[Geoscience Australia](http://www.ga.gov.au/)",
-                    "url": "http://www.ga.gov.au/gis/services/hazards/NEXIS_2012_WMS/MapServer/WMSServer",
                     "type": "wms-getCapabilities"
                 }
             ]


### PR DESCRIPTION
Fixes #472 

The single nexis wms server is gone and has been replaced with several esri rest servers and the occasional wms server at http://www.ga.gov.au/gis/rest/services/hazards
- I fixed population under Social and Economic as well as I could and earthquake was fixed a while ago
- I removed the nexis wms provider since it no longer exists.
- Of the remaining nexis data sets
  - We have a newer catchments one from data.gov.au
  - Agricultural commodities and buildings require esri featureInfo and more esri map selection support to be usable
