### PR TITLE
Don't use gigs of memory to load WMS metadata.

### DIFF
--- a/src/Models/Cesium.js
+++ b/src/Models/Cesium.js
@@ -145,7 +145,7 @@ var Cesium = function(application, viewer) {
             message: '\
 <p>An error occurred while rendering in 3D.  This probably indicates a bug in National Map or an incompatibility with your system \
 or web browser.  We\'ll now switch you to 2D so that you can continue your work.  We would appreciate it if you report this \
-errror by sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.au</a> with the \
+error by sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@lists.nicta.com.au</a> with the \
 technical details below.  Thank you!</p><pre style="overflow:auto;margin-top:10px;padding:10px;border:1px solid gray;">' + formatError(error) + '</pre>'
         }));
 

--- a/src/Models/WebMapServiceCatalogItem.js
+++ b/src/Models/WebMapServiceCatalogItem.js
@@ -482,7 +482,7 @@ function findLayer(startLayer, name) {
 }
 
 function populateMetadataGroup(metadataGroup, sourceMetadata) {
-    if (typeof sourceMetadata === 'string' || sourceMetadata instanceof Array) {
+    if (typeof sourceMetadata === 'string' || sourceMetadata instanceof String || sourceMetadata instanceof Array) {
         return;
     }
 


### PR DESCRIPTION
When a GetCapabilities has an element with a huge amount of text, that text gets stored in an object for which `typeof value === 'string'` is false but `value instanceof String` is true.  Since we were only checking for strings with the former test, these huge strings would instead be interpreted as objects and each letter would a separate sub-property.  This caused memory usage to explode, not to mention it made the metadata display pretty useless.  So this change adds the latter test as well.

Also fixed a typo in an error message.
