### PR TITLE
clear terria flag for picked features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 * Fixed incorrect date formatting in the timeline and animation controls on Internet Explorer 9.
 * Add support for CSV files with longitude and latitude columns but no numeric value column.  Such datasets are visualized as points with a default color and do not have a legend.
+* The Feature Information popup is now automatically closed when the user changes the `AbsIttCatalogItem` filter.
 
 ### 1.0.24
 

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -348,7 +348,11 @@ AbsIttCatalogItem.prototype._load = function() {
 
             var codes = json.codes;
 
-            function absCodeUpdate() { return updateAbsResults(that); }
+            function absCodeUpdate() {
+                //close feature info panel and then update results
+                that.terria.pickedFeatures = undefined;
+                return updateAbsResults(that);
+            }
             if (createDefaultFilter) {
                 for (var i = 0; i < codes.length; ++i) {
                     if (codes[i].parentCode === "") {


### PR DESCRIPTION
Small addition to the abs data update function to clear terria's pickedFeatures member when the data display is updated via the Now Viewing UI.
