### PR TITLE
Set max-width of images in catalog info panes to 100%

### DIFF
--- a/lib/Styles/CatalogItemInfo.less
+++ b/lib/Styles/CatalogItemInfo.less
@@ -49,6 +49,10 @@
     margin-bottom: 20px;
 }
 
+.catalog-item-info img {
+    max-width: 100%;
+}
+
 .catalog-item-info-description {
     font-size: 10pt;
     font-weight: normal;


### PR DESCRIPTION
We're including images in some of our info dialogues, and this change stops them overflowing and being clipped.
