### PR TITLE
Be smarter about finding the terriajs-cesium package.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,13 +10,13 @@ var browserify = require('browserify');
 var jshint = require('gulp-jshint');
 var jsdoc = require('gulp-jsdoc');
 var uglify = require('gulp-uglify');
-var exec = require('child_process').exec;
 var sourcemaps = require('gulp-sourcemaps');
 var exorcist = require('exorcist');
 var buffer = require('vinyl-buffer');
 var transform = require('vinyl-transform');
 var source = require('vinyl-source-stream');
 var watchify = require('watchify');
+var resolve = require('resolve');
 
 var specJSName = 'TerriaJS-specs.js';
 var sourceGlob = ['./lib/**/*.js', '!./lib/ThirdParty/**/*.js'];
@@ -65,9 +65,17 @@ gulp.task('docs', function(){
 gulp.task('prepare-cesium', ['copy-cesium-assets']);
 
 gulp.task('copy-cesium-assets', function() {
+    var cesium = resolve.sync('terriajs-cesium/wwwroot', {
+        basedir: __dirname,
+        extentions: ['.'],
+        isFile: function(file) {
+            try { return fs.statSync(file).isDirectory(); }
+            catch (e) { return false; }
+        }
+    });
     return gulp.src([
-            './node_modules/terriajs-cesium/wwwroot/**'
-        ], { base: './node_modules/terriajs-cesium/wwwroot' })
+            cesium + '/**'
+        ], { base: cesium })
         .pipe(gulp.dest('wwwroot/build/Cesium'));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,6 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var browserify = require('browserify');
 var jshint = require('gulp-jshint');
-var jsdoc = require('gulp-jsdoc');
 var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
 var exorcist = require('exorcist');
@@ -56,6 +55,7 @@ gulp.task('lint', function(){
 });
 
 gulp.task('docs', function(){
+    var jsdoc = require('gulp-jsdoc');
     return gulp.src(sourceGlob)
         .pipe(jsdoc('./wwwroot/doc', undefined, {
             plugins : ['plugins/markdown']

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "prepublish": "bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\"",
     "postpublish": "bash -c \"git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}\"",
-    "postinstall": "bash && bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\""
+    "postinstall": "pwd && ls -l ../node_modules/terriajs-cesium && ls -l ../node_modules/terriajs-cesium/wwwroot && bash && bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\""
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "prepublish": "bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\"",
     "postpublish": "bash -c \"git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}\"",
-    "postinstall": "bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\""
+    "postinstall": "bash && bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\""
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "prepublish": "bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\"",
     "postpublish": "bash -c \"git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}\"",
-    "postinstall": "pwd && ls -l ../node_modules/terriajs-cesium && ls -l ../node_modules/terriajs-cesium/wwwroot && bash && bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\""
+    "postinstall": "pwd && ls -l ../terriajs-cesium && ls -l ../terriajs-cesium/wwwroot && bash && bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\""
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "less-plugin-npm-import": "^2.0.0",
     "markdown-it": "^4.2.0",
     "proj4": "^2.3.6",
+    "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
     "terriajs-cesium": "^1.8.3",
     "togeojson": "^0.9.0"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "scripts": {
     "prepublish": "bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\"",
     "postpublish": "bash -c \"git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}\"",
-    "postinstall": "pwd && ls -l ../terriajs-cesium && ls -l ../terriajs-cesium/wwwroot && bash && bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\""
+    "postinstall": "bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\""
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Instead of assuming it's in `./node_modules/terriajs-cesium`, find the actual path using npm package resolution.  This should let allow it to be found correctly even when npm de-duping puts `terriajs-cesium` as a sibling of `terriajs` instead of a child.
