### PR TITLE
Made navigation toolbar modular by abstracting out its controls

### DIFF
--- a/lib/Models/NavControl.js
+++ b/lib/Models/NavControl.js
@@ -1,0 +1,168 @@
+'use strict';
+
+/*global require*/
+
+var defined = require('terriajs-cesium/Source/Core/defined');
+var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
+var Ray = require('terriajs-cesium/Source/Core/Ray');
+var IntersectionTests = require('terriajs-cesium/Source/Core/IntersectionTests');
+var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
+var Tween = require('terriajs-cesium/Source/ThirdParty/Tween');
+var CesiumMath = require('terriajs-cesium/Source/Core/Math');
+
+/**
+ * The model for a control in the navigation control tool bar
+ *
+ * @alias NavControl
+ * @constructor
+ * @abstract
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+var NavControl = function(terria) {
+    if (!defined(terria)) {
+        throw new DeveloperError('terria is required');
+    }
+
+    this._terria = terria;
+
+    /**
+     * Gets or sets the name of the control which is set as the control's title.
+     * This property is observable.
+     * @type {String}
+     */
+    this.name = 'Unnamed Control';
+
+    /**
+     * Gets or sets the text to be displayed in the nav control. Controls that
+     * have text do not display the svgIcon.
+     * This property is observable.
+     * @type {String}
+     */
+    this.text = undefined;
+
+    /**
+     * Gets or sets the svg icon of the control.  This property is observable.
+     * @type {Object}
+     */
+    this.svgIcon = undefined;
+
+    /**
+     * Gets or sets the height of the svg icon.  This property is observable.
+     * @type {Integer}
+     */
+    this.svgHeight = undefined;
+
+    /**
+     * Gets or sets the width of the svg icon.  This property is observable.
+     * @type {Integer}
+     */
+    this.svgWidth = undefined;
+
+    /**
+     * Gets or sets the CSS class of the control. This property is observable.
+     * @type {String}
+     */
+    this.cssClass = undefined;
+
+    /**
+     * Gets or sets the property describing whether or not the control is in the active state.
+     * This property is observable.
+     * @type {Boolean}
+     */
+    this.isActive = false;
+
+    knockout.track(this, ['name', 'svgIcon', 'svgHeight', 'svgWidth', 'cssClass', 'isActive']);
+};
+
+defineProperties(NavControl.prototype, {
+
+    /**
+      * Gets the Terria instance.
+     * @memberOf NavControl.prototype
+     * @type {Terria}
+     */
+    terria : {
+        get : function() {
+            return this._terria;
+        }
+    }
+
+});
+
+/**
+ * When implemented in a derived class, performs an action when the user clicks
+ * on this control
+ * @abstract
+ * @protected
+ */
+NavControl.prototype.didClick = function() {
+    throw new DeveloperError('diClick must be implemented in the derived class.');
+};
+
+/**
+ * Detects whether or not text is set
+ * @protected
+ */
+NavControl.prototype.hasText = function() {
+    return defined(this.text) && typeof this.text === "string";
+};
+
+NavControl.prototype.flyToPosition = function (scene, position, durationMilliseconds) {
+    var camera = scene.camera;
+    var startPosition = camera.position;
+    var endPosition = position;
+
+    durationMilliseconds = defaultValue(durationMilliseconds, 200);
+
+    var controller = scene.screenSpaceCameraController;
+    controller.enableInputs = false;
+
+    scene.tweens.add({
+        duration : durationMilliseconds / 1000.0,
+        easingFunction : Tween.Easing.Sinusoidal.InOut,
+        startObject : {
+            time: 0.0
+        },
+        stopObject : {
+            time : 1.0
+        },
+        update : function(value) {
+            if (scene.isDestroyed()) {
+                return;
+            }
+            scene.camera.position.x = CesiumMath.lerp(startPosition.x, endPosition.x, value.time);
+            scene.camera.position.y = CesiumMath.lerp(startPosition.y, endPosition.y, value.time);
+            scene.camera.position.z = CesiumMath.lerp(startPosition.z, endPosition.z, value.time);
+        },
+        complete : function() {
+            if (controller.isDestroyed()) {
+                return;
+            }
+            controller.enableInputs = true;
+        },
+        cancel: function() {
+            if (controller.isDestroyed()) {
+                return;
+            }
+            controller.enableInputs = true;
+        }
+    });
+};
+
+NavControl.prototype.getCameraFocus = function (scene) {
+    var ray = new Ray(scene.camera.positionWC, scene.camera.directionWC);
+    var intersections = IntersectionTests.rayEllipsoid(ray, Ellipsoid.WGS84);
+    if (defined(intersections)) {
+        return Ray.getPoint(ray, intersections.start);
+    } else {
+        // Camera direction is not pointing at the globe, so use the ellipsoid horizon point as
+        // the focal point.
+        return IntersectionTests.grazingAltitudeLocation(ray, Ellipsoid.WGS84);
+    }
+};
+
+module.exports = NavControl;

