### PR TITLE
Use correct template for search results.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.34
+
+* Fixed a bug that prevented catalog items inside groups on the Search tab from being enabled.
+
 ### 1.0.33
 
 * Added the `legendUrls` property to allow a catalog item to optionally have multiple legend images.

--- a/lib/ViewModels/SearchResultViewModel.js
+++ b/lib/ViewModels/SearchResultViewModel.js
@@ -14,6 +14,7 @@ var SearchResultViewModel = function(options) {
     this.clickAction = options.clickAction;
     this.catalogItem = options.catalogItem;
     this.isOpen = false;
+    this.type = "search_result";
 
     knockout.track(this, ['name', 'tooltip', 'isImportant', 'clickAction', 'catalogItem', 'isOpen']);
 };

--- a/lib/Views/SearchTab.html
+++ b/lib/Views/SearchTab.html
@@ -35,7 +35,7 @@
             <!-- /ko -->
 
             <!-- ko if: $parent.isOpen -->
-                <div class="data-catalog-group-contents" data-bind="template: { name: 'data-catalog-item-template', foreach: items }"></div>
+                <div class="data-catalog-group-contents" data-bind="template: { name: 'search-catalog-item-template', foreach: items }"></div>
             <!-- /ko -->
         </div>
     <!-- /ko -->

--- a/lib/Views/SearchTab.html
+++ b/lib/Views/SearchTab.html
@@ -17,13 +17,13 @@
     <!-- ko if: !isHidden && typeof items !== 'undefined' -->
         <div class="data-catalog-member" data-bind="css: 'data-catalog-indent' + ($parents.length - 2)">
             <div class="data-catalog-member-top-row">
-                <div class="data-catalog-icon-holder clickable" data-bind="click: $parent.toggleOpen.bind($parent)">
+                <div class="data-catalog-icon-holder clickable" data-bind="click: $parent.type === 'search_result' ? $parent.toggleOpen.bind($parent) : toggleOpen">
                     <div class="data-catalog-arrow" data-bind="cesiumSvgPath: { path: $parent.isOpen ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }, css: { 'data-catalog-opened-group': $parent.isOpen }"></div>
                 </div>
-                <div class="data-catalog-group-label clickable" data-bind="click: $parent.toggleOpen.bind($parent), text: name, css: { 'data-catalog-opened-group': $parent.isOpen }"></div>
+                <div class="data-catalog-group-label clickable" data-bind="click: $parent.type === 'search_result' ? $parent.toggleOpen.bind($parent) : toggleOpen, text: name, css: { 'data-catalog-opened-group': $parent.isOpen }"></div>
             </div>
 
-            <!-- ko if: $parent.isOpen && (isLoading || items.length === 0) -->
+            <!-- ko if: ($parent.type === "search_result" ? $parent.isOpen : isOpen) && (isLoading || items.length === 0) -->
                 <div class="data-catalog-group-contents">
                     <div class="data-catalog-member" data-bind="css: 'data-catalog-indent' + ($parents.length - 1)">
                         <div class="data-catalog-member-top-row">
@@ -34,7 +34,7 @@
                 </div>
             <!-- /ko -->
 
-            <!-- ko if: $parent.isOpen -->
+            <!-- ko if: $parent.type === "search_result" ? $parent.isOpen : isOpen -->
                 <div class="data-catalog-group-contents" data-bind="template: { name: 'search-catalog-item-template', foreach: items }"></div>
             <!-- /ko -->
         </div>

--- a/lib/Views/SearchTab.html
+++ b/lib/Views/SearchTab.html
@@ -23,7 +23,7 @@
                 <div class="data-catalog-group-label clickable" data-bind="click: $parent.type === 'search_result' ? $parent.toggleOpen.bind($parent) : toggleOpen, text: name, css: { 'data-catalog-opened-group': $parent.isOpen }"></div>
             </div>
 
-            <!-- ko if: ($parent.type === "search_result" ? $parent.isOpen : isOpen) && (isLoading || items.length === 0) -->
+            <!-- ko if: ($parent.type === 'search_result' ? $parent.isOpen : isOpen) && (isLoading || items.length === 0) -->
                 <div class="data-catalog-group-contents">
                     <div class="data-catalog-member" data-bind="css: 'data-catalog-indent' + ($parents.length - 1)">
                         <div class="data-catalog-member-top-row">
@@ -34,7 +34,7 @@
                 </div>
             <!-- /ko -->
 
-            <!-- ko if: $parent.type === "search_result" ? $parent.isOpen : isOpen -->
+            <!-- ko if: $parent.type === 'search_result' ? $parent.isOpen : isOpen -->
                 <div class="data-catalog-group-contents" data-bind="template: { name: 'search-catalog-item-template', foreach: items }"></div>
             <!-- /ko -->
         </div>


### PR DESCRIPTION
The data-catalog-item template was being used, which prevented some
interactions with the search results.
