### PR TITLE
Search all datasets, not just the loaded ones.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### 1.0.7
 
 * `CatalogItemNameSearchProviderViewModel` now asynchronously loads groups so items in unloaded groups can be found, too.
+* Do not automatically fly to the first location when pressing Enter in the Search input box.
 
 ### 1.0.6
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.7
+
+* `CatalogItemNameSearchProviderViewModel` now asynchronously loads groups so items in unloaded groups can be found, too.
+
 ### 1.0.6
 
 * Added support for region mapping based on region names instead of region numbers (example in `public/test/countries.csv`).

--- a/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
+++ b/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
@@ -7,13 +7,14 @@ var SearchResultViewModel = require('./SearchResultViewModel');
 
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var CatalogItemNameSearchProviderViewModel = function(options) {
     SearchProviderViewModel.call(this);
 
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-     this.terria = options.terria;
+    this.terria = options.terria;
     this._geocodeInProgress = undefined;
 
     this.name = 'Catalogue Items';
@@ -37,16 +38,20 @@ CatalogItemNameSearchProviderViewModel.prototype.search = function(searchText) {
 
     var path = [];
     var topLevelGroup =  this.terria.catalog.group;
-    findMatchingItemsRecursively(this, new RegExp(searchText, 'i'), topLevelGroup, path);
+    var promises = [];
+    findMatchingItemsRecursively(this, new RegExp(searchText, 'i'), topLevelGroup, path, promises);
 
-    if (this.searchResults.length === 0) {
-        this.searchMessage = 'Sorry, no catalogue items match your search query.';
-    }
+    var that = this;
+    when.all(promises, function() {
+        if (that.searchResults.length === 0) {
+            that.searchMessage = 'Sorry, no catalogue items match your search query.';
+        }
 
-    this.isSearching = false;
+        that.isSearching = false;
+    });
 };
 
-function findMatchingItemsRecursively(viewModel, searchExpression, group, path) {
+function findMatchingItemsRecursively(viewModel, searchExpression, group, path, promises) {
     path.push(group);
 
     var items = group.items;
@@ -64,11 +69,27 @@ function findMatchingItemsRecursively(viewModel, searchExpression, group, path) 
         }
 
         if (defined(item.items)) {
-            findMatchingItemsRecursively(viewModel, searchExpression, item, path);
+            var loadPromise = item.load();
+            if (defined(loadPromise) && item.isLoading) {
+                var searchPromise = loadPromise.then(findItemsInLoadedGroup.bind(undefined, viewModel, searchExpression, item, path.slice()));
+                searchPromise = searchPromise.otherwise(ignoreLoadErrors);
+                promises.push(searchPromise);
+            } else {
+                findMatchingItemsRecursively(viewModel, searchExpression, item, path, promises);
+            }
         }
     }
 
     path.pop();
+}
+
+function findItemsInLoadedGroup(viewModel, searchExpression, item, path) {
+    var childPromises = [];
+    findMatchingItemsRecursively(viewModel, searchExpression, item, path, childPromises);
+    return when.all(childPromises);
+}
+
+function ignoreLoadErrors() {
 }
 
 function pathToTooltip(path) {

--- a/lib/ViewModels/SearchTabViewModel.js
+++ b/lib/ViewModels/SearchTabViewModel.js
@@ -2,7 +2,6 @@
 
 /*global require,ga*/
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
-var defined = require('terriajs-cesium/Source/Core/defined');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 
 var CatalogItemInfoViewModel = require('./CatalogItemInfoViewModel');

--- a/lib/ViewModels/SearchTabViewModel.js
+++ b/lib/ViewModels/SearchTabViewModel.js
@@ -64,16 +64,7 @@ SearchTabViewModel.prototype.search = function() {
 };
 
 SearchTabViewModel.prototype.activateFirstResult = function() {
-    for (var i = 0; i < this.searchProviders.length; ++i) {
-        var searchProvider = this.searchProviders[i];
-        for (var j = 0; j < searchProvider.searchResults.length; ++j) {
-            var searchResult = searchProvider.searchResults[j];
-            if (defined(searchResult.clickAction)) {
-                searchResult.clickAction();
-                return;
-            }
-        }
-    }
+    // When we have keyboard navigation for search results, this will move focus to the first result.
 };
 
 SearchTabViewModel.prototype.showInfo = function(item) {


### PR DESCRIPTION
Fixes #658 

This does the simplest possible thing: before searching a group, go load it.  It happens asynchronously, so a slow group won't keep the quick results from coming back, and the UI displays a "Searching..." message until all results are in.  There are smarter things we could do, but this is pretty good and really simple.

We currently have a broken server, the Tasmania "Planning Online" group, that takes about 25 seconds and then returns an error.  All the others take less than 5 seconds on my system.