--- a/lib/Models/ResetViewNavControl.js
+++ b/lib/Models/ResetViewNavControl.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/*global require,ga*/
+
+var inherit = require('../Core/inherit');
+var NavControl = require('./NavControl');
+
+var svgReset = require('../SvgPaths/svgReset');
+
+/**
+ * The model for a zoom in control in the navigation control tool bar
+ *
+ * @alias ResetViewNavControl
+ * @constructor
+ * @abstract
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+var ResetViewNavControl = function(terria) {
+    NavControl.call(this, terria);
+
+    /**
+     * Gets or sets the name of the control which is set as the control's title.
+     * This property is observable.
+     * @type {String}
+     */
+    this.name = 'Reset View';
+
+    /**
+     * Gets or sets the svg icon of the control.  This property is observable.
+     * @type {Object}
+     */
+    this.svgIcon = svgReset;
+
+    /**
+     * Gets or sets the height of the svg icon.  This property is observable.
+     * @type {Integer}
+     */
+    this.svgHeight = 15;
+
+    /**
+     * Gets or sets the width of the svg icon.  This property is observable.
+     * @type {Integer}
+     */
+    this.svgWidth = 15;
+
+    /**
+     * Gets or sets the CSS class of the control. This property is observable.
+     * @type {String}
+     */
+    this.cssClass = "navigation-control-icon-reset";
+
+};
+
+inherit(NavControl, ResetViewNavControl);
+
+ResetViewNavControl.prototype.resetView = function() {
+    ga('send', 'event', 'navigation', 'click', 'reset');
+    this.isActive = true;
+    this.terria.currentViewer.zoomTo(this.terria.homeView, 1.5);
+    this.isActive = false;
+};
+
+/**
+ * When implemented in a derived class, performs an action when the user clicks
+ * on this control
+ * @abstract
+ * @protected
+ */
+ResetViewNavControl.prototype.didClick = function() {
+    this.resetView();
+};
+
+module.exports = ResetViewNavControl;

--- a/lib/Models/ZoomInNavControl.js
+++ b/lib/Models/ZoomInNavControl.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/*global require,ga*/
+
+var defined = require('terriajs-cesium/Source/Core/defined');
+var Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3');
+
+var inherit = require('../Core/inherit');
+var NavControl = require('./NavControl');
+
+/**
+ * The model for a zoom in control in the navigation control tool bar
+ *
+ * @alias ZoomInNavControl
+ * @constructor
+ * @abstract
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+var ZoomInNavControl = function(terria) {
+    NavControl.call(this, terria);
+
+    /**
+     * Gets or sets the name of the control which is set as the control's title.
+     * This property is observable.
+     * @type {String}
+     */
+    this.name = 'Zoom In';
+
+    /**
+     * Gets or sets the text to be displayed in the nav control. Controls that
+     * have text do not display the svgIcon.
+     * This property is observable.
+     * @type {String}
+     */
+    this.text = '+';
+
+    /**
+     * Gets or sets the CSS class of the control. This property is observable.
+     * @type {String}
+     */
+    this.cssClass = "navigation-control-icon-zoom-in";
+
+};
+
+inherit(NavControl, ZoomInNavControl);
+
+var cartesian3Scratch = new Cartesian3();
+
+ZoomInNavControl.prototype.zoomIn = function() {
+    ga('send', 'event', 'navigation', 'click', 'zoomIn');
+
+    this.isActive = true;
+
+    if (defined(this.terria.leaflet)) {
+         this.terria.leaflet.map.zoomIn(1);
+    }
+
+    if (defined(this.terria.cesium)) {
+        var scene =  this.terria.cesium.scene;
+        var camera = scene.camera;
+        var focus = this.getCameraFocus(scene);
+        var direction = Cartesian3.subtract(focus, camera.position, cartesian3Scratch);
+        var movementVector = Cartesian3.multiplyByScalar(direction, 2.0 / 3.0, cartesian3Scratch);
+        var endPosition = Cartesian3.add(camera.position, movementVector, cartesian3Scratch);
+
+        this.flyToPosition(scene, endPosition);
+    }
+
+     this.terria.currentViewer.notifyRepaintRequired();
+     this.isActive = false;
+};
+
+/**
+ * When implemented in a derived class, performs an action when the user clicks
+ * on this control
+ * @abstract
+ * @protected
+ */
+ZoomInNavControl.prototype.didClick = function() {
+    this.zoomIn();
+};
+
+module.exports = ZoomInNavControl;

