### PR TITLE
Improvements in the course of building a Queensland blacklist.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Change Log
 
 * Added `OpenStreetMapCatalogItem` for connecting to tile servers using the OpenStreetMap tiling scheme.
 * Added `CkanCatalogGroup.allowEntireWmsServers` property.  When set and the group discovers a WMS resource without a layer parameter, it adds a catalog item for the entire server instead of ignoring the resource.
+* Handle the case of an `ArcGisMapServerCatalogItem` with an advertised extent that is outside the valid range.
+* We now pass ArcGIS MapServer metadata, when it's available, through to Cesium's `ArcGisMapServerImageryProvider` so that it doesn't need to re-request the metadata.
 
 ### 1.0.17
 

--- a/lib/Models/ArcGisCatalogGroup.js
+++ b/lib/Models/ArcGisCatalogGroup.js
@@ -8,6 +8,7 @@ var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var definedNotNull = require('terriajs-cesium/Source/Core/definedNotNull');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
@@ -299,6 +300,7 @@ function createDataSource(mapServiceGroup, topLevelJson, layer, dataCustodian) {
     result.url = mapServiceGroup.url;
     result.layers = layer.id.toString();
     result.maximumScale = layer.maxScale;
+    result.mapServerData = topLevelJson;
 
     if (topLevelJson.description && topLevelJson.description.length > 0) {
         result.info.push({
@@ -321,9 +323,9 @@ function createDataSource(mapServiceGroup, topLevelJson, layer, dataCustodian) {
             result.rectangle = Rectangle.fromDegrees(extent.xmin, extent.ymin, extent.xmax, extent.ymax);
         } else if (wkid === 3857 || wkid === 900913 || wkid === 102100) {
             var projection = new WebMercatorProjection();
-            var sw = projection.unproject(new Cartesian3(extent.xmin, extent.ymin, 0.0));
-            var ne = projection.unproject(new Cartesian3(extent.xmax, extent.ymax, 0.0));
-            result.rectangle = new Rectangle(sw.longitude, sw.latitude, ne.longitude, ne.latitude);
+            var sw = projection.unproject(new Cartesian3(Math.max(extent.xmin, -Ellipsoid.WGS84.maximumRadius * Math.PI), Math.max(extent.ymin, -Ellipsoid.WGS84.maximumRadius * Math.PI), 0.0));
+            var ne = projection.unproject(new Cartesian3(Math.min(extent.xmax, Ellipsoid.WGS84.maximumRadius * Math.PI), Math.min(extent.ymax, Ellipsoid.WGS84.maximumRadius * Math.PI), 0.0));
+            result.rectangle = new Rectangle(Math.max(sw.longitude, -Math.PI), Math.max(sw.latitude, -WebMercatorProjection.MaximumLatitude), Math.min(ne.longitude, Math.PI), Math.min(ne.latitude, WebMercatorProjection.MaximumLatitude));
         }
     }
 

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -53,6 +53,13 @@ var ArcGisMapServerCatalogItem = function(terria) {
      */
     this.maximumScale = undefined;
 
+    /**
+     * Gets or sets the MapServer metadata obtained from the server.  If this property is undefined, the data will be retrieved from the server when the
+     * catalog item is enabled.
+     * @type {Object}
+     */
+    this.mapServerData = undefined;
+
     knockout.track(this, ['url', 'layers', 'maximumScale', '_legendUrl']);
 
     // metadataUrl and legendUrl are derived from url if not explicitly specified.
@@ -147,7 +154,8 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
         url: cleanAndProxyUrl( this.terria, this.url),
         layers: this.layers,
         tilingScheme: new WebMercatorTilingScheme(),
-        maximumLevel: maximumLevel
+        maximumLevel: maximumLevel,
+        mapServerData: this.mapServerData
     });
 };
 

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -191,6 +191,29 @@ ToolsPanelViewModel.prototype.countDatasets = function() {
     });
 };
 
