### PR TITLE
Use data.gov.au wms_layer feld.

### DIFF
--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -240,7 +240,6 @@ Otherwise, if reloading doesn\'t fix it, please report the problem by sending an
 // The "format" field of CKAN resources must match this regular expression to be considered a WMS resource.
 var wmsFormatRegex = /^wms$/i;
 var esriRestFormatRegex = /^esri rest$/i;
-var jsonFormatRegex = /^JSON$/i;
 var kmlFormatRegex = /^KML$/i;
 
 function filterResultsByGetCapabilities(ckanGroup, json) {
@@ -379,8 +378,6 @@ function populateGroupFromResults(ckanGroup, json) {
             }
         }
 
-        var dataGovCkan = (ckanGroup.url === 'http://www.data.gov.au');  //data.gov.au hack
-
         // Currently, we support WMS and Esri REST layers.
         var resources = item.resources;
         for (var resourceIndex = 0; resourceIndex < resources.length; ++resourceIndex) {
@@ -391,23 +388,12 @@ function populateGroupFromResults(ckanGroup, json) {
             }
 
             var isWms;
-            if (dataGovCkan) {
-                if (resource.format.match(jsonFormatRegex)) {
-                    isWms = true;
-                } else if (resource.format.match(kmlFormatRegex)) {
-                    isWms = false;
-                } else {
-                    continue;
-                }
-            }
-            else {
-                if (resource.format.match(wmsFormatRegex)) {
-                    isWms = true;
-                } else if (resource.format.match(esriRestFormatRegex) || resource.format.match(kmlFormatRegex)) {
-                    isWms = false;
-                } else {
-                    continue;
-                }
+            if (resource.format.match(wmsFormatRegex)) {
+                isWms = true;
+            } else if (resource.format.match(esriRestFormatRegex) || resource.format.match(kmlFormatRegex)) {
+                isWms = false;
+            } else {
+                continue;
             }
 
             var baseUrl = resource.wms_url;
@@ -421,7 +407,7 @@ function populateGroupFromResults(ckanGroup, json) {
             // Extract the layer name from the URL.
             var uri = new URI(baseUrl);
             var params = uri.search(true);
-            var layerName = params.LAYERS || params.layers || params.typeName;
+            var layerName = resource.wms_layer || params.LAYERS || params.layers || params.typeName;
 
             if (isWms && !defined(layerName)) {
                 continue;
@@ -432,10 +418,6 @@ function populateGroupFromResults(ckanGroup, json) {
             if (isWms) {
                 uri.search('');
                 url = uri.toString();
-
-                if (dataGovCkan) {
-                    url = url.replace('wfs', 'wms');  //data.gov.au hack
-                }
             }
 
             var newItem;


### PR DESCRIPTION
Many data.gov.au WMS resources now have a `wms_layer` field, so we can use that instead of attempting to deduce the layer name from the JSON/WFS URL.  After this change, the number of catalog items in the data.gov.au group went from 153 to 158 and the handful I spot checked worked well.
