### PR TITLE
Allow zooming to smaller rectangles.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Added the `legendUrls` property to allow a catalog item to optionally have multiple legend images.
 * Added `CatalogGroup.sortFunction` property to allow custom sorting of catalog items within a group.
 * Added `ImageryLayerCatalogItem.treat403AsError` property.
+* `CatalogItem.zoomTo` can now zoom to much smaller bounding box rectangles.
 
 ### 1.0.32
 

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -473,16 +473,15 @@ var scratchRectangle = new Rectangle();
 
         var epsilon = CesiumMath.EPSILON3;
 
-        if (rect.east - rect.west < epsilon) {
+        if (rect.east === rect.west) {
             rect.east += epsilon;
             rect.west -= epsilon;
         }
 
-        if (rect.north - rect.south < epsilon) {
+        if (rect.north === rect.south) {
             rect.north += epsilon;
             rect.south -= epsilon;
         }
-
 
         var terria =  that.terria;
         terria.currentViewer.zoomTo(rect);


### PR DESCRIPTION
This is an alternative to #780.

Neither Cesium nor Leaflet will break when asked to zoom in really close (e.g. 1e-12 degrees difference between south/west and north/east, so this check is not necessary anymore.  We still check for exact equality, which will happen when zooming to a single point.
