### PR TITLE
Add option to KnockoutMarkdownBinding to allow unsafe HTML.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Added `ImageryLayerCatalogItem.treat403AsError` property.
 * Added a title text when hovering over the label of an enabled catalog item.  The title text informs the user that clicking will zoom to the item.
 * Added `createBingBaseMapOptions` function.
+* Added an option to `KnockoutMarkdownBinding` to optionally skip HTML sanitization and therefore to allow unsafe HTML.
 
 ### 1.0.32
 

--- a/lib/Core/KnockoutMarkdownBinding.js
+++ b/lib/Core/KnockoutMarkdownBinding.js
@@ -7,6 +7,8 @@ var sanitizeCaja = require('sanitize-caja/sanitizer-bundle');
 var htmlTagRegex = /<html(.|\s)*>(.|\s)*<\/html>/im;
 
 var KnockoutMarkdownBinding = {
+    allowUnsafeHtml : false,
+
     register : function(knockout) {
         knockout.bindingHandlers.markdown = {
             'init': function() {
@@ -49,7 +51,11 @@ var md = new MarkdownIt({
 
 function markdownToHtml(markdownString) {
     var unsafeHtml = md.render(markdownString);
-    return sanitizeCaja(unsafeHtml, cleanUrl, cleanId);
+    if (KnockoutMarkdownBinding.allowUnsafeHtml) {
+        return unsafeHtml;
+    } else {
+        return sanitizeCaja(unsafeHtml, cleanUrl, cleanId);
+    }
 }
 
 function setAnchorTargets(element) {


### PR DESCRIPTION
This allows the user of JavaScript, for example, in feature info popups in apps that are ok with the security tradeoffs.
