### PR TITLE
CKAN, GeoJSON, and KML improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@ Change Log
 
 * Fixed a bug that prevented catalog items inside groups on the Search tab from being enabled.
 * Added `PopupMessageConfirmationViewModel`. It prevents the Popup from being closed unless the confirm button is pressed. Can also optionally have a deny button with a custom action.
+* Added support for discovering GeoJSON datasets from CKAN.
+* Added support for zipped GeoJSON files.
+* Made `KmlCatalogItem` use the proxy when required.
+* Made `FeatureInfoPanelViewModel` use the white panel background in more cases.
 
 ### 1.0.33
 

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -19,6 +19,7 @@ var corsProxy = require('../Core/corsProxy');
 var CsvCatalogItem = require('./CsvCatalogItem');
 var ModelError = require('./ModelError');
 var CatalogGroup = require('./CatalogGroup');
+var GeoJsonCatalogItem = require('./GeoJsonCatalogItem');
 var inherit = require('../Core/inherit');
 var KmlCatalogItem = require('./KmlCatalogItem');
 var WebMapServiceCatalogGroup = require('./WebMapServiceCatalogGroup');
@@ -170,7 +171,20 @@ var CkanCatalogGroup = function(terria) {
      */
     this.esriMapServerResourceFormat = /^esri rest$/i;
 
-    knockout.track(this, ['url', 'dataCustodian', 'filterQuery', 'blacklist', 'wmsParameters', 'groupBy', 'useResourceName', 'allowEntireWmsServers', 'includeWms', 'includeKml', 'includeCsv', 'includeEsriMapServer']);
+    /**
+     * True to allow GeoJSON resources to be added to the catalog; otherwise, false.
+     * @type {Boolean}
+     * @default false
+     */
+    this.includeGeoJson = false;
+
+    /**
+     * Gets or sets a regular expression that, when it matches a resource's format, indicates that the resource is a GeoJSON resource.
+     * @type {RegExp}
+     */
+    this.geoJsonResourceFormat = /^geojson$/i;
+
+    knockout.track(this, ['url', 'dataCustodian', 'filterQuery', 'blacklist', 'wmsParameters', 'groupBy', 'useResourceName', 'allowEntireWmsServers', 'includeWms', 'includeKml', 'includeCsv', 'includeEsriMapServer', 'includeGeoJson']);
 };
 
 inherit(CatalogGroup, CkanCatalogGroup);
