### PR TITLE
tile caching tuning

### DIFF
--- a/public/init_nm.json
+++ b/public/init_nm.json
@@ -1,9 +1,6 @@
 {
     "corsDomains" : [
-        "data.gov.au",
-        "ga.gov.au",
-        "corsproxy.com",
-        "programs.communications.gov.au"
+        "corsproxy.com"
     ],
     "camera": {
         "west": 105,
@@ -2482,7 +2479,13 @@
                     "description": "[Licence](http://creativecommons.org/licenses/by/3.0/au/)",
                     "dataCustodian": "[Australian Bureau of Meteorology](http://www.bom.gov.au/water/geofabric/)",
                     "url": "http://geofabric.bom.gov.au/simplefeatures/ows",
-                    "type": "wms-getCapabilities"
+                    "type": "wms-getCapabilities",
+                    "blacklist": {
+                        "Groundwater Cartography 2.1": true,
+                        "Groundwater Cartography 2.1": true,
+                        "Surface Cartography": true,
+                        "Surface Network 2.1": true
+                    }
                 },
                 {
                     "name": "Boundaries (Australia Bureau of Statistics)",

--- a/src/Models/WebFeatureServiceCatalogGroup.js
+++ b/src/Models/WebFeatureServiceCatalogGroup.js
@@ -42,7 +42,15 @@ var WebFeatureServiceCatalogGroup = function(application) {
      */
     this.dataCustodian = undefined;
 
-    knockout.track(this, ['url', 'dataCustodian']);
+    /**
+     * Gets or sets a hash of names of blacklisted data layers.  A layer that appears in this hash
+     * will not be shown to the user.  In this hash, the keys should be the Title of the layers to blacklist,
+     * and the values should be "true".  This property is observable.
+     * @type {Object}
+     */
+    this.blacklist = undefined;
+
+    knockout.track(this, ['url', 'dataCustodian', 'blacklist']);
 };
 
 inherit(CatalogGroup, WebFeatureServiceCatalogGroup);
@@ -115,7 +123,7 @@ WebFeatureServiceCatalogGroup.defaultSerializers.isLoading = function(wfsGroup, 
 freezeObject(WebFeatureServiceCatalogGroup.defaultSerializers);
 
 WebFeatureServiceCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
-    return [this.url];
+    return [this.url, this.blacklist];
 };
 
 WebFeatureServiceCatalogGroup.prototype._load = function() {
@@ -226,6 +234,12 @@ function addFeatureTypes(wfsGroup, featureTypes, items, parent, supportsJsonGetF
 
     for (var i = 0; i < featureTypes.length; ++i) {
         var featureType = featureTypes[i];
+        
+        if (wfsGroup.blacklist && wfsGroup.blacklist[featureType.Title]) {
+            console.log('Provider Feedback: Filtering out ' + featureType.Title + ' (' + featureType.Name + ') because it is blacklisted.');
+            continue;
+        }
+
         items.push(createWfsDataSource(wfsGroup, featureType, supportsJsonGetFeature, dataCustodian));
     }
 }

--- a/src/Models/WebMapServiceCatalogGroup.js
+++ b/src/Models/WebMapServiceCatalogGroup.js
@@ -51,7 +51,15 @@ var WebMapServiceCatalogGroup = function(application) {
      */
     this.parameters = undefined;
 
-    knockout.track(this, ['url', 'dataCustodian', 'parameters']);
+    /**
+     * Gets or sets a hash of names of blacklisted data layers.  A layer that appears in this hash
+     * will not be shown to the user.  In this hash, the keys should be the Title of the layers to blacklist,
+     * and the values should be "true".  This property is observable.
+     * @type {Object}
+     */
+    this.blacklist = undefined;
+
+    knockout.track(this, ['url', 'dataCustodian', 'parameters', 'blacklist']);
 };
 
 inherit(CatalogGroup, WebMapServiceCatalogGroup);
@@ -126,7 +134,7 @@ WebMapServiceCatalogGroup.defaultSerializers.isLoading = function(wmsGroup, json
 freezeObject(WebMapServiceCatalogGroup.defaultSerializers);
 
 WebMapServiceCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
-    return [this.url];
+    return [this.url, this.blacklist];
 };
 
 WebMapServiceCatalogGroup.prototype._load = function() {
@@ -243,6 +251,11 @@ function addLayersRecursively(wmsGroup, layers, items, parent, supportsJsonGetFe
 
         // Record this layer's parent, so we can walk up the layer hierarchy looking for inherited properties.
         layer.parent = parent;
+
+        if (wmsGroup.blacklist && wmsGroup.blacklist[layer.Title]) {
+            console.log('Provider Feedback: Filtering out ' + layer.Title + ' (' + layer.Name + ') because it is blacklisted.');
+            continue;
+        }
 
         if (defined(layer.Layer)) {
             // WMS 1.1.1 spec section 7.1.4.5.2 says any layer with a Name property can be used

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -126,7 +126,7 @@ function requestTiles(app, requests, maxLevel) {
     var i;
     for (i = 0; i < requests.length; ++i) {
         var request = requests[i];
-        var extent = request.item.rectangle;
+        var extent = request.item.rectangle || app.initialBoundingBox;
         name = request.item.name;
 
         var enabledHere = false;


### PR DESCRIPTION
Tuning up the tile caching support
- fix tile cache extent for items that don't have one
- blacklist support for wms/wfs
- remove existing cors domains for national map datasets/providers so we cache image tiles

The last one is the contentious one, so we can discuss with Bill.  The more I think about, the more I think it's the right thing.  The weakest link in our service is the data providers, so:
a) anything we can do to shield the customer from data related performance/accessibility issues is goodness
b) and anything we can do to help take load off the data providers is probably a good idea.
