### PR TITLE
Use WMS layer hierarchy in GetCapabilities for the catalogue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.8
+
+* `WebMapServiceCatalogGroup` now populates the catalog using the hierarchy of layers returned by the WMS server in GetCapabilities.  To keep the previous behavior, set the `flatten` property to true.
+
 ### 1.0.7
 
 * `CatalogItemNameSearchProviderViewModel` now asynchronously loads groups so items in unloaded groups can be found, too.

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -73,7 +73,15 @@ var WebMapServiceCatalogGroup = function(terria) {
      */
     this.itemProperties = undefined;
 
-    knockout.track(this, ['url', 'dataCustodian', 'parameters', 'blacklist', 'titleField', 'itemProperties']);
+    /**
+     * Gets or sets a value indicating whether the list of layers queried from GetCapabilities should be
+     * flattened into a list with no hierarchy.
+     * @type {Boolean}
+     * @default false
+     */
+    this.flatten = false;
+
+    knockout.track(this, ['url', 'dataCustodian', 'parameters', 'blacklist', 'titleField', 'itemProperties', 'flatten']);
 };
 
 inherit(CatalogGroup, WebMapServiceCatalogGroup);
@@ -257,6 +265,13 @@ function addLayersRecursively(wmsGroup, layers, items, parent, supportsJsonGetFe
         layers = [layers];
     }
 
+    if (layers.length === 1 && (!defined(layers[0].Name) || layers[0].Name.length === 0)) {
+        layers = layers[0].Layer;
+        if (!(layers instanceof Array)) {
+            layers = [layers];
+        }
+    }
+
     for (var i = 0; i < layers.length; ++i) {
         var layer = layers[i];
 
@@ -269,12 +284,42 @@ function addLayersRecursively(wmsGroup, layers, items, parent, supportsJsonGetFe
         }
 
         if (defined(layer.Layer)) {
+            var recurseItems = items;
+
+            var group;
+            if (!wmsGroup.flatten) {
+                // Create a group for this layer
+                group = createWmsSubGroup(wmsGroup, layer);
+                recurseItems = group.items;
+            }
+
             // WMS 1.1.1 spec section 7.1.4.5.2 says any layer with a Name property can be used
             // in the 'layers' parameter of a GetMap request.  This is true in 1.0.0 and 1.3.0 as well.
+            var allName = '(All)';
+            var originalNameForAll;
             if (defined(layer.Name) && layer.Name.length > 0) {
-                items.push(createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian));
+                var all = createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian);
+
+                if (!wmsGroup.flatten) {
+                    originalNameForAll = all.name;
+                    all.name = allName + ' ' + all.name;
+                }
+
+                recurseItems.push(all);
             }
-            addLayersRecursively(wmsGroup, layer.Layer, items, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian);
+
+            addLayersRecursively(wmsGroup, layer.Layer, recurseItems, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian);
+
+            if (!wmsGroup.flatten) {
+                if (recurseItems.length === 1) {
+                    if (recurseItems[0].name.indexOf(allName) === 0) {
+                        recurseItems[0].name = originalNameForAll;
+                    }
+                    items.push(recurseItems[0]);
+                } else if (recurseItems.length > 0) {
+                    items.push(group);
+                }
+            }
         }
         else {
             items.push(createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian));
@@ -361,6 +406,20 @@ function createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, suppor
         }
     }
 
+
+    return result;
+}
+
+function createWmsSubGroup(wmsGroup, layer) {
+    var result = new CatalogGroup(wmsGroup.terria);
+
+    if (wmsGroup.titleField === 'name') {
+        result.name = layer.Name;
+    } else if (wmsGroup.titleField === 'abstract') {
+        result.name = layer.Abstract;
+    } else {
+        result.name = layer.Title;
+    }
 
     return result;
 }

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -226,7 +226,23 @@ sending an email to <a href="mailto:nationalmap@lists.nicta.com.au">nationalmap@
             dataCustodian = text;
         }
 
-        addLayersRecursively(that, json.Capability.Layer, that.items, undefined, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian);
+        // Skip the root layer, if there's only one.
+        // But use it for the name of this catalog item if the item is currently named by the URL.
+        var rootLayers = json.Capability.Layer;
+        if (rootLayers) {
+            if (!(rootLayers instanceof Array)) {
+                rootLayers = [rootLayers];
+            }
+            if (rootLayers.length === 1 && rootLayers[0].Layer) {
+                var singleRoot = rootLayers[0];
+                if (that.name === that.url) {
+                    that.name = getNameFromLayer(that, singleRoot);
+                }
+                rootLayers = singleRoot.Layer;
+            }
+
+            addLayersRecursively(that, rootLayers, that.items, undefined, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian);
+        }
     }).otherwise(function(e) {
         throw new ModelError({
             sender: that,
@@ -260,16 +276,19 @@ function cleanAndProxyUrl(terria, url) {
     return cleanedUrl;
 }
 
+function getNameFromLayer(wmsGroup, layer) {
+    if (wmsGroup.titleField === 'name') {
+        return layer.Name;
+    } else if (wmsGroup.titleField === 'abstract') {
+        return layer.Abstract;
+    } else {
+        return layer.Title;
+    }
+}
+
 function addLayersRecursively(wmsGroup, layers, items, parent, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian) {
     if (!(layers instanceof Array)) {
         layers = [layers];
-    }
-
-    if (layers.length === 1 && (!defined(layers[0].Name) || layers[0].Name.length === 0)) {
-        layers = layers[0].Layer;
-        if (!(layers instanceof Array)) {
-            layers = [layers];
-        }
     }
 
     for (var i = 0; i < layers.length; ++i) {
@@ -311,10 +330,8 @@ function addLayersRecursively(wmsGroup, layers, items, parent, supportsJsonGetFe
             addLayersRecursively(wmsGroup, layer.Layer, recurseItems, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian);
 
             if (!wmsGroup.flatten) {
-                if (recurseItems.length === 1) {
-                    if (recurseItems[0].name.indexOf(allName) === 0) {
-                        recurseItems[0].name = originalNameForAll;
-                    }
+                if (recurseItems.length === 1 && recurseItems[0].name.indexOf(allName) === 0) {
+                    recurseItems[0].name = originalNameForAll;
                     items.push(recurseItems[0]);
                 } else if (recurseItems.length > 0) {
                     items.push(group);
@@ -330,13 +347,7 @@ function addLayersRecursively(wmsGroup, layers, items, parent, supportsJsonGetFe
 function createWmsDataSource(wmsGroup, layer, supportsJsonGetFeatureInfo, supportsXmlGetFeatureInfo, xmlContentType, dataCustodian) {
     var result = new WebMapServiceCatalogItem(wmsGroup.terria);
 
-    if (wmsGroup.titleField === 'name') {
-        result.name = layer.Name;
-    } else if (wmsGroup.titleField === 'abstract') {
-        result.name = layer.Abstract;
-    } else {
-        result.name = layer.Title;
-    }
+    result.name = getNameFromLayer(wmsGroup, layer);
     result.description = defined(layer.Abstract) && layer.Abstract.length > 0 ? layer.Abstract : wmsGroup.description;
     result.dataCustodian = dataCustodian;
     result.url = wmsGroup.url;


### PR DESCRIPTION
If desired, the old behavior can be restored by setting flatten=true.

When a layer is both a container for other layers and a toggle-able thing itself, the first item in the group will be "(All) Whatever Layer Name".  See the screenshot below.

Fixes #672 

![image](https://cloud.githubusercontent.com/assets/924374/7604558/a155c1bc-f987-11e4-8c18-63f639733ba5.png)
