### PR TITLE
Load and show errors once, and make sure the clock can stop.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.0.36
+
+* Fixed a bug that caused the `Terria#clock` to keep ticking (and therefore using CPU / battery) once started even after selecting a non-time-dynamic dataset.
+* Fixed a bug that caused the popup message to appear twice when a dataset failed to load.
+
 ### 1.0.35
 
 * Polygons from GeoJSON datasets are now filled.

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -785,9 +785,8 @@ function isShownChanged(catalogItem) {
         // actually gone through.
         if (!defined(catalogItem._loadForEnablePromise)) {
             catalogItem._hide();
+            catalogItem.useClock();
         }
-
-        catalogItem.useClock();
 
         var duration;
         if (defined(catalogItem._shownDate)) {

--- a/lib/Models/ModelError.js
+++ b/lib/Models/ModelError.js
@@ -10,7 +10,7 @@ var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
  *
  * @alias ModelError
  * @constructor
- * 
+ *
  * @param {Object} options Object with the following properties:
  * @param {Object} [options.sender] The object raising the error.
  * @param {String} [options.title='An error occurred'] A short title describing the error.
@@ -34,6 +34,13 @@ var ModelError = function(options) {
      * @type {String}
      */
     this.message = options.message;
+
+    /**
+     * True if the user has seen this error; otherwise, false.
+     * @type {Boolean}
+     * @default false
+     */
+    this.raisedToUser = false;
 };
 
 module.exports = ModelError;

--- a/lib/Models/raiseErrorToUser.js
+++ b/lib/Models/raiseErrorToUser.js
@@ -6,7 +6,10 @@ var ModelError = require('../Models/ModelError');
 
 var raiseErrorToUser = function(terria, error) {
     if (error instanceof ModelError) {
-        terria.error.raiseEvent(error);
+        if (!error.raisedToUser) {
+            error.raisedToUser = true;
+            terria.error.raiseEvent(error);
+        }
     } else {
         terria.error.raiseEvent(new ModelError({
             sender: undefined,

--- a/lib/ViewModels/AnimationViewModel.js
+++ b/lib/ViewModels/AnimationViewModel.js
@@ -57,7 +57,9 @@ var AnimationViewModel = function(options) {
     knockout.getObservable(this.terria, 'showTimeline').subscribe(function(showTimeline) {
         that.showAnimation = (showTimeline > 0);
             //default to playing and looping when shown
-        that.terria.clock.shouldAnimate = true;
+        if (that.showAnimation) {
+            that.terria.clock.shouldAnimate = true;
+        }
         that.terria.clock.clockRange = ClockRange.LOOP_STOP;
 
         that.isPlaying = that.terria.clock.shouldAnimate;
@@ -88,7 +90,7 @@ var AnimationViewModel = function(options) {
             }
         }
         if (showTimeline) {
-            that.timeline.zoomTo( that.terria.clock.startTime, that.terria.clock.stopTime);
+            that.timeline.zoomTo(that.terria.clock.startTime, that.terria.clock.stopTime);
         }
     }, this);
 
@@ -173,7 +175,7 @@ AnimationViewModel.prototype.togglePlay = function() {
 
     if (this.terria.clock.multiplier < 0) {
         this.terria.clock.multiplier = -this.terria.clock.multiplier;
-    }        
+    }
     this.terria.clock.shouldAnimate = !this.terria.clock.shouldAnimate;
     this.isPlaying = this.terria.clock.shouldAnimate;
 
@@ -186,7 +188,7 @@ AnimationViewModel.prototype.playSlower = function() {
     this.terria.clock.multiplier /= 2;
     this.terria.clock.shouldAnimate = true;
     this.isPlaying = true;
-    
+
     this.terria.currentViewer.notifyRepaintRequired();
 };
 


### PR DESCRIPTION
- Don't use a catalog item's clock when it is hidden unless it was actually successfully shown first.
- Only show a given `ModelError` instance to the user once.
- Only set the clock's `shouldAnimate` to true when the `AnimationViewModel` is shown, not when it's hidden.  Prior to this change, the clock would keep ticking once started even when zooming to a non-time-dynamic dataset.
