### PR TITLE
Clean up and document corsProxy.js for readability, and slightly

### DIFF
--- a/lib/Core/corsProxy.js
+++ b/lib/Core/corsProxy.js
@@ -11,35 +11,47 @@ var corsProxy = {
         var flag = (proxyFlag === undefined) ? '' : '_' + proxyFlag + '/';
         return corsProxy.baseProxyUrl + flag + resource;
     },
-    proxyDomains : [],
-    corsDomains : [],
-    alwaysUseProxy : false
+    proxyDomains : [],     // domains that should be proxied for, as set by config files
+    corsDomains : [],      // domains that are known to support CORS, as set by config files
+    alwaysUseProxy : false // use proxy on all domains, for browsers that don't support CORS
 };
 
+/**
+ * Determines if the proxying service should be used to access the given URL, based on our list of
+ * domains we're willing to proxy for and hosts that are known to support CORS.
+ *
+ * @return {Boolean} true if the proxy should be used, false if not.
+ */
 corsProxy.shouldUseProxy = function(url) {
     var uri = new URI(url);
-    var host = uri.host();
-    var proxyAvail = proxyAllowedHost(host, corsProxy.proxyDomains);
-    var corsAvail = !corsProxy.alwaysUseProxy && proxyAllowedHost(host, corsProxy.corsDomains);
-
-    if (proxyAvail && !corsAvail) {
-//        console.log('PROXY:', host);
+    var host = uri.host();  
+    
+    if (!hostInDomains(host, corsProxy.proxyDomains)) {
+        // we're not willing to proxy for this host
+        return false;
+    }
+    if (corsProxy.alwaysUseProxy) {
         return true;
     }
-//    console.log('CORS:', host);
-    return false;
+
+    if (hostInDomains(host, corsProxy.corsDomains)) {
+        // we don't need to proxy for this host, because it supports CORS
+        return false;
+    }
+
+    // we are ok with proxying for this host and we need to
+    return true;
 };
 
-//Non CORS hosts we proxy to
-function proxyAllowedHost(host, domains) {
+/* Is this host a (sub)domain in the provided list? */
+function hostInDomains(host, domains) {
     if (!defined(domains)) {
         return false;
     }
 
     host = host.toLowerCase();
-    //check that host is from one of these domains
     for (var i = 0; i < domains.length; i++) {
-        if (host.indexOf(domains[i], host.length - domains[i].length) !== -1) {
+        if (host.match("(^|\.)" + domains[i] + "$")) {
             return true;
         }
     }


### PR DESCRIPTION
clamp down on domain matching rules: must be a strict "sub.domain.com",
not "subdomain.com".
