### PR TITLE
Distinguish initial camera from home camera

### DIFF
--- a/public/init_ckan.json
+++ b/public/init_ckan.json
@@ -5,7 +5,7 @@
         "corsproxy.com",
         "programs.communications.gov.au"
     ],
-    "camera": {
+    "homeCamera": {
         "west": 105,
         "south": -45,
         "east": 155,

--- a/public/init_csiro.json
+++ b/public/init_csiro.json
@@ -1,5 +1,5 @@
 {
-    "camera": {
+    "homeCamera": {
         "west": 105,
         "south": -45,
         "east": 155,

--- a/public/init_geelong.json
+++ b/public/init_geelong.json
@@ -5,7 +5,7 @@
         "corsproxy.com",
         "programs.communications.gov.au"
     ],
-    "camera": {
+    "homeCamera": {
         "west": 144.3,
         "south": -38.3,
         "east": 144.5,

--- a/public/init_nm.json
+++ b/public/init_nm.json
@@ -3,7 +3,7 @@
         "corsproxy.com",
         "programs.communications.gov.au"
     ],
-    "camera": {
+    "homeCamera": {
         "west": 105,
         "south": -45,
         "east": 155,

--- a/public/init_sa.json
+++ b/public/init_sa.json
@@ -1,5 +1,5 @@
 {
-    "camera": {
+    "homeCamera": {
         "west": 129,
         "south": -38,
         "east": 141,

--- a/public/init_vic.json
+++ b/public/init_vic.json
@@ -1,5 +1,5 @@
 {
-    "camera": {
+    "homeCamera": {
         "west": 140,
         "south": -39,
         "east": 150,

--- a/src/Models/CameraView.js
+++ b/src/Models/CameraView.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/*global require*/
+var defined = require('../../third_party/cesium/Source/Core/defined');
+var defineProperties = require('../../third_party/cesium/Source/Core/defineProperties');
+var DeveloperError = require('../../third_party/cesium/Source/Core/DeveloperError');
+
+/**
+ * Holds a camera view parameters, expressed as a rectangular extent and/or as a camera position, direction,
+ * and up vector.
+ *
+ * @alias CameraView
+ * @constructor
+ */
+var CameraView = function(rectangle, position, direction, up) {
+    if (!defined(rectangle)) {
+        throw new DeveloperError('rectangle is required.');
+    }
+    if (defined(position) || defined(direction) || defined(up)) {
+        if (!defined(position) || !defined(direction) || !defined(up)) {
+            throw new DeveloperError('If any of position, direction, or up are specified, all must be specified.');
+        }
+    }
+
+    this._rectangle = rectangle;
+    this._position = position;
+    this._direction = direction;
+    this._up = up;
+};
+
+defineProperties(CameraView.prototype, {
+    /**
+     * Gets the rectangular extent of the view.  If {@link CameraView#position}, {@link CameraView#direction},
+     * and {@link CameraView#up} are specified, this property will be ignored for viewers that support those parameters
+     * (e.g. Cesium).  This property must always be supplied, however, for the benefit of viewers that do not understand
+     * these parameters (e.g. Leaflet).
+     * @type {Rectangle}
+     */
+    rectangle: {
+        get: function() {
+            return this._rectangle;
+        }
+    },
+
+    /**
+     * Gets the position of the camera in the Earth-centered Fixed frame.
+     * @type {Cartesian3}
+     */
+    position: {
+        get: function() {
+            return this._position;
+        }
+    },
+
+    /**
+     * Gets the look direction of the camera in the Earth-centered Fixed frame.
+     * @type {Cartesian3}
+     */
+    direction: {
+        get: function() {
+            return this._direction;
+        }
+    },
+
+    /**
+     * Gets the up vector direction of the camera in the Earth-centered Fixed frame.
+     * @type {Cartesian3}
+     */
+    up: {
+        get: function() {
+            return this._up;
+        }
+    }
+});
+
+module.exports = CameraView;

--- a/src/Models/Leaflet.js
+++ b/src/Models/Leaflet.js
@@ -2,7 +2,9 @@
 
 /*global require,html2canvas*/
 var CesiumMath = require('../../third_party/cesium/Source/Core/Math');
+var defined = require('../../third_party/cesium/Source/Core/defined');
 var destroyObject = require('../../third_party/cesium/Source/Core/destroyObject');
+var DeveloperError = require('../../third_party/cesium/Source/Core/DeveloperError');
 var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
 var when = require('../../third_party/cesium/Source/ThirdParty/when');
 
@@ -30,13 +32,24 @@ Leaflet.prototype.getCurrentExtent = function() {
 };
 
 /**
- * Zooms to a specified extent.
+ * Zooms to a specified camera view or extent.
  *
- * @param {Rectangle} extent The extent to which to zoom.
-  * @param {Number} [flightDurationSeconds=3.0] The length of the flight animation in seconds.  Leaflet ignores the actual value,
-  *                                             but will use an animated transition when this value is greater than 0.
+ * @param {CameraView|Rectangle} viewOrExtent The view or extent to which to zoom.
+ * @param {Number} [flightDurationSeconds=3.0] The length of the flight animation in seconds.  Leaflet ignores the actual value,
+ *                                             but will use an animated transition when this value is greater than 0.
 */
-Leaflet.prototype.zoomTo = function(extent, flightDurationSeconds) {
+Leaflet.prototype.zoomTo = function(viewOrExtent, flightDurationSeconds) {
+    if (!defined(viewOrExtent)) {
+        throw new DeveloperError('viewOrExtent is required.');
+    }
+
+    var extent;
+    if (viewOrExtent instanceof Rectangle) {
+        extent = viewOrExtent;
+    } else {
+        extent = viewOrExtent.rectangle;
+    }
+
     // Account for a bounding box crossing the date line.
     if (extent.east < extent.west) {
         extent = Rectangle.clone(extent);

--- a/src/ViewModels/NavigationViewModel.js
+++ b/src/ViewModels/NavigationViewModel.js
@@ -142,8 +142,7 @@ NavigationViewModel.prototype.zoomOut = function() {
 NavigationViewModel.prototype.resetView = function() {
     ga('send', 'event', 'navigation', 'click', 'reset');
 
-    var bbox = this.application.initialBoundingBox;
-    this.application.currentViewer.zoomTo(bbox, 1.5);
+    this.application.currentViewer.zoomTo(this.application.homeView, 1.5);
 };
 
 var tilts = [0, 40, 80];

--- a/src/ViewModels/SharePopupViewModel.js
+++ b/src/ViewModels/SharePopupViewModel.js
@@ -22,7 +22,7 @@ var SharePopupViewModel = function(options) {
     var cameraExtent = this.application.currentViewer.getCurrentExtent();
 
     var request = {
-        version: '0.0.03',
+        version: '0.0.04',
         initSources: this.application.initSources.slice()
     };
 
@@ -58,7 +58,7 @@ var SharePopupViewModel = function(options) {
     }
 
     // Add an init source with the camera position.
-    var camera = {
+    var initialCamera = {
         west: CesiumMath.toDegrees(cameraExtent.west),
         south: CesiumMath.toDegrees(cameraExtent.south),
         east: CesiumMath.toDegrees(cameraExtent.east),
@@ -67,13 +67,24 @@ var SharePopupViewModel = function(options) {
 
     if (defined(this.application.cesium)) {
         var cesiumCamera = this.application.cesium.scene.camera;
-        camera.position = cesiumCamera.positionWC;
-        camera.direction = cesiumCamera.directionWC;
-        camera.up = cesiumCamera.upWC;
+        initialCamera.position = cesiumCamera.positionWC;
+        initialCamera.direction = cesiumCamera.directionWC;
+        initialCamera.up = cesiumCamera.upWC;
     }
 
+    var homeCamera = {
+        west: CesiumMath.toDegrees(this.application.homeView.rectangle.west),
+        south: CesiumMath.toDegrees(this.application.homeView.rectangle.south),
+        east: CesiumMath.toDegrees(this.application.homeView.rectangle.east),
+        north: CesiumMath.toDegrees(this.application.homeView.rectangle.north),
+        position: this.application.homeView.position,
+        direction: this.application.homeView.direction,
+        up: this.application.homeView.up
+    };
+
     initSources.push({
-        camera: camera
+        initialCamera: initialCamera,
+        homeCamera: homeCamera
     });
 
     var uri = new URI(window.location);

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -65,7 +65,7 @@ ToolsPanelViewModel.prototype.cacheTiles = function() {
 ToolsPanelViewModel.prototype.exportFile = function() {
     //Create the initialization file text
     var catalog = this.application.catalog.serializeToJson({serializeForSharing:false});
-    var camera = getDegreesRect(this.application.initialBoundingBox);
+    var camera = getDegreesRect(this.application.homeView.rectangle);
     var initJsonObject = { corsDomains: corsProxy.corsDomains, camera: camera, services: [], catalog: catalog};
     var initFile = JSON.stringify(initJsonObject, null, 4);
 
@@ -126,7 +126,7 @@ function requestTiles(app, requests, maxLevel) {
     var i;
     for (i = 0; i < requests.length; ++i) {
         var request = requests[i];
-        var extent = request.item.rectangle || app.initialBoundingBox;
+        var extent = request.item.rectangle || app.homeView.rectangle;
         name = request.item.name;
 
         var enabledHere = false;

--- a/src/viewer/AusGlobeViewer.js
+++ b/src/viewer/AusGlobeViewer.js
@@ -64,8 +64,6 @@ var AusGlobeViewer = function(application) {
     this._distanceLegendBarWidth = undefined;
     this._distanceLegendLabel = undefined;
 
-    var that = this;
-    
     var url = window.location;
     var uri = new URI(url);
     var params = uri.search(true);
@@ -123,26 +121,6 @@ If you\'re on a desktop or laptop, consider increasing the size of your window.'
     knockout.getObservable(this.application, 'baseMap').subscribe(function() {
         changeBaseMap(this, this.application.baseMap);
     }, this);
-
-    knockout.getObservable(this.application, 'initialBoundingBox').subscribe(function() {
-        if (!defined(that.application.initialCamera) || !defined(that.application.cesium)) {
-            that.application.currentViewer.zoomTo(that.application.initialBoundingBox, 2.0);
-        }
-    });
-
-    knockout.getObservable(this.application, 'initialCamera').subscribe(function() {
-        if (defined(that.application.initialCamera) && defined(that.application.cesium)) {
-            var cesiumCamera = that.application.cesium.scene.camera;
-            cesiumCamera.flyTo({
-                duration: 2.0,
-                destination: that.application.initialCamera.position,
-                orientation: {
-                    direction: that.application.initialCamera.direction,
-                    up: that.application.initialCamera.up
-                }
-            });
-        }
-    });
 };
 
 AusGlobeViewer.create = function(application) {
@@ -501,7 +479,7 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
                 rect = this.application.cesium.getCurrentExtent();
             } catch (e) {
                 console.log('Using default screen extent', e.message);
-                rect = this.application.initialBoundingBox;
+                rect = this.application.initialView.rectangle;
             }
 
             this.application.cesium.destroy();
@@ -521,7 +499,7 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
             this.viewer = undefined;
         }
         else {
-            rect = this.application.initialBoundingBox;
+            rect = this.application.initialView.rectangle;
         }
 
        //create leaflet viewer
@@ -666,19 +644,7 @@ AusGlobeViewer.prototype.selectViewer = function(bCesium) {
         if (defined(rect)) {
             this.application.cesium.zoomTo(rect, 0.0);
         } else {
-            if (defined(this.application.initialCamera)) {
-                var cesiumCamera = this.application.cesium.scene.camera;
-                cesiumCamera.flyTo({
-                    duration: 0.0,
-                    destination: this.application.initialCamera.position,
-                    orientation: {
-                        direction: this.application.initialCamera.direction,
-                        up: this.application.initialCamera.up
-                    }
-                });
-            } else {
-                this.application.cesium.zoomTo(this.application.initialBoundingBox, 0.0);
-            }
+            this.application.cesium.zoomTo(this.application.initialView, 0.0);
         }
     }
 


### PR DESCRIPTION
The initial camera view is the one that is visible when the application starts.  The home camera view is the one you get when you click the Reset button the UI.  Previously these were always the same, and usually they should be.  But when sharing, they should be different.  Visiting the share URL should restore whatever view was in place when the URL was created, but then hitting the Reset button should return to the home view (usually, all of Australia).

Init sources (such as `init_nm.json` or the `start=` URL parameter) can now specify both a `homeCamera` and an `initialCamera` property.  I've implemented backward compatibility for share URLs based on their version, so old ones with a `camera` property will still work correctly.  Because init files typically don't specify a version (though they could), they will need to be updated to use the new property names .

Fixes #575.