@@ -510,7 +524,7 @@ function populateGroupFromResults(ckanGroup, json) {
             var isWms;
             if (resource.format.match(ckanGroup.wmsResourceFormat)) {
                 isWms = true;
-            } else if (resource.format.match(ckanGroup.esriMapServerResourceFormat) || resource.format.match(ckanGroup.kmlResourceFormat) || resource.format.match(ckanGroup.csvResourceFormat)) {
+            } else if (resource.format.match(ckanGroup.esriMapServerResourceFormat) || resource.format.match(ckanGroup.kmlResourceFormat) || resource.format.match(ckanGroup.geoJsonResourceFormat) || resource.format.match(ckanGroup.csvResourceFormat)) {
                 isWms = false;
             } else {
                 continue;
@@ -561,6 +575,11 @@ function populateGroupFromResults(ckanGroup, json) {
                     continue;
                 }
                 newItem = new KmlCatalogItem(ckanGroup.terria);
+            } else if (resource.format.match(ckanGroup.geoJsonResourceFormat)) {
+                if (!ckanGroup.includeGeoJson) {
+                    continue;
+                }
+                newItem = new GeoJsonCatalogItem(ckanGroup.terria);
             } else if (resource.format.match(ckanGroup.csvResourceFormat)) {
                 if (!ckanGroup.includeCsv) {
                     continue;

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -12,10 +12,12 @@ var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var GeoJsonDataSource = require('terriajs-cesium/Source/DataSources/GeoJsonDataSource');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var loadBlob = require('terriajs-cesium/Source/Core/loadBlob');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
 var loadText = require('terriajs-cesium/Source/Core/loadText');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
+var zip = require('terriajs-cesium/Source/ThirdParty/zip');
 
 var PointGraphics = require('terriajs-cesium/Source/DataSources/PointGraphics');
 
@@ -134,6 +136,9 @@ GeoJsonCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
     return [this.url, this.data];
 };
 
+var zipFileRegex = /.zip\b/i;
+var geoJsonRegex = /.geojson\b/i;
+
 GeoJsonCatalogItem.prototype._load = function() {
     this._geoJsonDataSource = new GeoJsonDataSource(this.name);
 
@@ -176,9 +181,55 @@ GeoJsonCatalogItem.prototype._load = function() {
             });
         });
     } else {
-        return loadJson(proxyUrl( that.terria, that.url)).then(function(json) {
+        var jsonPromise;
+        if (zipFileRegex.test(that.url)) {
+            if (typeof FileReader === 'undefined') {
+                throw new ModelError({
+                    sender: that,
+                    title: 'Unsupported web browser',
+                    message: '\
+Sorry, your web browser does not support the File API, which '+this.terria.appName+' requires in order to \
+load this dataset.  Please upgrade your web browser.  For the best experience, we recommend the latest versions of \
+<a href="http://www.google.com/chrome" target="_blank">Google Chrome</a>, or \
+<a href="http://www.mozilla.org/firefox" target="_blank">Mozilla Firefox</a>, or \
+<a href="http://www.microsoft.com/ie" target="_blank">Internet Explorer 11</a>.'
+                });
+            }
+
+            jsonPromise = loadBlob(proxyUrl(that.terria, that.url)).then(function(blob) {
+                var deferred = when.defer();
+                zip.createReader(new zip.BlobReader(blob), function(reader) {
+                    // Look for a file with a .geojson extension.
+                    reader.getEntries(function(entries) {
+                        var resolved = false;
+                        for (var i = 0; i < entries.length; i++) {
+                            var entry = entries[i];
+                            if (geoJsonRegex.test(entry.filename)) {
+                                getJson(entry, deferred);
+                                resolved = true;
+                            }
+                        }
+
+                        if (!resolved) {
+                            deferred.reject();
+                        }
+                    });
+                }, function(e) {
+                    deferred.reject(e);
+                });
+                return deferred.promise;
+            });
+        } else {
+            jsonPromise = loadJson(proxyUrl(that.terria, that.url));
+        }
+
+        return jsonPromise.then(function(json) {
             return updateModelFromData(that, json);
         }).otherwise(function(e) {
+            if (e instanceof ModelError) {
+                throw e;
+            }
+
             throw new ModelError({
                 sender: that,
                 title: 'Could not load JSON',
@@ -198,6 +249,12 @@ sending an email to <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.
         });
     }
 };
+
+function getJson(entry, deferred) {
+    entry.getData(new zip.TextWriter(), function(text) {
+        deferred.resolve(JSON.parse(text));
+    });
+}
 
 GeoJsonCatalogItem.prototype._enable = function() {
 };
@@ -400,6 +457,8 @@ function reprojectToGeographic(geoJson) {
                defined(geoJson.crs.properties.name)) {
         if (geoJson.crs.properties.name.indexOf('EPSG:') === 0) {
             code = geoJson.crs.properties.name;
+        } else if (geoJson.crs.properties.name.indexOf('urn:ogc:def:crs:EPSG::') === 0) {
+            code = 'EPSG:' + geoJson.crs.properties.name.substring('urn:ogc:def:crs:EPSG::'.length);
         } else if (geoJson.crs.properties.name.indexOf('CRS84') !== -1) {
             code = 'EPSG:4326';
         }

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -251,8 +251,8 @@ sending an email to <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.
 };
 
 function getJson(entry, deferred) {
-    entry.getData(new zip.TextWriter(), function(text) {
-        deferred.resolve(JSON.parse(text));
+    entry.getData(new zip.Data64URIWriter(), function(uri) {
+        deferred.resolve(loadJson(uri));
     });
 }
 

--- a/lib/Models/KmlCatalogItem.js
+++ b/lib/Models/KmlCatalogItem.js
@@ -198,9 +198,9 @@ KmlCatalogItem.prototype._hide = function() {
     dataSources.remove(this._kmlDataSource, false);
 };
 
-function proxyUrl(terria, url) {
-    if (defined(terria.corsProxy) && terria.corsProxy.shouldUseProxy(url)) {
-        return terria.corsProxy.getURL(url);
+function proxyUrl(catalogItem, url) {
+    if (defined(catalogItem.terria.corsProxy) && catalogItem.terria.corsProxy.shouldUseProxy(url)) {
+        return catalogItem.terria.corsProxy.getURL(url);
     }
 
     return url;

--- a/lib/ViewModels/FeatureInfoPanelViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelViewModel.js
@@ -13,7 +13,7 @@ var when = require('terriajs-cesium/Source/ThirdParty/when');
 var loadView = require('../Core/loadView');
 var removeView = require('../Core/removeView');
 
-var htmlTagRegex = /<html(.|\s)*>(.|\s)*<\/html>/im;
+var htmlTagRegex = /(<html(.|\s)*>(.|\s)*<\/html>|<body(.|\s)*>(.|\s)*<\/body>|<meta(.|\s)*>)/im;
 
 var FeatureInfoPanelViewModel = function(options) {
     if (!defined(options) || !defined(options.terria)) {


### PR DESCRIPTION
- Added support for discovering GeoJSON datasets from CKAN.
- Added support for zipped GeoJSON files.
- Made `KmlCatalogItem` use the proxy when required.
- Made `FeatureInfoPanelViewModel` use the white panel background in more cases.
