### PR TITLE
Add "preserveOrder" flag to CatalogGroup.

### DIFF
--- a/src/Models/CatalogGroup.js
+++ b/src/Models/CatalogGroup.js
@@ -58,7 +58,8 @@ var CatalogGroup = function(application) {
     this.items = [];
 
     /**
-     * Gets or sets flag to prevent items in group being sorted. Subgroups will still sort unless their own preserveOrder flag is set.
+     * Gets or sets flag to prevent items in group being sorted. Subgroups will still sort unless their own preserveOrder flag is set.  The value
+     * of this property only has an effect during {@CatalogGroup#load} and {@CatalogItem#updateFromJson}.
      */
     this.preserveOrder = false; 
 
@@ -106,18 +107,6 @@ defineProperties(CatalogGroup.prototype, {
     typeName : {
         get : function() {
             return 'Group';
-        }
-    },
-
-    /**
-     * Gets a value indicating whether the items in this group (and their sub-items, if any) should be sorted when
-     * {@link CatalogGroup#load} is complete.
-     * @memberOf CatalogGroup.prototype
-     * @type {Boolean}
-     */
-    sortItemsOnLoad : {
-        get : function() {
-            return true; // Even if preserveOrder is set, the process of sorting should take place.
         }
     },
 
@@ -203,9 +192,7 @@ CatalogGroup.defaultUpdaters.items = function(catalogGroup, json, propertyName, 
         }
 
         return when.all(promises, function() {
-            if (defaultValue(json.sortItemsOnLoad, true)) {
-                catalogGroup.sortItems();
-            }
+            catalogGroup.sortItems();
         });
     });
 };
@@ -288,9 +275,7 @@ CatalogGroup.prototype.load = function() {
 
         return that._load();
     }).then(function() {
-        if (defaultValue(that.sortItemsOnLoad, true)) {
-            that.sortItems(true);
-        }
+        that.sortItems(true);
         that._loadingPromise = undefined;
         that.isLoading = false;
     }).otherwise(function(e) {

--- a/src/Models/CatalogGroup.js
+++ b/src/Models/CatalogGroup.js
@@ -57,6 +57,11 @@ var CatalogGroup = function(application) {
      */
     this.items = [];
 
+    /**
+     * Gets or sets flag to prevent items in group being sorted. Subgroups will still sort unless their own preserveOrder flag is set.
+     */
+    this.preserveOrder = false; 
+
     knockout.track(this, ['isOpen', 'isLoading', 'items']);
 
     var that = this;
@@ -112,7 +117,7 @@ defineProperties(CatalogGroup.prototype, {
      */
     sortItemsOnLoad : {
         get : function() {
-            return true;
+            return true; // Even if preserveOrder is set, the process of sorting should take place.
         }
     },
 
@@ -371,9 +376,12 @@ CatalogGroup.prototype.findFirstItemByName = function(name) {
  */
 CatalogGroup.prototype.sortItems = function(sortRecursively) {
     naturalSort.insensitive = true;
-    this.items.sort(function(a, b) {
-        return naturalSort(a.name, b.name);
-    });
+    // Allow a group to be non-sorted, while still containing sorted groups.
+    if (!this.preserveOrder) {
+        this.items.sort(function(a, b) {
+            return naturalSort(a.name, b.name);
+        });
+    }
 
     if (defaultValue(sortRecursively, false)) {
         for (var i = 0; i < this.items.length; ++i) {


### PR DESCRIPTION
Allows a group to be unsorted, which gives better results when you're hand-crafting the entries.
