### PR TITLE
Socrata2

### DIFF
--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -5,6 +5,7 @@
 var ArcGisCatalogGroup = require('./ArcGisCatalogGroup');
 var ArcGisMapServerCatalogItem = require('./ArcGisMapServerCatalogItem');
 var CkanCatalogGroup = require('./CkanCatalogGroup');
+var SocrataCatalogGroup = require('./SocrataCatalogGroup');
 var createCatalogMemberFromType = require('./createCatalogMemberFromType');
 var createCatalogItemFromUrl = require('./createCatalogItemFromUrl');
 var CzmlCatalogItem = require('./CzmlCatalogItem');
@@ -39,6 +40,7 @@ var registerCatalogMembers = function() {
     createCatalogMemberFromType.register('kml', KmlCatalogItem);
     createCatalogMemberFromType.register('kmz', KmlCatalogItem);
     createCatalogMemberFromType.register('ogr', OgrCatalogItem);
+    createCatalogMemberFromType.register('socrata', SocrataCatalogGroup);
     createCatalogMemberFromType.register('wfs', WebFeatureServiceCatalogItem);
     createCatalogMemberFromType.register('wfs-getCapabilities', WebFeatureServiceCatalogGroup);
     createCatalogMemberFromType.register('wms', WebMapServiceCatalogItem);

--- a/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
+++ b/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
@@ -42,6 +42,16 @@ CatalogItemNameSearchProviderViewModel.prototype.search = function(searchText) {
         searchFilters.typeIs.push(searchText.match(isRE)[1].toLowerCase());
         searchText = searchText.replace(isRE, '');
     }
+    var showRE = /\bshow:(all|[0-9]+)\b/i;
+    while (searchText.match(showRE)) {
+        searchFilters.maxResults = searchText.match(showRE)[1].toLowerCase();
+        if (searchFilters.maxResults === 'all') {
+            searchFilters.maxResults = 1000;
+        } else {
+            searchFilters.maxResults = Number.parseInt(searchFilters.maxResults);
+        }
+        searchText = searchText.replace(showRE, '');
+    }
 
     this.isSearching = true;
     this.searchResults.removeAll();
@@ -74,9 +84,12 @@ CatalogItemNameSearchProviderViewModel.prototype.search = function(searchText) {
 
 function findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, group, path, promises, searchFilters) {
     path.push(group);
-
+    if (!defined (searchFilters)) {
+        searchFilters = {};
+    }
     var items = group.items;
-    for (var i = 0; !searchInProgress.cancel && viewModel.searchResults.length < viewModel.maxResults && i < items.length; ++i) {
+    var maxResults = (defined(searchFilters.maxResults) ? searchFilters.maxResults : viewModel.maxResults);
+    for (var i = 0; !searchInProgress.cancel && viewModel.searchResults.length < maxResults && i < items.length; ++i) {
         var item = items[i];
 
         if (item.isHidden) {
@@ -85,7 +98,7 @@ function findMatchingItemsRecursively(viewModel, searchInProgress, searchExpress
 
         // Match non-top-level items whose name contain the search text.
         if (searchExpression.test(item.name)) {
-            if (!defined(searchFilters) || searchFilters.typeIs.length === 0 || searchFilters.typeIs.indexOf(item.type.toLowerCase()) >= 0) {
+            if (searchFilters.typeIs.length === 0 || searchFilters.typeIs.indexOf(item.type.toLowerCase()) >= 0) {
                 viewModel.searchResults.push(new SearchResultViewModel({
                     name: item.name,
                     isImportant: true,


### PR DESCRIPTION
Adds basic support for Socrata, and hence data.melbourne.vic.gov.au and data.act.gov.au.

By "basic" I mean that it doesn't support:
- blacklists
- datasets which don't have a Map visualisation defined on them. Well, I'm not really sure exactly what subset is covered.
- accessing data other than via WMS. It's a bit quick and dirty.
