### PR TITLE
don't use localString by default to deal with IE9

### DIFF
--- a/lib/Map/TableDataSource.js
+++ b/lib/Map/TableDataSource.js
@@ -18,7 +18,6 @@ var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var loadText = require('terriajs-cesium/Source/Core/loadText');
 
 var DataTable = require('./DataTable');
-var VarType = require('./VarType');
 
 /**
 * @class TableDataSource is a cesium based datasource for table based geodata

--- a/lib/Styles/Animation.less
+++ b/lib/Styles/Animation.less
@@ -15,13 +15,14 @@
     font-family: 'Roboto Mono', light;
     font-size: 13px;
     color: @menu-bar-text-color;
-    padding-left: 1px;
+    padding-left: 3px;
     padding-right: 1px;
     padding-top: 1px;
     height: 18px;
     cursor: pointer;
-    text-align: center;
+    text-align: left;
     border-bottom: @panel-element-border;
+    white-space: nowrap;
 }
 
 .animation-text-display {

--- a/lib/ViewModels/AnimationViewModel.js
+++ b/lib/ViewModels/AnimationViewModel.js
@@ -51,11 +51,7 @@ var AnimationViewModel = function(options) {
     var that = this;
     this.terria.clock.onTick.addEventListener(function(clock) {
         var time = clock.currentTime;
-        if (defined(that.locale)) {
-            that.currentTimeString = JulianDate.toDate(time).toLocaleString(that.locale);
-        } else {
-            that.currentTimeString = formatDate(JulianDate.toDate(time));
-        }
+        that.currentTimeString = formatDateTime(JulianDate.toDate(time), that.locale);
     });
 
     knockout.getObservable(this.terria, 'showTimeline').subscribe(function(showTimeline) {
@@ -103,11 +99,26 @@ var AnimationViewModel = function(options) {
     }, false);
 };
 
-function formatDate(d) {
+function formatDate(d, locale) {
     function pad(s) { return (s < 10) ? '0' + s : s; }
-    return [pad(d.getDate()), pad(d.getMonth()+1), d.getFullYear()].join('/') + ', ' +
-        [pad(d.getHours()), pad(d.getMinutes()), pad(d.getSeconds())].join(':');
+    if (defined(locale)) {
+        return d.toLocaleDateString(locale);
+    }
+    return [pad(d.getDate()), pad(d.getMonth()+1), d.getFullYear()].join('/');
 }
+
+function formatTime(d, locale) {
+    function pad(s) { return (s < 10) ? '0' + s : s; }
+    if (defined(locale)) {
+        return d.toLocaleTimeString(locale);
+    }
+    return [pad(d.getHours()), pad(d.getMinutes()), pad(d.getSeconds())].join(':');
+}
+
+function formatDateTime(d, locale) {
+    return formatDate(d, locale) + ', ' + formatTime(d, locale);
+}
+
 
 function setupTimeline(viewModel) {
     var timelineContainer = document.getElementsByClassName('animation-timeline')[0];
@@ -119,12 +130,12 @@ function setupTimeline(viewModel) {
         var totalDays = JulianDate.daysDifference(viewModel.terria.clock.stopTime, viewModel.terria.clock.startTime);
 
         if (totalDays > 14) {
-            return JulianDate.toDate(time).toLocaleDateString(viewModel.locale);
+            return formatDate(JulianDate.toDate(time), viewModel.locale);
         }
         else if (totalDays < 1) {
-            return JulianDate.toDate(time).toLocaleTimeString(viewModel.locale);
+            return formatTime(JulianDate.toDate(time), viewModel.locale);
         }
-        return JulianDate.toDate(time).toLocaleString(viewModel.locale);
+        return formatDateTime(JulianDate.toDate(time), viewModel.locale);
     };
 
     timeline.scrubFunction = function(e) {

--- a/lib/ViewModels/AnimationViewModel.js
+++ b/lib/ViewModels/AnimationViewModel.js
@@ -51,7 +51,11 @@ var AnimationViewModel = function(options) {
     var that = this;
     this.terria.clock.onTick.addEventListener(function(clock) {
         var time = clock.currentTime;
-        that.currentTimeString = JulianDate.toDate(time).toLocaleString(that.locale);
+        if (defined(that.locale)) {
+            that.currentTimeString = JulianDate.toDate(time).toLocaleString(that.locale);
+        } else {
+            that.currentTimeString = formatDate(JulianDate.toDate(time));
+        }
     });
 
     knockout.getObservable(this.terria, 'showTimeline').subscribe(function(showTimeline) {
@@ -98,6 +102,12 @@ var AnimationViewModel = function(options) {
         }
     }, false);
 };
+
+function formatDate(d) {
+    function pad(s) { return (s < 10) ? '0' + s : s; }
+    return [pad(d.getDate()), pad(d.getMonth()+1), d.getFullYear()].join('/') + ', ' +
+        [pad(d.getHours()), pad(d.getMinutes()), pad(d.getSeconds())].join(':');
+}
 
 function setupTimeline(viewModel) {
     var timelineContainer = document.getElementsByClassName('animation-timeline')[0];


### PR DESCRIPTION
fixes #760

hardcode format that works with timeline if no localestring entered.
change styling to not wrap date - string
