### PR TITLE
keepOnTop work with region mapping to create region masking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Change Log
 * `ArcGisMapServerCatalogItem` now offers metadata, used to populate the Data Details and Service Details sections of the catalog item info panel.
 * `ArcGisMapServerCatalogGroup` now populates a "Service Description" and a "Data Description" info section for each catalog item from the MapServer's metadata.
 * The `metadataUrl` is now populated (and shown) from the regular MapServer URL.
+* Added 'keepOnTop' flag support for imageryLayers in init file to allow a layer to serve as a mask.
+* Added 'keepOnTop' support to region mapping to allow arbitrary masks based on supported regions.
 
 ### 1.0.7
 

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -44,7 +44,6 @@ var CsvCatalogItem = function(terria, url) {
     CatalogItem.call(this, terria);
 
     this._tableDataSource = undefined;
-    this._clockTickUnsubscribe = undefined;
 
     this._regionMapped = false;
 
@@ -83,7 +82,9 @@ var CsvCatalogItem = function(terria, url) {
      */
     this.opacity = 0.6;
 
-    knockout.track(this, ['url', 'data', 'dataSourceUrl', 'tableStyle', 'opacity', '_regionMapped']);
+    this.keepOnTop = false;
+
+    knockout.track(this, ['url', 'data', 'dataSourceUrl', 'tableStyle', 'opacity', 'keepOnTop', '_regionMapped']);
 
     knockout.getObservable(this, 'opacity').subscribe(function(newValue) {
         updateOpacity(this);
@@ -147,7 +148,7 @@ defineProperties(CsvCatalogItem.prototype, {
      */
     supportsReordering : {
         get : function() {
-            return this._regionMapped;
+            return this._regionMapped && !this.keepOnTop;
         }
     },
 
@@ -193,6 +194,7 @@ defineProperties(CsvCatalogItem.prototype, {
  * @type {String[]}
  */
 CsvCatalogItem.defaultPropertiesForSharing = clone(CatalogItem.defaultPropertiesForSharing);
+CsvCatalogItem.defaultPropertiesForSharing.push('keepOnTop');
 CsvCatalogItem.defaultPropertiesForSharing.push('opacity');
 CsvCatalogItem.defaultPropertiesForSharing.push('tableStyle');
 freezeObject(CsvCatalogItem.defaultPropertiesForSharing);

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -268,6 +268,7 @@ freezeObject(ImageryLayerCatalogItem.defaultSerializers);
  */
 ImageryLayerCatalogItem.defaultPropertiesForSharing = clone(CatalogItem.defaultPropertiesForSharing);
 ImageryLayerCatalogItem.defaultPropertiesForSharing.push('opacity');
+ImageryLayerCatalogItem.defaultPropertiesForSharing.push('keepOnTop');
 
 freezeObject(ImageryLayerCatalogItem.defaultPropertiesForSharing);
 


### PR DESCRIPTION
Some easy changes to region mapping to support keepOnTop.  Allows arbitrary region based masks in case we should need them.
