### PR TITLE
Added optional 403 handling for ImageryLayerCatalogItems

### DIFF
--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -59,6 +59,15 @@ var ImageryLayerCatalogItem = function(terria) {
     this.treat404AsError = false;
 
     /**
+     * Gets or sets a value indicating whether a 403 response code when requesting a tile should be
+     * treated as an error.  If false, 403s are assumed to just be missing tiles and need not be
+     * reported to the user.
+     * @type {Boolean}
+     * @default false
+     */
+    this.treat403AsError = true;
+
+    /**
      * Gets or sets a value indicating whether non-specific (no HTTP status code) tile errors should be ignored. This is a
      * last resort, for dealing with odd cases such as data sources that return non-images (eg XML) with a 200 status code.
      * No error messages will be shown to the user.
@@ -445,6 +454,10 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
 
                 if (defined(tileProviderError.error) && tileProviderError.error.statusCode === 404) {
                     if(!catalogItem.treat404AsError) {
+                        return;
+                    }
+                } else if (defined(tileProviderError.error) && tileProviderError.error.statusCode === 403) {
+                    if(!catalogItem.treat403AsError) {
                         return;
                     }
                     // ignoreUnknownTileErrors is only for genuinely unknown (no status code) issues


### PR DESCRIPTION
Added a treat403AsError flag to ImageryLayerCatalogItem. This is useful when serving tiles from S3, which gives a 403 when an object does not exist.
