### PR TITLE
Extent-related fixes

### DIFF
--- a/src/Models/Application.js
+++ b/src/Models/Application.js
@@ -225,7 +225,7 @@ Application.prototype.addInitSource = function(initSource) {
                 position: initSource.camera.position,
                 direction: initSource.camera.direction,
                 up: initSource.camera.up
-            }
+            };
         } else {
             this.initialCamera = undefined;
         }

--- a/src/Models/Application.js
+++ b/src/Models/Application.js
@@ -77,6 +77,13 @@ var Application = function() {
     this.initialBoundingBox = Rectangle.MAX_VALUE;
 
     /**
+     * Gets or sets the initial parameters of the Camera's view.  This object has three properties,
+     * position, direction, and up.  All three are Cartesian3s expressed in the Earth-centered Fixed frame.
+     * @type {Object}
+     */
+    this.initialCamera = undefined;
+
+    /**
      * Gets or sets the {@link corsProxy} used to determine if a URL needs to be proxied and to proxy it if necessary.
      * @type {corsProxy}
      */
@@ -138,7 +145,7 @@ var Application = function() {
      */
     this.nowViewing = new NowViewing(this);
 
-    knockout.track(this, ['viewerMode', 'baseMap', 'initialBoundingBox']);
+    knockout.track(this, ['viewerMode', 'baseMap', 'initialBoundingBox', 'initialCamera']);
 
     // IE versions prior to 10 don't support CORS, so always use the proxy.
     corsProxy.alwaysUseProxy = (FeatureDetection.isInternetExplorer() && FeatureDetection.internetExplorerVersion()[0] < 10);
@@ -213,6 +220,16 @@ Application.prototype.addInitSource = function(initSource) {
 
     // The last init source to specify a camera position wins.
     if (defined(initSource.camera)) {
+        if (defined(initSource.camera.position)) {
+            this.initialCamera = {
+                position: initSource.camera.position,
+                direction: initSource.camera.direction,
+                up: initSource.camera.up
+            }
+        } else {
+            this.initialCamera = undefined;
+        }
+
         this.initialBoundingBox = Rectangle.fromDegrees(initSource.camera.west, initSource.camera.south, initSource.camera.east, initSource.camera.north);
     }
 

--- a/src/Models/Cesium.js
+++ b/src/Models/Cesium.js
@@ -4,18 +4,18 @@
 var CameraFlightPath = require('../../third_party/cesium/Source/Scene/CameraFlightPath');
 var Cartesian2 = require('../../third_party/cesium/Source/Core/Cartesian2');
 var Cartesian3 = require('../../third_party/cesium/Source/Core/Cartesian3');
-var CesiumMath = require('../../third_party/cesium/Source/Core/Math');
+var Cartographic = require('../../third_party/cesium/Source/Core/Cartographic');
 var defaultValue = require('../../third_party/cesium/Source/Core/defaultValue');
 var defined = require('../../third_party/cesium/Source/Core/defined');
 var destroyObject = require('../../third_party/cesium/Source/Core/destroyObject');
 var DeveloperError = require('../../third_party/cesium/Source/Core/DeveloperError');
-var Ellipsoid = require('../../third_party/cesium/Source/Core/Ellipsoid');
 var formatError = require('../../third_party/cesium/Source/Core/formatError');
 var getTimestamp = require('../../third_party/cesium/Source/Core/getTimestamp');
 var JulianDate = require('../../third_party/cesium/Source/Core/JulianDate');
 var knockout = require('../../third_party/cesium/Source/ThirdParty/knockout');
 var Matrix4 = require('../../third_party/cesium/Source/Core/Matrix4');
 var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
+var Transforms = require('../../third_party/cesium/Source/Core/Transforms');
 var when = require('../../third_party/cesium/Source/ThirdParty/when');
 
 var ModelError = require('./ModelError');
@@ -165,6 +165,11 @@ Cesium.prototype.destroy = function() {
 };
 
 var cartesian3Scratch = new Cartesian3();
+var enuToFixedScratch = new Matrix4();
+var southwestScratch = new Cartesian3();
+var northeastScratch = new Cartesian3();
+var southwestCartographicScratch = new Cartographic();
+var northeastCartographicScratch = new Cartographic();
 
 /**
  * Gets the current extent of the camera.  This may be approximate if the viewer does not have a strictly rectangular view.
@@ -172,22 +177,41 @@ var cartesian3Scratch = new Cartesian3();
  */
 Cesium.prototype.getCurrentExtent = function() {
     var scene = this.scene;
+    var camera = scene.camera;
 
     var width = scene.canvas.clientWidth;
     var height = scene.canvas.clientHeight;
 
     var centerOfScreen = new Cartesian2(width / 2.0, height / 2.0);
     var pickRay = scene.camera.getPickRay(centerOfScreen);
-    var focus = scene.globe.pick(pickRay, scene);
+    var center = scene.globe.pick(pickRay, scene);
 
-    var focusCartographic = Ellipsoid.WGS84.cartesianToCartographic(focus);
+    if (!defined(center)) {
+        // TODO: binary search to find the horizon point and use that as the center.
+        return this.application.initialBoundingBox;
+    }
 
-    var distance = Cartesian3.magnitude(Cartesian3.subtract(focus, scene.camera.position, cartesian3Scratch));
-    var offset = CesiumMath.toRadians(distance * 2.5e-6);
+    var ellipsoid = this.scene.globe.ellipsoid;
 
-    var longitude = focusCartographic.longitude;
-    var latitude = focusCartographic.latitude;
-    return new Rectangle(longitude - offset, latitude - offset, longitude + offset, latitude + offset);
+    var fovy = scene.camera.frustum.fovy * 0.5;
+    var fovx = Math.atan(Math.tan(fovy) * scene.camera.frustum.aspectRatio);
+
+    var cameraOffset = Cartesian3.subtract(camera.positionWC, center, cartesian3Scratch);
+    var cameraHeight = Cartesian3.magnitude(cameraOffset);
+    var xDistance = cameraHeight * Math.tan(fovx);
+    var yDistance = cameraHeight * Math.tan(fovy);
+
+    var southwestEnu = new Cartesian3(-xDistance, -yDistance, 0.0);
+    var northeastEnu = new Cartesian3(xDistance, yDistance, 0.0);
+
+    var enuToFixed = Transforms.eastNorthUpToFixedFrame(center, ellipsoid, enuToFixedScratch);
+    var southwest = Matrix4.multiplyByPoint(enuToFixed, southwestEnu, southwestScratch);
+    var northeast = Matrix4.multiplyByPoint(enuToFixed, northeastEnu, northeastScratch);
+
+    var southwestCartographic = ellipsoid.cartesianToCartographic(southwest, southwestCartographicScratch);
+    var northeastCartographic = ellipsoid.cartesianToCartographic(northeast, northeastCartographicScratch);
+
+    return new Rectangle(southwestCartographic.longitude, southwestCartographic.latitude, northeastCartographic.longitude, northeastCartographic.latitude);
 };
 
 /**

--- a/src/Models/Cesium.js
+++ b/src/Models/Cesium.js
@@ -5,6 +5,7 @@ var CameraFlightPath = require('../../third_party/cesium/Source/Scene/CameraFlig
 var Cartesian2 = require('../../third_party/cesium/Source/Core/Cartesian2');
 var Cartesian3 = require('../../third_party/cesium/Source/Core/Cartesian3');
 var Cartographic = require('../../third_party/cesium/Source/Core/Cartographic');
+var CesiumMath = require('../../third_party/cesium/Source/Core/Math');
 var defaultValue = require('../../third_party/cesium/Source/Core/defaultValue');
 var defined = require('../../third_party/cesium/Source/Core/defined');
 var destroyObject = require('../../third_party/cesium/Source/Core/destroyObject');
@@ -221,10 +222,18 @@ Cesium.prototype.getCurrentExtent = function() {
     var northeastCartographic = ellipsoid.cartesianToCartographic(northeast, northeastCartographicScratch);
     var northwestCartographic = ellipsoid.cartesianToCartographic(northwest, northwestCartographicScratch);
 
+    // Account for date-line wrapping
+    if (southeastCartographic.longitude < southwestCartographic.longitude) {
+        southeastCartographic.longitude += CesiumMath.TWO_PI;
+    }
+    if (northeastCartographic.longitude < northwestCartographic.longitude) {
+        northeastCartographic.longitude += CesiumMath.TWO_PI;
+    }
+
     var rect = new Rectangle(
-        Math.min(southwestCartographic.longitude, northwestCartographic.longitude),
+        CesiumMath.convertLongitudeRange(Math.min(southwestCartographic.longitude, northwestCartographic.longitude)),
         Math.min(southwestCartographic.latitude, southeastCartographic.latitude),
-        Math.max(northeastCartographic.longitude, southeastCartographic.longitude),
+        CesiumMath.convertLongitudeRange(Math.max(northeastCartographic.longitude, southeastCartographic.longitude)),
         Math.max(northeastCartographic.latitude, northwestCartographic.latitude));
     rect.center = center;
     return rect;

--- a/src/Models/Leaflet.js
+++ b/src/Models/Leaflet.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /*global require,html2canvas*/
+var CesiumMath = require('../../third_party/cesium/Source/Core/Math');
 var destroyObject = require('../../third_party/cesium/Source/Core/destroyObject');
 var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
 var when = require('../../third_party/cesium/Source/ThirdParty/when');
@@ -32,9 +33,19 @@ Leaflet.prototype.getCurrentExtent = function() {
  * Zooms to a specified extent.
  *
  * @param {Rectangle} extent The extent to which to zoom.
- */
-Leaflet.prototype.zoomTo = function(extent) {
-    this.map.fitBounds(rectangleToLatLngBounds(extent));
+  * @param {Number} [flightDurationSeconds=3.0] The length of the flight animation in seconds.  Leaflet ignores the actual value,
+  *                                             but will use an animated transition when this value is greater than 0.
+*/
+Leaflet.prototype.zoomTo = function(extent, flightDurationSeconds) {
+    // Account for a bounding box crossing the date line.
+    if (extent.east < extent.west) {
+        extent = Rectangle.clone(extent);
+        extent.east += CesiumMath.TWO_PI;
+    }
+
+    this.map.fitBounds(rectangleToLatLngBounds(extent), {
+        animate: flightDurationSeconds > 0.0
+    });
 };
 
 /**

--- a/src/ViewModels/SharePopupViewModel.js
+++ b/src/ViewModels/SharePopupViewModel.js
@@ -58,13 +58,22 @@ var SharePopupViewModel = function(options) {
     }
 
     // Add an init source with the camera position.
+    var camera = {
+        west: CesiumMath.toDegrees(camera.west),
+        south: CesiumMath.toDegrees(camera.south),
+        east: CesiumMath.toDegrees(camera.east),
+        north: CesiumMath.toDegrees(camera.north),
+    };
+
+    if (defined(this.application.cesium)) {
+        var cesiumCamera = this.application.cesium.scene.camera;
+        camera.position = cesiumCamera.positionWC;
+        camera.direction = cesiumCamera.directionWC;
+        camera.up = cesiumCamera.upWC;
+    }
+
     initSources.push({
-        camera: {
-            west: CesiumMath.toDegrees(camera.west),
-            south: CesiumMath.toDegrees(camera.south),
-            east: CesiumMath.toDegrees(camera.east),
-            north: CesiumMath.toDegrees(camera.north)
-        }
+        camera: camera
     });
 
     var uri = new URI(window.location);

--- a/src/ViewModels/SharePopupViewModel.js
+++ b/src/ViewModels/SharePopupViewModel.js
@@ -19,7 +19,7 @@ var SharePopupViewModel = function(options) {
     knockout.track(this, ['imageUrl', 'url', 'embedCode', 'itemsSkippedBecauseTheyHaveLocalData']);
 
     // Build the share URL.
-    var camera = this.application.currentViewer.getCurrentExtent();
+    var cameraExtent = this.application.currentViewer.getCurrentExtent();
 
     var request = {
         version: '0.0.03',
@@ -59,10 +59,10 @@ var SharePopupViewModel = function(options) {
 
     // Add an init source with the camera position.
     var camera = {
-        west: CesiumMath.toDegrees(camera.west),
-        south: CesiumMath.toDegrees(camera.south),
-        east: CesiumMath.toDegrees(camera.east),
-        north: CesiumMath.toDegrees(camera.north),
+        west: CesiumMath.toDegrees(cameraExtent.west),
+        south: CesiumMath.toDegrees(cameraExtent.south),
+        east: CesiumMath.toDegrees(cameraExtent.east),
+        north: CesiumMath.toDegrees(cameraExtent.north),
     };
 
     if (defined(this.application.cesium)) {

--- a/src/main.js
+++ b/src/main.js
@@ -51,11 +51,8 @@ if (start) {
     var copyright = require('./CopyrightModule'); // jshint ignore:line
 
     var BingMapsStyle = require('../third_party/cesium/Source/Scene/BingMapsStyle');
-    var Color = require('../third_party/cesium/Source/Core/Color');
     var defined = require('../third_party/cesium/Source/Core/defined');
     var knockout = require('../third_party/cesium/Source/ThirdParty/knockout');
-    var Rectangle = require('../third_party/cesium/Source/Core/Rectangle');
-    var sampleTerrain = require('../third_party/cesium/Source/Core/sampleTerrain');
 
     var AusGlobeViewer = require('./viewer/AusGlobeViewer');
     var registerKnockoutBindings = require('./Core/registerKnockoutBindings');
@@ -238,32 +235,6 @@ if (start) {
             var toolsProperty = application.getUserProperty('tools');
             return defined(toolsProperty) && toolsProperty !== 'false' && toolsProperty !== 'no' && toolsProperty !== '0';
         });
-
-        var entity;
-
-        menuBar.items.push(new MenuBarItemViewModel({
-            label: 'Show visible extent',
-            callback: function() {
-                var extent = application.cesium.getCurrentExtent();
-                sampleTerrain(application.cesium.scene.globe.terrainProvider, 11, [Rectangle.center(extent)]).then(function(positions) {
-                    application.cesium.viewer.entities.remove(entity);
-                    entity = application.cesium.viewer.entities.add({
-                        rectangle: {
-                            coordinates: extent,
-                            extrudedHeight: positions[0].height,
-                            fill: false,
-                            outline: true,
-                            outlineColor: Color.RED
-                        },
-                        position: extent.center,
-                        point: {
-                            color: Color.RED,
-                            pixelSize: 3
-                        }
-                    });
-                });
-            }
-        }));
 
         var toolsMenuItem = new MenuBarItemViewModel({
             visible: showToolsMenuItem(),

--- a/src/main.js
+++ b/src/main.js
@@ -51,8 +51,11 @@ if (start) {
     var copyright = require('./CopyrightModule'); // jshint ignore:line
 
     var BingMapsStyle = require('../third_party/cesium/Source/Scene/BingMapsStyle');
+    var Color = require('../third_party/cesium/Source/Core/Color');
     var defined = require('../third_party/cesium/Source/Core/defined');
     var knockout = require('../third_party/cesium/Source/ThirdParty/knockout');
+    var Rectangle = require('../third_party/cesium/Source/Core/Rectangle');
+    var sampleTerrain = require('../third_party/cesium/Source/Core/sampleTerrain');
 
     var AusGlobeViewer = require('./viewer/AusGlobeViewer');
     var registerKnockoutBindings = require('./Core/registerKnockoutBindings');
@@ -235,6 +238,32 @@ if (start) {
             var toolsProperty = application.getUserProperty('tools');
             return defined(toolsProperty) && toolsProperty !== 'false' && toolsProperty !== 'no' && toolsProperty !== '0';
         });
+
+        var entity;
+
+        menuBar.items.push(new MenuBarItemViewModel({
+            label: 'Show visible extent',
+            callback: function() {
+                var extent = application.cesium.getCurrentExtent();
+                sampleTerrain(application.cesium.scene.globe.terrainProvider, 11, [Rectangle.center(extent)]).then(function(positions) {
+                    application.cesium.viewer.entities.remove(entity);
+                    entity = application.cesium.viewer.entities.add({
+                        rectangle: {
+                            coordinates: extent,
+                            extrudedHeight: positions[0].height,
+                            fill: false,
+                            outline: true,
+                            outlineColor: Color.RED
+                        },
+                        position: extent.center,
+                        point: {
+                            color: Color.RED,
+                            pixelSize: 3
+                        }
+                    });
+                });
+            }
+        }));
 
         var toolsMenuItem = new MenuBarItemViewModel({
             visible: showToolsMenuItem(),

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -8,8 +8,6 @@
 /*global require,L,URI,$,Document,html2canvas,console,ga*/
 
 var BingMapsApi = require('../../third_party/cesium/Source/Core/BingMapsApi');
-var CameraFlightPath = require('../../third_party/cesium/Source/Scene/CameraFlightPath');
-var Cartesian2 = require('../../third_party/cesium/Source/Core/Cartesian2');
 var Cartesian3 = require('../../third_party/cesium/Source/Core/Cartesian3');
 var Cartographic = require('../../third_party/cesium/Source/Core/Cartographic');
 var CesiumMath = require('../../third_party/cesium/Source/Core/Math');
@@ -60,7 +58,6 @@ var corsProxy = require('../Core/corsProxy');
 var Cesium = require('../Models/Cesium');
 var Leaflet = require('../Models/Leaflet');
 var PopupMessageViewModel = require('../ViewModels/PopupMessageViewModel');
-var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
 var LeafletVisualizer = require('../Map/LeafletVisualizer');
 var ViewerMode = require('../Models/ViewerMode');
 
@@ -871,8 +868,6 @@ AusGlobeViewer.prototype.updateTimeline = function(start, finish, cur, run) {
     return {start: clock.startTime, stop: clock.stopTime, cur: clock.currentTime};
  };
 
-
-var cartesian3Scratch = new Cartesian3();
 
 // -------------------------------------------
 // Camera management


### PR DESCRIPTION
- Improve the computation of view extent in Cesium.
- Tell Leaflet to animate zooming (though it ignores it when zooming far away)
- Make Leaflet zooming work when the extent crosses the international date line.
- Remove some redundant code in AusGlobeViewer.
- When sharing, share the actual Cesium camera parameters in addition to the estimated bounding box.  This way the view is recreated exactly when possible.

Fixes #282
Fixes part of #55.
