### PR TITLE
Handle missing numbers in CSV files more gracefully.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.8
+
+* The feature info popup for points loaded from CSV files now shows numeric columns with a missing value as blank instead of as 1e-34.
+
 ### 1.0.7
 
 * `CatalogItemNameSearchProviderViewModel` now asynchronously loads groups so items in unloaded groups can be found, too.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,7 @@ gulp.task('watch-specs', ['prepare-cesium'], function() {
     return watch(specJSName, glob.sync(testGlob), false);
 });
 
-gulp.task('watch', ['watch-specs', 'watch-workers']);
+gulp.task('watch', ['watch-specs']);
 
 gulp.task('lint', function(){
     var sources = glob.sync(sourceGlob.concat(testGlob));

--- a/lib/Map/DataTable.js
+++ b/lib/Map/DataTable.js
@@ -353,7 +353,7 @@ DataTable.prototype.getVariableEnums = function (varName) {
 */
 DataTable.prototype.isNoData = function (ptVal) {
     function _float_equals(a, b) { return (Math.abs((a - b) / b) < 0.00001); }
-    return _float_equals(this.noData, ptVal);
+    return ptVal === null || !defined(ptVal) || _float_equals(this.noData, ptVal);
 };
 
 /**

--- a/lib/Map/DataVariable.js
+++ b/lib/Map/DataVariable.js
@@ -99,10 +99,7 @@ DataVariable.prototype._calculateVarMinMax = function () {
     var minVal = Number.MAX_VALUE;
     var maxVal = -Number.MAX_VALUE;
     for (var i = 0; i < vals.length; i++) {
-        if (vals[i] === undefined || vals[i] === null) {
-            vals[i] = this.noData;
-        }
-        else {
+        if (defined(vals[i]) && vals[i] !== null) {
             if (minVal > vals[i]) {
                 minVal = vals[i];
             }
@@ -136,7 +133,7 @@ DataVariable.prototype._processTimeVariable = function () {
     if (this.varType !== VarType.TIME || this.vals.length === 0 || typeof this.vals[0] !== 'string') {
         return;
     }
-    
+
     function swapDateFormat(v) {
         var part = v.split(/[/-]/);
         if (part.length === 3) {

--- a/lib/Map/TableDataSource.js
+++ b/lib/Map/TableDataSource.js
@@ -132,12 +132,12 @@ defineProperties(TableDataSource.prototype, {
  * Set the table display style parameters
  *
  * @param {Object} style An object containing the style parameters for the datasource.
- * @param {Float} [style.scaleByValue] The scale of the displayed point. 
- * @param {Boolean} [style.imageUrl] Whether to scale the point based on normalized value. 
- * @param {String} [style.displayTime] A string representing an image to display for the point. 
- * @param {Float} [style.minDisplayValue] Set the minimum value for the colormap. 
- * @param {Float} [style.maxDisplayValue] Set the maximum value for the colormap. 
- * @param {Float} [style.clampDisplayValue] Display values that fall outside the display range as min and max colors. 
+ * @param {Float} [style.scaleByValue] The scale of the displayed point.
+ * @param {Boolean} [style.imageUrl] Whether to scale the point based on normalized value.
+ * @param {String} [style.displayTime] A string representing an image to display for the point.
+ * @param {Float} [style.minDisplayValue] Set the minimum value for the colormap.
+ * @param {Float} [style.maxDisplayValue] Set the maximum value for the colormap.
+ * @param {Float} [style.clampDisplayValue] Display values that fall outside the display range as min and max colors.
  * @param {Array} [style.colorMap] A colormap applied to color the data points.
  * @param {String}[style.dataVariable] Which data variable to display.
  *
@@ -237,6 +237,10 @@ var endScratch = new JulianDate();
 
 
 TableDataSource.prototype.describe = function(properties) {
+    if (!defined(properties) || properties === null) {
+        return '';
+    }
+
     var html = '<table class="cesium-infoBox-defaultTable">';
     for ( var key in properties) {
         if (properties.hasOwnProperty(key)) {
@@ -272,7 +276,7 @@ TableDataSource.prototype._czmlRecFromPoint = function (point) {
             "cartographicDegrees" : [0, 0, 0]
         }
     };
-    
+
     var color = this._mapValue2Color(point.val);
     var scale = this._mapValue2Scale(point.val);
 
@@ -339,12 +343,12 @@ TableDataSource.prototype.getCzmlDataPointList = function () {
     }
 
     var pointList = this.dataset.getPointList();
-    
+
     var dispRecords = [{
         id : 'document',
         version : '1.0'
     }];
-    
+
     for (var i = 0; i < pointList.length; i++) {
             //set position, scale, color, and display time
         var rec = this._czmlRecFromPoint(pointList[i]);
@@ -369,9 +373,9 @@ TableDataSource.prototype.getDataPointList = function (time) {
     }
 
     var pointList = this.dataset.getPointList();
-    
+
     var dispRecords = [];
-    
+
     var start, finish;
     if (this.dataset.hasTimeData()) {
         start = JulianDate.addMinutes(time, -this.displayTime, endScratch);
@@ -379,7 +383,7 @@ TableDataSource.prototype.getDataPointList = function (time) {
     }
     for (var i = 0; i < pointList.length; i++) {
         if (this.dataset.hasTimeData()) {
-            if (JulianDate.lessThan(pointList[i].time, start) || 
+            if (JulianDate.lessThan(pointList[i].time, start) ||
                 JulianDate.greaterThan(pointList[i].time, finish)) {
                 continue;
             }
@@ -468,20 +472,20 @@ TableDataSource.prototype.getLegendGraphic = function () {
     ctx.rotate(180 * Math.PI / 180);
     ctx.fillStyle = linGrad;
     ctx.fillRect(0,0,gradW,gradH);
-    
+
         //text
     var val;
     var minText = (val = this.minDisplayValue || this.dataset.getDataMinValue()) === undefined ? 'und.' : val.toString();
     var maxText = (val = this.maxDisplayValue || this.dataset.getDataMaxValue()) === undefined ? 'und.' : val.toString();
     var varText = this.dataset.getDataVariable();
-    
+
     ctx.setTransform(1,0,0,1,0,0);
     ctx.font = "16px Arial Narrow";
     ctx.fillStyle = "#FFFFFF";
     ctx.fillText(varText, 5, 15);
     ctx.fillText(maxText, gradW + 25, 15+h-gradH-5);
     ctx.fillText(minText, gradW + 25, h-5);
-    
+
     return canvas.toDataURL("image/png");
 };
 
@@ -489,7 +493,7 @@ TableDataSource.prototype.getLegendGraphic = function () {
 /**
 * Set the gradient used to color the data points
 *
-* @param {Array} colorMap A colormap with an array of entries as defined for html5 
+* @param {Array} colorMap A colormap with an array of entries as defined for html5
 *   canvas linear gradients e.g., { offset: xx, color: 'rgba(32,0,200,1.0)'}
 *
 */
@@ -497,7 +501,7 @@ TableDataSource.prototype.setColorGradient = function (colorMap) {
     if (colorMap === undefined) {
         return;
     }
-    
+
     this.colorMap = colorMap;
 
     var canvas = document.createElement("canvas");
@@ -507,7 +511,7 @@ TableDataSource.prototype.setColorGradient = function (colorMap) {
     var w = canvas.width = 64;
     var h = canvas.height = 256;
     var ctx = canvas.getContext('2d');
-    
+
     // Create Linear Gradient
     var grad = this.colorMap;
     var linGrad = ctx.createLinearGradient(0,0,0,h);
@@ -515,7 +519,7 @@ TableDataSource.prototype.setColorGradient = function (colorMap) {
         this._colorByValue = false;
         linGrad.addColorStop(0.0, grad[0].color);
         linGrad.addColorStop(1.0, grad[0].color);
-    } 
+    }
     else {
         for (var i = 0; i < grad.length; i++) {
             linGrad.addColorStop(grad[i].offset, grad[i].color);

--- a/test/ViewModels/CsvCatalogItemSpec.js
+++ b/test/ViewModels/CsvCatalogItemSpec.js
@@ -6,6 +6,7 @@ var Terria = require('../../lib/Models/Terria');
 var CatalogItem = require('../../lib/Models/CatalogItem');
 var CsvCatalogItem = require('../../lib/Models/CsvCatalogItem');
 
+var Color = require('terriajs-cesium/Source/Core/Color');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 
 var terria;
@@ -169,4 +170,25 @@ describe('CsvCatalogItem', function() {
         expect(csvItem instanceof CatalogItem).toBe(true);
     });
 
+    it('has a blank in the description table for a missing number', function(done) {
+        csvItem.url = 'test/missingNumberFormatting.csv';
+        return csvItem.load().then(function() {
+            var entities = csvItem._tableDataSource.entities.values;
+            expect(entities.length).toBe(2);
+            expect(entities[0].description.getValue()).toContain('<td>Vals</td><td>10</td>');
+            expect(entities[1].description.getValue()).toContain('<td>Vals</td><td></td>');
+            done();
+        });
+    });
+
+    it('renders a point with no value in transparent black', function(done) {
+        csvItem.url = 'test/missingNumberFormatting.csv';
+        return csvItem.load().then(function() {
+            var entities = csvItem._tableDataSource.entities.values;
+            expect(entities.length).toBe(2);
+            expect(entities[0].point.color.getValue()).not.toEqual(new Color(0.0, 0.0, 0.0, 0.0));
+            expect(entities[1].point.color.getValue()).toEqual(new Color(0.0, 0.0, 0.0, 0.0));
+            done();
+        });
+    });
 });

--- a/wwwroot/test/missingNumberFormatting.csv
+++ b/wwwroot/test/missingNumberFormatting.csv
@@ -1,0 +1,3 @@
+Vals,Bar,Lat,Lon
+10.0,thing,150.0,35.0
+,thing,160.0,40


### PR DESCRIPTION
Instead of replacing nulls with 1e-34, leave them in place, treat them as a missing value, and format them as an empty string.

Fixes #680 
