### PR TITLE
Allow parameters to be specified in config.json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.7
+
+* Arbitrary parameters can now be specified in `config.json` by adding them to the `parameters` property.
+
 ### 1.0.6
 
 * Added support for region mapping based on region names instead of region numbers (example in `public/test/countries.csv`).

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -197,7 +197,13 @@ var Terria = function(options) {
      */
     this.selectedFeature = undefined;
 
-    knockout.track(this, ['viewerMode', 'baseMap', '_initialView', 'homeView', 'pickedFeatures', 'selectedFeature']);
+    /**
+     * Gets or sets the configuration parameters set at startup.
+     * @type {Object}
+     */
+    this.configParameters = {};
+
+    knockout.track(this, ['viewerMode', 'baseMap', '_initialView', 'homeView', 'pickedFeatures', 'selectedFeature', 'configParameters']);
 
     // IE versions prior to 10 don't support CORS, so always use the proxy.
     corsProxy.alwaysUseProxy = (FeatureDetection.isInternetExplorer() && FeatureDetection.internetExplorerVersion()[0] < 10);
@@ -242,6 +248,10 @@ Terria.prototype.start = function(options) {
 
     var that = this;
     return loadJson(options.configUrl).then(function(config) {
+        if (defined(config.parameters)) {
+            that.configParameters = config.parameters;
+        }
+
         corsProxy.proxyDomains.push.apply(corsProxy.proxyDomains, config.proxyDomains);
 
         var initializationUrls = config.initializationUrls;
@@ -275,7 +285,7 @@ Terria.prototype.updateApplicationUrl = function(newUrl) {
 };
 
 /**
- * Gets the value of a user property.  If the property doesn't exist, it is created as an observable property with the 
+ * Gets the value of a user property.  If the property doesn't exist, it is created as an observable property with the
  * value undefined.  This way, if it becomes defined in the future, anyone depending on the value will be notified.
  * @param {String} propertyName The name of the user property for which to get the value.
  * @return {Object} The value of the property, or undefined if the property does not exist.


### PR DESCRIPTION
This is to support specifying the Bing Maps API key in that file.
