### PR TITLE
Populate the dataUrl property from CKAN.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * `itemProperties` are now applied through the normal JSON loading mechanism, so properties that are represented differently in code and in JSON will now work as well.
 * Added support for `csv-geo-*` (e.g. csv-geo-au) to `CkanCatalogGroup`.
 * The format name used in CKAN can now be specified to `CkanCatalogGroup` using the `wmsResourceFormat`, `kmlResourceFormat`, `csvResourceFormat`, and `esriMapServerResourceFormat` properties.  These properties are all regular expressions.  When the format of a CKAN resource returned from `package_search` matches one of these regular expressions, it is treated as that type within TerriaJS.
+* `CkanCatalogGroup` now fills the `dataUrl` property of created items by pointing to the dataset's page on CKAN.
 
 ### 1.0.29
 

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -489,9 +489,6 @@ function populateGroupFromResults(ckanGroup, json) {
             }
         }
 
-        var dataUrl = extras.data_url;
-        var dataUrlType = extras.data_url_type;
-
         var rectangle;
         var bboxString = item.geo_coverage || extras.geo_coverage;
         if (defined(bboxString)) {
@@ -593,8 +590,8 @@ function populateGroupFromResults(ckanGroup, json) {
 
             newItem.url = url;
             newItem.rectangle = rectangle;
-            newItem.dataUrl = dataUrl;
-            newItem.dataUrlType = dataUrlType;
+            newItem.dataUrl = ckanGroup.url + '/dataset/' + item.name;
+            newItem.dataUrlType = 'direct';
 
             if (isWms) {
                 //This should be deprecated and done on a server by server basis when feasible


### PR DESCRIPTION
It points to the dataset's page on CKAN, e.g. http://www.data.gov.au/dataset/wyndham-city-buildings-and-amenity

This property is used to feed the "Data URL" section on the dataset info popup:

![image](https://cloud.githubusercontent.com/assets/924374/8425873/c3024074-1f4d-11e5-90b6-13c7c190a323.png)

Fixes #624 
Fixes #782 
