### PR TITLE
Tools panel

### DIFF
--- a/src/Models/Application.js
+++ b/src/Models/Application.js
@@ -242,6 +242,7 @@ Application.prototype.addInitSource = function(initSource) {
 };
 
 var initSourceNameRegex = /\b(\w+)\b/i;
+var reservedProperties = ['tools'];
 
 function interpretHash(hashProperties, userProperties, persistentInitSources, temporaryInitSources) {
     for (var property in hashProperties) {
@@ -274,9 +275,11 @@ function interpretHash(hashProperties, userProperties, persistentInitSources, te
                 knockout.track(userProperties, [property]);
             } else {
                 var name = initSourceNameRegex.exec(property);
-                var initSourceFile = 'init_' + name[0] + '.json';
-                persistentInitSources.push(initSourceFile);
-                temporaryInitSources.push(initSourceFile);
+                if (reservedProperties.indexOf(name[0]) === -1) {
+                    var initSourceFile = 'init_' + name[0] + '.json';
+                    persistentInitSources.push(initSourceFile);
+                    temporaryInitSources.push(initSourceFile);
+                }
             }
         }
     }

--- a/src/Models/Application.js
+++ b/src/Models/Application.js
@@ -186,7 +186,7 @@ Application.prototype.updateApplicationUrl = function(newUrl) {
     var hashProperties = queryToObject(hash);
 
     var initSources = this.initSources.slice();
-    interpretHash(hashProperties, this.userProperties, this.initSources, initSources);
+    interpretHash(hashProperties, this.userProperties, this.initSources, initSources, this.reservedProperties);
 
     return loadInitSources(this, initSources);
 };
@@ -242,9 +242,8 @@ Application.prototype.addInitSource = function(initSource) {
 };
 
 var initSourceNameRegex = /\b(\w+)\b/i;
-var reservedProperties = ['tools'];
 
