### PR TITLE
Update the terrain server URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### 1.0.29
 
 * Add support for loading init files via the proxy when necessary.
+* Switched to using the updated URL for STK World Terrain, `//assets.agi.com/stk-terrain/v1/tilesets/world/tiles`.
 
 ### 1.0.28
 

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -113,7 +113,7 @@ If you\'re on a desktop or laptop, consider increasing the size of your window.'
             this._terrainProvider = options.terrain;
         } else {
             this._terrainProvider = new CesiumTerrainProvider({
-                url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles'
+                url : '//assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
             });
         }
     }


### PR DESCRIPTION
The old one still works, and will continue to do so for a little while.  However, it redirects to the new one with a 301, which means getting every tile takes two requests.  This should improve terrain performance.
