### PR TITLE
Add support for WMS MinScaleDenominator and Esri maxScale

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -170,11 +170,11 @@ function bundle(name, bundler, minify, catchErrors) {
 }
 
 function build(name, files, minify) {
-    return bundle(name, browserify(files).transform('brfs').transform('deamdify'), minify, false);
+    return bundle(name, browserify(files).transform('brfs'), minify, false);
 }
 
 function watch(name, files, minify) {
-    var bundler = watchify(files).transform('brfs').transform('deamdify');
+    var bundler = watchify(files).transform('brfs');
 
     function rebundle() {
         var start = new Date();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -170,11 +170,11 @@ function bundle(name, bundler, minify, catchErrors) {
 }
 
 function build(name, files, minify) {
-    return bundle(name, browserify(files).transform('brfs'), minify, false);
+    return bundle(name, browserify(files).transform('brfs').transform('deamdify'), minify, false);
 }
 
 function watch(name, files, minify) {
-    var bundler = watchify(files).transform('brfs');
+    var bundler = watchify(files).transform('brfs').transform('deamdify');
 
     function rebundle() {
         var start = new Date();

--- a/src/Map/CesiumTileLayer.js
+++ b/src/Map/CesiumTileLayer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /*global require,L*/
+var defined = require('../../third_party/cesium/Source/Core/defined');
 var DeveloperError = require('../../third_party/cesium/Source/Core/DeveloperError');
 var ImageryProvider = require('../../third_party/cesium/Source/Scene/ImageryProvider');
 var WebMercatorTilingScheme = require('../../third_party/cesium/Source/Core/WebMercatorTilingScheme');
@@ -60,6 +61,10 @@ var CesiumTileLayer = L.TileLayer.extend({
                 this._zSubtract = 1;
             } else if (tilingScheme.getNumberOfXTilesAtLevel(0) !== 1 || tilingScheme.getNumberOfYTilesAtLevel(0) !== 1) {
                 throw new DeveloperError('Only ImageryProviders with 1x1 or 2x2 tiles at level 0 can be used with Leaflet.');
+            }
+
+            if (defined(this.imageryProvider.maximumLevel)) {
+                this.options.maxNativeZoom = this.imageryProvider.maximumLevel;
             }
         }
 

--- a/src/Models/ArcGisMapServerCatalogGroup.js
+++ b/src/Models/ArcGisMapServerCatalogGroup.js
@@ -231,6 +231,7 @@ function createDataSource(mapServiceGroup, layer, dataCustodian) {
     result.dataUrl = mapServiceGroup.url;
     result.dataUrlType = 'direct';
     result.layers = layer.id.toString();
+    result.maximumScale = layer.maxScale;
 
     result.description = '';
 

--- a/src/Models/ArcGisMapServerCatalogItem.js
+++ b/src/Models/ArcGisMapServerCatalogItem.js
@@ -92,29 +92,30 @@ defineProperties(ArcGisMapServerCatalogItem.prototype, {
 });
 
 ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
-    var maxLevel;
+    var maximumLevel;
 
     if (defined(this.maximumScale)) {
-        var dpi = 96;
+        var dpi = 96; // Esri default DPI, unless we specify otherwise.
         var centimetersPerInch = 2.54;
         var centimetersPerMeter = 100;
         var dotsPerMeter = dpi * centimetersPerMeter / centimetersPerInch;
+        var tileWidth = 256;
 
         var circumferenceAtEquator = 2 * Math.PI * Ellipsoid.WGS84.maximumRadius;
-        var distancePerPixelAtLevel0 = circumferenceAtEquator / 256;
+        var distancePerPixelAtLevel0 = circumferenceAtEquator / tileWidth;
         var level0ScaleDenominator = distancePerPixelAtLevel0 * dotsPerMeter;
 
         // 1e-6 epsilon from WMS 1.3.0 spec, section 7.2.4.6.9.
         var ratio = level0ScaleDenominator / (this.maximumScale - 1e-6);
         var levelAtMinScaleDenominator = Math.log(ratio) / Math.log(2);
-        maxLevel = levelAtMinScaleDenominator | 0;
+        maximumLevel = levelAtMinScaleDenominator | 0;
     }
 
     return new ArcGisMapServerImageryProvider({
         url: cleanAndProxyUrl(this.application, this.url),
         layers: this.layers,
         tilingScheme: new WebMercatorTilingScheme(),
-        maximumLevel: maxLevel
+        maximumLevel: maximumLevel
     });
 };
 

--- a/src/Models/ArcGisMapServerCatalogItem.js
+++ b/src/Models/ArcGisMapServerCatalogItem.js
@@ -39,7 +39,15 @@ var ArcGisMapServerCatalogItem = function(application) {
      */
     this.layers = undefined;
 
-    knockout.track(this, ['url', 'layers', '_legendUrl']);
+    /**
+     * Gets or sets the denominator of the largest scale (smallest denominator) for which tiles should be requested.  For example, if this value is 1000, then tiles representing
+     * a scale larger than 1:1000 (i.e. when zooming in closer) will not be requested.  Instead, tiles of the largest-available scale, as specified by this property,
+     * will be used and will simply get blurier as the user zooms in closer.
+     * @type {Number}
+     */
+    this.minScaleDenominator = undefined;
+
+    knockout.track(this, ['url', 'layers', 'minScaleDenominator', '_legendUrl']);
 
     // dataUrl, metadataUrl, and legendUrl are derived from url if not explicitly specified.
     overrideProperty(this, 'legendUrl', {
@@ -83,6 +91,12 @@ defineProperties(ArcGisMapServerCatalogItem.prototype, {
 });
 
 ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
+    var maxLevel;
+
+    if (defined(this.minScaleDenominator)) {
+
+    }
+
     return new ArcGisMapServerImageryProvider({
         url : cleanAndProxyUrl(this.application, this.url),
         layers : this.layers,

--- a/src/Models/ImageryLayerCatalogItem.js
+++ b/src/Models/ImageryLayerCatalogItem.js
@@ -393,7 +393,7 @@ ImageryLayerCatalogItem.prototype.pickFeaturesInLeaflet = function(mapExtent, ma
     var ll = projection.unproject(new Cartesian2(x, y));
 
     // Map the lon/lat to a tile in the current zoom level and query that tile for features.
-    var level = map.getZoom();
+    var level = Math.min(map.getZoom(), imageryProvider.maximumLevel);
     var tilingScheme = imageryProvider.tilingScheme;
     var tileCoordinates = tilingScheme.positionToTileXY(ll, level);
     if (!defined(tileCoordinates)) {

--- a/src/Models/WebMapServiceCatalogGroup.js
+++ b/src/Models/WebMapServiceCatalogGroup.js
@@ -200,18 +200,6 @@ sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@
             }
         }
 
-        if (defined(json.Capability.VendorSpecificCapabilities) &&
-            defined(json.Capability.VendorSpecificCapabilities.TileSet)) {
-
-            var tileSet = json.Capability.VendorSpecificCapabilities.TileSet;
-            for (var i = 0; i < tileSet.length; i++) {
-                if (tileSet[i].SRS ===  "EPSG:3857") {
-                    that.parameters = combine(that.parameters, {'tiled': true});
-                    break;
-                }
-            }
-        }
-
         var dataCustodian = that.dataCustodian;
         if (!defined(dataCustodian) && defined(json.Service.ContactInformation)) {
             var contactInfo = json.Service.ContactInformation;

--- a/src/Models/WebMapServiceCatalogGroup.js
+++ b/src/Models/WebMapServiceCatalogGroup.js
@@ -150,7 +150,7 @@ WebMapServiceCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
 };
 
 WebMapServiceCatalogGroup.prototype._load = function() {
-    var url = cleanAndProxyUrl(this.application, this.url) + '?service=WMS&request=GetCapabilities&version=1.1.1&tiled=true';
+    var url = cleanAndProxyUrl(this.application, this.url) + '?service=WMS&request=GetCapabilities&version=1.3.0&tiled=true';
 
     var that = this;
     return loadXML(url).then(function(xml) {
@@ -311,6 +311,7 @@ function createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, suppor
     result.url = wmsGroup.url;
     result.layers = layer.Name;
     result.parameters = wmsGroup.parameters;
+    result.minScaleDenominator = layer.MinScaleDenominator;
 
     result.description = '';
 

--- a/src/ViewModels/SettingsPanelViewModel.js
+++ b/src/ViewModels/SettingsPanelViewModel.js
@@ -79,7 +79,7 @@ function updateDocumentSubscription(viewModel) {
             if (defined(e) && defined(viewModel._domNodes)) {
                 var element = e.target;
                 while (isClickOutside && element) {
-                    isClickOutside = viewModel._domNodes.indexOf(element) < 0 && (!defined(element.className) || element.className.indexOf('menu-bar-item') < 0);
+                    isClickOutside = viewModel._domNodes.indexOf(element) < 0 && (!defined(element.className) || !defined(element.className.indexOf) || element.className.indexOf('menu-bar-item') < 0);
                     element = element.parentNode;
                 }
             }


### PR DESCRIPTION
This prevents layers from disappearing when you zoom in too close.  Instead, we continue to use the lower-detail tiles and the layer just gets blurry.
