### PR TITLE
Fix some IE9 problems

### DIFF
--- a/lib/Core/isBrowserCompatible.js
+++ b/lib/Core/isBrowserCompatible.js
@@ -8,6 +8,14 @@
  *                        that there is no chance of a good result.
  */
 var isBrowserCompatible = function() {
+    // IE9 doesn't have a console object until the debugging tools are opened.
+    // Add a shim.
+    if (typeof window.console === 'undefined') {
+        window.console = {
+            log : function() {}
+        };
+    }
+
     return typeof Object.create !== 'undefined';
 };
 

--- a/lib/ViewModels/BrandBarViewModel.js
+++ b/lib/ViewModels/BrandBarViewModel.js
@@ -2,6 +2,7 @@
 
 /*global require*/
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
+var deprecationWarning = require('terriajs-cesium/Source/Core/deprecationWarning');
 var destroyObject = require('terriajs-cesium/Source/Core/destroyObject');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var getElement = require('terriajs-cesium/Source/Widgets/getElement');
@@ -27,6 +28,7 @@ BrandBarViewModel.prototype.destroy = function() {
 BrandBarViewModel.create = function(options) {
     var createOptions = options;
     if (arguments.length > 1) {
+        deprecationWarning('BrandBarViewModel.create', 'BrandBarViewModel.create now takes only one parameter.  Pass the container in the "container" property instead of as the first argument.');
         createOptions = arguments[1];
         createOptions.container = arguments[0];
     }

--- a/lib/ViewModels/BrandBarViewModel.js
+++ b/lib/ViewModels/BrandBarViewModel.js
@@ -25,11 +25,12 @@ BrandBarViewModel.prototype.destroy = function() {
 };
 
 BrandBarViewModel.create = function(options) {
+    var createOptions = options;
     if (arguments.length > 1) {
-        options = arguments[1];
-        options.container = arguments[0];
+        createOptions = arguments[1];
+        createOptions.container = arguments[0];
     }
-    return new BrandBarViewModel(options);
+    return new BrandBarViewModel(createOptions);
 };
 
 module.exports = BrandBarViewModel;

--- a/lib/ViewModels/BrandBarViewModel.js
+++ b/lib/ViewModels/BrandBarViewModel.js
@@ -24,7 +24,11 @@ BrandBarViewModel.prototype.destroy = function() {
     destroyObject(this);
 };
 
-BrandBarViewModel.create = function(container, options) {
+BrandBarViewModel.create = function(options) {
+    if (arguments.length > 1) {
+        options = arguments[1];
+        options.container = arguments[0];
+    }
     return new BrandBarViewModel(options);
 };
 

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -104,16 +104,18 @@ If you\'re on a desktop or laptop, consider increasing the size of your window.'
     ga('send', 'event', 'startup', 'initialViewer', useCesium ? 'cesium' : 'leaflet');
 
     this._terrainProvider = undefined;
-    if (typeof options.terrain === 'string' || options.terrain instanceof String) {
-        this._terrainProvider = new CesiumTerrainProvider({
-            url : options.terrain
-        });
-    } else if (defined(options.terrain)) {
-        this._terrainProvider = options.terrain;
-    } else {
-        this._terrainProvider = new CesiumTerrainProvider({
-            url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
-        });
+    if (supportsWebgl()) {
+        if (typeof options.terrain === 'string' || options.terrain instanceof String) {
+            this._terrainProvider = new CesiumTerrainProvider({
+                url : options.terrain
+            });
+        } else if (defined(options.terrain)) {
+            this._terrainProvider = options.terrain;
+        } else {
+            this._terrainProvider = new CesiumTerrainProvider({
+                url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
+            });
+        }
     }
 
     this.selectViewer(useCesium);


### PR DESCRIPTION
- Install the `console` shim earlier, because the one in `Terria` wasn't installed soon enough for e.g. the `AusGlobeViewer` deprecation warning.
- Makes the brand bar a child of the `ui` element instead of the root document.  This fixes #761.
