### PR TITLE
Brand bar style tweaks.

### DIFF
--- a/lib/Styles/BrandBar.less
+++ b/lib/Styles/BrandBar.less
@@ -12,18 +12,28 @@
 
 .brand-bar-main {
     position: absolute;
-    width: @brand-bar-width;
+    width: @brand-bar-width - 20px;
     height: 68px;
     top: 0;
     left: 0;
     display: table;
     padding-left: 10px;
+    padding-right: 10px;
 }
 
 .brand-bar-element {
     display: table-cell;
     height: 68px;
     vertical-align: middle;
+    text-align: center;
+}
+
+.brand-bar-element-first {
+    text-align: left;
+}
+
+.brand-bar-element-last {
+    text-align: right;
 }
 
 .brand-bar-name {

--- a/lib/Views/BrandBar.html
+++ b/lib/Views/BrandBar.html
@@ -1,6 +1,6 @@
 <div class="brand-bar">
     <div class="brand-bar-main" data-bind="foreach: elements">
-        <div class="brand-bar-element" data-bind="html: $data">
+        <div class="brand-bar-element" data-bind="html: $data, css: { 'brand-bar-element-first': $index() === 0, 'brand-bar-element-last': $index() === $parent.elements.length - 1 }">
         </div>
     </div>
 </div>


### PR DESCRIPTION
- Make it actually the right size so padding on the edges is maintained.
- Make the left-most element left aligned, the right-most element right aligned, and other elements center aligned.
