### PR TITLE
Default terrain server to use Geoscience Australia's server

### DIFF
--- a/lib/viewer/AusGlobeViewer.js
+++ b/lib/viewer/AusGlobeViewer.js
@@ -140,7 +140,7 @@ latest version of <a href="http://www.google.com/chrome" target="_blank">Google 
                     viewer.selectViewer(true);
                 } else {
                     terria.cesium.scene.globe.terrainProvider = new CesiumTerrainProvider({
-                        url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
+                        url : '//www.ga.gov.au/terrain/terrain/'
                     });
                 }
             } else if (newMode === ViewerMode.CesiumEllipsoid) {


### PR DESCRIPTION
Hi Team,

I was asked to update the terrain server URL to use GA's own terrain server. I'd understand that you might not want to take a direct dependency on another terrain server out of your own control into TerriaJS framework, however I'm told this is something the NationalMap project needs.

Also note that although the URL updated below is also using a protocol relative URL as previously used, the HTTPS endpoint will redirect to HTTP for the Geoscience Australia server which may not be appropriate for your requirements.

Is this URL planned to be exposed via a form of configuration in the future?

Cheers!
