### PR TITLE
Improve ArcGIS MapServer support.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.0.7
+
+* Changed `ArcGisMapServerCatalogItem` to interpret a `maxScale` of 0 from an ArcGIS MapServer as "not specified".
+* Added an `itemProperties` property to `ArcGisMapServerCatalogGroup`, allowing properties of auto-discovered layers to be specified explicitly.
+
 ### 1.0.6
 
 * Added support for region mapping based on region names instead of region numbers (example in `public/test/countries.csv`).

--- a/lib/Models/ArcGisMapServerCatalogGroup.js
+++ b/lib/Models/ArcGisMapServerCatalogGroup.js
@@ -25,7 +25,7 @@ var ArcGisMapServerCatalogItem = require('./ArcGisMapServerCatalogItem');
  * @alias WebMapServiceCatalogGroup
  * @constructor
  * @extends CatalogGroup
- * 
+ *
  * @param {Terria} terria The Terria instance.
  */
 var ArcGisMapServerCatalogGroup = function(terria) {
@@ -53,7 +53,13 @@ var ArcGisMapServerCatalogGroup = function(terria) {
      */
     this.blacklist = undefined;
 
-    knockout.track(this, ['url', 'dataCustodian', 'blacklist']);
+    /**
+     * Gets or sets a hash of properties that will be set on each child item.
+     * For example, { 'treat404AsError': false }
+     */
+    this.itemProperties = undefined;
+
+    knockout.track(this, ['url', 'dataCustodian', 'blacklist', 'itemProperties']);
 };
 
 inherit(CatalogGroup, ArcGisMapServerCatalogGroup);
@@ -262,6 +268,12 @@ function createDataSource(mapServiceGroup, layer, dataCustodian) {
             var ne = projection.unproject(new Cartesian3(extent.xmax, extent.ymax, 0.0));
             result.rectangle = new Rectangle(sw.longitude, sw.latitude, ne.longitude, ne.latitude);
         }
+    }
+
+    if (typeof(mapServiceGroup.itemProperties) === 'object') {
+        Object.keys(mapServiceGroup.itemProperties).forEach(function(k) {
+            result[k] = mapServiceGroup.itemProperties[k];
+        });
     }
 
     return result;

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -20,7 +20,7 @@ var overrideProperty = require('../Core/overrideProperty');
  * @alias ArcGisMapServerCatalogItem
  * @constructor
  * @extends ImageryLayerCatalogItem
- * 
+ *
  * @param {Terria} terria The Terria instance.
  */
 var ArcGisMapServerCatalogItem = function(terria) {
@@ -95,7 +95,7 @@ defineProperties(ArcGisMapServerCatalogItem.prototype, {
 ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
     var maximumLevel;
 
-    if (defined(this.maximumScale)) {
+    if (defined(this.maximumScale) && this.maximumScale > 0.0) {
         var dpi = 96; // Esri default DPI, unless we specify otherwise.
         var centimetersPerInch = 2.54;
         var centimetersPerMeter = 100;


### PR DESCRIPTION
- Interpret a maxScale of 0 as "not specified".
- Add `itemProperties` property to esri-mapServer-group to allow properties of auto-discovered layers to be specified explicitly.