--- a/lib/Models/ZoomOutNavControl.js
+++ b/lib/Models/ZoomOutNavControl.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/*global require,ga*/
+
+var defined = require('terriajs-cesium/Source/Core/defined');
+var Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3');
+
+var inherit = require('../Core/inherit');
+var NavControl = require('./NavControl');
+
+/**
+ * The model for a zoom in control in the navigation control tool bar
+ *
+ * @alias ZoomOutNavControl
+ * @constructor
+ * @abstract
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+var ZoomOutNavControl = function(terria) {
+    NavControl.call(this, terria);
+
+    /**
+     * Gets or sets the name of the control which is set as the control's title.
+     * This property is observable.
+     * @type {String}
+     */
+    this.name = 'Zoom Out';
+
+    /**
+     * Gets or sets the text to be displayed in the nav control. Controls that
+     * have text do not display the svgIcon.
+     * This property is observable.
+     * @type {String}
+     */
+    this.text = '–';
+
+    /**
+     * Gets or sets the CSS class of the control. This property is observable.
+     * @type {String}
+     */
+    this.cssClass = "navigation-control-icon-zoom-out";
+
+};
+
+inherit(NavControl, ZoomOutNavControl);
+
+var cartesian3Scratch = new Cartesian3();
+
+ZoomOutNavControl.prototype.zoomOut = function() {
+    ga('send', 'event', 'navigation', 'click', 'zoomOut');
+
+    this.isActive = true;
+
+    if (defined( this.terria.leaflet)) {
+         this.terria.leaflet.map.zoomOut(1);
+    }
+
+    if (defined( this.terria.cesium)) {
+        var scene =  this.terria.cesium.scene;
+        var camera = scene.camera;
+        var focus = this.getCameraFocus(scene);
+        var direction = Cartesian3.subtract(focus, camera.position, cartesian3Scratch);
+        var movementVector = Cartesian3.multiplyByScalar(direction, -2.0, cartesian3Scratch);
+        var endPosition = Cartesian3.add(camera.position, movementVector, cartesian3Scratch);
+
+        this.flyToPosition(scene, endPosition);
+    }
+
+     this.terria.currentViewer.notifyRepaintRequired();
+     this.isActive = false;
+};
+
+/**
+ * When implemented in a derived class, performs an action when the user clicks
+ * on this control
+ * @abstract
+ * @protected
+ */
+ZoomOutNavControl.prototype.didClick = function() {
+    this.zoomOut();
+};
+
+module.exports = ZoomOutNavControl;

--- a/lib/ViewModels/NavigationViewModel.js
+++ b/lib/ViewModels/NavigationViewModel.js
@@ -1,32 +1,29 @@
 'use strict';
 
-/*global require,ga*/
+/*global require*/
 var CameraFlightPath = require('terriajs-cesium/Source/Scene/CameraFlightPath');
 var Cartesian2 = require('terriajs-cesium/Source/Core/Cartesian2');
 var Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3');
 var CesiumMath = require('terriajs-cesium/Source/Core/Math');
-var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
 var getTimestamp = require('terriajs-cesium/Source/Core/getTimestamp');
-var IntersectionTests = require('terriajs-cesium/Source/Core/IntersectionTests');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var Matrix4 = require('terriajs-cesium/Source/Core/Matrix4');
 var Ray = require('terriajs-cesium/Source/Core/Ray');
 var Transforms = require('terriajs-cesium/Source/Core/Transforms');
-var Tween = require('terriajs-cesium/Source/ThirdParty/Tween');
 
 var loadView = require('../Core/loadView');
 
