### PR TITLE
Simple tools to test datasets

### DIFF
--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -207,7 +207,7 @@ function requestTiles(app, requests, maxLevel) {
 
     var popup = PopupMessageViewModel.open('ui', {
         title: 'Dataset Testing',
-        message: '<div>Caching ' + urls.length + ' URLs</div>'
+        message: '<div>Requesting ' + urls.length + ' URLs</div>'
     });
 
     var maxRequests = 1;

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -2,12 +2,14 @@
 
 /*global require,L,URI*/
 var loadView = require('../Core/loadView');
+var PopupMessageViewModel = require('./PopupMessageViewModel');
 var defined = require('../../third_party/cesium/Source/Core/defined');
 var DeveloperError = require('../../third_party/cesium/Source/Core/DeveloperError');
 var knockout = require('../../third_party/cesium/Source/ThirdParty/knockout');
 var when = require('../../third_party/cesium/Source/ThirdParty/when');
 var corsProxy = require('../Core/corsProxy');
 
+var getTimestamp = require('../../third_party/cesium/Source/Core/getTimestamp');
 var loadImage = require('../../third_party/cesium/Source/Core/loadImage');
 var loadWithXhr = require('../../third_party/cesium/Source/Core/loadWithXhr');
 var Rectangle = require('../../third_party/cesium/Source/Core/Rectangle');
@@ -95,7 +97,7 @@ function getAllRequests(types, mode, requests, group) {
     for (var i = 0; i < group.items.length; ++i) {
         var item = group.items[i];
         if (item instanceof CatalogGroup) {
-            if (item.isOpen || mode === 'all') {
+            if (item.isOpen || mode === 'all' || mode === 'enabled') {
                 getAllRequests(types, mode, requests, item);
             }
         } else if ((types.indexOf(item.type) !== -1) && (mode !== 'enabled' || item.isEnabled)) {
@@ -110,11 +112,15 @@ function getAllRequests(types, mode, requests, group) {
 function requestTiles(app, requests, maxLevel) {
     var urls = [];
     var names = [];
+    var stats = [];
+    var uniqueStats = [];
     var name;
+    var stat;
 
     loadImage.createImage = function(url, crossOrigin, deferred) {
         urls.push(url);
         names.push(name);
+        stats.push(stat);
         if (defined(deferred)) {
             deferred.resolve();
         }
@@ -146,6 +152,23 @@ function requestTiles(app, requests, maxLevel) {
             request.provider = request.item._imageryLayer.imageryProvider;
             tilingScheme = request.provider.tilingScheme;
         }
+
+        stat = {
+            name: name,
+            success: {
+                min: 999999,
+                max: 0,
+                sum: 0,
+                number: 0
+            },
+            error: {
+                min: 999999,
+                max: 0,
+                sum: 0,
+                number: 0
+            }
+        };
+        uniqueStats.push(stat);
 
         for (var level = 0; level <= maxLevel; ++level) {
             var nw = tilingScheme.positionToTileXY(Rectangle.northwest(extent), level);
@@ -182,45 +205,98 @@ function requestTiles(app, requests, maxLevel) {
     loadImage.createImage = loadImage.defaultCreateImage;
     throttleRequestByServer.maximumRequestsPerServer = oldMax;
 
-    console.log('Caching ' + urls.length + ' URLs');
+    var popup = PopupMessageViewModel.open('ui', {
+        title: 'Dataset Testing',
+        message: '<div>Caching ' + urls.length + ' URLs</div>'
+    });
 
-    var maxRequests = 2;
+    var maxRequests = 1;
     var nextRequestIndex = 0;
     var inFlight = 0;
     var urlsRequested = 0;
 
-    function doneUrl() {
+    function doneUrl(stat, startTime, error) {
+        var ellapsed = getTimestamp() - startTime;
+
+        var resultStat;
+        if (error) {
+            resultStat = stat.error;
+        } else {
+            resultStat = stat.success;
+        }
+
+        ++resultStat.number;
+        resultStat.sum += ellapsed;
+
+        if (ellapsed > resultStat.max) {
+            resultStat.max = ellapsed;
+        }
+        if (ellapsed < resultStat.min) {
+            resultStat.min = ellapsed;
+        }
+
         --inFlight;
         doNext();
     }
 
     function getNextUrl() {
         var url;
+        var stat;
 
         if (nextRequestIndex >= urls.length) {
             return undefined;
         }
 
         if ((nextRequestIndex % 10) === 0) {
-            console.log('Finished ' + nextRequestIndex + ' URLs.');
+            //popup.message += '<div>Finished ' + nextRequestIndex + ' URLs.</div>';
         }
 
         url = urls[nextRequestIndex];
         name = names[nextRequestIndex]; //track for error reporting
+        stat = stats[nextRequestIndex];
         ++nextRequestIndex;
 
         return {
             url: url,
-            name: name
+            name: name,
+            stat: stat
         };
     }
 
+    var last;
+    var failedRequests = 0;
+    var slowDatasets = 0;
+
+    var maxAverage = 400;
+    var maxMaximum = 800;
+
     function doNext() {
         var next = getNextUrl();
+        if (defined(last) && (!defined(next) || next.name !== last.name)) {
+            popup.message += '<h1>' + last.name + '</h1>';
+            popup.message += '<div style="' + (last.stat.error.number > 0 ? 'color:red' : '') + '">Failed tile requests: ' + last.stat.error.number + ' / ' + (last.stat.success.number + last.stat.error.number) + '</div>';
+            popup.message += '<div>Minimum time: ' + Math.round(last.stat.success.min) + 'ms</div>';
+            popup.message += '<div style="' + (last.stat.success.max > maxMaximum ? 'color:red' : '') + '">Maximum time: ' + Math.round(last.stat.success.max) + 'ms</div>';
+
+            var average = Math.round(last.stat.success.sum / last.stat.success.number);
+            popup.message += '<div style="' + (average > maxAverage ? 'color:red' : '') + '">Average time: ' + average + 'ms</div>';
+
+            failedRequests += last.stat.error.number;
+
+            if (average > maxAverage || last.stat.success.max > maxMaximum) {
+                ++slowDatasets;
+            }
+        }
+
+        last = next;
+
         if (!defined(next)) {
             if (inFlight === 0) {
-                console.log('Finished ' + nextRequestIndex + ' URLs.  DONE!');
-                console.log('Actual number of URLs requested: ' + urlsRequested);
+                popup.message += '<h1>Summary</h1>';
+                popup.message += '<div>Finished ' + nextRequestIndex + ' URLs.  DONE!</div>';
+                popup.message += '<div>Actual number of URLs requested: ' + urlsRequested + '</div>';
+                popup.message += '<div style="' + (failedRequests > 0 ? 'color:red' : '') + '">Failed tile requests: ' + failedRequests + '</div>';
+                popup.message += '<div style="' + (slowDatasets > 0 ? 'color:red' : '') + '">Slow datasets: ' + slowDatasets + '</div>';
             }
             return;
         }
@@ -228,11 +304,16 @@ function requestTiles(app, requests, maxLevel) {
         ++urlsRequested;
         ++inFlight;
 
+        ++next.stat.number;
+
+        var start = getTimestamp();
         loadWithXhr({
             url : next.url
-        }).then(doneUrl).otherwise(function() {
-            console.log('Returned an error while working on layer: ' + next.name);
-            doneUrl();
+        }).then(function() {
+            doneUrl(next.stat, start, false);
+        }).otherwise(function() {
+            popup.message += 'Returned an error while working on layer: ' + next.name + '</div>';
+            doneUrl(next.stat, start, true);
         });
     }
 

--- a/src/Views/ToolsPanel.html
+++ b/src/Views/ToolsPanel.html
@@ -6,22 +6,22 @@
         </div>
         <div class="tools-content">
             <form class="tools-form" data-bind="submit: cacheTiles">
-                <h2>Tile Caching</h2>
+                <h2>Dataset Testing</h2>
                 <label class="tools-content-type">
-                    Select the dataset layers to cache:
+                    Select the datasets to test:
                     <select class="tools-content-type-select" data-bind="value: cacheFilter">
-                        <option value="opened">Opened</option>
-                        <option value="seleteced">Selected</option>
+                        <option value="opened">All Opened</option>
+                        <option value="enabled">All Enabled</option>
                         <option value="all">All</option>
                     </select>
                 </label>
 
-                Enter the number of tile levels to cache
+                Enter the number of tile levels to request
                 <div class="tools-url-input-outer-holder">
                     <div class="tools-url-input-inner-holder">
                         <input class="tools-url-input" type="text" data-bind="value: cacheLevels" />
                     </div>
-                    <input class="tools-url-add-button" type="submit" value="Cache Tiles" />
+                    <input class="tools-url-add-button" type="submit" value="Request Tiles" />
                 </div>
             </form>
 


### PR DESCRIPTION
This pull request extends the Tile Cache tools (accessible by appending `#tools=1` to the URL) to be useful for measuring dataset performance.  

You can specify to test All Opened (all datasets in a group that is opened/expanded in the UI), All Enabled (all datasets that are checked in the Data Catalogue UI), or All (all datasets, but not including those that won't be known until we expand their group and query their WMS/CKAN server).  You can also specify the number of quadtree tile levels to request.

The results are then displayed:

![image](https://cloud.githubusercontent.com/assets/924374/6660444/50455f2a-cbed-11e4-8b58-365607000ef4.png)

For most accurate results, clear your browser's cache before running the test.  Also, you probably want to access National Map on port 3001 so that NM's Varnish cache does not impact the results.
