### PR TITLE
Support loading init files via proxy when necessary.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.29
+
+* Add support for loading init files via the proxy when necessary.
+
 ### 1.0.28
 
 * Fixed a bug that prevented links to non-image (e.g. ArcGIS Map Server) legends from appearing on the Now Viewing panel.

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -453,7 +453,7 @@ function generateInitializationUrl(url) {
 }
 
 function loadInitSources(terria, initSources) {
-    return when.all(initSources.map(loadInitSource), function(initSources) {
+    return when.all(initSources.map(loadInitSource.bind(undefined, terria)), function(initSources) {
         var promises = [];
 
         for (var i = 0; i < initSources.length; ++i) {
@@ -468,16 +468,20 @@ function loadInitSources(terria, initSources) {
     });
 }
 
-function loadInitSource(source) {
+function loadInitSource(terria, source) {
     if (typeof source === 'string') {
+        if (corsProxy.shouldUseProxy(source)) {
+            source = corsProxy.getURL(source);
+        }
         return loadJson(source).then(function(initSource) {
             initSource.isFromExternalFile = true;
             return initSource;
         }).otherwise(function() {
-            throw new ModelError({
+            terria.error.raiseEvent({
                 title: 'Error loading initialization source',
                 message: 'An error occurred while loading initialization information from ' + source + '.  This may indicate that you followed an invalid link or that there is a problem with your Internet connection.'
             });
+            return undefined;
         });
     } else {
         return source;

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -23,7 +23,6 @@ var corsProxy = require('../Core/corsProxy');
 var NowViewing = require('./NowViewing');
 var Services = require('./Services');
 var ViewerMode = require('./ViewerMode');
-var ModelError = require('./ModelError');
 var NoViewer = require('./NoViewer');
 
 /**


### PR DESCRIPTION
Also don't stop trying to load other init files when one fails.
