### PR TITLE
Don't crash when WMS layer is missing

### DIFF
--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -302,6 +302,22 @@ WebMapServiceCatalogItem.prototype.updateFromCapabilities = function(capabilitie
         if (!defined(thisLayer)) {
             return;
         }
+
+        if (defined(this.layers)) {
+            var layers = this.layers.split(',');
+            for (var i = 0; i < thisLayer.length; ++i) {
+                if (!defined(thisLayer[i])) {
+                    console.log('A layer with the name or ID \"' + layers[i] + '\" does not exist on the WMS Server - ignoring it.');
+                    thisLayer.splice(i, 1);
+                    layers.splice(i, 1);
+                    --i;
+                }
+            }
+        }
+
+        if (thisLayer.length === 0) {
+            return;
+        }
     }
 
     this._rawMetadata = capabilities;
@@ -603,7 +619,7 @@ function requestMetadata(wmsItem) {
 
     result.promise = when(wmsItem.load()).then(function() {
         var json = wmsItem._rawMetadata;
-        if (json.Service) {
+        if (json && json.Service) {
             populateMetadataGroup(result.serviceMetadata, json.Service);
         } else {
             result.serviceErrorMessage = 'Service information not found in GetCapabilities operation response.';


### PR DESCRIPTION
E.g. National Map's `Elevation  -> SRTM 1 sec DEM Image` specifies a layer name that doesn't exist in the GetCapabilities.

Instead of crashing, it prints a message to the console and proceeds.  In the example above, proceeding actually works because the layer name given in the init file is the MapServer's layer ID, which the server understands even though it doesn't advertise it in GetCapabilities.
