### PR TITLE
Improvements to the catalog item info panel.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Change Log
 * `itemProperties` are now applied through the normal JSON loading mechanism, so properties that are represented differently in code and in JSON will now work as well.
 * Added support for `csv-geo-*` (e.g. csv-geo-au) to `CkanCatalogGroup`.
 * The format name used in CKAN can now be specified to `CkanCatalogGroup` using the `wmsResourceFormat`, `kmlResourceFormat`, `csvResourceFormat`, and `esriMapServerResourceFormat` properties.  These properties are all regular expressions.  When the format of a CKAN resource returned from `package_search` matches one of these regular expressions, it is treated as that type within TerriaJS.
+* The catalog item information panel now displays `info` sections in a consistent order.  The order can be overridden by setting `CatalogItemInfoViewModel.infoSectionOrder`.
+* An empty `description` or `info` section is no longer shown on the catalog item information panel.  This can be used to remove sections that would otherwise be populated from dataset metadata.
 
 ### 1.0.29
 

--- a/lib/ViewModels/CatalogItemInfoViewModel.js
+++ b/lib/ViewModels/CatalogItemInfoViewModel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /*global require*/
+var naturalSort = require('javascript-natural-sort');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 
@@ -20,7 +21,37 @@ var CatalogItemInfoViewModel = function(catalogItem) {
     this._domNodes = undefined;
 
     knockout.track(this, ['showDataDetails', 'showServiceDetails']);
+
+    knockout.defineProperty(this, 'sortedInfo', {
+        get: function() {
+            var items = this.catalogItem.info.slice();
+            naturalSort.insensitive = true;
+            items.sort(function(a, b) {
+                var aIndex = CatalogItemInfoViewModel.infoSectionOrder.indexOf(a.name);
+                var bIndex = CatalogItemInfoViewModel.infoSectionOrder.indexOf(b.name);
+                if (aIndex >= 0 && bIndex < 0) {
+                    return -1;
+                } else if (aIndex < 0 && bIndex >= 0) {
+                    return 1;
+                } else if (aIndex < 0 && bIndex < 0) {
+                    return naturalSort(a.name, b.name);
+                } else {
+                    return aIndex - bIndex;
+                }
+            });
+            return items;
+        }
+    });
 };
+
+CatalogItemInfoViewModel.infoSectionOrder = [
+    'Data Description',
+    'Dataset Description',
+    'Service Description',
+    'Resource Description',
+    'Licence',
+    'Access Constraints'
+];
 
 CatalogItemInfoViewModel.prototype.show = function(container) {
     this._domNodes = loadView(require('fs').readFileSync(__dirname + '/../Views/CatalogItemInfo.html', 'utf8'), container, this);

--- a/lib/Views/CatalogItemInfo.html
+++ b/lib/Views/CatalogItemInfo.html
@@ -38,7 +38,7 @@
             <h1 data-bind="text: catalogItem.name"></h1>
         </div>
         <div class="catalog-item-info-content">
-            <!-- ko if: catalogItem.description -->
+            <!-- ko if: catalogItem.description && catalogItem.description.length > 0 -->
             <div class="catalog-item-info-section">
                 <h2>Description</h2>
                 <div class="catalog-item-info-description" data-bind="markdown: catalogItem.description"></div>
@@ -52,17 +52,19 @@
             <!-- /ko -->
 
 
-            <!-- ko foreach: catalogItem.info -->
-            <div class="catalog-item-info-section">
-                <h2 data-bind="text: name"></h2>
-                <div class="catalog-item-info-description">
-                    <div data-bind="markdown: content"></div>
-                </div>
-            </div>
+            <!-- ko foreach: sortedInfo -->
+                <!-- ko if: content && content.length > 0 -->
+                    <div class="catalog-item-info-section">
+                        <h2 data-bind="text: name"></h2>
+                        <div class="catalog-item-info-description">
+                            <div data-bind="markdown: content"></div>
+                        </div>
+                    </div>
+                <!-- /ko -->
             <!-- /ko -->
 
             <!-- ko if: catalogItem.dataCustodian -->
-            <div class="catalog-item-info-section">
+            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataCustodian && catalogItem.dataCustodian.length > 0">
                 <h2>Data Custodian</h2>
                 <div class="catalog-item-info-description" data-bind="markdown: catalogItem.dataCustodian"></div>
             </div>


### PR DESCRIPTION
- The catalog item information panel now displays `info` sections in a consistent order.  The order can be overridden by setting `CatalogItemInfoViewModel.infoSectionOrder`.
- An empty `description` or `info` section is no longer shown on the catalog item information panel.  This can be used to remove sections that would otherwise be populated from dataset metadata.
