### PR TITLE
Add allowEntireWmsServers property to CkanCatalogGroup.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.18
+
+* Added `CkanCatalogGroup.allowEntireWmsServers` property.  When set and the group discovers a WMS resource without a layer parameter, it adds a catalog item for the entire server instead of ignoring the resource.
+
 ### 1.0.17
 
 * Upgraded to TerriajS Cesium 1.10.2.

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -20,6 +20,7 @@ var ModelError = require('./ModelError');
 var CatalogGroup = require('./CatalogGroup');
 var inherit = require('../Core/inherit');
 var KmlCatalogItem = require('./KmlCatalogItem');
+var WebMapServiceCatalogGroup = require('./WebMapServiceCatalogGroup');
 var WebMapServiceCatalogItem = require('./WebMapServiceCatalogItem');
 var xml2json = require('../ThirdParty/xml2json');
 
@@ -109,11 +110,19 @@ var CkanCatalogGroup = function(terria) {
      */
     this.useResourceName = false;
 
+    /**
+     * True to allow entire WMS servers (that is, WMS resources without a clearly-defined layer) to be
+     * added to the catalog; otherwise, false.
+     * @type {Boolean}
+     * @default false
+     */
+    this.allowEntireWmsServers = false;
+
     this.includeWms = true;
     this.includeKml = false;
     this.includeEsriMapServer = false;
 
-    knockout.track(this, ['url', 'dataCustodian', 'filterQuery', 'blacklist', 'wmsParameters', 'groupBy', 'useResourceName']);
+    knockout.track(this, ['url', 'dataCustodian', 'filterQuery', 'blacklist', 'wmsParameters', 'groupBy', 'useResourceName', 'allowEntireWmsServers']);
 };
 
 inherit(CatalogGroup, CkanCatalogGroup);
@@ -188,7 +197,7 @@ CkanCatalogGroup.defaultSerializers.isLoading = function(ckanGroup, json, proper
 freezeObject(CkanCatalogGroup.defaultSerializers);
 
 CkanCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
-    return [this.url, this.filterQuery, this.blacklist, this.filterByWmsGetCapabilities, this.minimumMaxScaleDenominator];
+    return [this.url, this.filterQuery, this.blacklist, this.filterByWmsGetCapabilities, this.minimumMaxScaleDenominator, this.allowEntireWmsServers];
 };
 
 CkanCatalogGroup.prototype._load = function() {
@@ -409,7 +418,7 @@ function populateGroupFromResults(ckanGroup, json) {
             var params = uri.search(true);
             var layerName = resource.wms_layer || params.LAYERS || params.layers || params.typeName;
 
-            if (isWms && !defined(layerName)) {
+            if (isWms && !defined(layerName) && !ckanGroup.allowEntireWmsServers) {
                 continue;
             }
 
@@ -425,7 +434,12 @@ function populateGroupFromResults(ckanGroup, json) {
                 if (!ckanGroup.includeWms) {
                     continue;
                 }
-                newItem = new WebMapServiceCatalogItem(ckanGroup.terria);
+                if (defined(layerName)) {
+                    newItem = new WebMapServiceCatalogItem(ckanGroup.terria);
+                    newItem.layers = layerName;
+                } else {
+                    newItem = new WebMapServiceCatalogGroup(ckanGroup.terria);
+                }
             } else if (resource.format.match(esriRestFormatRegex)) {
                 if (!ckanGroup.includeEsriMapServer) {
                     continue;
@@ -464,7 +478,6 @@ function populateGroupFromResults(ckanGroup, json) {
             newItem.dataUrlType = dataUrlType;
 
             if (isWms) {
-                newItem.layers = layerName;
                 //This should be deprecated and done on a server by server basis when feasible
                 newItem.parameters = ckanGroup.wmsParameters;
             }


### PR DESCRIPTION
When set and the group discovers a WMS resource without a layer parameter, it adds a catalog item for the entire server instead of ignoring the resource.
