### PR TITLE
Add nowViewingMessage property to catalog items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.0.21
+
+* Added an `itemProperties` property to `AbsIttCatalogGroup`.
+* Added a `nowViewingMessage` property to `CatalogItem`.  This message is shown by the `NowViewingAttentionGrabberViewModel` when the item is enabled.  Each unique message is shown only once.
+
 ### 1.0.20
 
 * Added the ability to specify SVG icons on Explorer Panel tabs.

--- a/lib/Models/AbsIttCatalogGroup.js
+++ b/lib/Models/AbsIttCatalogGroup.js
@@ -77,7 +77,13 @@ var AbsIttCatalogGroup = function(terria) {
      */
     this.whitelist = undefined;
 
-    knockout.track(this, ['url', 'dataSetID', 'regionType', 'dataCustodian', 'blacklist', 'whitelist']);
+    /**
+     * Gets or sets a hash of properties that will be set on each child item.
+     * For example, { 'treat404AsError': false }
+     */
+    this.itemProperties = undefined;
+
+    knockout.track(this, ['url', 'dataSetID', 'regionType', 'dataCustodian', 'blacklist', 'whitelist', 'itemProperties']);
 };
 
 inherit(CatalogGroup, AbsIttCatalogGroup);
@@ -252,6 +258,12 @@ function createItemForDataset(absGroup, dataset) {
     result.url = absGroup.url;
     result.dataSetID = dataset.id;
     result.regionType = absGroup.regionType;
+
+    if (typeof(absGroup.itemProperties) === 'object') {
+        Object.keys(absGroup.itemProperties).forEach(function(k) {
+            result[k] = absGroup.itemProperties[k];
+        });
+    }
 
     return result;
 }

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -130,9 +130,15 @@ var CatalogItem = function(terria) {
      */
     this.isLoading = false;
 
+    /**
+     * Gets or sets a message to show when this item is enabled for the first time in order to call attention to the Now Viewing panel.
+     * @type {String}
+     */
+    this.nowViewingMessage = undefined;
+
     knockout.track(this, ['rectangle', 'legendUrl', 'dataUrlType', 'dataUrl', 'dataCustodian',
                           'metadataUrl', 'isEnabled', 'isShown', 'isLegendVisible', 'clock',
-                          'isLoading']);
+                          'isLoading', 'nowViewingMessage']);
 
     knockout.getObservable(this, 'isEnabled').subscribe(function(newValue) {
         isEnabledChanged(this);

--- a/lib/Styles/NowViewingAttentionGrabber.less
+++ b/lib/Styles/NowViewingAttentionGrabber.less
@@ -27,6 +27,10 @@
     font-weight: bold;
 }
 
+.now-viewing-attention-grabber-message em {
+    font-weight: bold;
+}
+
 .now-viewing-attention-grabber-dismiss-button {
     .clickable;
     color: @highlight-color;

--- a/lib/ViewModels/NowViewingAttentionGrabberViewModel.js
+++ b/lib/ViewModels/NowViewingAttentionGrabberViewModel.js
@@ -30,12 +30,15 @@ var NowViewingAttentionGrabberViewModel = function(options) {
             if (topItem.nowViewingMessage) {
                 message = topItem.nowViewingMessage;
             }
-            this.message = message;
-            this.isVisible = !shownBefore(this, message);
 
-            this._shownBefore[message] = true;
-            if (this.onlyShowOncePerKeyAcrossSessions && typeof localStorage !== 'undefined') {
-                localStorage.setItem(localStorageShownBeforeKey(this, message), true);
+            if (!shownBefore(this, message)) {
+                this.message = message;
+                this.isVisible = true;
+
+                this._shownBefore[message] = true;
+                if (this.onlyShowOncePerKeyAcrossSessions && typeof localStorage !== 'undefined') {
+                    localStorage.setItem(localStorageShownBeforeKey(this, message), true);
+                }
             }
         }
     }, this);

--- a/lib/ViewModels/NowViewingAttentionGrabberViewModel.js
+++ b/lib/ViewModels/NowViewingAttentionGrabberViewModel.js
@@ -14,24 +14,29 @@ var NowViewingAttentionGrabberViewModel = function(options) {
     }
 
     this.terria = options.terria;
+    this.defaultMessage = defaultValue(options.defaultMessage, 'Look here for the *legend* and for dataset options.');
+    this.message = this.defaultMessage;
     this.isVisible = defaultValue(options.isVisible, false);
-    this.onlyShowOnceAcrossSessions = defaultValue(options.onlyShowOnceAcrossSessions, true);
+    this.onlyShowOncePerKeyAcrossSessions = defaultValue(options.onlyShowOncePerKeyAcrossSessions, true);
     this.nowViewingTabViewModel = options.nowViewingTabViewModel;
+    this._shownBefore = {};
 
-    var defaultShownBeforeValue = false;
-    if (this.onlyShowOnceAcrossSessions && typeof localStorage !== 'undefined') {
-        if (localStorage.getItem(localStorageShownBeforeKey(this)) !== null) {
-            defaultShownBeforeValue = localStorage.getItem(localStorageShownBeforeKey(this)) === 'true';
-        }
-    }
-
-    this.shownBefore = defaultValue(options.showBefore, defaultShownBeforeValue);
-
-    knockout.track(this, ['isVisible']);
+    knockout.track(this, ['isVisible', 'message']);
 
     knockout.getObservable(this.terria.nowViewing, 'items').subscribe(function() {
-        if (!this.shownBefore && this.terria.nowViewing.items.length > 0) {
-            this.isVisible = true;
+        if (this.terria.nowViewing.items.length > 0) {
+            var topItem = this.terria.nowViewing.items[0];
+            var message = this.defaultMessage;
+            if (topItem.nowViewingMessage) {
+                message = topItem.nowViewingMessage;
+            }
+            this.message = message;
+            this.isVisible = !shownBefore(this, message);
+
+            this._shownBefore[message] = true;
+            if (this.onlyShowOncePerKeyAcrossSessions && typeof localStorage !== 'undefined') {
+                localStorage.setItem(localStorageShownBeforeKey(this, message), true);
+            }
         }
     }, this);
 
@@ -48,12 +53,7 @@ NowViewingAttentionGrabberViewModel.prototype.show = function(container) {
 };
 
 NowViewingAttentionGrabberViewModel.prototype.close = function() {
-    this.shownBefore = true;
     this.isVisible = false;
-
-    if (this.onlyShowOnceAcrossSessions && typeof localStorage !== 'undefined') {
-        localStorage.setItem(localStorageShownBeforeKey(this), true);
-    }
 };
 
 NowViewingAttentionGrabberViewModel.create = function(options) {
@@ -62,8 +62,20 @@ NowViewingAttentionGrabberViewModel.create = function(options) {
     return result;
 };
 
-function localStorageShownBeforeKey(viewModel) {
-    return viewModel.terria.appName + '.NowViewingAttentionGrabberViewModel.shownBefore';
+function shownBefore(viewModel, itemKey) {
+    if (viewModel.onlyShowOncePerKeyAcrossSessions && typeof localStorage !== 'undefined') {
+        if (localStorage.getItem(localStorageShownBeforeKey(viewModel, itemKey)) !== null) {
+            return localStorage.getItem(localStorageShownBeforeKey(viewModel, itemKey)) === 'true';
+        } else {
+            return false;
+        }
+    } else {
+        return viewModel._shownBefore[itemKey];
+    }
+}
+
+function localStorageShownBeforeKey(viewModel, itemKey) {
+    return viewModel.terria.appName + '.NowViewingAttentionGrabberViewModel.' + itemKey;
 }
 
 module.exports = NowViewingAttentionGrabberViewModel;

--- a/lib/Views/NowViewingAttentionGrabber.html
+++ b/lib/Views/NowViewingAttentionGrabber.html
@@ -1,9 +1,7 @@
 <div class="now-viewing-attention-grabber-container" data-bind="css: { 'now-viewing-attention-grabber-container-visible': isVisible }">
     <div class="now-viewing-attention-grabber-callout"></div>
     <div class="now-viewing-attention-grabber">
-        <div class="now-viewing-attention-grabber-message">
-            Look here for the <strong>legend</strong> and for dataset options.
-        </div>
+        <div class="now-viewing-attention-grabber-message" data-bind="markdown: message"></div>
         <div class="now-viewing-attention-grabber-dismiss-button" data-bind="click: close">
             GOT IT, THANKS!
         </div>


### PR DESCRIPTION
This message is shown by the `NowViewingAttentionGrabberViewModel` when the catalog item is enabled.  Each unique message is shown only once.

Also added an `itemProperties` property to `AbsIttCatalogGroup`, used to set properties on automatically-created items in the group.
