### PR TITLE
Improve double-click zoom.

### DIFF
--- a/lib/ViewModels/NavigationViewModel.js
+++ b/lib/ViewModels/NavigationViewModel.js
@@ -19,7 +19,6 @@ var Tween = require('terriajs-cesium/Source/ThirdParty/Tween');
 var loadView = require('../Core/loadView');
 
 var svgReset = require('../SvgPaths/svgReset');
-var svgTilt = require('../SvgPaths/svgTilt');
 var svgCompassOuterRing = require('../SvgPaths/svgCompassOuterRing');
 var svgCompassGyro = require('../SvgPaths/svgCompassGyro');
 var svgCompassRotationMarker = require('../SvgPaths/svgCompassRotationMarker');
@@ -28,13 +27,9 @@ var NavigationViewModel = function(options) {
      this.terria = options.terria;
 
     this.svgReset = svgReset;
-    this.svgTilt = svgTilt;
     this.svgCompassOuterRing = svgCompassOuterRing;
     this.svgCompassGyro = svgCompassGyro;
     this.svgCompassRotationMarker = svgCompassRotationMarker;
-
-    this._tiltInProgress = false;
-    this._nextTilt = undefined;
 
     this.showCompass = defined( this.terria.cesium);
     this.heading = this.showCompass ?  this.terria.cesium.scene.camera.heading : 0.0;
@@ -139,30 +134,6 @@ NavigationViewModel.prototype.resetView = function() {
     ga('send', 'event', 'navigation', 'click', 'reset');
 
      this.terria.currentViewer.zoomTo( this.terria.homeView, 1.5);
-};
-
-var tilts = [0, 40, 80];
-
-NavigationViewModel.prototype.tilt = function() {
-    ga('send', 'event', 'navigation', 'click', 'tilt');
-
-    if (defined( this.terria.cesium)) {
-        var scene =  this.terria.cesium.scene;
-
-        var currentTilt = this.currentTilt;
-        var index;
-        for (index = 0; index < tilts.length && tilts[index] <= currentTilt; ++index) {
-        }
-
-        if (index >= tilts.length) {
-            index = 0;
-        }
-
-        this.currentTilt = tilts[index];
-        animateToTilt(this, scene, this.currentTilt);
-    }
-
-     this.terria.currentViewer.notifyRepaintRequired();
 };
 
 var vectorScratch = new Cartesian2();
@@ -458,84 +429,6 @@ function flyToPosition(scene, position, durationMilliseconds) {
                 return;
             }
             controller.enableInputs = true;
-        }
-    });
-}
-
-function animateToTilt(viewModel, scene, targetTiltDegrees, durationMilliseconds) {
-    if (viewModel._tiltInProgress) {
-        viewModel._nextTilt = targetTiltDegrees;
-        return;
-    }
-
-    durationMilliseconds = defaultValue(durationMilliseconds, 500);
-
-    // Get focus and camera position
-    var focus = getCameraFocus(scene);
-    if (!defined(focus)) {
-        return;
-    }
-
-    var campos = Cartesian3.subtract(scene.camera.position, focus, cartesian3Scratch);
-
-    // Get tilt
-    var startTilt = Cartesian3.angleBetween(campos, focus);
-    var endTilt = CesiumMath.toRadians(targetTiltDegrees);
-    var curTilt = 0;
-
-    // Translate camera reference to focus
-    var trans = Matrix4.fromTranslation(focus);
-    var oldTrans = scene.camera.transform;
-    scene.camera.transform = trans;
-
-    Cartesian3.clone(campos, scene.camera.position);
-
-    // Translate camera in reference to current pos
-    var controller = scene.screenSpaceCameraController;
-    controller.enableInputs = false;
-
-    viewModel._tiltInProgress = true;
-
-    scene.tweens.add({
-        duration : durationMilliseconds / 1000.0,
-        easingFunction : Tween.Easing.Sinusoidal.InOut,
-        startObject : {
-            time: 0.0
-        },
-        stopObject : {
-            time : 1.0
-        },
-        update : function(value) {
-            if (scene.isDestroyed()) {
-                return;
-            }
-            var amount = CesiumMath.lerp(startTilt, endTilt, value.time) - (startTilt + curTilt);
-            scene.camera.rotate(scene.camera.right, -amount);
-            curTilt += amount;
-       },
-        complete : function() {
-            if (controller.isDestroyed()) {
-                return;
-            }
-            controller.enableInputs = true;
-            scene.camera.position = Cartesian3.add(scene.camera.position, focus, scene.camera.position);
-            scene.camera.transform = oldTrans;
-            viewModel._tiltInProgress = false;
-
-            if (defined(viewModel._nextTilt)) {
-                var nextTilt = viewModel._nextTilt;
-                viewModel._nextTilt = undefined;
-                animateToTilt(viewModel, scene, nextTilt, durationMilliseconds);
-            }
-        },
-        cancel: function() {
-            if (controller.isDestroyed()) {
-                return;
-            }
-            controller.enableInputs = true;
-            scene.camera.position = Cartesian3.add(scene.camera.position, focus, scene.camera.position);
-            scene.camera.transform = oldTrans;
-            viewModel._tiltInProgress = false;
         }
     });
 }

--- a/lib/viewer/AusGlobeViewer.js
+++ b/lib/viewer/AusGlobeViewer.js
@@ -10,6 +10,7 @@ var L = require('leaflet');
 var URI = require('URIjs');
 
 var BingMapsApi = require('terriajs-cesium/Source/Core/BingMapsApi');
+var Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3');
 var Cartographic = require('terriajs-cesium/Source/Core/Cartographic');
 var CesiumMath = require('terriajs-cesium/Source/Core/Math');
 var CesiumTerrainProvider = require('terriajs-cesium/Source/Core/CesiumTerrainProvider');
@@ -839,6 +840,8 @@ function flyToPosition(scene, position, durationMilliseconds) {
     });
 }
 
+var destinationScratch = new Cartesian3();
+
 function zoomCamera(scene, distFactor, pos) {
     var camera = scene.camera;
     var pickRay = camera.getPickRay(pos);
@@ -846,11 +849,8 @@ function zoomCamera(scene, distFactor, pos) {
     if (targetCartesian) {
         // Zoom to the picked latitude/longitude, at a distFactor multiple
         // of the height.
-        var targetCartographic = Ellipsoid.WGS84.cartesianToCartographic(targetCartesian);
-        var cameraCartographic = Ellipsoid.WGS84.cartesianToCartographic(camera.position);
-        targetCartographic.height = cameraCartographic.height - (cameraCartographic.height - targetCartographic.height) * distFactor;
-        targetCartesian = Ellipsoid.WGS84.cartographicToCartesian(targetCartographic);
-        flyToPosition(scene, targetCartesian);
+        var destination = Cartesian3.lerp(camera.position, targetCartesian, distFactor, destinationScratch);
+        flyToPosition(scene, destination);
     }
 }
 


### PR DESCRIPTION
Fixes #679 

This is still imperfect, but it's better.  Ideally, the double-clicked point would stay exactly under the mouse cursor after zooming, but it's non-trivial to work this out on a 3D globe.
