### PR TITLE
add featureInfoFields to tableStyle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Change Log
 
 ### 1.0.18
 
-* Added featureInfoFields to csvCatalogItem.tableStyle (see NationalMap test.json for example).  Allows setting which fields and what name is shown in the featureInfo popup.
+* Added `featureInfoFields` property to `CsvCatalogItem.tableStyle`.  It allows setting which fields to show in the Feature Info popup, and the name to use for each.
 * Added `CkanCatalogGroup.allowEntireWmsServers` property.  When set and the group discovers a WMS resource without a layer parameter, it adds a catalog item for the entire server instead of ignoring the resource.
 
 ### 1.0.17

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 ### 1.0.18
 
+* Added featureInfoFields to csvCatalogItem.tableStyle (see NationalMap test.json for example).  Allows setting which fields and what name is shown in the featureInfo popup.
 * Added `CkanCatalogGroup.allowEntireWmsServers` property.  When set and the group discovers a WMS resource without a layer parameter, it adds a catalog item for the entire server instead of ignoring the resource.
 
 ### 1.0.17

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -337,7 +337,6 @@ LeafletGeomVisualizer.prototype._updateBillboard = function(entity, time) {
     if (!defined(geomLayer)) {
         var markerOptions = {icon: L.icon({iconUrl: tmpImage})};
         marker = L.marker(latlng, markerOptions);
-        marker.on('click', featureClicked.bind(undefined, this, entity));
         featureGroup.addLayer(marker);
         entity._geomBillboard = marker;
         redrawIcon = true;
@@ -369,6 +368,7 @@ LeafletGeomVisualizer.prototype._updateBillboard = function(entity, time) {
                 iconOptions.iconUrl = recolorBillboard(image, color);
             }
             marker.setIcon(L.icon(iconOptions));
+            marker.on('click', featureClicked.bind(undefined, this, entity));
         };
         var img = new Image();
         img.onload = function() {
@@ -444,6 +444,7 @@ LeafletGeomVisualizer.prototype._updateLabel = function(entity, time) {
             var yOff = (h/2)*(1+verticalOrigin) - pixelOffset.y;
             iconOptions.iconAnchor = [xOff, yOff];
             marker.setIcon(L.icon(iconOptions));
+            marker.on('click', featureClicked.bind(undefined, this, entity));
         };
 
         var canvas = writeTextToCanvas(text, {fillColor: fillColor, font: font});

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -17,7 +17,7 @@ var isArray = require('terriajs-cesium/Source/Core/isArray');
 var PolygonHierarchy = require('terriajs-cesium/Source/Core/PolygonHierarchy');
 var Property = require('terriajs-cesium/Source/DataSources/Property');
 var writeTextToCanvas = require('terriajs-cesium/Source/Core/writeTextToCanvas');
- 
+
 
 var defaultColor = Color.WHITE;
 var defaultOutlineColor = Color.BLACK;
@@ -274,7 +274,7 @@ function recolorBillboard(img, color) {
             image.data[j+i] *= normClr[j];
         }
     }
-    
+
     context.putImageData(image, 0, 0);
     return canvas.toDataURL();
 //    return context.getImageData(0, 0, canvas.width, canvas.height);
@@ -337,6 +337,7 @@ LeafletGeomVisualizer.prototype._updateBillboard = function(entity, time) {
     if (!defined(geomLayer)) {
         var markerOptions = {icon: L.icon({iconUrl: tmpImage})};
         marker = L.marker(latlng, markerOptions);
+        marker.on('click', featureClicked.bind(undefined, this, entity));
         featureGroup.addLayer(marker);
         entity._geomBillboard = marker;
         redrawIcon = true;
@@ -368,7 +369,6 @@ LeafletGeomVisualizer.prototype._updateBillboard = function(entity, time) {
                 iconOptions.iconUrl = recolorBillboard(image, color);
             }
             marker.setIcon(L.icon(iconOptions));
-            marker.on('click', featureClicked.bind(undefined, this, entity));
         };
         var img = new Image();
         img.onload = function() {
@@ -417,6 +417,7 @@ LeafletGeomVisualizer.prototype._updateLabel = function(entity, time) {
     if (!defined(geomLayer)) {
         var markerOptions = {icon: L.icon({iconUrl: tmpImage})};
         marker = L.marker(latlng, markerOptions);
+        marker.on('click', featureClicked.bind(undefined, this, entity));
         featureGroup.addLayer(marker);
         entity._geomLabel = marker;
         redrawLabel = true;
@@ -444,7 +445,6 @@ LeafletGeomVisualizer.prototype._updateLabel = function(entity, time) {
             var yOff = (h/2)*(1+verticalOrigin) - pixelOffset.y;
             iconOptions.iconAnchor = [xOff, yOff];
             marker.setIcon(L.icon(iconOptions));
-            marker.on('click', featureClicked.bind(undefined, this, entity));
         };
 
         var canvas = writeTextToCanvas(text, {fillColor: fillColor, font: font});

--- a/lib/Map/TableDataSource.js
+++ b/lib/Map/TableDataSource.js
@@ -41,6 +41,7 @@ var TableDataSource = function () {
     this.maxDisplayValue = undefined;
     this.clampDisplayValue = true;
     this.legendTicks = 0;
+    this.featureInfoFields = undefined;
     //this are not used by the data source but they are stored with the style info for use by region mapping
     this.regionVariable = undefined;
     this.regionType = undefined;
@@ -145,6 +146,7 @@ defineProperties(TableDataSource.prototype, {
  * @param {Integer} [style.legendTicks] Set the number of ticks to add to the legend colormap. 
  * @param {Array} [style.colorMap] A colormap applied to color the data points.
  * @param {String}[style.dataVariable] Which data variable to display.
+ * @param {Object} [style.featureInfoFields] Fields to display in feature info popup.
  *
  */
 TableDataSource.prototype.setDisplayStyle = function (style) {
@@ -163,6 +165,7 @@ TableDataSource.prototype.setDisplayStyle = function (style) {
     this.maxDisplayValue = style.maxDisplayValue;
     this.regionVariable = style.regionVariable;
     this.regionType = style.regionType;
+    this.featureInfoFields = style.featureInfoFields;
 
     if (defined(style.colorMap)) {
         this.setColorGradient(style.colorMap);
@@ -193,7 +196,8 @@ TableDataSource.prototype.getDisplayStyle = function () {
         colorMap: this.colorMap,
         dataVariable: this.dataVariable,
         regionVariable: this.regionVariable,
-        regionType: this.regionType
+        regionType: this.regionType,
+        featureInfoFields: this.featureInfoFields
     };
 };
 
@@ -266,10 +270,13 @@ TableDataSource.prototype.describe = function(properties) {
         return '';
     }
 
+    var infoFields = defined(this.featureInfoFields) ? this.featureInfoFields : properties;
+
     var html = '<table class="cesium-infoBox-defaultTable">';
-    for ( var key in properties) {
-        if (properties.hasOwnProperty(key)) {
+    for ( var key in infoFields) {
+        if (infoFields.hasOwnProperty(key)) {
             var value = properties[key];
+            var name = defined(this.featureInfoFields) ? infoFields[key] : key;
             if (defined(value)) {
                     //see if we should skip this in the details - starts with __
                 if (key.substring(0, 2) === '__') {
@@ -280,12 +287,12 @@ TableDataSource.prototype.describe = function(properties) {
                     value = JulianDate.toDate(value).toDateString();
                 }
                 if (typeof value === 'object') {
-                    html += '<tr><td>' + key + '</td><td>' + this.describe(value) + '</td></tr>';
+                    html += '<tr><td>' + name + '</td><td align="right">' + this.describe(value) + '</td></tr>';
                 } else {
                     if (typeof value === 'number') {
                         value = numberWithCommas(value);
                     }
-                    html += '<tr><td>' + key + '</td><td>' + value + '</td></tr>';
+                    html += '<tr><td>' + name + '</td><td align="right">' + value + '</td></tr>';
                 }
             }
         }

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -192,35 +192,60 @@ Leaflet.prototype.computePositionOnScreen = function(position, result) {
 };
 
 function featurePicked(leaflet, entity) {
+    // Leaflet's event handling is... interesting.  When the user clicks on an
+    // L.circleMarker, we see these events (before the dot is the receiver of the event):
+    //   map.preclick
+    //   map.click
+    //   feature.click
+    // However, for an L.marker, we only see:
+    //   feature.click
+    //
+    // So, call prePickFeatures here.  prePickFeatures will only do anything the first time it is
+    // called since the last pickFeatures and it will arrange, using runLater, for pickFeatures
+    // to be called after all related events have been raised.  pickFeatures may be called multiple
+    // times as a result, but, again, only the first invocation will do anything.
+    prePickFeatures(leaflet);
     leaflet._pickedFeatures.features.push(entity);
 }
 
 function prePickFeatures(leaflet) {
-    leaflet._pickedFeatures = new PickedFeatures();
+    if (!defined(leaflet._pickedFeatures)) {
+        leaflet._pickedFeatures = new PickedFeatures();
+        runLater(function() {
+            pickFeatures(leaflet);
+        });
+    }
 }
 
 function pickFeatures(leaflet, latlng) {
-    // We can't count on pickFeatures (triggered by click on the map) being called after before
+    if (!defined(leaflet._pickedFeatures)) {
+        return;
+    }
+
+    // We can't count on pickFeatures (triggered by click on the map) being called after
     // featurePicked (triggered by click on an individual feature).  So don't resolve the pick
     // promise until we're sure all the click handlers have run, by waiting on a runLater.
     var promises = [];
     promises.push(runLater(function() {}));
 
-    var dataSources = leaflet.terria.nowViewing.items;
+    if (defined(latlng)) {
+        var dataSources = leaflet.terria.nowViewing.items;
 
-    var pickedLocation = Cartographic.fromDegrees(latlng.lng, latlng.lat);
-    var pickPosition = Ellipsoid.WGS84.cartographicToCartesian(pickedLocation);
-    leaflet._pickedFeatures.pickPosition = pickPosition;
+        var pickedLocation = Cartographic.fromDegrees(latlng.lng, latlng.lat);
+        var pickPosition = Ellipsoid.WGS84.cartographicToCartesian(pickedLocation);
+        leaflet._pickedFeatures.pickPosition = pickPosition;
 
-    for (var i = 0; i < dataSources.length ; ++i) {
-        var dataSource = dataSources[i];
-        if (dataSource.isEnabled && dataSource.isShown && defined(dataSource._imageryLayer) && defined(dataSource._imageryLayer.pickFeatures)) {
-            promises.push(dataSource._imageryLayer.pickFeatures(leaflet.map, CesiumMath.toRadians(latlng.lng), CesiumMath.toRadians(latlng.lat)));
+        for (var i = 0; i < dataSources.length ; ++i) {
+            var dataSource = dataSources[i];
+            if (dataSource.isEnabled && dataSource.isShown && defined(dataSource._imageryLayer) && defined(dataSource._imageryLayer.pickFeatures)) {
+                promises.push(dataSource._imageryLayer.pickFeatures(leaflet.map, CesiumMath.toRadians(latlng.lng), CesiumMath.toRadians(latlng.lat)));
+            }
         }
     }
 
+    var pickedFeatures = leaflet._pickedFeatures;
     leaflet._pickedFeatures.allFeaturesAvailablePromise = when.all(promises, function(results) {
-        leaflet._pickedFeatures.isLoading = false;
+        pickedFeatures.isLoading = false;
 
         for (var resultIndex = 0; resultIndex < results.length; ++resultIndex) {
             var result = results[resultIndex];
@@ -234,16 +259,17 @@ function pickFeatures(leaflet, latlng) {
                         feature.position = pickedLocation;
                     }
 
-                    leaflet._pickedFeatures.features.push(leaflet._createEntityFromImageryLayerFeature(feature));
+                    pickedFeatures.features.push(leaflet._createEntityFromImageryLayerFeature(feature));
                 }
             }
         }
     }).otherwise(function() {
-        leaflet._pickedFeatures.isLoading = false;
-        leaflet._pickedFeatures.error = 'An unknown error occurred while picking features.';
+        pickedFeatures.isLoading = false;
+        pickedFeatures.error = 'An unknown error occurred while picking features.';
     });
 
     leaflet.terria.pickedFeatures = leaflet._pickedFeatures;
+    leaflet._pickedFeatures = undefined;
 }
 
 function selectFeature(leaflet) {


### PR DESCRIPTION
Added featureInfoFields to csvCatalogItem.tableStyle (see nm test.json for example).  For example to show the incident_date and incident_severity items only with better names use the following in the style in the init.
"featureInfoFields": {
                                    "incident_date": "Date", 
                                    "incident_severity" : "Severity"
                                }
Also right aligned data in value column of featureInfoPopup and moved click bind in leaflet for markers so click works on images.
