### PR TITLE
Improvements to Esri MapServer catalog item info panel.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+### 1.0.8
+
+* `ArcGisMapServerCatalogItem` now offers metadata, used to populate the Data Details and Service Details sections of the catalog item info panel.
+* `ArcGisMapServerCatalogGroup` now populates a "Service Description" and a "Data Description" info section for each catalog item from the MapServer's metadata.
+* The `metadataUrl` is now populated (and shown) from the regular MapServer URL.
+
 ### 1.0.7
 
 * `CatalogItemNameSearchProviderViewModel` now asynchronously loads groups so items in unloaded groups can be found, too.

--- a/lib/Models/ArcGisMapServerCatalogGroup.js
+++ b/lib/Models/ArcGisMapServerCatalogGroup.js
@@ -164,7 +164,7 @@ sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@
             dataCustodian = serviceJson.documentInfo.Author;
         }
 
-        addLayersRecursively(that, -1, layersJson.layers, that.items, dataCustodian);
+        addLayersRecursively(that, serviceJson, -1, layersJson.layers, that.items, dataCustodian);
     }).otherwise(function(e) {
         throw new ModelError({
             sender: that,
@@ -198,7 +198,7 @@ function cleanAndProxyUrl(terria, url) {
     return cleanedUrl;
 }
 
-function addLayersRecursively(mapServiceGroup, parentID, layers, items, dataCustodian) {
+function addLayersRecursively(mapServiceGroup, topLevelJson, parentID, layers, items, dataCustodian) {
     if (!(layers instanceof Array)) {
         layers = [layers];
     }
@@ -221,40 +221,34 @@ function addLayersRecursively(mapServiceGroup, parentID, layers, items, dataCust
             var subGroup = new CatalogGroup(mapServiceGroup.terria);
             subGroup.name = layer.name;
             items.push(subGroup);
-            addLayersRecursively(mapServiceGroup, layer.id, layers, subGroup.items, dataCustodian);
+            addLayersRecursively(mapServiceGroup, topLevelJson, layer.id, layers, subGroup.items, dataCustodian);
         } else if (layer.type === 'Feature Layer') {
-            items.push(createDataSource(mapServiceGroup, layer, dataCustodian));
+            items.push(createDataSource(mapServiceGroup, topLevelJson, layer, dataCustodian));
         }
     }
 }
 
-function createDataSource(mapServiceGroup, layer, dataCustodian) {
+function createDataSource(mapServiceGroup, topLevelJson, layer, dataCustodian) {
     var result = new ArcGisMapServerCatalogItem(mapServiceGroup.terria);
 
     result.name = layer.name;
-    result.description = defined(layer.description) && layer.description.length > 0 ? layer.description : mapServiceGroup.description;
     result.dataCustodian = dataCustodian;
     result.url = mapServiceGroup.url;
-    result.dataUrl = mapServiceGroup.url;
-    result.dataUrlType = 'direct';
     result.layers = layer.id.toString();
     result.maximumScale = layer.maxScale;
 
-    result.description = '';
-
-    var groupHasDescription = defined(mapServiceGroup.description) && mapServiceGroup.description.length > 0;
-    var layerHasDescription = defined(layer.description) && layer.description.length > 0;
-
-    if (groupHasDescription) {
-        result.description += mapServiceGroup.description;
+    if (topLevelJson.description && topLevelJson.description.length > 0) {
+        result.info.push({
+            name: 'Service Description',
+            content: topLevelJson.description
+        });
     }
 
-    if (groupHasDescription && layerHasDescription) {
-        result.description += '<br/>';
-    }
-
-    if (layerHasDescription) {
-        result.description += layer.description;
+    if (layer.description && layer.description.length > 0) {
+        result.info.push({
+            name: 'Data Description',
+            content: layer.description
+        });
     }
 
     var extent = layer.extent;

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -8,10 +8,14 @@ var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var loadJson = require('terriajs-cesium/Source/Core/loadJson');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var ImageryLayerCatalogItem = require('./ImageryLayerCatalogItem');
 var inherit = require('../Core/inherit');
+var Metadata = require('./Metadata');
+var MetadataItem = require('./MetadataItem');
 var overrideProperty = require('../Core/overrideProperty');
 
 /**
@@ -51,7 +55,20 @@ var ArcGisMapServerCatalogItem = function(terria) {
 
     knockout.track(this, ['url', 'layers', 'maximumScale', '_legendUrl']);
 
-    // dataUrl, metadataUrl, and legendUrl are derived from url if not explicitly specified.
+    // metadataUrl and legendUrl are derived from url if not explicitly specified.
+    overrideProperty(this, 'metadataUrl', {
+        get : function() {
+            if (defined(this._metadataUrl)) {
+                return this._metadataUrl;
+            }
+
+            return cleanUrl(this.url);
+        },
+        set : function(value) {
+            this._metadataUrl = value;
+        }
+    });
+
     overrideProperty(this, 'legendUrl', {
         get : function() {
             if (defined(this._legendUrl)) {
@@ -88,6 +105,20 @@ defineProperties(ArcGisMapServerCatalogItem.prototype, {
     typeName : {
         get : function() {
             return 'Esri ArcGIS MapServer';
+        }
+    },
+
+    /**
+     * Gets the metadata associated with this data source and the server that provided it, if applicable.
+     * @memberOf ArcGisMapServerCatalogItem.prototype
+     * @type {Metadata}
+     */
+    metadata : {
+        get : function() {
+            if (!defined(this._metadata)) {
+                this._metadata = requestMetadata(this);
+            }
+            return this._metadata;
         }
     }
 });
@@ -137,6 +168,85 @@ function proxyUrl(terria, url) {
     }
 
     return url;
+}
+
+function requestMetadata(item) {
+    var result = new Metadata();
+
+    result.isLoading = true;
+
+    var servicePromise = loadJson(cleanAndProxyUrl(item.terria, item.metadataUrl) + '?f=json').then(function(serviceMetadata) {
+        populateMetadataGroup(result.serviceMetadata, serviceMetadata);
+    }).otherwise(function() {
+        result.serviceErrorMessage = 'An error occurred while invoking the ArcGIS map service.';
+    });
+
+    var dataPromise = loadJson(cleanAndProxyUrl(item.terria, item.metadataUrl) + '/layers?f=json').then(function(layerMetadata) {
+        if (item.layers) {
+            var layerIds = item.layers.split(', ');
+
+            var layers = [];
+            for (var i = 0; i < layerIds.length; ++i) {
+                var layer = findLayer(layerMetadata.layers, layerIds[i]);
+                if (defined(layer)) {
+                    layers.push(layer);
+                }
+            }
+
+            if (layers.length === 0) {
+                result.dataSourceErrorMessage = 'No details are available.';
+            } else if (layers.length === 1) {
+                populateMetadataGroup(result.dataSourceMetadata, layers[0]);
+            } else {
+                populateMetadataGroup(result.dataSourceMetadata, layers);
+            }
+        } else {
+            result.dataSourceErrorMessage = 'Using all layers from this service that are visible by default.  See the Service Details below.';
+        }
+    }).otherwise(function() {
+        result.dataSourceErrorMessage = 'An error occurred while invoking the ArcGIS map service.';
+    });
+
+    result.promise = when.all([servicePromise, dataPromise]).always(function() {
+        result.isLoading = false;
+    });
+
+    return result;
+}
+
+function populateMetadataGroup(metadataGroup, sourceMetadata) {
+    if (typeof sourceMetadata === 'string' || sourceMetadata instanceof String) {
+        return;
+    }
+
+    if (sourceMetadata instanceof Array && (sourceMetadata.length === 0 || typeof sourceMetadata[0] !== 'object')) {
+        return;
+    }
+
+    for (var name in sourceMetadata) {
+        if (sourceMetadata.hasOwnProperty(name)) {
+            var value = sourceMetadata[name];
+
+            var dest = new MetadataItem();
+            dest.name = name;
+            dest.value = value;
+
+            populateMetadataGroup(dest, value);
+
+            metadataGroup.items.push(dest);
+        }
+    }
+}
+
+function findLayer(layers, id) {
+    id = id.toString();
+    for (var i = 0; i < layers.length; ++i) {
+        var layer = layers[i];
+        if (layer.id.toString() === id.toString()) {
+            return layer;
+        }
+    }
+    return undefined;
 }
 
 module.exports = ArcGisMapServerCatalogItem;

--- a/lib/Styles/CatalogItemInfo.less
+++ b/lib/Styles/CatalogItemInfo.less
@@ -104,6 +104,22 @@
     padding-left: 60px;
 }
 
+.catalog-item-info-properties-level5 {
+    padding-left: 80px;
+}
+
+.catalog-item-info-properties-level6 {
+    padding-left: 100px;
+}
+
+.catalog-item-info-properties-level7 {
+    padding-left: 120px;
+}
+
+.catalog-item-info-properties-level8 {
+    padding-left: 140px;
+}
+
 .catalog-item-info-properties-parent {
     cursor: pointer;
 }

--- a/lib/Views/CatalogItemInfo.html
+++ b/lib/Views/CatalogItemInfo.html
@@ -15,7 +15,7 @@
         <!-- ko if: hasChildren -->
             <td></td>
         <!-- /ko -->
-        <!-- ko if: valueIsArray -->
+        <!-- ko if: valueIsArray && !hasChildren -->
             <td data-bind="foreach: value">
                 <span data-bind="if: $index() !== 0">; </span>
                 <span data-bind="text: $data"></span>


### PR DESCRIPTION
- `ArcGisMapServerCatalogItem` now offers metadata, used to populate the Data Details and Service Details sections of the catalog item info panel.
- `ArcGisMapServerCatalogGroup` now populates a "Service Description" and a "Data Description" info section for each catalog item from the MapServer's metadata.
- The `metadataUrl` is now populated (and shown) from the regular MapServer URL.

Fixes #636 

![image](https://cloud.githubusercontent.com/assets/924374/7587469/d03e4cb2-f8f9-11e4-886c-302db2efccda.png)
