### PR TITLE
Tile tool tweaks

### DIFF
--- a/src/Models/Cesium.js
+++ b/src/Models/Cesium.js
@@ -44,10 +44,15 @@ var Cesium = function(application, viewer) {
 
     /**
      * Gets or sets whether the viewer has stopped rendering since startup or last set to false.
-     * @type {Scene}
+     * @type {Boolean}
      */
     this.stoppedRendering = false;
 
+    /**
+     * Gets or sets whether to output info to the console when starting and stopping rendering loop.
+     * @type {Boolean}
+     */
+    this.verboseRendering = false;
 
     this._lastClockTime = new JulianDate(0, 0.0);
     this._lastCameraViewMatrix = new Matrix4();
@@ -340,7 +345,7 @@ Cesium.prototype.captureScreenshot = function() {
  * Notifies the viewer that a repaint is required.
  */
 Cesium.prototype.notifyRepaintRequired = function() {
-    if (!this.viewer.useDefaultRenderLoop) {
+    if (this.verboseRendering && !this.viewer.useDefaultRenderLoop) {
         console.log('starting rendering @ ' + getTimestamp());
     }
     this._lastCameraMoveTime = getTimestamp();
@@ -367,7 +372,9 @@ function postRender(cesium, date) {
     var tilesWaiting = !surface._tileProvider.ready || surface._tileLoadQueue.length > 0 || surface._debug.tilesWaitingForChildren > 0;
 
     if (!cameraMovedInLastSecond && !tilesWaiting && !cesium.viewer.clock.shouldAnimate) {
-        console.log('stopping rendering @ ' + getTimestamp());
+        if (cesium.verboseRendering) {
+            console.log('stopping rendering @ ' + getTimestamp());
+        }
         cesium.viewer.useDefaultRenderLoop = false;
         cesium.stoppedRendering = true;
     }

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -113,8 +113,11 @@ function getAllRequests(types, mode, requests, group, promises) {
                 getAllRequests(types, mode, requests, item, promises);
             }
         } else if ((types.indexOf(item.type) !== -1) && (mode !== 'enabled' || item.isEnabled)) {
-            var enabledHere = !item.isEnabled;
+           var enabledHere = !item.isEnabled;
             if (enabledHere) {
+                if (defined(item._imageryLayer)) {
+                    continue;
+                }
                 item._enable();
             }
 

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -251,6 +251,7 @@ function requestTiles(toolsPanel, requests, maxLevel) {
     var nextRequestIndex = 0;
     var inFlight = 0;
     var urlsRequested = 0;
+    var showProgress = true;
 
     function doneUrl(stat, startTime, error) {
         var ellapsed = getTimestamp() - startTime;
@@ -287,8 +288,10 @@ function requestTiles(toolsPanel, requests, maxLevel) {
             return undefined;
         }
 
-        if ((nextRequestIndex % 10) === 0) {
-            //popup.message += '<div>Finished ' + nextRequestIndex + ' URLs.</div>';
+        if (showProgress && (nextRequestIndex % 10) === 0) {
+            if (popup.message.substring(popup.message.length-8) === '.</span>') {
+                popup.message = popup.message.replace('.</span>', '..</span>');
+            }
         }
 
         url = urls[nextRequestIndex];
@@ -313,9 +316,13 @@ function requestTiles(toolsPanel, requests, maxLevel) {
     function doNext() {
         var next = getNextUrl();
         if (!defined(last) && defined(next)) {
-            popup.message += '<h1>' + next.name + '</h1>';
+            popup.message += '<h1>' + next.name + '</h1>' + (showProgress ? '<span>.</span>' : '');
         }
         if (defined(last) && (!defined(next) || next.name !== last.name)) {
+            var idx = popup.message.indexOf('<span>.');
+            if (idx !== -1) {
+                popup.message = popup.message.substring(0, idx);
+            }
             popup.message += '<div>';
             if (last.stat.error.number === 0) {
                 popup.message += last.stat.success.number + ' tiles <span style="color:green">✓</span>';
@@ -339,7 +346,7 @@ function requestTiles(toolsPanel, requests, maxLevel) {
             }
 
             if (next) {
-                popup.message += '<h1>' + next.name + '</h1>';
+                popup.message += '<h1>' + next.name + '</h1>' + (showProgress ? '<span>.</span>' : '');
             }
         }
 

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -368,7 +368,7 @@ function requestTiles(toolsPanel, requests, maxLevel) {
             }
         }
 
-        var elPopup = document.getElementById('popup-window-message');
+        var elPopup = document.getElementById('popup-window-content');
         if (elPopup !== null) {
             elPopup.scrollTop = elPopup.scrollHeight - elPopup.offsetHeight;
         } 

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -309,6 +309,7 @@ function requestTiles(toolsPanel, requests, maxLevel) {
     var last;
     var failedRequests = 0;
     var slowDatasets = 0;
+    var totalDatasets = 0;
 
     var maxAverage = 400;
     var maxMaximum = 800;
@@ -344,6 +345,7 @@ function requestTiles(toolsPanel, requests, maxLevel) {
             if (average > maxAverage || last.stat.success.max > maxMaximum) {
                 ++slowDatasets;
             }
+            totalDatasets++;
 
             if (next) {
                 popup.message += '<h1>' + next.name + '</h1>' + (showProgress ? '<span>.</span>' : '');
@@ -355,18 +357,20 @@ function requestTiles(toolsPanel, requests, maxLevel) {
         if (!defined(next)) {
             if (inFlight === 0) {
                 popup.message += '<h1>Summary</h1>';
-                popup.message += '<div>Finished ' + nextRequestIndex + ' URLs.  DONE!</div>';
+                popup.message += '<div>Finished ' + nextRequestIndex + ' URLs for ' + totalDatasets + ' datasets.</div>';
                 popup.message += '<div>Actual number of URLs requested: ' + urlsRequested + '</div>';
                 popup.message += '<div style="' + (failedRequests > 0 ? 'color:red' : '') + '">Failed tile requests: ' + failedRequests + '</div>';
                 popup.message += '<div style="' + (slowDatasets > 0 ? 'color:red' : '') + '">Slow datasets: ' + slowDatasets + 
                 ' <i>(>' + maxAverage + 'ms average, or >' + maxMaximum + 'ms maximum)</i></div>';
-                
             }
-            return;
         }
 
-        if (document.getElementById('popup-window') === null) {
-            console.log('Provider tile requests terminated');
+        var elPopup = document.getElementById('popup-window-message');
+        if (elPopup !== null) {
+            elPopup.scrollTop = elPopup.scrollHeight - elPopup.offsetHeight;
+        } 
+
+        if (elPopup === null || !defined(next)) {
             return;
         }
 
@@ -378,7 +382,7 @@ function requestTiles(toolsPanel, requests, maxLevel) {
         var url = next.url;
 
         if (!toolsPanel.usProxyCache) {
-            url = url.replace('/proxy/h', '/proxy/_0d/h');
+            url = url.replace('proxy/h', 'proxy/_0d/h');
         }
 
         if (!toolsPanel.useWmsTileCache) {

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -357,6 +357,11 @@ function requestTiles(toolsPanel, requests, maxLevel) {
             return;
         }
 
+        if (document.getElementById('popup-window') === null) {
+            console.log('Provider tile requests terminated');
+            return;
+        }
+
         ++urlsRequested;
         ++inFlight;
 

--- a/src/ViewModels/ToolsPanelViewModel.js
+++ b/src/ViewModels/ToolsPanelViewModel.js
@@ -30,12 +30,13 @@ var ToolsPanelViewModel = function(options) {
 
     this.cacheFilter = 'opened';
     this.cacheLevels = 3;
-    this.useCache = false;
+    this.useProxyCache = false;
+    this.useWmsTileCache = true;
     this.ckanFilter = 'opened';
     this.ckanUrl = 'http://localhost';
     this.ckanApiKey = 'xxxxxxxxxxxxxxx';
 
-    knockout.track(this, ['cacheFilter', 'cacheLevels', 'useCache', 'ckanFilter', 'ckanUrl', 'ckanApiKey']);
+    knockout.track(this, ['cacheFilter', 'cacheLevels', 'useProxyCache', 'useWmsTileCache', 'ckanFilter', 'ckanUrl', 'ckanApiKey']);
 };
 
 ToolsPanelViewModel.prototype.show = function(container) {
@@ -369,8 +370,12 @@ function requestTiles(toolsPanel, requests, maxLevel) {
 
         var url = next.url;
 
-        if (!toolsPanel.useCache) {
+        if (!toolsPanel.usProxyCache) {
             url = url.replace('/proxy/h', '/proxy/_0d/h');
+        }
+
+        if (!toolsPanel.useWmsTileCache) {
+            url = url.replace('tiled=true&', '');
         }
 
         var start = getTimestamp();

--- a/src/Views/PopupMessage.html
+++ b/src/Views/PopupMessage.html
@@ -1,4 +1,4 @@
-<div class="modal-background" data-bind="click: closeIfClickOnBackground">
+<div class="modal-background" id="popup-window" data-bind="click: closeIfClickOnBackground">
     <div class="popup-message">
         <div class="modal-header">
             <div class="modal-close-button" data-bind="click: close">&times;</div>

--- a/src/Views/PopupMessage.html
+++ b/src/Views/PopupMessage.html
@@ -4,7 +4,7 @@
             <div class="modal-close-button" data-bind="click: close">&times;</div>
             <h1 data-bind="text: title"></h1>
         </div>
-        <div class="popup-message-content"  id="popup-window-message" >
+        <div class="popup-message-content"  id="popup-window-content" >
             <div class="popup-message-label" data-bind="html: message"></div>
         </div>
     </div>

--- a/src/Views/PopupMessage.html
+++ b/src/Views/PopupMessage.html
@@ -1,10 +1,10 @@
-<div class="modal-background" id="popup-window" data-bind="click: closeIfClickOnBackground">
+<div class="modal-background" data-bind="click: closeIfClickOnBackground">
     <div class="popup-message">
         <div class="modal-header">
             <div class="modal-close-button" data-bind="click: close">&times;</div>
             <h1 data-bind="text: title"></h1>
         </div>
-        <div class="popup-message-content">
+        <div class="popup-message-content"  id="popup-window-message" >
             <div class="popup-message-label" data-bind="html: message"></div>
         </div>
     </div>

--- a/src/Views/ToolsPanel.html
+++ b/src/Views/ToolsPanel.html
@@ -16,13 +16,6 @@
                     </select>
                 </label>
 
-                <div>
-                    <label class="tools-content-type">
-                        <input type="checkbox" data-bind="checked: useCache" />
-                        Use proxy cache
-                    </label>
-                </div>
-
                 Enter the number of tile levels to request
                 <div class="tools-url-input-outer-holder">
                     <div class="tools-url-input-inner-holder">
@@ -30,6 +23,17 @@
                     </div>
                     <input class="tools-url-add-button" type="submit" value="Request Tiles" />
                 </div>
+                <div>
+                    <label class="tools-content-type">
+                        <input type="checkbox" data-bind="checked: useWmsTileCache" />
+                        Use WMS tile cache
+                    </label>
+                    <label class="tools-content-type">
+                        <input type="checkbox" data-bind="checked: useProxyCache" />
+                        Use proxy cache
+                    </label>
+                </div>
+
             </form>
 
             <form class="tools-form" data-bind="submit: exportFile">


### PR DESCRIPTION
Several minor things in provider testing tool based on testing with ga/vic/un/our datasets:
- added simple progress output
- stop getting urls if popup closed
- auto scroll to bottom of popup as results populates
- added option to skip wms tile cache to check base data provider server perf
- fixed problem with enabling image layer with dups (vic ckan issue)
- fixed relative proxy path issue.
- made render loop message a setting and off by default (tended to fill up console)
