### PR TITLE
Use the entire group name, not just the part before the first comma.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * Made `KmlCatalogItem` use the proxy when required.
 * Made `FeatureInfoPanelViewModel` use the white panel background in more cases.
 * Significantly improved the experience on devices with small screens, such as phones.
+* Fixed a bug that caused only the portion of a CKAN group name before the first comma to be used.
 
 ### 1.0.33
 

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -634,9 +634,6 @@ function populateGroupFromResults(ckanGroup, json) {
                 for (var groupIndex = 0; groupIndex < groups.length; ++groupIndex) {
                     var group = groups[groupIndex];
                     var groupName = group.display_name || group.title;
-                    if (groupName.indexOf(',') !== -1) {
-                        groupName = groupName.substring(0, groupName.indexOf(','));
-                    }
 
                     if (ckanGroup.blacklist && ckanGroup.blacklist[groupName]) {
                         continue;


### PR DESCRIPTION
When grouping CKAN datasets by Group.
