### PR TITLE
Show KML datasets from data.gov.au with #dgakml.

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -3,7 +3,9 @@
         "nicta.com.au",
         "gov.au",
         "csiro.au",
-        "arcgis.com"
+        "arcgis.com",
+        "argo.jcommops.org",
+        "www.abc.net.au"
     ],
     "initializationUrls" : [
         "init_nm.json"

--- a/public/init_dgakml.json
+++ b/public/init_dgakml.json
@@ -1,0 +1,18 @@
+{
+    "catalog": [
+        {
+            "name": "Data.gov.au KML",
+            "type": "ckan",
+            "url": "http://www.data.gov.au",
+            "filterQuery": ["fq=res_format%3aKML"],
+            "includeKml": true,
+            "includeWms": false,
+            "includeEsriMapServer": false,
+            "filterByWmsGetCapabilities": false,
+            "minimumMaxScaleDenominator": 1e10,
+            "blacklist": {
+                "Rainforests (EVC_2005)": true
+            }
+        }
+    ]
+}

--- a/src/Models/KmlCatalogItem.js
+++ b/src/Models/KmlCatalogItem.js
@@ -144,7 +144,7 @@ If you believe it is a bug in National Map, please report it by emailing \
             }
         });
     } else {
-        return dataSource.loadUrl(proxyUrl(that, that.url)).then(function() {
+        return dataSource.load(proxyUrl(that, that.url)).then(function() {
             doneLoading(that);
         }).otherwise(function() {
             errorLoading(that);


### PR DESCRIPTION
This is just a prototype and maybe some demo fodder for now, but it works reasonably well.

In addition to a new init file and changes to our CKAN support to support KML datasets in CKAN, this pull request also updates Cesium to include the latest changes from the `kml` branch.
