### PR TITLE
Repaint when XHR completes or a worker sends a message.

### DIFF
--- a/src/Models/CatalogItem.js
+++ b/src/Models/CatalogItem.js
@@ -353,6 +353,8 @@ CatalogItem.prototype.load = function() {
     }).then(function() {
         that._loadingPromise = undefined;
         that.isLoading = false;
+
+        that.application.currentViewer.notifyRepaintRequired();
     }).otherwise(function(e) {
         that._lastLoadInfluencingValues = undefined;
         that._loadingPromise = undefined;
@@ -704,6 +706,7 @@ function isEnabledChanged(catalogItem) {
             var loadPromise = when(catalogItem.load(), function() {
                 if (catalogItem.isEnabled) {
                     catalogItem._enable();
+                    catalogItem.application.currentViewer.notifyRepaintRequired();
                 }
             });
 
@@ -753,6 +756,7 @@ function isShownChanged(catalogItem) {
         when(catalogItem._loadForEnablePromise, function() {
             if (catalogItem.isEnabled && catalogItem.isShown) {
                 catalogItem._show();
+                catalogItem.application.currentViewer.notifyRepaintRequired();
             }
         });
 


### PR DESCRIPTION
This is a bit hacky - I really need to incorporate animation pausing into Cesium instead of doing it externally like this...

But basically, with this change, we watch for an `XMLHttpRequest` completing and for a Cesium `TaskProcessor` receiving a message from a Web Worker, and in both cases we force a repaint.  This ensures that we redraw with the new data when an asynchronous process completes, no matter how long it takes.

Fixes #540 
