### PR TITLE
Add support for HTML GetFeatureInfo responses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+### 1.0.8
+
+* Potentially breaking changes:
+  * The `getFeatureInfoAsGeoJson` and `getFeatureInfoAsXml` properties have been removed.  Use `getFeatureInfoFormats` instead.
+* Added support for text/html responses from WMS GetFeatureInfo.
+* Make the `FeatureInfoPanelViewModel` use a white background when displaying a complete HTML document.
+* `KnockoutMarkdownBinding` no longer tries to interpret complete HTML documents (i.e. those that contain an <html> tag) as Markdown.
+
 ### 1.0.7
 
 * `CatalogItemNameSearchProviderViewModel` now asynchronously loads groups so items in unloaded groups can be found, too.

--- a/lib/Core/KnockoutMarkdownBinding.js
+++ b/lib/Core/KnockoutMarkdownBinding.js
@@ -4,6 +4,8 @@
 var MarkdownIt = require('markdown-it');
 var sanitizeCaja = require('sanitize-caja/sanitizer-bundle');
 
+var htmlTagRegex = /<html>[^]*<\/html>/im;
+
 var KnockoutMarkdownBinding = {
     register : function(knockout) {
         knockout.bindingHandlers.markdown = {
@@ -17,7 +19,17 @@ var KnockoutMarkdownBinding = {
                     knockout.removeNode(element.firstChild);
                 }
 
-                var html = markdownToHtml(knockout.unwrap(valueAccessor()));
+                var rawText = knockout.unwrap(valueAccessor());
+
+                // If the text contains an <html> tag, don't try to interpret it as Markdown because
+                // we'll probably break it in the process.
+                var html;
+                if (htmlTagRegex.test(rawText)) {
+                    html = rawText;
+                } else {
+                    html = markdownToHtml(rawText);
+                }
+
                 var nodes = knockout.utils.parseHtmlFragment(html, element);
 
                 for (var i = 0; i < nodes.length; ++i) {

--- a/lib/Core/KnockoutMarkdownBinding.js
+++ b/lib/Core/KnockoutMarkdownBinding.js
@@ -4,7 +4,7 @@
 var MarkdownIt = require('markdown-it');
 var sanitizeCaja = require('sanitize-caja/sanitizer-bundle');
 
-var htmlTagRegex = /<html>[^]*<\/html>/im;
+var htmlTagRegex = /<html[^]*>[^]*<\/html>/im;
 
 var KnockoutMarkdownBinding = {
     register : function(knockout) {

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -9,6 +9,7 @@ var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
+var GetFeatureInfoFormat = require('terriajs-cesium/Source/Scene/GetFeatureInfoFormat');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var loadXML = require('terriajs-cesium/Source/Core/loadXML');
 var GeographicTilingScheme = require('terriajs-cesium/Source/Core/GeographicTilingScheme');
@@ -173,6 +174,7 @@ sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@
 
         var supportsJsonGetFeatureInfo = false;
         var supportsXmlGetFeatureInfo = false;
+        var supportsHtmlGetFeatureInfo = false;
         var xmlContentType = 'text/xml';
 
         if (defined(json.Capability.Request) &&
@@ -195,7 +197,20 @@ sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@
             } else if (defined(format.indexOf) && format.indexOf('application/vnd.ogc.gml') >= 0) {
                 supportsXmlGetFeatureInfo = true;
                 xmlContentType = 'application/vnd.ogc.gml';
+            } else if (defined(format.indexOf) && format.indexOf('text/html') >= 0) {
+                supportsHtmlGetFeatureInfo = true;
             }
+        }
+
+        var getFeatureInfoFormats = [];
+        if (supportsJsonGetFeatureInfo) {
+            getFeatureInfoFormats.push(new GetFeatureInfoFormat('json'));
+        }
+        if (supportsXmlGetFeatureInfo) {
+            getFeatureInfoFormats.push(new GetFeatureInfoFormat('xml', xmlContentType));
+        }
+        if (supportsHtmlGetFeatureInfo) {
+            getFeatureInfoFormats.push(new GetFeatureInfoFormat('html'));
         }
 
         var dataCustodian = that.dataCustodian;
@@ -218,7 +233,7 @@ sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@
             dataCustodian = text;
         }
 
-        addLayersRecursively(that, json.Capability.Layer, that.items, undefined, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian);
+        addLayersRecursively(that, json.Capability.Layer, that.items, undefined, getFeatureInfoFormats, dataCustodian);
     }).otherwise(function(e) {
         throw new ModelError({
             sender: that,
@@ -252,7 +267,7 @@ function cleanAndProxyUrl(terria, url) {
     return cleanedUrl;
 }
 
-function addLayersRecursively(wmsGroup, layers, items, parent, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian) {
+function addLayersRecursively(wmsGroup, layers, items, parent, getFeatureInfoFormats, dataCustodian) {
     if (!(layers instanceof Array)) {
         layers = [layers];
     }
@@ -272,17 +287,17 @@ function addLayersRecursively(wmsGroup, layers, items, parent, supportsJsonGetFe
             // WMS 1.1.1 spec section 7.1.4.5.2 says any layer with a Name property can be used
             // in the 'layers' parameter of a GetMap request.  This is true in 1.0.0 and 1.3.0 as well.
             if (defined(layer.Name) && layer.Name.length > 0) {
-                items.push(createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian));
+                items.push(createWmsDataSource(wmsGroup, layer, getFeatureInfoFormats, dataCustodian));
             }
-            addLayersRecursively(wmsGroup, layer.Layer, items, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian);
+            addLayersRecursively(wmsGroup, layer.Layer, items, layer, getFeatureInfoFormats, dataCustodian);
         }
         else {
-            items.push(createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian));
+            items.push(createWmsDataSource(wmsGroup, layer, getFeatureInfoFormats, dataCustodian));
         }
     }
 }
 
-function createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian) {
+function createWmsDataSource(wmsGroup, layer, getFeatureInfoFormats, dataCustodian) {
     var result = new WebMapServiceCatalogItem(wmsGroup.terria);
 
     if (wmsGroup.titleField === 'name') {
@@ -325,9 +340,7 @@ function createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, suppor
 
     var queryable = defaultValue(getInheritableProperty(layer, 'queryable'), false);
 
-    result.getFeatureInfoAsGeoJson = queryable && supportsJsonGetFeatureInfo;
-    result.getFeatureInfoAsXml = queryable && supportsXmlGetFeatureInfo;
-    result.getFeatureInfoXmlContentType = xmlContentType;
+    result.getFeatureInfoFormats = queryable ? getFeatureInfoFormats : [];
 
     result.rectangle = WebMapServiceCatalogItem.getRectangleFromLayer(layer);
     result.intervals = WebMapServiceCatalogItem.getIntervalsFromLayer(layer);

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -10,6 +10,7 @@ var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var GeographicTilingScheme = require('terriajs-cesium/Source/Core/GeographicTilingScheme');
+var GetFeatureInfoFormat = require('terriajs-cesium/Source/Scene/GetFeatureInfoFormat');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var loadXML = require('terriajs-cesium/Source/Core/loadXML');
@@ -75,29 +76,10 @@ var WebMapServiceCatalogItem = function(terria) {
     this.tilingScheme = undefined;
 
     /**
-     * Gets or sets a value indicating whether we should request information about individual features on click
-     * as GeoJSON.  If getFeatureInfoAsXml is true as well, feature information will be requested first as GeoJSON,
-     * and then as XML if the GeoJSON request fails.  If both are false, this data item will not support feature picking at all.
-     * @type {Boolean}
-     * @default true
+     * Gets or sets the formats in which to try WMS GetFeatureInfo requests.
+     * @type {GetFeatureInfoFormat[]]}
      */
-    this.getFeatureInfoAsGeoJson = true;
-
-    /**
-     * Gets or sets a value indicating whether we should request information about individual features on click
-     * as XML.  If getFeatureInfoAsGeoJson is true as well, feature information will be requested first as GeoJSON,
-     * and then as XML if the GeoJSON request fails.  If both are false, this data item will not support feature picking at all.
-     * @type {Boolean}
-     * @default true
-     */
-    this.getFeatureInfoAsXml = true;
-
-    /**
-     * Gets or sets the content type to request when invoking GetFeatureInfo.
-     * @type {String}
-     * @default 'text/xml'
-     */
-    this.getFeatureInfoXmlContentType = 'text/xml';
+    this.getFeatureInfoFormats = undefined;
 
     /**
      * Gets or sets a value indicating whether this dataset should be clipped to the {@link WebMapServiceCatalogItem#rectangle}.
@@ -129,7 +111,7 @@ var WebMapServiceCatalogItem = function(terria) {
 
     knockout.track(this, [
         '_dataUrl', '_dataUrlType', '_metadataUrl', '_legendUrl', '_rectangle', '_rectangleFromMetadata', '_intervalsFromMetadata', 'url',
-        'layers', 'parameters', 'getFeatureInfoAsGeoJson', 'getFeatureInfoAsXml', 'getFeatureInfoXmlContentType',
+        'layers', 'parameters', 'getFeatureInfoFormats',
         'tilingScheme', 'clipToRectangle', 'populateIntervalsFromTimeDimension', 'minScaleDenominator']);
 
     // dataUrl, metadataUrl, and legendUrl are derived from url if not explicitly specified.
@@ -311,6 +293,17 @@ WebMapServiceCatalogItem.defaultUpdaters.tilingScheme = function(wmsItem, json, 
     }
 };
 
+WebMapServiceCatalogItem.defaultUpdaters.getFeatureInfoFormats = function(wmsItem, json, propertyName, options) {
+    var formats = [];
+
+    for (var i = 0; i < json.getFeatureInfoFormats.length; ++i) {
+        var format = json.getFeatureInfoFormats[i];
+        formats.push(new GetFeatureInfoFormat(format.type, format.format));
+    }
+
+    wmsItem.getFeatureInfoFormats = formats;
+};
+
 freezeObject(WebMapServiceCatalogItem.defaultUpdaters);
 
 WebMapServiceCatalogItem.defaultSerializers = clone(ImageryLayerCatalogItem.defaultSerializers);
@@ -371,12 +364,10 @@ WebMapServiceCatalogItem.prototype._createImageryProvider = function(time) {
     return new WebMapServiceImageryProvider({
         url : cleanAndProxyUrl( this.terria, this.url),
         layers : this.layers,
-        getFeatureInfoAsGeoJson : this.getFeatureInfoAsGeoJson,
-        getFeatureInfoAsXml : this.getFeatureInfoAsXml,
+        getFeatureInfoFormats : this.getFeatureInfoFormats,
         parameters : parameters,
         getFeatureInfoParameters : parameters,
         tilingScheme : defined(this.tilingScheme) ? this.tilingScheme : new WebMercatorTilingScheme(),
-        getFeatureInfoXmlContentType : this.getFeatureInfoXmlContentType,
         maximumLevel: maximumLevel
     });
 };

--- a/lib/Styles/FeatureInfoPanel.less
+++ b/lib/Styles/FeatureInfoPanel.less
@@ -52,6 +52,15 @@
     max-height: 600px; // adjusted dynamically in FeatureInfoPanelViewModel.js
 }
 
+.feature-info-panel-section-content-white-background {
+    color: black;
+    background-color: white;
+}
+
+.feature-info-panel-section-content b {
+    font-weight: bold;
+}
+
 .feature-info-panel-close-button {
     position: absolute;
     right: 10px;

--- a/lib/ViewModels/FeatureInfoPanelViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelViewModel.js
@@ -11,6 +11,8 @@ var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var loadView = require('../Core/loadView');
 
+var htmlTagRegex = /<html>[^]*<\/html>/im;
+
 var FeatureInfoPanelViewModel = function(options) {
     if (!defined(options) || !defined(options.terria)) {
         throw new DeveloperError('options.terria is required.');
@@ -18,7 +20,7 @@ var FeatureInfoPanelViewModel = function(options) {
 
     var container = getElement(defaultValue(options.container, document.body));
 
-     this.terria = options.terria;
+    this.terria = options.terria;
     this.features = undefined;
 
     this.isVisible = false;
@@ -34,18 +36,24 @@ var FeatureInfoPanelViewModel = function(options) {
 
     knockout.track(this, ['isVisible', 'name', 'html', 'unselectFeaturesOnClose', 'createFakeSelectedFeatureDuringPicking', 'maxWidth', 'maxHeight']);
 
+    // Use a white background when displaying complete HTML documents rather than just snippets.
+    knockout.defineProperty(this, 'useWhiteBackground', {
+        get: function() {
+            return htmlTagRegex.test(this.html);
+        }
+    });
+
     this._clockSubscription = undefined;
     this._domNodes = loadView(require('fs').readFileSync(__dirname + '/../Views/FeatureInfoPanel.html', 'utf8'), container, this);
 
     knockout.getObservable(this, 'isVisible').subscribe(function() {
         if (!this.isVisible && this.unselectFeaturesOnClose) {
-
-             this.terria.selectedFeature = undefined;
+            this.terria.selectedFeature = undefined;
         }
     }, this);
 
-    knockout.getObservable( this.terria, 'pickedFeatures').subscribe(function() {
-        this.showFeatures( this.terria.pickedFeatures);
+    knockout.getObservable(this.terria, 'pickedFeatures').subscribe(function() {
+        this.showFeatures(this.terria.pickedFeatures);
     }, this);
 
     var that = this;
@@ -73,7 +81,7 @@ FeatureInfoPanelViewModel.prototype.showFeatures = function(features) {
     }
 
     this.features = features;
-     this.terria.selectedFeature = undefined;
+    this.terria.selectedFeature = undefined;
 
     this.name = 'Loading...';
     this.html = 'Loading feature information...';
@@ -85,9 +93,9 @@ FeatureInfoPanelViewModel.prototype.showFeatures = function(features) {
             id: 'Pick Location'
         });
         fakeFeature.position = features.pickPosition;
-         this.terria.selectedFeature = fakeFeature;
+        this.terria.selectedFeature = fakeFeature;
     } else {
-         this.terria.selectedFeature = undefined;
+        this.terria.selectedFeature = undefined;
     }
 
     var that = this;

--- a/lib/ViewModels/FeatureInfoPanelViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelViewModel.js
@@ -11,7 +11,7 @@ var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var loadView = require('../Core/loadView');
 
-var htmlTagRegex = /<html>[^]*<\/html>/im;
+var htmlTagRegex = /<html[^]*>[^]*<\/html>/im;
 
 var FeatureInfoPanelViewModel = function(options) {
     if (!defined(options) || !defined(options.terria)) {

--- a/lib/Views/FeatureInfoPanel.html
+++ b/lib/Views/FeatureInfoPanel.html
@@ -5,7 +5,7 @@
                 <span class="feature-info-panel-section-label" data-bind="text: name"></span>
                 <div class="feature-info-panel-close-button" data-bind="click: close">&times;</div>
             </div>
-            <div class="feature-info-panel-section-content" data-bind="markdown: html, style: { 'max-height': maxHeight + 'px' }"></div>
+            <div class="feature-info-panel-section-content" data-bind="markdown: html, style: { 'max-height': maxHeight + 'px' }, css: { 'feature-info-panel-section-content-white-background': useWhiteBackground }"></div>
         </div>
     </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "repository": {
@@ -19,7 +19,7 @@
     "proj4": "^2.3.6",
     "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
-    "terriajs-cesium": "^1.8.5",
+    "terriajs-cesium": "^1.8.6",
     "togeojson": "^0.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "proj4": "^2.3.6",
     "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
-    "terriajs-cesium": "^1.8.3",
+    "terriajs-cesium": "^1.8.5",
     "togeojson": "^0.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- The `getFeatureInfoAsGeoJson` and `getFeatureInfoAsXml` properties have been removed.  Use `getFeatureInfoFormats` instead.
- Added support for text/html responses from WMS GetFeatureInfo.
- Make the `FeatureInfoPanelViewModel` use a white background when displaying a complete HTML document.
- `KnockoutMarkdownBinding` no longer tries to interpret complete HTML documents (i.e. those that contain an `<html>` tag) as Markdown.

Fixes #655

![image](https://cloud.githubusercontent.com/assets/924374/7579079/7e5fae66-f8a1-11e4-9bc0-2b571720267b.png)
