### PR TITLE
Avoid slightly camera tilt when resetting view.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 2015-03-16
+
+* Fix a bug that caused the view to be tilted slightly away from North after clicking the Reset button.
+
 ### 2015-03-03
 
 * Add a prototype of loading KML files from data.gov.au, accessible at http://nationalmap.nicta.com.au/#dgakml.

--- a/src/ViewModels/NavigationViewModel.js
+++ b/src/ViewModels/NavigationViewModel.js
@@ -144,33 +144,7 @@ NavigationViewModel.prototype.resetView = function() {
     ga('send', 'event', 'navigation', 'click', 'reset');
 
     var bbox = this.application.initialBoundingBox;
-
-    if (defined(this.application.leaflet)) {
-        this.application.leaflet.map.fitBounds(rectangleToLatLngBounds(bbox));
-    }
-
-    if (defined(this.application.cesium)) {
-        var scene = this.application.cesium.scene;
-
-        var destination = scene.camera.getRectangleCameraCoordinates(bbox);
-
-        var direction = Cartesian3.normalize(destination, new Cartesian3());
-        Cartesian3.negate(direction, direction);
-        var right = Cartesian3.cross(direction, Cartesian3.UNIT_Z, new Cartesian3());
-        var up = Cartesian3.cross(right, direction, new Cartesian3());
-
-        scene.camera.flyTo({
-            destination : destination,
-            orientation : {
-                direction: direction,
-                up : up,
-            },
-            duration : 1.5,
-            endTransform : Matrix4.IDENTITY
-        });
-    }
-
-    this.application.currentViewer.notifyRepaintRequired();
+    this.application.currentViewer.zoomTo(bbox, 1.5);
 };
 
 var tilts = [0, 40, 80];

--- a/src/ViewModels/NavigationViewModel.js
+++ b/src/ViewModels/NavigationViewModel.js
@@ -17,7 +17,6 @@ var Transforms = require('../../third_party/cesium/Source/Core/Transforms');
 var Tween = require('../../third_party/cesium/Source/ThirdParty/Tween');
 
 var loadView = require('../Core/loadView');
-var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
 
 var svgZoomIn = require('../SvgPaths/svgZoomIn');
 var svgZoomOut = require('../SvgPaths/svgZoomOut');


### PR DESCRIPTION
When clicking Reset, the view would be tilted slightly away from North.  I replaced all the unnecessary custom logic in there with a call to the current viewer's `zoomTo`, which doesn't have that problem.