-function interpretHash(hashProperties, userProperties, persistentInitSources, temporaryInitSources) {
+function interpretHash(hashProperties, userProperties, persistentInitSources, temporaryInitSources, reservedProperties) {
     for (var property in hashProperties) {
         if (hashProperties.hasOwnProperty(property)) {
             var propertyValue = hashProperties[property];

--- a/src/Models/Application.js
+++ b/src/Models/Application.js
@@ -186,7 +186,7 @@ Application.prototype.updateApplicationUrl = function(newUrl) {
     var hashProperties = queryToObject(hash);
 
     var initSources = this.initSources.slice();
-    interpretHash(hashProperties, this.userProperties, this.initSources, initSources, this.reservedProperties);
+    interpretHash(hashProperties, this.userProperties, this.initSources, initSources);
 
     return loadInitSources(this, initSources);
 };
@@ -243,7 +243,7 @@ Application.prototype.addInitSource = function(initSource) {
 
 var initSourceNameRegex = /\b(\w+)\b/i;
 
-function interpretHash(hashProperties, userProperties, persistentInitSources, temporaryInitSources, reservedProperties) {
+function interpretHash(hashProperties, userProperties, persistentInitSources, temporaryInitSources) {
     for (var property in hashProperties) {
         if (hashProperties.hasOwnProperty(property)) {
             var propertyValue = hashProperties[property];
@@ -274,11 +274,9 @@ function interpretHash(hashProperties, userProperties, persistentInitSources, te
                 knockout.track(userProperties, [property]);
             } else {
                 var name = initSourceNameRegex.exec(property);
-                if (reservedProperties.indexOf(name[0]) === -1) {
-                    var initSourceFile = 'init_' + name[0] + '.json';
-                    persistentInitSources.push(initSourceFile);
-                    temporaryInitSources.push(initSourceFile);
-                }
+                var initSourceFile = 'init_' + name[0] + '.json';
+                persistentInitSources.push(initSourceFile);
+                temporaryInitSources.push(initSourceFile);
             }
         }
     }

--- a/src/Styles/ToolsPanel.less
+++ b/src/Styles/ToolsPanel.less
@@ -1,0 +1,157 @@
+@tools-panel-height: 470px;
+
+.tools-panel {
+    .modal;
+    width: 500px;
+    height: @tools-panel-height;
+    font-size: 0.9em;
+}
+
+.tools-header {
+    line-height: 40px;
+    border-bottom: @panel-element-border;
+    background-color: rgba(0,0,0,0.2);
+}
+
+.tools-header h1 {
+    color: @panel-emphasized-text-color;
+    padding-left: 15px;
+    margin: 0;
+}
+
+.tools-close-button {
+    position: absolute;
+    right: 15px;
+    cursor: pointer;
+    font-size: 18pt;
+    color: @panel-emphasized-text-color;
+}
+
+.tools-content {
+    font-weight: lighter;
+    margin-left: 15px;
+    margin-right: 15px;
+    margin-bottom: 15px;
+    overflow: auto;
+    height: @tools-panel-height - 40px - 30px;
+    line-height: 1.2em;
+}
+
+.tools-content p {
+    padding-right: 15px;
+    margin-top: 16px;
+    margin-bottom: 16px;
+}
+
+.tools-content h2 {
+    font-weight: bold;
+    padding-top: 10px;
+    padding-bottom: 5px;
+}
+
+.tools-select-file-button {
+    font-weight: bold;
+    cursor: pointer;
+    color: @highlight-color;
+}
+
+.tools-select-file-button:hover {
+    text-decoration: underline;
+}
+
+.tools-url-input-outer-holder {
+    position: relative;
+    width: 50%;
+    height: 30px;
+    background-color: @panel-form-input-background-color;
+    margin-top: 5px;
+}
+
+@tools-url-input-padding: 16px;
+@tools-url-input-border: 0px;
+
+.tools-url-input-inner-holder {
+    position: absolute;
+    height: 30px;
+    background-color: @panel-form-input-background-color;
+    left: @tools-url-input-padding * 2 + @tools-url-input-border + @tools-url-input-border;
+    right: 100px;
+    top: 0;
+    bottom: 0;
+}
+
+.tools-url-input {
+    padding-left: @tools-url-input-padding;
+    padding-right: @tools-url-input-padding;
+    border: @tools-url-input-border;
+    width: 100%;
+    height: 28px;
+    background-color: @panel-form-input-background-color;
+    color: @panel-form-input-text-color;
+    line-height: 28px;
+    margin-left: -(@tools-url-input-padding * 2 + @tools-url-input-border + @tools-url-input-border);
+}
+
+.tools-url-input::-webkit-input-placeholder {
+    color: @panel-form-input-text-color;
+    font-style: italic;
+}
+
+.tools-url-input:-moz-placeholder {
+    color: @panel-form-input-text-color;
+    opacity: 1;
+    font-style: italic;
+}
+
+.tools-url-input::-moz-placeholder {
+    color: @panel-form-input-text-color;
+    opacity: 1;
+    font-style: italic;
+}
+
+.tools-url-input:-ms-input-placeholder {
+    color: @panel-form-input-text-color;
+    font-style: italic;
+}
+
+p.tools-content-new-section {
+    margin-top: 32px;
+}
+
+.tools-content-type {
+}
+
+.tools-content-type-select {
+    display: block;
+    background-color: @panel-form-input-background-color;
+    color: @panel-form-input-text-color;
+    height: 30px;
+    border: 0;
+    margin-top: 5px;
+}
+
+.tools-url-add-button {
+    position: absolute;
+    background-color: @panel-form-button-background-color;
+    border: 0;
+    height: 30px;
+    width: 100px;
+    color: @panel-form-button-text-color;
+    right: 0;
+    top: 0;
+    bottom: 0;
+}
+
+.tools-or {
+    padding-left: 100px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+.tools-tip {
+    padding-top: 20px;
+}
+
+.tools-tip strong {
+    font-weight: bold;
+}

--- a/src/Styles/ToolsPanel.less
+++ b/src/Styles/ToolsPanel.less
@@ -1,4 +1,4 @@
-@tools-panel-height: 470px;
+@tools-panel-height: 500px;
 
 .tools-panel {
     .modal;
@@ -61,10 +61,11 @@
 
 .tools-url-input-outer-holder {
     position: relative;
-    width: 50%;
+    width: 80%;
     height: 30px;
     background-color: @panel-form-input-background-color;
     margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 @tools-url-input-padding: 16px;
@@ -128,6 +129,7 @@ p.tools-content-new-section {
     height: 30px;
     border: 0;
     margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 .tools-url-add-button {
@@ -135,7 +137,7 @@ p.tools-content-new-section {
     background-color: @panel-form-button-background-color;
     border: 0;
     height: 30px;
-    width: 100px;
+    width: 120px;
     color: @panel-form-button-text-color;
     right: 0;
     top: 0;

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -1,0 +1,438 @@
+'use strict';
+
+/*global require,ga*/
+var loadView = require('../Core/loadView');
+var ModelError = require('../Models/ModelError');
+var defined = require('../../third_party/cesium/Source/Core/defined');
+var DeveloperError = require('../../third_party/cesium/Source/Core/DeveloperError');
+var knockout = require('../../third_party/cesium/Source/ThirdParty/knockout');
+var when = require('../../third_party/cesium/Source/ThirdParty/when');
+
+var loadImage = require('../../third_party/cesium/Source/Core/loadImage');
+var loadWithXhr = require('../../third_party/cesium/Source/Core/loadWithXhr');
+var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
+var throttleRequestByServer = require('../../third_party/cesium/Source/Core/throttleRequestByServer');
+var TileMapServiceImageryProvider = require('../../third_party/cesium/Source/Scene/TileMapServiceImageryProvider');
+var WebMercatorTilingScheme = require('../../third_party/cesium/Source/Core/WebMercatorTilingScheme');
+var CatalogGroup = require('../Models/CatalogGroup');
+
+
+var ToolsPanelViewModel = function(options) {
+    if (!defined(options) || !defined(options.application)) {
+        throw new DeveloperError('options.application is required.');
+    }
+
+    this.application = options.application;
+
+    this._domNodes = undefined;
+
+    this.url = '';
+    this.cacheLevels = 3;
+    this.catalogFilter = 'opened';
+
+    knockout.track(this, ['url', 'dataType']);
+};
+
+ToolsPanelViewModel.prototype.show = function(container) {
+    this._domNodes = loadView(require('fs').readFileSync(__dirname + '/../Views/ToolsPanel.html', 'utf8'), container, this);
+};
+
+ToolsPanelViewModel.prototype.close = function() {
+    for (var i = 0; i < this._domNodes.length; ++i) {
+        var node = this._domNodes[i];
+        if (defined(node.parentElement)) {
+            node.parentElement.removeChild(node);
+        }
+    }
+};
+
+ToolsPanelViewModel.prototype.closeIfClickOnBackground = function(viewModel, e) {
+    if (e.target.className === 'modal-background') {
+        this.close();
+    }
+    return true;
+};
+
+ToolsPanelViewModel.prototype.cacheTiles = function() {
+    var that = this;
+
+    var requests = [];
+    getAllRequests(['wms'], this.catalogFilter, requests, this.application.catalog.group);
+    console.log('Requesting tiles from ' + requests.length + ' data sources.');
+    requestTiles(requests, this.cacheLevels);
+};
+
+ToolsPanelViewModel.prototype.exportFile = function() {
+    var that = this;
+
+    console.log('Export to File');
+
+};
+
+ToolsPanelViewModel.prototype.exportCkan = function() {
+    var that = this;
+
+    var ckanUrl = 'http://localhost';
+    var apiKey = 'xxxxxxxxx';
+
+    var requests = [];
+    getAllRequests(['wms', 'esri-mapService'], this.catalogFilter, requests, this.application.catalog.group);
+    console.log('Exporting metadata from ' + requests.length + ' data sources.');
+    populateCkan(requests, ckanUrl, apiKey);
+};
+
+ToolsPanelViewModel.open = function(container, options) {
+    var viewModel = new ToolsPanelViewModel(options);
+    viewModel.show(container);
+    return viewModel;
+};
+
+
+
+function getAllRequests(types, mode, requests, group) {
+    for (var i = 0; i < group.items.length; ++i) {
+        var item = group.items[i];
+        if (item instanceof CatalogGroup) {
+            if (item.isOpen) {
+                getAllRequests(types, mode, requests, item);
+            }
+        } else if ((types.indexOf(item.type) !== -1) && (mode === 'opened' || item.isEnabled)) {
+            requests.push({
+                item : item,
+                group : group.name
+            });
+        }
+    }
+}
+
+function requestTiles(requests, maxLevel) {
+    var urls = [];
+    var names = [];
+    var name;
+
+    loadImage.createImage = function(url, crossOrigin, deferred) {
+        urls.push(url);
+        names.push(name);
+        if (defined(deferred)) {
+            deferred.resolve();
+        }
+    };
+
+    var oldMax = throttleRequestByServer.maximumRequestsPerServer;
+    throttleRequestByServer.maximumRequestsPerServer = Number.MAX_VALUE;
+
+    var i;
+    for (i = 0; i < requests.length; ++i) {
+        var request = requests[i];
+        var extent = request.item.rectangle;
+        name = request.item.name;
+
+        var enabledHere = false;
+         if (!request.item.isEnabled) {
+            request.item._enable();
+            enabledHere = true;
+         }
+
+        var tilingScheme;
+        var leafletViewer = false; //that._viewer.isCesium();
+        if (leafletViewer) {
+            request.provider = request.item._imageryLayer;
+            tilingScheme = new WebMercatorTilingScheme();
+            that._viewer.map.addLayer(request.provider);
+        }
+        else {
+            request.provider = request.item._imageryLayer.imageryProvider;
+            tilingScheme = request.provider.tilingScheme;
+        }
+
+        for (var level = 0; level <= maxLevel; ++level) {
+            var nw = tilingScheme.positionToTileXY(Rectangle.northwest(extent), level);
+            var se = tilingScheme.positionToTileXY(Rectangle.southeast(extent), level);
+            if (!defined(nw) || !defined(se)) {
+                // Extent is probably junk.
+                continue;
+            }
+
+            for (var y = nw.y; y <= se.y; ++y) {
+                for (var x = nw.x; x <= se.x; ++x) {
+                    if (leafletViewer) {
+                        var coords = new L.Point(x, y);
+                        coords.z = level;
+                        var url = request.provider.getTileUrl(coords);
+                        loadImage.createImage(url);
+                    }
+                    else {
+                        if (!defined(request.provider.requestImage(x, y, level))) {
+                            console.log('too many requests in flight');
+                        }
+                    }
+                }
+            }
+        }
+        if (enabledHere) {
+            if (leafletViewer) {
+               that._viewer.map.removeLayer(request.provider);
+            }
+            request.item._disable();
+        }
+    }
+
+    loadImage.createImage = loadImage.defaultCreateImage;
+    throttleRequestByServer.maximumRequestsPerServer = oldMax;
+
+    console.log('Caching ' + urls.length + ' URLs');
+
+    var maxRequests = 2;
+    var nextRequestIndex = 0;
+    var inFlight = 0;
+    var urlsRequested = 0;
+
+    function doneUrl() {
+        --inFlight;
+        doNext();
+    }
+
+    function getNextUrl() {
+        var url;
+
+        if (nextRequestIndex >= urls.length) {
+            return undefined;
+        }
+
+        if ((nextRequestIndex % 10) === 0) {
+            console.log('Finished ' + nextRequestIndex + ' URLs.');
+        }
+
+        url = urls[nextRequestIndex];
+        name = names[nextRequestIndex]; //track for error reporting
+        ++nextRequestIndex;
+
+        return {
+            url: url,
+            name: name
+        };
+    }
+
+    function doNext() {
+        var next = getNextUrl();
+        if (!defined(next)) {
+            if (inFlight === 0) {
+                console.log('Finished ' + nextRequestIndex + ' URLs.  DONE!');
+                console.log('Actual number of URLs requested: ' + urlsRequested);
+            }
+            return;
+        }
+
+        ++urlsRequested;
+        ++inFlight;
+
+        loadWithXhr({
+            url : next.url
+        }).then(doneUrl).otherwise(function() {
+            console.log('Returned an error while working on layer: ' + next.name);
+            doneUrl();
+        });
+    }
+
+    for (i = 0; i < maxRequests; ++i) {
+        doNext();
+    }
+}
+
+
+function postToCkan(url, dataObj, func, apiKey) {
+    return loadWithXhr({
+        url : url,
+        method : "POST",
+        data : JSON.stringify(dataObj),
+        headers : {'Authorization' : apiKey},
+        responseType : 'json'
+    }).then(function(result) {
+        func(result);
+    }).otherwise(function() {
+        console.log('Returned an error while working on url', url);
+    });
+}
+
+function getCkanName(name) {
+    var ckanName = name.toLowerCase().replace(/\W/g,'-');
+    return ckanName;
+}
+
+function getCkanRect(rect) {
+    return CesiumMath.toDegrees(rect.west).toFixed(4) + ',' +
+        CesiumMath.toDegrees(rect.south).toFixed(4) + ',' +
+        CesiumMath.toDegrees(rect.east).toFixed(4) + ',' +
+        CesiumMath.toDegrees(rect.north).toFixed(4);
+}
+
+function cleanUrl(url) {
+    var uri = new URI(url);
+    uri.search('');
+    return uri.toString();
+}
+
+function populateCkan(requests, server, apiKey) {
+
+    var groups = [];
+    var orgs = [];
+    var orgsCkan = [];
+    var groupsCkan = [];
+    var packagesCkan = [];
+
+    var ckanServer = server; //get from entry field in ui (maxLevels)
+    var ckanApiKey = apiKey; //get from url - #populate-cache=xxxxxxxxx
+
+    for (var i = 0; i < requests.length; ++i) {
+        var gname = getCkanName(requests[i].group);
+        if (groups[gname] === undefined) {
+            groups[gname] = { title: requests[i].group };
+        }
+        var orgTitle = requests[i].item.dataCustodian;
+        var links = orgTitle.match(/[^[\]]+(?=])/g);
+        if (links.length > 0) {
+            orgTitle = links[0];  //use first link text as title
+        }
+        requests[i].owner_org = orgTitle;
+        var oname = getCkanName(orgTitle);
+        if (orgs[oname] === undefined) {
+            orgs[oname] = { title: orgTitle, description: requests[i].item.dataCustodian };
+        }
+    }
+
+    var promises = [];
+    promises[0] = postToCkan(
+        ckanServer + '/api/3/action/organization_list', 
+        {}, 
+        function(results) { orgsCkan = results.result; },
+        ckanApiKey
+    );
+    promises[1] = postToCkan(
+        ckanServer + '/api/3/action/group_list', 
+        {}, 
+        function(results) { groupsCkan = results.result; },
+        ckanApiKey
+    );
+    promises[2] = postToCkan(
+        ckanServer + '/api/3/action/package_list', 
+        {}, 
+        function(results) { packagesCkan = results.result; },
+        ckanApiKey
+    );
+
+    when.all(promises).then(function() {
+        var ckanRequests = [], ckanName, i, j, found;
+        for (ckanName in groups) {
+            if (groups.hasOwnProperty(ckanName)) {
+                found = false;
+                for (j = 0; j < groupsCkan.length; j++) {
+                    if (ckanName === groupsCkan[j]) {
+                        found = true;
+                        break;
+                    }
+                }
+                ckanRequests.push( {
+                    "url": ckanServer + '/api/3/action/group_' + (found ? 'update' : 'create'),
+                    "data" : {"name": ckanName, "title": groups[ckanName].title, "id": (found ? ckanName : '')}
+                });
+            }
+        }
+        for (ckanName in orgs) {
+            if (orgs.hasOwnProperty(ckanName)) {
+                found = false;
+                for (j = 0; j < orgsCkan.length; j++) {
+                    if (ckanName === orgsCkan[j]) {
+                        found = true;
+                        break;
+                    }
+                }
+                ckanRequests.push({
+                    "url": ckanServer + '/api/3/action/organization_' + (found ? 'update' : 'create'),
+                    "data" : {"name": ckanName, "title": orgs[ckanName].title, 
+                            "description": orgs[ckanName].description, "id": (found ? ckanName : '')}
+                });
+            }
+        }
+        for (i = 0; i < requests.length; i++) {
+            found = false;
+            for (j = 0; j < packagesCkan.length; j++) {
+                if (getCkanName(requests[i].item.name) === packagesCkan[j]) {
+                    found = true;
+                    break;
+                }
+            }
+            var bboxString = getCkanRect(requests[i].item.rectangle);
+            var extrasList = [ { "key": "geo_coverage", "value":  bboxString} ];
+            if (defined(requests[i].item.dataUrlType) && requests[i].item.dataUrlType !== 'wfs') {
+                extrasList.push({ "key": "data_url_type", "value":  requests[i].item.dataUrlType});
+            }
+            if (defined(requests[i].item.dataUrl)) {
+                var dataUrl = "";
+                if (requests[i].item.dataUrlType === 'wfs') {
+                    var baseUrl = cleanUrl(requests[i].item.dataUrl);
+                    if ((baseUrl !== requests[i].item.url)) {
+                        dataUrl = baseUrl;
+                    }
+                } else if (requests[i].item.dataUrlType !== 'none') {
+                    dataUrl = requests[i].item.dataUrl;
+                }
+                if (dataUrl !== "") {
+                    extrasList.push({ "key": "data_url", "value":  dataUrl});
+                }
+            }
+            var resource;
+            if (requests[i].item.type === 'wms') {
+                var wmsString = "?service=WMS&version=1.1.1&request=GetMap&width=256&height=256&format=image/png";
+                resource = {
+                    "wms_layer": requests[i].item.layers, 
+                    "wms_api_url": requests[i].item.url, 
+                    "url": requests[i].item.url+wmsString+'&layers='+requests[i].item.layers+'&bbox='+bboxString, 
+                    "format": "WMS", 
+                    "name": "WMS link",
+                };
+            } else if (requests[i].item.type === 'esri-mapService') {
+                resource = {
+                    "url": requests[i].item.url, 
+                    "format": "Esri REST", 
+                    "name": "ESRI REST link"
+                };
+            }
+            ckanRequests.push({
+                "url": ckanServer + '/api/3/action/package_' + (found ? 'update' : 'create'),
+                "data" : {
+                    "name": getCkanName(requests[i].item.name), 
+                    "title": requests[i].item.name, 
+                    "license_id": "cc-by", 
+                    "notes": requests[i].item.description, 
+                    "owner_org": getCkanName(requests[i].owner_org),
+                    "groups": [ { "name": getCkanName(requests[i].group) } ],
+                    "extras": extrasList,
+                    "resources": [ resource ]
+                }
+            });
+        }
+
+        var currentIndex = 0;
+        console.log('Starting ckan tasks:', ckanRequests.length);
+        var sendNext = function() {
+            if (currentIndex < ckanRequests.length) {
+                postToCkan(
+                    ckanRequests[currentIndex].url, 
+                    ckanRequests[currentIndex].data, 
+                    function() { 
+                        currentIndex++;
+                        if ((currentIndex % 5) === 0 || currentIndex === ckanRequests.length) {
+                            console.log('Completed', currentIndex, 'ckan tasks out of', ckanRequests.length);
+                        }
+                        sendNext(); 
+                    },
+                    ckanApiKey
+                );
+            }
+        };
+        sendNext();
+    });
+};
+
+
+module.exports = ToolsPanelViewModel;

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -87,7 +87,7 @@ ToolsPanelViewModel.prototype.exportCkan = function() {
     var requests = [];
     getAllRequests(['wms', 'esri-mapService'], this.ckanFilter, requests, this.application.catalog.group);
     console.log('Exporting metadata from ' + requests.length + ' data sources.');
-    populateCkan(requests, ckanUrl, apiKey);
+    populateCkan(requests, this.ckanUrl, this.ckanApiKey);
 };
 
 
@@ -102,10 +102,10 @@ function getAllRequests(types, mode, requests, group) {
     for (var i = 0; i < group.items.length; ++i) {
         var item = group.items[i];
         if (item instanceof CatalogGroup) {
-            if (item.isOpen) {
+            if (item.isOpen || mode === 'all') {
                 getAllRequests(types, mode, requests, item);
             }
-        } else if ((types.indexOf(item.type) !== -1) && (mode === 'opened' || item.isEnabled)) {
+        } else if ((types.indexOf(item.type) !== -1) && (mode !== 'enabled' || item.isEnabled)) {
             requests.push({
                 item : item,
                 group : group.name
@@ -427,10 +427,6 @@ function populateCkan(requests, server, apiKey) {
                 }
             });
         }
-
-        console.log(ckanRequests);
-
-        return;
 
         var currentIndex = 0;
         console.log('Starting ckan tasks:', ckanRequests.length);

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -28,12 +28,13 @@ var ToolsPanelViewModel = function(options) {
 
     this._domNodes = undefined;
 
+    this.cacheFilter = 'opened';
     this.cacheLevels = 3;
-    this.catalogFilter = 'opened';
+    this.ckanFilter = 'opened';
     this.ckanUrl = 'http://localhost';
-    this.ckanApiKey = '';
+    this.ckanApiKey = 'xxxxxxxxxxxxxxx';
 
-    knockout.track(this, ['catalogFilter', 'cacheLevels', 'ckanUrl', 'ckanApiKey']);
+    knockout.track(this, ['cacheFilter', 'cacheLevels', 'ckanFilter', 'ckanUrl', 'ckanApiKey']);
 };
 
 ToolsPanelViewModel.prototype.show = function(container) {
@@ -58,7 +59,7 @@ ToolsPanelViewModel.prototype.closeIfClickOnBackground = function(viewModel, e) 
 
 ToolsPanelViewModel.prototype.cacheTiles = function() {
     var requests = [];
-    getAllRequests(['wms'], this.catalogFilter, requests, this.application.catalog.group);
+    getAllRequests(['wms'], this.cacheFilter, requests, this.application.catalog.group);
     console.log('Requesting tiles from ' + requests.length + ' data sources.');
     requestTiles(this.application, requests, this.cacheLevels);
 };
@@ -84,7 +85,7 @@ ToolsPanelViewModel.prototype.exportCkan = function() {
     var apiKey = 'xxxxxxxxx';
 
     var requests = [];
-    getAllRequests(['wms', 'esri-mapService'], this.catalogFilter, requests, this.application.catalog.group);
+    getAllRequests(['wms', 'esri-mapService'], this.ckanFilter, requests, this.application.catalog.group);
     console.log('Exporting metadata from ' + requests.length + ' data sources.');
     populateCkan(requests, ckanUrl, apiKey);
 };

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -1,8 +1,7 @@
 'use strict';
 
-/*global require,ga*/
+/*global require,L,URI*/
 var loadView = require('../Core/loadView');
-var ModelError = require('../Models/ModelError');
 var defined = require('../../third_party/cesium/Source/Core/defined');
 var DeveloperError = require('../../third_party/cesium/Source/Core/DeveloperError');
 var knockout = require('../../third_party/cesium/Source/ThirdParty/knockout');
@@ -14,7 +13,6 @@ var loadWithXhr = require('../../third_party/cesium/Source/Core/loadWithXhr');
 var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
 var CesiumMath = require('../../third_party/cesium/Source/Core/Math');
 var throttleRequestByServer = require('../../third_party/cesium/Source/Core/throttleRequestByServer');
-var TileMapServiceImageryProvider = require('../../third_party/cesium/Source/Scene/TileMapServiceImageryProvider');
 var WebMercatorTilingScheme = require('../../third_party/cesium/Source/Core/WebMercatorTilingScheme');
 var CatalogGroup = require('../Models/CatalogGroup');
 
@@ -79,11 +77,6 @@ ToolsPanelViewModel.prototype.exportFile = function() {
 };
 
 ToolsPanelViewModel.prototype.exportCkan = function() {
-    var that = this;
-
-    var ckanUrl = 'http://localhost';
-    var apiKey = 'xxxxxxxxx';
-
     var requests = [];
     getAllRequests(['wms', 'esri-mapService'], this.ckanFilter, requests, this.application.catalog.group);
     console.log('Exporting metadata from ' + requests.length + ' data sources.');
@@ -448,7 +441,7 @@ function populateCkan(requests, server, apiKey) {
         };
         sendNext();
     });
-};
+}
 
 
 module.exports = ToolsPanelViewModel;

--- a/src/Views/MenuBar.html
+++ b/src/Views/MenuBar.html
@@ -1,4 +1,5 @@
 <div class="menu-bar" data-bind="foreach: items">
+    <!-- ko if: visible -->
     <!-- ko if: href -->
     <a class="menu-bar-item" data-bind="attr: { href: href, title: tooltip }" target="_blank">
         <!-- ko if: image -->
@@ -19,5 +20,6 @@
         <div class="menu-bar-item-label" data-bind="text: label"></div>
         <!-- /ko -->
     </div>
+    <!-- /ko -->
     <!-- /ko -->
 </div>

--- a/src/Views/ToolsPanel.html
+++ b/src/Views/ToolsPanel.html
@@ -1,0 +1,61 @@
+<div class="modal-background" data-bind="click: closeIfClickOnBackground">
+    <div class="tools-panel">
+        <div class="tools-header">
+            <div class="tools-close-button" data-bind="click: close">&times;</div>
+            <h1>Advanced Tools</h1>
+        </div>
+        <div class="tools-content">
+            <p>
+                This panel provides advanced tools for National Map
+            </p>
+            <form class="tools-form" data-bind="submit: cacheTiles">
+                <h2>Tile Caching</h2>
+                <label class="tools-content-type">
+                    Select the dataset layers to cache:
+                    <select class="tools-content-type-select" data-bind="value: catalogFilter">
+                        <option value="opened">Opened</option>
+                        <option value="seleteced">Selected</option>
+                        <option value="all">All</option>
+                    </select>
+                </label>
+
+                <p>
+                    Enter the number of tile levels to cache
+                </p>
+                <div class="tools-url-input-outer-holder">
+                    <div class="tools-url-input-inner-holder">
+                        <input class="tools-url-input" type="text" data-bind="value: cacheLevels" />
+                    </div>
+                    <input class="tools-url-add-button" type="submit" value="Cache Tiles" />
+                </div>
+            </form>
+            <form class="tools-form" data-bind="submit: exportCkan">
+                <h2>Export Data Menu</h2>
+                <label class="tools-content-type">
+                    Select the dataset layers to export:
+                    <select class="tools-content-type-select" data-bind="value: dataType">
+                        <option value="opened">Opened</option>
+                        <option value="seleteced">Selected</option>
+                        <option value="all">All</option>
+                    </select>
+                </label>
+
+                <p>
+                    Click to export to a text file
+                </p>
+                <div class="tools-url-input-outer-holder">
+                    <input class="tools-url-add-button" type="submit" value="Export to File" />
+                </div>
+                <p>
+                    Or enter the url of a ckan instance
+                </p>
+                <div class="tools-url-input-outer-holder">
+                    <div class="tools-url-input-inner-holder">
+                        <input class="tools-url-input" type="text" data-bind="value: cacheLevels" />
+                    </div>
+                    <input class="tools-url-add-button" type="submit" value="Export to CKAN" />
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/Views/ToolsPanel.html
+++ b/src/Views/ToolsPanel.html
@@ -33,7 +33,7 @@
                 <h2>Export Data Menu</h2>
                 <label class="tools-content-type">
                     Select the dataset layers to export:
-                    <select class="tools-content-type-select" data-bind="value: dataType">
+                    <select class="tools-content-type-select" data-bind="value: catalogFilter">
                         <option value="opened">Opened</option>
                         <option value="seleteced">Selected</option>
                         <option value="all">All</option>

--- a/src/Views/ToolsPanel.html
+++ b/src/Views/ToolsPanel.html
@@ -29,8 +29,14 @@
                     <input class="tools-url-add-button" type="submit" value="Cache Tiles" />
                 </div>
             </form>
+            <form class="tools-form" data-bind="submit: exportFile">
+                <h2>Export Data Menu to File</h2>
+                <div class="tools-url-input-outer-holder">
+                    <input class="tools-url-add-button" type="submit" value="Export to File" />
+                </div>
+            </form>
             <form class="tools-form" data-bind="submit: exportCkan">
-                <h2>Export Data Menu</h2>
+                <h2>Export to CKAN</h2>
                 <label class="tools-content-type">
                     Select the dataset layers to export:
                     <select class="tools-content-type-select" data-bind="value: catalogFilter">

--- a/src/Views/ToolsPanel.html
+++ b/src/Views/ToolsPanel.html
@@ -5,23 +5,18 @@
             <h1>Advanced Tools</h1>
         </div>
         <div class="tools-content">
-            <p>
-                This panel provides advanced tools for National Map
-            </p>
             <form class="tools-form" data-bind="submit: cacheTiles">
                 <h2>Tile Caching</h2>
                 <label class="tools-content-type">
                     Select the dataset layers to cache:
-                    <select class="tools-content-type-select" data-bind="value: catalogFilter">
+                    <select class="tools-content-type-select" data-bind="value: cacheFilter">
                         <option value="opened">Opened</option>
                         <option value="seleteced">Selected</option>
                         <option value="all">All</option>
                     </select>
                 </label>
 
-                <p>
-                    Enter the number of tile levels to cache
-                </p>
+                Enter the number of tile levels to cache
                 <div class="tools-url-input-outer-holder">
                     <div class="tools-url-input-inner-holder">
                         <input class="tools-url-input" type="text" data-bind="value: cacheLevels" />
@@ -29,35 +24,36 @@
                     <input class="tools-url-add-button" type="submit" value="Cache Tiles" />
                 </div>
             </form>
+
             <form class="tools-form" data-bind="submit: exportFile">
-                <h2>Export Data Menu to File</h2>
+                <h2>Download Data Menu to File</h2>
                 <div class="tools-url-input-outer-holder">
-                    <input class="tools-url-add-button" type="submit" value="Export to File" />
+                    <input class="tools-url-add-button" type="submit" value="Download to File" />
                 </div>
             </form>
+
             <form class="tools-form" data-bind="submit: exportCkan">
-                <h2>Export to CKAN</h2>
+                <h2>Export Data Menu to CKAN</h2>
                 <label class="tools-content-type">
                     Select the dataset layers to export:
-                    <select class="tools-content-type-select" data-bind="value: catalogFilter">
+                    <select class="tools-content-type-select" data-bind="value: ckanFilter">
                         <option value="opened">Opened</option>
                         <option value="seleteced">Selected</option>
                         <option value="all">All</option>
                     </select>
                 </label>
 
-                <p>
-                    Click to export to a text file
-                </p>
-                <div class="tools-url-input-outer-holder">
-                    <input class="tools-url-add-button" type="submit" value="Export to File" />
-                </div>
-                <p>
-                    Or enter the url of a ckan instance
-                </p>
+                Enter the url of a ckan server
                 <div class="tools-url-input-outer-holder">
                     <div class="tools-url-input-inner-holder">
-                        <input class="tools-url-input" type="text" data-bind="value: cacheLevels" />
+                        <input class="tools-url-input" type="text" data-bind="value: ckanUrl" />
+                    </div>
+                </div>
+
+                Enter the api key to the ckan server
+                <div class="tools-url-input-outer-holder">
+                    <div class="tools-url-input-inner-holder">
+                        <input class="tools-url-input" type="text" data-bind="value: ckanApiKey" />
                     </div>
                     <input class="tools-url-add-button" type="submit" value="Export to CKAN" />
                 </div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/*global require*/
+/*global require,URI*/
 
 var start = true;
 
@@ -75,6 +75,7 @@ if (start) {
     var SearchTabViewModel = require('./ViewModels/SearchTabViewModel');
     var SettingsPanelViewModel = require('./ViewModels/SettingsPanelViewModel');
     var SharePopupViewModel = require('./ViewModels/SharePopupViewModel');
+    var ToolsPanelViewModel = require('./ViewModels/ToolsPanelViewModel');
 
     var Application = require('./Models/Application');
     var ArcGisMapServerCatalogItem = require('./Models/ArcGisMapServerCatalogItem');
@@ -126,6 +127,9 @@ if (start) {
         defaultBaseMap.opacity = 1.0;
 
         application.baseMap = defaultBaseMap;
+
+        var uri = new URI(window.location);
+        var hash = uri.fragment();
 
         // Create the user interface.
         var ui = document.getElementById('ui');
@@ -259,6 +263,17 @@ if (start) {
             tooltip: 'Help using National Map.',
             href: 'http://nicta.github.io/nationalmap/public/faq.html'
         }));
+        if (hash === 'tools') {
+            menuBar.items.push(new MenuBarItemViewModel({
+                label: 'Tools',
+                tooltip: 'Advance National Map Tools.',
+                callback: function() {
+                    ToolsPanelViewModel.open(ui, {
+                        application: application
+                    });
+                }
+            }));
+        }
         menuBar.show(ui);
 
         var locationBar = new LocationBarViewModel(application, document.getElementById('cesiumContainer'));

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/*global require,URI*/
+/*global require*/
 
 var start = true;
 

--- a/src/main.js
+++ b/src/main.js
@@ -90,6 +90,7 @@ if (start) {
 
     var application = new Application();
     application.catalog.isLoading = true;
+    application.reservedProperties = ['tools'];
 
     application.error.addEventListener(function(e) {
         PopupMessageViewModel.open('ui', {
@@ -107,7 +108,9 @@ if (start) {
     }).always(function() {
         // Watch the hash portion of the URL.  If it changes, try to interpret as an init source.
         window.addEventListener("hashchange", function() {
-            application.updateApplicationUrl(window.location);
+            if (!addToolsPanel(window.location)) {
+                application.updateApplicationUrl(window.location);
+            }
         }, false);
 
         application.catalog.isLoading = false;
@@ -127,9 +130,6 @@ if (start) {
         defaultBaseMap.opacity = 1.0;
 
         application.baseMap = defaultBaseMap;
-
-        var uri = new URI(window.location);
-        var hash = uri.fragment();
 
         // Create the user interface.
         var ui = document.getElementById('ui');
@@ -263,17 +263,26 @@ if (start) {
             tooltip: 'Help using National Map.',
             href: 'http://nicta.github.io/nationalmap/public/faq.html'
         }));
-        if (hash === 'tools') {
-            menuBar.items.push(new MenuBarItemViewModel({
-                label: 'Tools',
-                tooltip: 'Advance National Map Tools.',
-                callback: function() {
-                    ToolsPanelViewModel.open(ui, {
-                        application: application
-                    });
-                }
-            }));
+
+        function addToolsPanel(url) {
+            var uri = new URI(url);
+            var hash = uri.fragment();
+            if (hash === 'tools') {
+                menuBar.items.push(new MenuBarItemViewModel({
+                    label: 'Tools',
+                    tooltip: 'Advance National Map Tools.',
+                    callback: function() {
+                        ToolsPanelViewModel.open(ui, {
+                            application: application
+                        });
+                    }
+                }));
+                return true;
+            }
+            return false;
         }
+        addToolsPanel();
+
         menuBar.show(ui);
 
         var locationBar = new LocationBarViewModel(application, document.getElementById('cesiumContainer'));

--- a/src/main.less
+++ b/src/main.less
@@ -64,6 +64,7 @@
 @import "Styles/PopupMessage.less";
 @import "Styles/SettingsPanel.less";
 @import "Styles/SharePopup.less";
+@import "Styles/ToolsPanel.less";
 
 // Tabs on the Explorer Panel
 @import "Styles/DataCatalogTab.less";


### PR DESCRIPTION
Added a tools panel that is invoked by #tools on the url which holds our non-enduser system/dev tools.

Currently holds our old tile caching and ckan exporting code as well as a new tool to export a serialized version of the current data menu.
