### PR TITLE
Add a PopupMessageConfirmationViewModel.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### 1.0.34
 
 * Fixed a bug that prevented catalog items inside groups on the Search tab from being enabled.
+* Added `PopupMessageConfirmationViewModel`. It prevents the Popup from being closed unless the confirm button is pressed. Can also optionally have a deny button with a custom action.
 
 ### 1.0.33
 

--- a/lib/Styles/PopupMessage.less
+++ b/lib/Styles/PopupMessage.less
@@ -50,3 +50,21 @@
     padding:10px;
     border:1px solid gray;
 }
+
+.popup-message-actions {
+  margin-top: 20px;
+  .popup-message-action {
+    float: right;
+    margin-left: 20px;
+    padding: 10px 20px;
+    background: #596069;
+    min-width: 80px;
+    text-align: center;
+    border-radius: 2px;
+    color: white;
+    &:hover {
+      cursor: pointer;
+      background: @highlight-color;
+    }
+  }
+}

--- a/lib/ViewModels/PopupMessageConfirmationViewModel.js
+++ b/lib/ViewModels/PopupMessageConfirmationViewModel.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/*global require*/
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+
+var inherit = require('../Core/inherit');
+var PopupMessageViewModel = require('./PopupMessageViewModel');
+
+var PopupMessageConfirmationViewModel = function(options) {
+    PopupMessageViewModel.call(this, options);
+
+    this.title = defaultValue(options.title, 'Confirm');
+
+    this.confirmText = defaultValue(options.confirmText, 'OK');
+    this.confirmAction = defaultValue(options.confirmAction, this.close);
+
+    // enableDeny needs be explicitly set, because there is no good default denyAction to take.
+    this.enableDeny = defaultValue(options.enableDeny, false);
+    this.denyText = defaultValue(options.denyText, 'Cancel');
+    this.denyAction = defaultValue(options.denyAction, function() {});
+
+    this.view = require('fs').readFileSync(__dirname + '/../Views/PopupMessageConfirmation.html', 'utf8');
+
+    knockout.track(this, ['confirmText', 'denyText']);
+};
+
+inherit(PopupMessageViewModel, PopupMessageConfirmationViewModel);
+
+PopupMessageConfirmationViewModel.open = function(container, options) {
+    var viewModel = new PopupMessageConfirmationViewModel(options);
+    viewModel.show(container);
+    return viewModel;
+};
+
+module.exports = PopupMessageConfirmationViewModel;

--- a/lib/Views/PopupMessageConfirmation.html
+++ b/lib/Views/PopupMessageConfirmation.html
@@ -1,0 +1,16 @@
+<div class="modal-background">
+    <div class="popup-message" data-bind="style: { width: width + 'px', height: height + 'px', 'max-width': maxWidth + 'px', 'max-height': maxHeight + 'px' }">
+        <div class="modal-header">
+            <h1 data-bind="text: title"></h1>
+        </div>
+        <div class="popup-message-content"  id="popup-window-content">
+            <div class="popup-message-label" data-bind="markdown: message"></div>
+            <div class="popup-message-actions">
+                <!-- ko if: enableDeny -->
+                    <div class="popup-message-action popup-message-actions-deny" data-bind="click: denyAction, text: denyText"></div>
+                <!-- /ko -->
+                <div class="popup-message-action popup-message-actions-confirm" data-bind="click: confirmAction, text: confirmText"></div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
For when the user should not continue using the application without an explicit action.

Supports doing something when the user presses deny, but since there is no good default action, the deny button is only shown if explicitly enabled.

By default the accept button closes the popup, but that is configurable as well.
