### PR TITLE
Flexible catalog item zoomTo tolerance

### DIFF
--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -463,7 +463,7 @@ var scratchRectangle = new Rectangle();
 
         ga('send', 'event', 'dataSource', 'zoomTo', that.name);
 
-        var epsilon = this.zoomTolerance;
+        var epsilon = that.zoomTolerance;
 
         if (rect.east - rect.west < epsilon) {
             rect.east += epsilon;

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -136,6 +136,14 @@ var CatalogItem = function(terria) {
      */
     this.nowViewingMessage = undefined;
 
+    /**
+     * Gets or sets the tolerance to which this catalog item is zoomed. If the item's rectangle is smaller than this tolerance,
+     * the tolerance is added before zooming.
+     * @type {Float}
+     */
+    this.zoomTolerance = CesiumMath.EPSILON3;
+
+
     knockout.track(this, ['rectangle', 'legendUrl', 'dataUrlType', 'dataUrl', 'dataCustodian',
                           'metadataUrl', 'isEnabled', 'isShown', 'isLegendVisible', 'clock',
                           'isLoading', 'nowViewingMessage']);
@@ -455,7 +463,7 @@ var scratchRectangle = new Rectangle();
 
         ga('send', 'event', 'dataSource', 'zoomTo', that.name);
 
-        var epsilon = CesiumMath.EPSILON3;
+        var epsilon = this.zoomTolerance;
 
         if (rect.east - rect.west < epsilon) {
             rect.east += epsilon;


### PR DESCRIPTION
Made zoomTolerance a property of CatalogItem so that the zoomTo tolerance (epsilon) can be altered. This is useful for catalog items with small rectangles. Without changing it, zoomTo doesn't zoom in far enough.
