### PR TITLE
Allow loading init files in .hjson format.

### DIFF
--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -13,10 +13,11 @@ var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var FeatureDetection = require('terriajs-cesium/Source/Core/FeatureDetection');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
+var loadText = require('terriajs-cesium/Source/Core/loadText');
 var queryToObject = require('terriajs-cesium/Source/Core/queryToObject');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
-
+var Hjson = require('hjson');
 var CameraView = require('./CameraView');
 var Catalog = require('./Catalog');
 var corsProxy = require('../Core/corsProxy');
@@ -381,7 +382,7 @@ function interpretHash(hashProperties, userProperties, persistentInitSources, te
 }
 
 function generateInitializationUrl(url) {
-    if (url.toLowerCase().substring(url.length-5) !== '.json') {
+    if (!url.match(/\.h?json$/i)) {
         return 'init/' + url + '.json';
     }
     return url;
@@ -405,7 +406,17 @@ function loadInitSources(terria, initSources) {
 
 function loadInitSource(source) {
     if (typeof source === 'string') {
-        return loadJson(source).then(function(initSource) {
+        var p;
+        if (source.match(/\.json$/)) {
+            p = loadJson(source);
+        } else {
+            p = loadText(source, "Accept : 'application/json,application/hjson,*/*;q=0.01'")
+                .then(function (h) {
+                    return Hjson.parse(h);
+                });
+        }
+
+        return p.then(function(initSource) {
             initSource.isFromExternalFile = true;
             return initSource;
         }).otherwise(function() {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "URIjs": "^1.15.0",
     "brfs": "^1.4.0",
+    "hjson": "^1.6",
     "html2canvas": "^0.5.0-alpha2",
     "javascript-natural-sort": "^0.7.1",
     "leaflet": "^0.7.3",


### PR DESCRIPTION
HJson (http://hjson.org/) is more user friendly (no quotes or commas),
allows inline comments, and is slightly smaller.

Quick explanation: the init/*.json files are our primary link with data sources, but they're relatively hard for us to maintain, very hard to data custodians to maintain, and don't allow comments, which makes it hard to document issues as we go.

Using hjson isn't a full solution, but it's a modest improvement, I think. There are other "JSON plus" formats which all work on the "JSON is not a great format for configuration files" problem, including [json5](json5.org). Hjson seems as good as any.

I opted for browser side processing so that you can modify the .hjson file and see the change straight away without rebuilding. It will also work better with a purely static deployment. The cost of the hjson library is more than made up for the reduction in size in the .json files themselves.

There's no lock-in risk as we can always trivially convert the .hjson back to .json.
