### PR TITLE
Don't show async results from old searches.

### DIFF
--- a/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
+++ b/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
@@ -15,7 +15,7 @@ var CatalogItemNameSearchProviderViewModel = function(options) {
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
     this.terria = options.terria;
-    this._geocodeInProgress = undefined;
+    this._searchInProgress = undefined;
 
     this.name = 'Catalogue Items';
     this.maxResults = defaultValue(options.maxResults, 10);
@@ -24,6 +24,11 @@ var CatalogItemNameSearchProviderViewModel = function(options) {
 inherit(SearchProviderViewModel, CatalogItemNameSearchProviderViewModel);
 
 CatalogItemNameSearchProviderViewModel.prototype.search = function(searchText) {
+    if (this._searchInProgress) {
+        this._searchInProgress.cancel = true;
+        this._searchInProgress = undefined;
+    }
+
     if (!defined(searchText) || /^\s*$/.test(searchText)) {
         this.isSearching = false;
         this.searchResults.removeAll();
@@ -36,13 +41,21 @@ CatalogItemNameSearchProviderViewModel.prototype.search = function(searchText) {
 
     ga('send', 'event', 'search', 'catalogue', searchText);
 
+    var searchInProgress = this._searchInProgress = {
+        cancel: false
+    };
+
     var path = [];
     var topLevelGroup =  this.terria.catalog.group;
     var promises = [];
-    findMatchingItemsRecursively(this, new RegExp(searchText, 'i'), topLevelGroup, path, promises);
+    findMatchingItemsRecursively(this, searchInProgress, new RegExp(searchText, 'i'), topLevelGroup, path, promises);
 
     var that = this;
     when.all(promises, function() {
+        if (searchInProgress.cancel) {
+            return;
+        }
+
         if (that.searchResults.length === 0) {
             that.searchMessage = 'Sorry, no catalogue items match your search query.';
         }
@@ -51,11 +64,11 @@ CatalogItemNameSearchProviderViewModel.prototype.search = function(searchText) {
     });
 };
 
-function findMatchingItemsRecursively(viewModel, searchExpression, group, path, promises) {
+function findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, group, path, promises) {
     path.push(group);
 
     var items = group.items;
-    for (var i = 0; viewModel.searchResults.length < viewModel.maxResults && i < items.length; ++i) {
+    for (var i = 0; !searchInProgress.cancel && viewModel.searchResults.length < viewModel.maxResults && i < items.length; ++i) {
         var item = items[i];
 
         // Match non-top-level items whose name contain the search text.
@@ -71,11 +84,11 @@ function findMatchingItemsRecursively(viewModel, searchExpression, group, path, 
         if (defined(item.items)) {
             var loadPromise = item.load();
             if (defined(loadPromise) && item.isLoading) {
-                var searchPromise = loadPromise.then(findItemsInLoadedGroup.bind(undefined, viewModel, searchExpression, item, path.slice()));
+                var searchPromise = loadPromise.then(findItemsInLoadedGroup.bind(undefined, viewModel, searchInProgress, searchExpression, item, path.slice()));
                 searchPromise = searchPromise.otherwise(ignoreLoadErrors);
                 promises.push(searchPromise);
             } else {
-                findMatchingItemsRecursively(viewModel, searchExpression, item, path, promises);
+                findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, item, path, promises);
             }
         }
     }
@@ -83,9 +96,9 @@ function findMatchingItemsRecursively(viewModel, searchExpression, group, path, 
     path.pop();
 }
 
-function findItemsInLoadedGroup(viewModel, searchExpression, item, path) {
+function findItemsInLoadedGroup(viewModel, searchInProgress, searchExpression, item, path) {
     var childPromises = [];
-    findMatchingItemsRecursively(viewModel, searchExpression, item, path, childPromises);
+    findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, item, path, childPromises);
     return when.all(childPromises);
 }
 


### PR DESCRIPTION
If you typed a few characters in the search box, paused for a second, and then typed some more, you could end up seeing async catalog results for the first few characters you typed.  This pull request cancels old searches when starting new ones.
