### PR TITLE
Specify valid/invalid elements to DragDropViewModel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.7
+
+* Added `validDropElements`, `validDropClasses`, `invalidDropElements`, and `invalidDropClasses` properties to `DragDropViewModel` for finer control over where dropping is allowed.
+
 ### 1.0.6
 
 * Added support for region mapping based on region names instead of region numbers (example in `public/test/countries.csv`).

--- a/lib/ThirdParty/TileLayer.Filter.js
+++ b/lib/ThirdParty/TileLayer.Filter.js
@@ -1,5 +1,3 @@
-'use strict';
-
 function install(L) {
     /*
      @preserve Leaflet Tile Filters, a JavaScript plugin for applying image filters to tile images

--- a/lib/ViewModels/DragDropViewModel.js
+++ b/lib/ViewModels/DragDropViewModel.js
@@ -31,7 +31,39 @@ var DragDropViewModel = function(options) {
     this.allowDropDataFiles = defaultValue(options.allowDropDataFiles, true);
     this.allowDropInitFiles = defaultValue(options.allowDropInitFiles, true);
 
-    knockout.track(this, ['showDropMessage', 'allowDropDataFiles', 'allowDropInitFiles']);
+    /**
+     * Gets or sets the list of elements or element IDs that are valid for dropping.
+     * These elements plus all of the elements they contain, directly or indirectly, are
+     * valid for dropping, unless they're also specified in one of the invalid lists.
+     * @type {Array}
+     */
+    this.validDropElements = defaultValue(options.validDropElements, []).slice();
+
+    /**
+     * Gets or sets the list of CSS class names that are valid for dropping.  These elements
+     * plus all of the elements they contain, directly or indirectly, are valid for dropping,
+     * unless they're also specified in one the invalid lists.
+     * @type {[type]}
+     */
+    this.validDropClasses = defaultValue(options.validDropClasses, []).slice();
+
+    /**
+     * Gets or sets the list of elements or element IDs that are not valid for dropping,
+     * even if they are present in one of the valid lists.
+     * Dropping is not allowed in these elements or any elements they contain.
+     * @type {Array}
+     */
+    this.invalidDropElements = defaultValue(options.invalidDropElements, []).slice();
+
+    /**
+     * Gets or sets the list of CSS class names that are not valid for dropping, even if they
+     * are present in the one of valid lists.  Dropping is not allowed in these elements or
+     * any elements they contain.
+     * @type {Array}
+     */
+    this.invalidDropClasses = defaultValue(options.invalidDropClasses, []).slice();
+
+    knockout.track(this, ['showDropMessage', 'allowDropDataFiles', 'allowDropInitFiles', 'validDropElements', 'invalidDropClasses']);
 
     var that = this;
 
@@ -53,12 +85,20 @@ var DragDropViewModel = function(options) {
             return;
         }
 
+        if (!isValidDropTarget(that, evt.target)) {
+            return;
+        }
+
         evt.preventDefault();
         that.showDropMessage = true;
     }, false);
 
     this.dropTarget.addEventListener("dragover", function(evt) {
         if (!evt.dataTransfer.types || !arrayContains(evt.dataTransfer.types, 'Files')) {
+            return;
+        }
+
+        if (!isValidDropTarget(that, evt.target)) {
             return;
         }
 
@@ -71,6 +111,10 @@ var DragDropViewModel = function(options) {
             return;
         }
 
+        if (!isValidDropTarget(that, evt.target)) {
+            return;
+        }
+
         evt.preventDefault();
 
         if (evt.target.className === 'drag-drop') {
@@ -80,6 +124,10 @@ var DragDropViewModel = function(options) {
 
     this.dropTarget.addEventListener("drop", function(evt) {
         if (!evt.dataTransfer.types || !arrayContains(evt.dataTransfer.types, 'Files')) {
+            return;
+        }
+
+        if (!isValidDropTarget(that, evt.target)) {
             return;
         }
 
@@ -129,6 +177,46 @@ function addFile(viewModel, file) {
     }
 
     return addUserCatalogMember(viewModel.terria, createCatalogItemFromFileOrUrl(viewModel.terria, file, 'auto', true));
+}
+
+function isValidDropTarget(viewModel, target) {
+    var included = false;
+    var excluded = false;
+
+    var validDropClasses = viewModel.validDropClasses.map(function(item) {
+        return new RegExp('(\\s|^)' + item + '(\\s|$)');
+    });
+
+    var invalidDropClasses = viewModel.invalidDropClasses.map(function(item) {
+        return new RegExp('(\\s|^)' + item + '(\\s|$)');
+    });
+
+    var node = target;
+    while (!excluded && node) {
+        if (viewModel.validDropElements.indexOf(node.id) >= 0 || viewModel.validDropElements.indexOf(node) >= 0) {
+            included = true;
+        }
+
+        for (var i = 0; i < validDropClasses.length; ++i) {
+            if (validDropClasses[i].test(node.className)) {
+                included = true;
+            }
+        }
+
+        if (viewModel.invalidDropElements.indexOf(node.id) >= 0 || viewModel.invalidDropElements.indexOf(node) >= 0) {
+            excluded = true;
+        }
+
+        for (var i = 0; !excluded && i < invalidDropClasses.length; ++i) {
+            if (invalidDropClasses[i].test(node.className)) {
+                excluded = true;
+            }
+        }
+
+        node = node.parentNode;
+    }
+
+    return included && !excluded;
 }
 
 module.exports = DragDropViewModel;

--- a/lib/ViewModels/DragDropViewModel.js
+++ b/lib/ViewModels/DragDropViewModel.js
@@ -193,24 +193,17 @@ function isValidDropTarget(viewModel, target) {
 
     var node = target;
     while (!excluded && node) {
-        if (viewModel.validDropElements.indexOf(node.id) >= 0 || viewModel.validDropElements.indexOf(node) >= 0) {
-            included = true;
+        included = included || viewModel.validDropElements.indexOf(node.id) >= 0 || viewModel.validDropElements.indexOf(node) >= 0;
+
+        var i;
+        for (i = 0; !included && i < validDropClasses.length; ++i) {
+            included = validDropClasses[i].test(node.className);
         }
 
-        for (var i = 0; i < validDropClasses.length; ++i) {
-            if (validDropClasses[i].test(node.className)) {
-                included = true;
-            }
-        }
+        excluded = viewModel.invalidDropElements.indexOf(node.id) >= 0 || viewModel.invalidDropElements.indexOf(node) >= 0;
 
-        if (viewModel.invalidDropElements.indexOf(node.id) >= 0 || viewModel.invalidDropElements.indexOf(node) >= 0) {
-            excluded = true;
-        }
-
-        for (var i = 0; !excluded && i < invalidDropClasses.length; ++i) {
-            if (invalidDropClasses[i].test(node.className)) {
-                excluded = true;
-            }
+        for (i = 0; !excluded && i < invalidDropClasses.length; ++i) {
+            excluded = invalidDropClasses[i].test(node.className);
         }
 
         node = node.parentNode;


### PR DESCRIPTION
This allows fixing #653 in apps by specifying these parameters to `DragDropViewModel`'s constructor:

```
validDropElements: ['ui', 'cesiumContainer'],
invalidDropClasses: ['modal-background']
```
