### PR TITLE
Several picking improvements

### DIFF
--- a/src/Models/WebMapServiceCatalogItem.js
+++ b/src/Models/WebMapServiceCatalogItem.js
@@ -87,6 +87,8 @@ var WebMapServiceCatalogItem = function(application) {
      */
     this.getFeatureInfoAsXml = true;
 
+    this.getFeatureInfoXmlContentType = 'text/xml';
+
     /**
      * Gets or sets a value indicating whether this dataset should be clipped to the {@link WebMapServiceCatalogItem#rectangle}.
      * If true, no part of the dataset will be displayed outside the rectangle.  This property is false by default because it requires
@@ -303,7 +305,8 @@ WebMapServiceCatalogItem.prototype._enableInCesium = function() {
         getFeatureInfoAsGeoJson : this.getFeatureInfoAsGeoJson,
         getFeatureInfoAsXml : this.getFeatureInfoAsXml,
         parameters : combine(this.parameters, WebMapServiceCatalogItem.defaultParameters),
-        tilingScheme : defined(this.tilingScheme) ? this.tilingScheme : new WebMercatorTilingScheme()
+        tilingScheme : defined(this.tilingScheme) ? this.tilingScheme : new WebMercatorTilingScheme(),
+        getFeatureInfoXmlContentType : this.getFeatureInfoXmlContentType
     });
 
     this._imageryLayer = new ImageryLayer(imageryProvider, {

--- a/src/Models/WebMapServiceCatalogItem.js
+++ b/src/Models/WebMapServiceCatalogItem.js
@@ -14,9 +14,9 @@ var GeographicTilingScheme = require('../../third_party/cesium/Source/Core/Geogr
 var ImageryLayer = require('../../third_party/cesium/Source/Scene/ImageryLayer');
 var knockout = require('../../third_party/cesium/Source/ThirdParty/knockout');
 var loadXML = require('../../third_party/cesium/Source/Core/loadXML');
+var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
 var WebMapServiceImageryProvider = require('../../third_party/cesium/Source/Scene/WebMapServiceImageryProvider');
 var WebMercatorTilingScheme = require('../../third_party/cesium/Source/Core/WebMercatorTilingScheme');
-var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
 var WebMercatorProjection = require('../../third_party/cesium/Source/Core/WebMercatorProjection');
 
 var Metadata = require('./Metadata');


### PR DESCRIPTION
- Fix bad merge in our `nm` branch of Cesium that caused WMS picking to be inaccurate in Cesium for Web Mercator layers (which is to say, basically all of them).
- Make WMS feature clicking work with servers that only provide feature info in GML format (like old versions of Geoserver as seen on the PREVIEW Global Risk server).
- Use Cesium code for WMS picking in Leaflet, rather than maintaining two sets of code (so I didn't have to implement the above twice).
- Delete a bunch of old code from `AusGlobeViewer.js`.
- Make Leaflet picking of non-raster features work correctly even when a raster layer exists underneath it.  Previously, the non-raster feature info would appear, only to be replaced by the raster info or "No features found" half a second later.
