### PR TITLE
Improve Gazetteer search ordering, filtering and show states where avail...

### DIFF
--- a/src/ViewModels/GazetteerSearchProviderViewModel.js
+++ b/src/ViewModels/GazetteerSearchProviderViewModel.js
@@ -63,7 +63,16 @@ GazetteerSearchProviderViewModel.prototype.search = function(searchText) {
         latitudeDegrees = center.lat;
     }
 
+    // I don't know how to get server-side sorting, so we have to retrieve lots of rows, then filter.
+    // Retrieving only 10 rows (default) means "Sydney" fails to actually retrieve Sydney...
+
+    // Worth considering using "fq=class_code:(R%20X)", which would only return towns, states etc
+
+
     var url = this.url + '?q=name:*' + searchText + '*';
+    // filter out bores, built structures, caves, landmarks, trig stations
+    url += '%20-class_code:(D%20E%20G%20J%20T)%20-feature_code:PRS';
+    url += '&rows=200';
 
     if (this.forceUseOfProxy || corsProxy.shouldUseProxy(url)) {
         url = corsProxy.getURL(url);
@@ -72,17 +81,20 @@ GazetteerSearchProviderViewModel.prototype.search = function(searchText) {
     var promise = loadJson(url);
 
     var that = this;
-    var geocodeInProgress = this._geocodeInProgress = promise.then(function(solarQueryResponse) {
+    var geocodeInProgress = this._geocodeInProgress = promise.then(function(solrQueryResponse) {
         if (geocodeInProgress.cancel) {
             return;
         }
         that.isSearching = false;
 
-        if (defined(solarQueryResponse.response) && solarQueryResponse.response.numFound > 0) {
-            solarQueryResponse.response.docs.forEach(function(result) {
+
+        if (defined(solrQueryResponse.response) && solrQueryResponse.response.numFound > 0) {
+            var results = solrQueryResponse.response.docs.sort(
+                function (a,b) { return sortResults(a,b,searchText); } );
+            results.slice(0,10).forEach(function(result) {
                 that.searchResults.push(new SearchResultViewModel({
-                    name: result.name,
-                    isImportant: true,
+                    name: result.name + (result.state_id !== 'N/A' ? ' (' + result.state_id + ')' : ''),
+                    isImportant: !!result.feature_code.match('^(CNTY|CONT|DI|PRSH|STAT|LOCB|LOCU|SUB|URBN)$'),
                     clickAction: createZoomToFunction(that, result)
                 }));
             });
@@ -100,6 +112,45 @@ GazetteerSearchProviderViewModel.prototype.search = function(searchText) {
         that.searchMessage = 'An error occurred while searching.  Please check your internet connection or try again later.';
     });
 };
+
+function featureScore(a, searchText) {
+    // could be further refined using http://www.ga.gov.au/image_cache/GA19367.pdf
+    // feature_code is defined on p24
+    // class_code (A-X) matches a row in the table on p23 (eg, 'C' is 'Bays & Gulfs')
+    var featureTypes = ['CONT', 'STAT', 'URBN', 'LOCB', 'LOCU', 'SUB', 'DI', 'CNTY', 'DI'];
+    featureTypes.push('HBR', 'CAPE','PEN','PT', 'BAY','PORT','GULF', 'BGHT','COVE','MT','HILL','PEAK','OCEN','SEA','RESV','LAKE','RES','STRM');
+    featureTypes.push('PLN','REEF','VAL', 'PRSH');
+
+    var aScore = 10000 - (featureTypes.indexOf(a.feature_code) + 1) *100;
+    if (aScore === 10000) {
+        aScore = 0;
+    }
+    
+    if (a.name.toUpperCase() === searchText.toUpperCase()) {
+        // Bonus for exact match
+        // More testing required to choose this value. Should "Geelong" (parish in Queensland) outrank "North Geelong" (suburb in Vic)?
+        aScore += 10 * 100; 
+    } else if (a.name.match(new RegExp('^' + searchText + '\\b', 'i'))) {
+        // bonus for first word match ('Steve Bay' better than 'West Steve Bay')
+        aScore += 8 * 100;
+    } else if (a.name.match(new RegExp('\\b' + searchText + '\\b', 'i'))) {
+        // bonus for word-boundary match ('Steve' better than 'Steveville')
+        aScore += 4 * 100;
+    } else if (a.name.match(new RegExp('^' + searchText, 'i'))) {
+        // bonus for word-boundary match ('Steventon' better than 'Nosteve Town')
+        aScore += 2 * 100;
+    }
+    if (a.state_id === 'N/A') {
+        // seems to be an indicator of a low quality result
+        aScore -= 10 * 100;
+    }
+    
+    return aScore;
+}
+
+function sortResults(a, b, searchText) {
+    return featureScore(b, searchText) - featureScore(a, searchText);
+}
 
 function createZoomToFunction(viewModel, resource) {
     // Server does not return information of a bounding box, just a location.


### PR DESCRIPTION
...able.

It's not perfect, but some major improvements:
- get 200 results, not just 10, so "Sydney" is actually in the result list.
- filter out low value results (trees, boreholes) before we even get them
- rank search results, giving more value to cities, and place names that closely match the query text.
- show the state name for each result, if it's provided. Not so easy to provide other context, eg, city name.
