### PR TITLE
Stop the Cesium render loop more reliably.

### DIFF
--- a/src/Models/Cesium.js
+++ b/src/Models/Cesium.js
@@ -342,7 +342,7 @@ function postRender(cesium, date) {
 
     var scene = cesium.scene;
 
-    if (!Matrix4.equals(cesium._lastCameraViewMatrix, scene.camera.viewMatrix)) {
+    if (!Matrix4.equalsEpsilon(cesium._lastCameraViewMatrix, scene.camera.viewMatrix, 1e-5)) {
         cesium._lastCameraMoveTime = now;
     }
 


### PR DESCRIPTION
The epsilon works around a problem where Cesium's camera position likes to float around even when the camera isn't moving.  This is caused by a tiny bit of numerical noise introduced in `_setTransform` when getting, for example, the camera's heading.

The Cesium change fixes a bug where it marks a tile as "waiting for children" when really the child it's waiting on doesn't exist at all.  Since we don't stop rendering when tiles are waiting on children, this bug caused laptop melting when zoomed in really close to the globe.