-var svgReset = require('../SvgPaths/svgReset');
 var svgCompassOuterRing = require('../SvgPaths/svgCompassOuterRing');
 var svgCompassGyro = require('../SvgPaths/svgCompassGyro');
 var svgCompassRotationMarker = require('../SvgPaths/svgCompassRotationMarker');
 
 var NavigationViewModel = function(options) {
-     this.terria = options.terria;
+    this.terria = options.terria;
 
-    this.svgReset = svgReset;
+    this.controls = options.controls;
+
     this.svgCompassOuterRing = svgCompassOuterRing;
     this.svgCompassGyro = svgCompassGyro;
     this.svgCompassRotationMarker = svgCompassRotationMarker;
@@ -52,7 +49,7 @@ var NavigationViewModel = function(options) {
 
     this._unsubcribeFromPostRender = undefined;
 
-    knockout.track(this, ['showCompass', 'heading', 'isOrbiting', 'orbitCursorAngle', 'isRotating']);
+    knockout.track(this, ['controls', 'showCompass', 'heading', 'isOrbiting', 'orbitCursorAngle', 'isRotating']);
 
     var that = this;
 
@@ -86,54 +83,28 @@ NavigationViewModel.prototype.show = function(container) {
     loadView(require('fs').readFileSync(__dirname + '/../Views/Navigation.html', 'utf8'), container, this);
 };
 
-var cartesian3Scratch = new Cartesian3();
-
-NavigationViewModel.prototype.zoomIn = function() {
-    ga('send', 'event', 'navigation', 'click', 'zoomIn');
-
-    if (defined( this.terria.leaflet)) {
-         this.terria.leaflet.map.zoomIn(1);
-    }
-
-    if (defined( this.terria.cesium)) {
-        var scene =  this.terria.cesium.scene;
-        var camera = scene.camera;
-        var focus = getCameraFocus(scene);
-        var direction = Cartesian3.subtract(focus, camera.position, cartesian3Scratch);
-        var movementVector = Cartesian3.multiplyByScalar(direction, 2.0 / 3.0, cartesian3Scratch);
-        var endPosition = Cartesian3.add(camera.position, movementVector, cartesian3Scratch);
-
-        flyToPosition(scene, endPosition);
-    }
-
-     this.terria.currentViewer.notifyRepaintRequired();
+/**
+ * Adds a control to this toolbar.
+ * @param {NavControl} The control to add.
+ */
+NavigationViewModel.prototype.add = function(control) {
+    this.controls.push(control);
 };
 
-NavigationViewModel.prototype.zoomOut = function() {
-    ga('send', 'event', 'navigation', 'click', 'zoomOut');
-
-    if (defined( this.terria.leaflet)) {
-         this.terria.leaflet.map.zoomOut(1);
-    }
-
-    if (defined( this.terria.cesium)) {
-        var scene =  this.terria.cesium.scene;
-        var camera = scene.camera;
-        var focus = getCameraFocus(scene);
-        var direction = Cartesian3.subtract(focus, camera.position, cartesian3Scratch);
-        var movementVector = Cartesian3.multiplyByScalar(direction, -2.0, cartesian3Scratch);
-        var endPosition = Cartesian3.add(camera.position, movementVector, cartesian3Scratch);
-
-        flyToPosition(scene, endPosition);
-    }
-
-     this.terria.currentViewer.notifyRepaintRequired();
+/**
+ * Removes a control from this toolbar.
+ * @param {NavControl} The control to remove.
+ */
+NavigationViewModel.prototype.remove = function(control) {
+    this.controls.remove(control);
 };
 
-NavigationViewModel.prototype.resetView = function() {
-    ga('send', 'event', 'navigation', 'click', 'reset');
-
-     this.terria.currentViewer.zoomTo( this.terria.homeView, 1.5);
+/**
+ * Checks if the control given is the last control in the control array.
+ * @param {NavControl} The control to remove.
+ */
+NavigationViewModel.prototype.isLastControl = function(control) {
+    return (control === this.controls[this.controls.length-1]);
 };
 
 var vectorScratch = new Cartesian2();
@@ -179,7 +150,7 @@ NavigationViewModel.prototype.handleDoubleClick = function(viewModel, e) {
     var center = scene.globe.pick(ray, scene, centerScratch);
     if (!defined(center)) {
         // Globe is barely visible, so reset to home view.
-        this.resetView();
+        this.terria.currentViewer.zoomTo( this.terria.homeView, 1.5);
         return;
     }
 
@@ -377,60 +348,6 @@ function rotate(viewModel, compassElement, cursorVector) {
 
     document.addEventListener('mousemove', viewModel.rotateMouseMoveFunction, false);
     document.addEventListener('mouseup', viewModel.rotateMouseUpFunction, false);
-}
-
-function getCameraFocus(scene) {
-    var ray = new Ray(scene.camera.positionWC, scene.camera.directionWC);
-    var intersections = IntersectionTests.rayEllipsoid(ray, Ellipsoid.WGS84);
-    if (defined(intersections)) {
-        return Ray.getPoint(ray, intersections.start);
-    } else {
-        // Camera direction is not pointing at the globe, so use the ellipsoid horizon point as
-        // the focal point.
-        return IntersectionTests.grazingAltitudeLocation(ray, Ellipsoid.WGS84);
-    }
-}
-
-function flyToPosition(scene, position, durationMilliseconds) {
-    var camera = scene.camera;
-    var startPosition = camera.position;
-    var endPosition = position;
-
-    durationMilliseconds = defaultValue(durationMilliseconds, 200);
-
-    var controller = scene.screenSpaceCameraController;
-    controller.enableInputs = false;
-
-    scene.tweens.add({
-        duration : durationMilliseconds / 1000.0,
-        easingFunction : Tween.Easing.Sinusoidal.InOut,
-        startObject : {
-            time: 0.0
-        },
-        stopObject : {
-            time : 1.0
-        },
-        update : function(value) {
-            if (scene.isDestroyed()) {
-                return;
-            }
-            scene.camera.position.x = CesiumMath.lerp(startPosition.x, endPosition.x, value.time);
-            scene.camera.position.y = CesiumMath.lerp(startPosition.y, endPosition.y, value.time);
-            scene.camera.position.z = CesiumMath.lerp(startPosition.z, endPosition.z, value.time);
-        },
-        complete : function() {
-            if (controller.isDestroyed()) {
-                return;
-            }
-            controller.enableInputs = true;
-        },
-        cancel: function() {
-            if (controller.isDestroyed()) {
-                return;
-            }
-            controller.enableInputs = true;
-        }
-    });
 }
 
 module.exports = NavigationViewModel;

--- a/lib/Views/Navigation.html
+++ b/lib/Views/Navigation.html
@@ -9,13 +9,14 @@ TIP: You can also free orbit by holding the CTRL key and dragging the map." data
     <div class="compass-gyro" data-bind="cesiumSvgPath: { path: svgCompassGyro, width: 145, height: 145 }, css: { 'compass-gyro-active': isOrbiting }"></div>
 </div>
 <div class="navigation-controls">
-    <div class="navigation-control" data-bind="click: zoomIn" title="Zoom In">
-        <div class="navigation-control-icon-zoom-in">+</div>
+    <!-- ko foreach: controls -->
+    <div data-bind="click: didClick, attr: { title: $data.name }, css: $root.isLastControl($data) ? 'navigation-control-last' : 'navigation-control' ">
+        <!-- ko if: $data.hasText() -->
+        <div data-bind="text: $data.text, css: $data.isActive ?  'navigation-control-icon-active ' + $data.cssClass : $data.cssClass"></div>
+        <!-- /ko -->
+        <!-- ko ifnot: $data.hasText() -->
+        <div data-bind="cesiumSvgPath: { path: $data.svgIcon, width: $data.svgWidth, height: $data.svgHeight }, css: $data.isActive ?  'navigation-control-icon-active ' + $data.cssClass : $data.cssClass"></div>
+        <!-- /ko -->
     </div>
-    <div class="navigation-control" data-bind="click: resetView" title="Reset View">
-        <div class="navigation-control-icon-reset" data-bind="cesiumSvgPath: { path: svgReset, width: 15, height: 15 }"></div>
-    </div>
-    <div class="navigation-control-last" data-bind="click: zoomOut" title="Zoom Out">
-        <div class="navigation-control-icon-zoom-out">–</div>
-    </div>
+    <!-- /ko -->
 </div>


### PR DESCRIPTION
Each control is abstracted out into a NavControl which is then added to list of controls on the NavigationViewModel. This is to allow easier addition of navigation controls (e.g. find my position). To make this work the NavigationViewModel should be instantiated with the desired nav controls. 

```
// Create the navigation controls.
    NavigationViewModel.create({
        container: ui,
        terria: terria,
        controls: [
            new ZoomInNavControl(terria),
            new ResetViewNavControl(terria),
            new ZoomOutNavControl(terria)
        ]
    });
```