+ToolsPanelViewModel.prototype.openAllInOpenGroups = function() {
+    function go(group) {
+        if (!group.isOpen) {
+            return;
+        }
+
+        when(group.load(), function() {
+            for (var i = 0; i < group.items.length; ++i) {
+                var item = group.items[i];
+                if (defined(item.items)) {
+                    item.isOpen = true;
+                    go(item);
+                }
+            }
+        });
+    }
+
+    var group = this.terria.catalog.group;
+    for (var i = 0; i < group.items.length; ++i) {
+        go(group.items[i]);
+    }
+};
+
 ToolsPanelViewModel.open = function(options) {
     var viewModel = new ToolsPanelViewModel(options);
     viewModel.show(options.container);
@@ -198,7 +221,7 @@ ToolsPanelViewModel.open = function(options) {
 };
 
 
-function getAllRequests(types, mode, requests, group, promises) {
+function getAllRequests(types, mode, requests, group, promises, blacklistGroup) {
     function alreadyInRequests(item) {
         for (var i=0; i < requests.length; i++) {
             if (requests[i].item === item) {
@@ -211,7 +234,11 @@ function getAllRequests(types, mode, requests, group, promises) {
         var item = group.items[i];
         if (item instanceof CatalogGroup) {
             if (item.isOpen || mode === 'all' || mode === 'enabled') {
-                getAllRequests(types, mode, requests, item, promises);
+                var currentBlacklistGroup = blacklistGroup;
+                if (item.type !== 'group') {
+                    currentBlacklistGroup = item.name;
+                }
+                getAllRequests(types, mode, requests, item, promises, currentBlacklistGroup);
             }
         } else if ((types.indexOf(item.type) !== -1) && (mode !== 'enabled' || item.isEnabled)) {
 
@@ -225,6 +252,7 @@ function getAllRequests(types, mode, requests, group, promises) {
                 var imageryProvider = item._imageryLayer.imageryProvider;
                 requests.push({
                     item : item,
+                    blacklistGroup : blacklistGroup,
                     group : group.name,
                     enabledHere : enabledHere,
                     provider : imageryProvider
@@ -239,7 +267,8 @@ function getAllRequests(types, mode, requests, group, promises) {
 function whenImageryProviderIsReady(imageryProvider) {
     return pollToPromise(function() {
         return imageryProvider.ready;
-    }, { timeout: 60000, pollInterval: 100 });
+    }, { timeout: 60000, pollInterval: 100 }).otherwise(function() {
+    });
 }
 
 function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
@@ -247,15 +276,18 @@ function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
 
     var urls = [];
     var names = [];
+    var blacklistGroups = [];
     var stats = [];
     var uniqueStats = [];
     var name;
+    var blacklistGroup;
     var stat;
     var maxTilesPerLevel = -1; // only request this number of tiles per zoom level, randomly selected. -1 = no limit.
 
     loadImage.createImage = function(url, crossOrigin, deferred) {
         urls.push(url);
         names.push(name);
+        blacklistGroups.push(blacklistGroup);
         stats.push(stat);
         if (defined(deferred)) {
             deferred.resolve();
@@ -265,9 +297,19 @@ function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
     var oldMax = throttleRequestByServer.maximumRequestsPerServer;
     throttleRequestByServer.maximumRequestsPerServer = Number.MAX_VALUE;
 
+    var popup = PopupMessageViewModel.open('ui', {
+        title: 'Dataset Testing',
+        message: ''
+    });
+
     var i;
     for (i = 0; i < requests.length; ++i) {
         var request = requests[i];
+
+        if (!request.provider.ready) {
+            popup.message += '<div>Catalog item ' + request.item.name + ' skipped because it did not get ready in time.</div>';
+            continue;
+        }
 
         var extent;
         if (request.provider.rectangle && request.item.rectangle) {
@@ -283,6 +325,7 @@ function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
         }
 
         name = request.item.name;
+        blacklistGroup = request.blacklistGroup;
 
         var tilingScheme;
         var leaflet = app.leaflet;
@@ -317,6 +360,7 @@ function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
             var se = tilingScheme.positionToTileXY(Rectangle.southeast(extent), level);
             if (!defined(nw) || !defined(se)) {
                 // Extent is probably junk.
+                popup.message += '<div>Catalog item ' + request.item.name + ' level ' + level + ' skipped because its extent is not valid.</div>';
                 continue;
             }
             var potentialTiles = [];
@@ -353,13 +397,10 @@ function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
         }
     }
 
+    popup.message += '<div>Requesting ' + urls.length + ' URLs from ' + requests.length + ' data sources, at zooms ' + minLevel + ' to ' + maxLevel + '</div>';
+
     loadImage.createImage = loadImage.defaultCreateImage;
     throttleRequestByServer.maximumRequestsPerServer = oldMax;
-
-    var popup = PopupMessageViewModel.open('ui', {
-        title: 'Dataset Testing',
-        message: '<div>Requesting ' + urls.length + ' URLs from ' + requests.length + ' data sources, at zooms ' + minLevel + ' to ' + maxLevel + '</div>'
-    });
 
     var maxRequests = 1;
     var nextRequestIndex = 0;
@@ -411,12 +452,14 @@ function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
         url = urls[nextRequestIndex];
         name = names[nextRequestIndex]; //track for error reporting
         stat = stats[nextRequestIndex];
+        blacklistGroup = blacklistGroups[nextRequestIndex];
         ++nextRequestIndex;
 
         return {
             url: url,
             name: name,
-            stat: stat
+            stat: stat,
+            blacklistGroup: blacklistGroup
         };
     }
 
@@ -515,7 +558,11 @@ function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
             doneUrl(next.stat, start, false);
         }).otherwise(function(e) {
             if (e && e.isTimeout) {
-                blacklist[next.name] = true;
+                var blacklistGroup = blacklist[next.blacklistGroup];
+                if (!defined(blacklistGroup)) {
+                    blacklistGroup = blacklist[next.blacklistGroup] = {};
+                }
+                blacklistGroup[next.name] = true;
                 popup.message += '<div><a href="' + next.url + '">Tile request</a> timed out (2 seconds).</div>';
             } else {
                 popup.message += '<div><a href="' + next.url + '">Tile request</a> returned error' + (e.statusCode ? (' (code ' + e.statusCode + ')') : '') + '</div>';

--- a/lib/Views/ToolsPanel.html
+++ b/lib/Views/ToolsPanel.html
@@ -78,6 +78,13 @@
                     <input class="tools-content-type-select" type="submit" value="Count" />
                 </label>
             </form>
+
+            <form class="tools-form" data-bind="submit: openAllInOpenGroups">
+                <h2>Open all items in open groups</h2>
+                <label class="tools-content-type">
+                    <input class="tools-content-type-select" type="submit" value="Open All" />
+                </label>
+            </form>
         </div>
     </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "proj4": "^2.3.6",
     "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
-    "terriajs-cesium": "^1.10.4",
+    "terriajs-cesium": "1.10.5",
     "togeojson": "^0.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "proj4": "^2.3.6",
     "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
-    "terriajs-cesium": "^1.10.2",
+    "terriajs-cesium": "^1.10.4",
     "togeojson": "^0.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Deal with ArcGIS MapServers with advertised extents that are outside the valid range.
- Pass MapServer metadata through to Cesium's imagery provider so that it doesn't need to re-request it for each catalog item.
- Add a cheesy feature to the tools panel to recursively open all groups that are in an open top-level group.
- Make the blacklist report at the end of dataset testing break down the blacklist by group, so we know where to add the blacklist.
- Make dataset testing tolerant of imagery providers that don't get into a ready state in a timely fashion, and add more error reporting.
