### PR TITLE
Tweaks to OpenStreetMapCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.18
+
+* Added `OpenStreetMapCatalogItem` for connecting to tile servers using the OpenStreetMap tiling scheme.
+
 ### 1.0.17
 
 * Upgraded to TerriajS Cesium 1.10.2.

--- a/lib/Models/OpenStreetMapCatalogItem.js
+++ b/lib/Models/OpenStreetMapCatalogItem.js
@@ -5,7 +5,6 @@
 var OpenStreetMapImageryProvider = require('terriajs-cesium/Source/Scene/OpenStreetMapImageryProvider');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
-var Credit = require('terriajs-cesium/Source/Core/Credit');
 var ImageryLayerCatalogItem = require('./ImageryLayerCatalogItem');
 var inherit = require('../Core/inherit');
 
@@ -21,7 +20,15 @@ var inherit = require('../Core/inherit');
 var OpenStreetMapCatalogItem = function(terria) {
     ImageryLayerCatalogItem.call(this, terria);
 
-    knockout.track(this, []);
+    this.url = '';
+
+    this.fileExtension = 'png';
+
+    this.maximumLevel = 25;
+
+    this.attribution = undefined;
+
+    knockout.track(this, ['url', 'fileExtension', 'maximumLevel', 'attribution']);
 };
 
 inherit(ImageryLayerCatalogItem, OpenStreetMapCatalogItem);
@@ -51,14 +58,12 @@ defineProperties(OpenStreetMapCatalogItem.prototype, {
 });
 
 OpenStreetMapCatalogItem.prototype._createImageryProvider = function() {
-    var result = new OpenStreetMapImageryProvider({
-        url: this.url      
+    return new OpenStreetMapImageryProvider({
+        url: this.url,
+        fileExtension: this.fileExtension,
+        maximumLevel: this.maximumLevel,
+        credit: this.attribution
     });
-
-    result._credit = new Credit('© OpenStreetMap contributors', undefined, 'https://www.openstreetmap.org/');
-    result.defaultGamma = 1.0;
-
-    return result;
 };
 
 module.exports = OpenStreetMapCatalogItem;

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -39,7 +39,7 @@ var registerCatalogMembers = function() {
     createCatalogMemberFromType.register('wfs-getCapabilities', WebFeatureServiceCatalogGroup);
     createCatalogMemberFromType.register('wms', WebMapServiceCatalogItem);
     createCatalogMemberFromType.register('wms-getCapabilities', WebMapServiceCatalogGroup);
-    createCatalogMemberFromType.register(matchesExtension('openstreet'), OpenStreetMapCatalogItem);
+    createCatalogMemberFromType.register('open-street-map', OpenStreetMapCatalogItem);
 
     createCatalogItemFromUrl.register(matchesExtension('csv'), CsvCatalogItem);
     createCatalogItemFromUrl.register(matchesExtension('czm'), CzmlCatalogItem);

--- a/lib/ViewModels/AddDataPanelViewModel.js
+++ b/lib/ViewModels/AddDataPanelViewModel.js
@@ -150,7 +150,7 @@ AddDataPanelViewModel.prototype.addUrl = function() {
         promise = loadWfs(this);
     } else if (this.dataType === 'esri-group') {
         promise = loadMapServer(this);
-    } else if (this.dataType === 'openstreet') {
+    } else if (this.dataType === 'open-street-map') {
         promise = loadOpenStreetMapServer(this);
     } else {
         promise = loadFile(this);

--- a/lib/Views/AddDataPanel.html
+++ b/lib/Views/AddDataPanel.html
@@ -20,12 +20,12 @@
                         <option value="wms-getCapabilities">Web Map Service (WMS) Server</option>
                         <option value="wfs-getCapabilities">Web Feature Service (WFS) Server</option>
                         <option value="esri-group">Esri ArcGIS Server</option>
+                        <option value="open-street-map">Open Street Map Server</option>
                         <option value="geojson">GeoJSON</option>
                         <option value="kml">KML or KMZ</option>
                         <option value="csv">CSV</option>
                         <option value="czml">CZML</option>
                         <option value="gpx">GPX</option>
-                        <option value="openstreet">Open Street Map</option>
                         <option value="other">Other (use conversion service)</option>
                     </select>
                 </label>


### PR DESCRIPTION
Minor tweaks to @reneenoble's `OpenStreetMapCatalogItem`.  

@axman6, @meh9, and @stevage:
With this new catalog item, it's simple to add the CartoDB Positron and Dark Matter maps.  Here's an init file you can drag in:

```
{
    "catalog": [
        {
            "name": "CartoDB",
            "type": "group",
            "items": [
                {
                    "name": "Positron",
                    "type": "open-street-map",
                    "url": "http://c.basemaps.cartocdn.com/light_all/",
                    "attribution": "Map tiles by CartoDB, under CC BY 3.0. Data by OpenStreetMap, under ODbL.",
                    "dataCustodian": "[CartoDB](https://cartodb.com/basemaps/)",
                    "opacity": 1.0
                },
                {
                    "name": "Dark Matter",
                    "type": "open-street-map",
                    "url": "http://c.basemaps.cartocdn.com/dark_all/",
                    "attribution": "Map tiles by CartoDB, under CC BY 3.0. Data by OpenStreetMap, under ODbL.",
                    "dataCustodian": "[CartoDB](https://cartodb.com/basemaps/)",
                    "opacity": 1.0
                }
            ]
        }
    ]
}
```
