### PR TITLE
Show tile credits/attribution in Leaflet.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.9
+
+* Show Cesium `ImageryProvider` tile credits / attribution in Leaflet when using `CesiumTileLayer`.
+
 ### 1.0.8
 
 * `WebMapServiceCatalogGroup` now populates the catalog using the hierarchy of layers returned by the WMS server in GetCapabilities.  To keep the previous behavior, set the `flatten` property to true.

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -29,10 +29,6 @@ var CesiumTileLayer = L.TileLayer.extend({
         L.TileLayer.prototype.initialize.call(this, undefined, options);
     },
 
-    getAttribution: function() {
-        console.log(arguments);
-    },
-
     getTileUrl: function(tilePoint) {
         var z = tilePoint.z - this._zSubtract;
         if (z < 0) {
@@ -82,6 +78,10 @@ var CesiumTileLayer = L.TileLayer.extend({
             if (defined(this.imageryProvider.maximumLevel)) {
                 this.options.maxNativeZoom = this.imageryProvider.maximumLevel;
             }
+
+            if (defined(this.imageryProvider.credit) && defined(this.imageryProvider.credit.text)) {
+                this.attribution = this.imageryProvider.credit.text;
+            }
         }
 
         L.TileLayer.prototype._update.apply(this, arguments);
@@ -128,6 +128,9 @@ var CesiumTileLayer = L.TileLayer.extend({
         for (var j = ne.y; j < sw.y; ++j) {
             for (i = sw.x; i < ne.x; ++i) {
                 var credits = this.imageryProvider.getTileCredits(i, j, zoom);
+                if (!defined(credits)) {
+                    continue;
+                }
 
                 for (var k = 0; k < credits.length; ++k) {
                     var credit = credits[k];
@@ -173,6 +176,16 @@ var CesiumTileLayer = L.TileLayer.extend({
 
             return that.imageryProvider.pickFeatures(tileCoordinates.x, tileCoordinates.y, level, longitudeRadians, latitudeRadians);
         });
+    },
+
+    onRemove: function(map) {
+        for (var i = 0; i < this._previousCredits.length; ++i) {
+            this._previousCredits[i]._shownInLeafletLastUpdate = false;
+            this._previousCredits[i]._shownInLeaflet = false;
+            map.attributionControl.removeAttribution(this._previousCredits[i].text);
+        }
+
+        L.TileLayer.prototype.onRemove.apply(this, [map]);
     }
 });
 

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -2,13 +2,20 @@
 
 /*global require*/
 var L = require('leaflet');
+var Cartesian2 = require('terriajs-cesium/Source/Core/Cartesian2');
 var Cartographic = require('terriajs-cesium/Source/Core/Cartographic');
+var CesiumMath = require('terriajs-cesium/Source/Core/Math');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
 
 var pollToPromise = require('../Core/pollToPromise');
+
+var swScratch = new Cartographic();
+var neScratch = new Cartographic();
+var swTileCoordinatesScratch = new Cartesian2();
+var neTileCoordinatesScratch = new Cartesian2();
 
 var CesiumTileLayer = L.TileLayer.extend({
     initialize: function(imageryProvider, options) {
@@ -17,8 +24,13 @@ var CesiumTileLayer = L.TileLayer.extend({
         this._delayedUpdate = undefined;
         this._ready = false;
         this._zSubtract = 0;
+        this._previousCredits = [];
 
         L.TileLayer.prototype.initialize.call(this, undefined, options);
+    },
+
+    getAttribution: function() {
+        console.log(arguments);
     },
 
     getTileUrl: function(tilePoint) {
@@ -28,7 +40,7 @@ var CesiumTileLayer = L.TileLayer.extend({
         }
 
         var oldLoad = ImageryProvider.loadImage;
-        
+
         var tileUrl = this.options.errorTileUrl;
         ImageryProvider.loadImage = function(imageryProvider, url) {
             tileUrl = url;
@@ -73,6 +85,75 @@ var CesiumTileLayer = L.TileLayer.extend({
         }
 
         L.TileLayer.prototype._update.apply(this, arguments);
+
+        this._updateAttribution();
+    },
+
+    _updateAttribution: function() {
+        if (!this._ready || !defined(this.imageryProvider.getTileCredits)) {
+            return;
+        }
+
+        var i;
+        for (i = 0; i < this._previousCredits.length; ++i) {
+            this._previousCredits[i]._shownInLeafletLastUpdate = this._previousCredits[i]._shownInLeaflet;
+            this._previousCredits[i]._shownInLeaflet = false;
+        }
+
+        var bounds = this._map.getBounds();
+        var zoom = this._map.getZoom() - this._zSubtract;
+
+        var tilingScheme = this.imageryProvider.tilingScheme;
+
+        swScratch.longitude = Math.max(CesiumMath.negativePiToPi(CesiumMath.toRadians(bounds.getWest())), tilingScheme.rectangle.west);
+        swScratch.latitude = Math.max(CesiumMath.toRadians(bounds.getSouth()), tilingScheme.rectangle.south);
+        var sw = tilingScheme.positionToTileXY(swScratch, zoom, swTileCoordinatesScratch);
+        if (!defined(sw)) {
+            sw = swTileCoordinatesScratch;
+            sw.x = 0;
+            sw.y = tilingScheme.getNumberOfYTilesAtLevel(zoom) - 1;
+        }
+
+        neScratch.longitude = Math.min(CesiumMath.negativePiToPi(CesiumMath.toRadians(bounds.getEast())), tilingScheme.rectangle.east);
+        neScratch.latitude = Math.min(CesiumMath.toRadians(bounds.getNorth()), tilingScheme.rectangle.north);
+        var ne = tilingScheme.positionToTileXY(neScratch, zoom, neTileCoordinatesScratch);
+        if (!defined(ne)) {
+            ne = neTileCoordinatesScratch;
+            ne.x = tilingScheme.getNumberOfXTilesAtLevel(zoom) - 1;
+            ne.y = 0;
+        }
+
+        var nextCredits = [];
+
+        for (var j = ne.y; j < sw.y; ++j) {
+            for (i = sw.x; i < ne.x; ++i) {
+                var credits = this.imageryProvider.getTileCredits(i, j, zoom);
+
+                for (var k = 0; k < credits.length; ++k) {
+                    var credit = credits[k];
+                    if (credit._shownInLeaflet) {
+                        continue;
+                    }
+
+                    credit._shownInLeaflet = true;
+                    nextCredits.push(credit);
+
+                    if (!credit._shownInLeafletLastUpdate) {
+                        this._map.attributionControl.addAttribution(credit.text);
+                    }
+                }
+            }
+        }
+
+        // Remove attributions that applied last update but not this one.
+        for (i = 0; i < this._previousCredits.length; ++i) {
+            if (!this._previousCredits[i]._shownInLeaflet) {
+                this._map.attributionControl.removeAttribution(this._previousCredits[i].text);
+                this._previousCredits[i]._shownInLeafletLastUpdate = false;
+            }
+        }
+
+        this._previousCredits = nextCredits;
     },
 
     pickFeatures: function(map, longitudeRadians, latitudeRadians) {

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -79,8 +79,8 @@ var CesiumTileLayer = L.TileLayer.extend({
                 this.options.maxNativeZoom = this.imageryProvider.maximumLevel;
             }
 
-            if (defined(this.imageryProvider.credit) && defined(this.imageryProvider.credit.text)) {
-                this.attribution = this.imageryProvider.credit.text;
+            if (defined(this.imageryProvider.credit)) {
+                this._map.attributionControl.addAttribution(getCreditHtml(this.imageryProvider.credit));
             }
         }
 
@@ -142,7 +142,7 @@ var CesiumTileLayer = L.TileLayer.extend({
                     nextCredits.push(credit);
 
                     if (!credit._shownInLeafletLastUpdate) {
-                        this._map.attributionControl.addAttribution(credit.text);
+                        this._map.attributionControl.addAttribution(getCreditHtml(credit));
                     }
                 }
             }
@@ -151,7 +151,7 @@ var CesiumTileLayer = L.TileLayer.extend({
         // Remove attributions that applied last update but not this one.
         for (i = 0; i < this._previousCredits.length; ++i) {
             if (!this._previousCredits[i]._shownInLeaflet) {
-                this._map.attributionControl.removeAttribution(this._previousCredits[i].text);
+                this._map.attributionControl.removeAttribution(getCreditHtml(this._previousCredits[i]));
                 this._previousCredits[i]._shownInLeafletLastUpdate = false;
             }
         }
@@ -182,11 +182,31 @@ var CesiumTileLayer = L.TileLayer.extend({
         for (var i = 0; i < this._previousCredits.length; ++i) {
             this._previousCredits[i]._shownInLeafletLastUpdate = false;
             this._previousCredits[i]._shownInLeaflet = false;
-            map.attributionControl.removeAttribution(this._previousCredits[i].text);
+            map.attributionControl.removeAttribution(getCreditHtml(this._previousCredits[i]));
+        }
+
+        if (this._ready && defined(this.imageryProvider.credit)) {
+            map.attributionControl.removeAttribution(getCreditHtml(this.imageryProvider.credit));
         }
 
         L.TileLayer.prototype.onRemove.apply(this, [map]);
     }
 });
+
+function getCreditHtml(credit) {
+    var result = '';
+    if (credit.link) {
+        result += '<a href="' + credit.link + '">';
+    }
+    if (credit.imageUrl) {
+        result += '<img src="' + credit.imageUrl + '" />';
+    } else if (credit.text) {
+        result += credit.text;
+    }
+    if (credit.link) {
+        result += '</a>';
+    }
+    return result;
+}
 
 module.exports = CesiumTileLayer;

--- a/lib/Models/BingMapsCatalogItem.js
+++ b/lib/Models/BingMapsCatalogItem.js
@@ -4,6 +4,7 @@
 
 var BingMapsImageryProvider = require('terriajs-cesium/Source/Scene/BingMapsImageryProvider');
 var BingMapsStyle = require('terriajs-cesium/Source/Scene/BingMapsStyle');
+var Credit = require('terriajs-cesium/Source/Core/Credit');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 
@@ -16,7 +17,7 @@ var inherit = require('../Core/inherit');
  * @alias BingMapsCatalogItem
  * @constructor
  * @extends ImageryLayerCatalogItem
- * 
+ *
  * @param {Terria} terria The Terria instance.
  */
 var BingMapsCatalogItem = function(terria) {
@@ -71,6 +72,7 @@ BingMapsCatalogItem.prototype._createImageryProvider = function() {
         key: this.key
     });
 
+    result._credit = new Credit('Bing', undefined, 'http://www.bing.com');
     result.defaultGamma = 1.0;
 
     return result;

--- a/lib/Styles/Map.less
+++ b/lib/Styles/Map.less
@@ -21,7 +21,7 @@
     font-weight: bolder;
 }
 
-.cesium-credit-text:nth-child(3) {
+.cesium-credit-text:nth-child(2) {
     font-weight: bolder;
 }
 

--- a/lib/viewer/AusGlobeViewer.js
+++ b/lib/viewer/AusGlobeViewer.js
@@ -418,7 +418,6 @@ us via email at nationalmap@lists.nicta.com.au.'
     globe.depthTestAgainstTerrain = false;
 
     scene.frameState.creditDisplay.addDefaultCredit(new Credit('CESIUM', undefined, 'http://cesiumjs.org/'));
-    scene.frameState.creditDisplay.addDefaultCredit(new Credit('BING', undefined, 'http://www.bing.com/'));
 
     var inputHandler = viewer.screenSpaceEventHandler;
 


### PR DESCRIPTION
The Leaflet credits vanished when we switched to using `CesiumTileLayer` instead of provider-specific layers for Leaflet awhile back.
