### PR TITLE
Add support for Markdown image references to layer description sanitiser...

### DIFF
--- a/src/Core/KnockoutSanitizedHtmlBinding.js
+++ b/src/Core/KnockoutSanitizedHtmlBinding.js
@@ -22,16 +22,25 @@ var KnockoutSanitizedHtmlBinding = {
 function sanitize(html) {
     // Escape HTML
     var div = document.createElement('div');
-    
+
     if (defined(div.textContent)) {
         div.textContent = html;
     } else {
         div.innerText = html;
     }
 
-    // Replace Markdown style links (such as: [Link Text](http://link.url.com) ) with actual links.
+    // Replace Markdown style links (such as: [Link Text](http://link.url.com) ) with actual links,
+    // Markdown  style image references (![Alt text](http://path.com/foo.png) ) with img tags,
+    // and <br/>'s with actual <br/>'s.
     var escaped = div.innerHTML;
-    var fixedLinks = escaped.replace(/\[([^\]]+)\]\(([^\)]+)\)/g, function(match, name, href) {
+
+    // Replace inline Markdown image references
+    var fixedImages = escaped.replace(/!\[([^\]]+)\]\(([^\)]+)\)/g, function(match, alt, link) {
+        return '<img src="' + link + '" alt="' + alt +  '"/>';
+    });
+
+    // Replace inline Markdown links
+    var fixedLinks = fixedImages.replace(/\[([^\]]+)\]\(([^\)]+)\)/g, function(match, name, href) {
         return '<a href="' + href + '" target="_blank">' + name + '</a>';
     });
 


### PR DESCRIPTION
We may need to embed custodian logos in the descriptions of some layers so thought we'd add support. Code is heavily based on the link replacement code so I'm not sure if there's a better way or not, but this seems to work.
