### PR TITLE
Fill GeoJSON polygons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.35
+
+* Polygons from GeoJSON datasets are now filled.
+
 ### 1.0.34
 
 * Fixed a bug that prevented catalog items inside groups on the Search tab from being enabled.

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -356,11 +356,11 @@ function proxyUrl(terria, url) {
 }
 
 function loadGeoJson(geoJsonItem) {
-    var fillPolygons = false;
+    var fillPolygons = true;
     var pointColor = getRandomColor(pointPalette, geoJsonItem.name);
     var lineColor = getRandomColor(lineAndFillPalette, geoJsonItem.name);
     var fillColor = Color.clone(lineColor);
-    fillColor.alpha = 0.75;
+    fillColor.alpha = 0.5;
 
     var pointSize = 10;
     var lineWidth = 2;


### PR DESCRIPTION
Request from SA.  I don't know why we weren't doing this already.  Performance concerns maybe?  Filled polygons take a bit longer to show up, but it's not too bad.  I think it used to be worse in older versions of Cesium.
