### PR TITLE
Start with the clock stopped.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.35
+
+* Fixed a bug that caused the 3D view to use significant CPU time even when idle.
+
 ### 1.0.34
 
 * Fixed a bug that prevented catalog items inside groups on the Search tab from being enabled.

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -123,7 +123,9 @@ var Terria = function(options) {
      * Gets or sets the clock that controls how time-varying data items are displayed.
      * @type {Clock}
      */
-    this.clock = new Clock();
+    this.clock = new Clock({
+        shouldAnimate: false
+    });
 
     // See the intialView property below.
     this._initialView = undefined;


### PR DESCRIPTION
TerriaJS will only stop the rendering loop in 3D when the clock is not ticking.  Somewhere along the line (possibly when we switched from `Viewer` to `CesiumWidget` or possible as a result of a change in Cesium itself) something changed such that the clock was set to tick at startup.  As a result, TerriaJS never stopped the rendering loop and used far more CPU / battery than necessary.
