### PR TITLE
Restore missing legend.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.28
+
+* Fixed a bug that prevented links to non-image (e.g. ArcGIS Map Server) legends from appearing on the Now Viewing panel.
+
 ### 1.0.27
 
 * Use terriajs-cesium 1.10.7, fixing a module load problem in really old browers like IE8.

--- a/lib/Views/NowViewingTab.html
+++ b/lib/Views/NowViewingTab.html
@@ -70,6 +70,10 @@
                 </a>
                 <!-- /ko -->
 
+                <!-- ko if: hasLegend && !legendIsImage -->
+                <a class="now-viewing-legend-text" data-bind="attr: { href: legendUrl }" target="_blank">Open legend in a separate tab</a>
+                <!-- /ko -->
+
                 <!-- ko if: !hasLegend -->
                     <!-- ko if: type !== 'abs-itt' -->
                     <div class="now-viewing-legend-text">No legend available for this data item.</div>


### PR DESCRIPTION
Non-image legends vanished with the ABS merge.  This brings them back (and doesn't seem to negatively impact ABS).
