### PR TITLE
Support disclaimers, licenses and updates in catalog item info pane

### DIFF
--- a/src/Models/CatalogMember.js
+++ b/src/Models/CatalogMember.js
@@ -48,7 +48,7 @@ var CatalogMember = function(application) {
      */
     this.isUserSupplied = true;
 
-    knockout.track(this, ['name', 'description', 'isUserSupplied']);
+    knockout.track(this, ['name', 'description', 'disclaimer', 'license', 'updates', 'isUserSupplied']);
 };
 
 defineProperties(CatalogMember.prototype, {

--- a/src/Models/CatalogMember.js
+++ b/src/Models/CatalogMember.js
@@ -40,6 +40,15 @@ var CatalogMember = function(application) {
     this.description = '';
 
     /**
+    * An array of section titles and contents for display in the layer info panel.
+    * In future this may replace 'description' above. Content will be rendered using sanitizeHtml.
+    * This property is observable.
+    * @type {{name:string, content:string}}
+    * @default []
+    */
+    this.info = [];
+
+    /**
      * Gets or sets a value indicating whether this member was supplied by the user rather than loaded from one of the
      * {@link Application#initSources}.  User-supplied members must be serialized completely when, for example,
      * serializing enabled members for sharing.  This property is observable.

--- a/src/Models/CatalogMember.js
+++ b/src/Models/CatalogMember.js
@@ -48,7 +48,7 @@ var CatalogMember = function(application) {
      */
     this.isUserSupplied = true;
 
-    knockout.track(this, ['name', 'description', 'disclaimer', 'license', 'updates', 'isUserSupplied']);
+    knockout.track(this, ['name', 'info', 'description', 'isUserSupplied']);
 };
 
 defineProperties(CatalogMember.prototype, {

--- a/src/Models/CatalogMember.js
+++ b/src/Models/CatalogMember.js
@@ -40,10 +40,13 @@ var CatalogMember = function(application) {
     this.description = '';
 
     /**
-    * An array of section titles and contents for display in the layer info panel.
-    * In future this may replace 'description' above. Content will be rendered using sanitizeHtml.
+    * Gets or sets the array of section titles and contents for display in the layer info panel.
+    * In future this may replace 'description' above - this list should not contain
+    * sections named 'description' or 'Description' if the 'description' property
+    * is also set as both will be displayed.
+    * Content will be rendered using sanitizedHtml.
     * This property is observable.
-    * @type {{name:string, content:string}}
+    * @type [{name:string, content:string}]
     * @default []
     */
     this.info = [];
@@ -132,6 +135,23 @@ defineProperties(CatalogMember.prototype, {
     propertiesForSharing : {
         get : function() {
             return CatalogMember.defaultPropertiesForSharing;
+        }
+    },
+
+    /**
+    * Tests whether a description is available, either in the 'description' property
+    * or as a member of the 'info' array.
+    * @memberOf CatalogMember.prototype
+    * @type bool
+    */
+    hasDescription : {
+        get : function() {
+            return this.description ||
+                (this.info &&
+                 this.info.some(function(i){
+                    return (i.name === "Description" || i.name === "description");
+                    })
+                );
         }
     }
 });

--- a/src/Views/CatalogItemInfo.html
+++ b/src/Views/CatalogItemInfo.html
@@ -47,15 +47,7 @@
             </div>
             <!-- /ko -->
 
-            <!-- ko if: catalogItem.disclaimer -->
-            <div class="catalog-item-info-section">
-                <h2>Licensing, Terms &amp; Conditions</h2>
-                <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.license">
-                </div>
-            </div>
-            <!-- /ko -->
-
-            <!-- ko if: catalogItem.disclaimer -->
+            <!-- ko if: catalogItem.description -->
             <div class="catalog-item-info-section">
                 <h2>Description</h2>
                 <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.description"></div>
@@ -80,6 +72,15 @@
                 <h2>Data Custodian</h2>
                 <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.dataCustodian"></div>
             </div>
+
+
+            <!-- ko if: catalogItem.disclaimer -->
+            <div class="catalog-item-info-section">
+                <h2>Licensing, Terms &amp; Conditions</h2>
+                <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.license">
+                </div>
+            </div>
+            <!-- /ko -->
 
             <div class="catalog-item-info-section" data-bind="if: catalogItem.url">
                 <h2><span data-bind="text: catalogItem.typeName"></span> URL</h2>

--- a/src/Views/CatalogItemInfo.html
+++ b/src/Views/CatalogItemInfo.html
@@ -38,15 +38,6 @@
             <h1 data-bind="text: catalogItem.name"></h1>
         </div>
         <div class="catalog-item-info-content">
-            <!-- ko if: catalogItem.disclaimer -->
-            <div class="catalog-item-info-section">
-                <h2>Disclaimer</h2>
-                <div class="catalog-item-info-description">
-                    <strong style="font-weight: bold; color: #C13C2D;" data-bind="sanitizedHtml: catalogItem.disclaimer"></strong>
-                </div>
-            </div>
-            <!-- /ko -->
-
             <!-- ko if: catalogItem.description -->
             <div class="catalog-item-info-section">
                 <h2>Description</h2>
@@ -54,33 +45,24 @@
             </div>
             <!-- /ko -->
 
-            <!-- ko if: !catalogItem.description -->
+            <!-- ko if:
+            !catalogItem.description &&
+            (!catalogItem.info || !catalogItem.info.some(function(i){return (i.name === "Description" || i.name == "description")}))
+            -->
             <div class="catalog-item-info-section">
                 <div class="catalog-item-info-description">Please contact the provider of this data for more information, including information about usage rights and constraints.</div>
             </div>
             <!-- /ko -->
 
-            <!-- ko if: catalogItem.updates -->
+
+        <!-- ko foreach: catalogItem.info -->
             <div class="catalog-item-info-section">
-                <h2>Data Updates</h2>
-                <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.updates">
+                <h2 data-bind="text: name"></h2>
+                <div class="catalog-item-info-description">
+                    <div data-bind="sanitizedHtml: content"></div>
                 </div>
             </div>
-            <!-- /ko -->
-
-            <div class="catalog-item-info-section">
-                <h2>Data Custodian</h2>
-                <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.dataCustodian"></div>
-            </div>
-
-
-            <!-- ko if: catalogItem.disclaimer -->
-            <div class="catalog-item-info-section">
-                <h2>Licensing, Terms &amp; Conditions</h2>
-                <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.license">
-                </div>
-            </div>
-            <!-- /ko -->
+        <!-- /ko -->
 
             <div class="catalog-item-info-section" data-bind="if: catalogItem.url">
                 <h2><span data-bind="text: catalogItem.typeName"></span> URL</h2>

--- a/src/Views/CatalogItemInfo.html
+++ b/src/Views/CatalogItemInfo.html
@@ -38,18 +38,49 @@
             <h1 data-bind="text: catalogItem.name"></h1>
         </div>
         <div class="catalog-item-info-content">
+            <!-- ko if: catalogItem.disclaimer -->
             <div class="catalog-item-info-section">
-                <!-- ko if: catalogItem.description -->
-                <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.description"></div>
-                <!-- /ko -->
-                <!-- ko if: !catalogItem.description -->
-                <div class="catalog-item-info-description">Please contact the provider of this data for more information, including information about usage rights and constraints.</div>
-                <!-- /ko -->
+                <h2>Disclaimer</h2>
+                <div class="catalog-item-info-description">
+                    <strong style="font-weight: bold; color: #C13C2D;" data-bind="sanitizedHtml: catalogItem.disclaimer"></strong>
+                </div>
             </div>
+            <!-- /ko -->
+
+            <!-- ko if: catalogItem.disclaimer -->
+            <div class="catalog-item-info-section">
+                <h2>Licensing, Terms &amp; Conditions</h2>
+                <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.license">
+                </div>
+            </div>
+            <!-- /ko -->
+
+            <!-- ko if: catalogItem.disclaimer -->
+            <div class="catalog-item-info-section">
+                <h2>Description</h2>
+                <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.description"></div>
+            </div>
+            <!-- /ko -->
+
+            <!-- ko if: !catalogItem.description -->
+            <div class="catalog-item-info-section">
+                <div class="catalog-item-info-description">Please contact the provider of this data for more information, including information about usage rights and constraints.</div>
+            </div>
+            <!-- /ko -->
+
+            <!-- ko if: catalogItem.updates -->
+            <div class="catalog-item-info-section">
+                <h2>Data Updates</h2>
+                <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.updates">
+                </div>
+            </div>
+            <!-- /ko -->
+
             <div class="catalog-item-info-section">
                 <h2>Data Custodian</h2>
                 <div class="catalog-item-info-description" data-bind="sanitizedHtml: catalogItem.dataCustodian"></div>
             </div>
+
             <div class="catalog-item-info-section" data-bind="if: catalogItem.url">
                 <h2><span data-bind="text: catalogItem.typeName"></span> URL</h2>
                 <input class="catalog-item-info-baseUrl" readonly type="text" data-bind="value: catalogItem.url" size="80" onclick="this.select();" />

--- a/src/Views/CatalogItemInfo.html
+++ b/src/Views/CatalogItemInfo.html
@@ -45,10 +45,7 @@
             </div>
             <!-- /ko -->
 
-            <!-- ko if:
-            !catalogItem.description &&
-            (!catalogItem.info || !catalogItem.info.some(function(i){return (i.name === "Description" || i.name == "description")}))
-            -->
+            <!-- ko if: !catalogItem.hasDescription -->
             <div class="catalog-item-info-section">
                 <div class="catalog-item-info-description">Please contact the provider of this data for more information, including information about usage rights and constraints.</div>
             </div>


### PR DESCRIPTION
We need some more fine grain control of what information is available in the info pane for layers in the AREMI project. These changes meet our needs so we don't have to stuff everything into the description field. It would be good to have the UX team take a look and give their opinions on this.
