### PR TITLE
Fix problems preventing MODIS WMTS layers from working.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change Log
 ### 1.0.37
 
 * Added `CswCatalogGroup` for populating a catalog by querying an OGC CSW service.
+* Fixed a bug that prevented WMTS layers with a single `TileMatrixSetLink` from working correctly.
+* Added support for WMTS layers that can only provide tiles in JPEG format.
 
 ### 1.0.36
 

--- a/lib/Models/WebMapTileServiceCatalogItem.js
+++ b/lib/Models/WebMapTileServiceCatalogItem.js
@@ -4,6 +4,7 @@
 var URI = require('URIjs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var definedNotNull = require('terriajs-cesium/Source/Core/definedNotNull');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
@@ -108,10 +109,16 @@ var WebMapTileServiceCatalogItem = function(terria) {
      */
     this.minScaleDenominator = undefined;
 
+    /**
+     * Gets or sets the format in which to request tile images.  If not specified, 'image/png' is used.  This property is observable.
+     * @type {String}
+     */
+    this.format = undefined;
+
     knockout.track(this, [
         '_dataUrl', '_dataUrlType', '_metadataUrl', '_legendUrl', '_rectangle', '_rectangleFromMetadata', '_intervalsFromMetadata', 'url',
         'layer', 'style', 'tileMatrixSetID', 'getFeatureInfoFormats',
-        'tilingScheme', 'populateIntervalsFromTimeDimension', 'minScaleDenominator']);
+        'tilingScheme', 'populateIntervalsFromTimeDimension', 'minScaleDenominator', 'format']);
 
     // dataUrl, metadataUrl, and legendUrl are derived from url if not explicitly specified.
     overrideProperty(this, 'metadataUrl', {
@@ -315,11 +322,32 @@ WebMapTileServiceCatalogItem.prototype.updateFromCapabilities = function(capabil
     updateValue(this, overwrite, 'getFeatureInfoFormats', getFeatureInfoFormats(thisLayer));
     updateValue(this, overwrite, 'rectangle', getRectangleFromLayer(thisLayer));
 
+    // Find a suitable image format.  Prefer PNG but fall back on JPEG is necessary
+    var formats = thisLayer.Format;
+    if (defined(formats)) {
+        if (!Array.isArray(formats)) {
+            formats = [formats];
+        }
+
+        var format;
+        if (formats.indexOf('image/png') >= 0) {
+            format = 'image/png';
+        } else if (formats.indexOf('image/jpeg') >= 0 || formats.indexOf('images/jpg') >= 0) {
+            format = 'image/jpeg';
+        }
+
+        updateValue(this, overwrite, 'format', format);
+    }
+
     // Find a suitable tile matrix set.
     var tileMatrixSetID = 'urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible';
     var tileMatrixSetLabels;
 
     var tileMatrixSetLinks = thisLayer.TileMatrixSetLink;
+    if (!Array.isArray(tileMatrixSetLinks)) {
+        tileMatrixSetLinks = [tileMatrixSetLinks];
+    }
+
     var i;
     for (i = 0; i < tileMatrixSetLinks.length; ++i) {
         var link = tileMatrixSetLinks[i];
@@ -391,7 +419,7 @@ WebMapTileServiceCatalogItem.prototype._createImageryProvider = function() {
         style: this.style,
         getFeatureInfoFormats : this.getFeatureInfoFormats,
         tilingScheme : defined(this.tilingScheme) ? this.tilingScheme : new WebMercatorTilingScheme(),
-        format : 'image/png'
+        format : defaultValue(this.format, 'image/png')
     });
 };
 


### PR DESCRIPTION
- Fixed a bug that prevented WMTS layers with a single `TileMatrixSetLink` from working correctly.
- Added support for WMTS layers that can only provide tiles in JPEG format.

Fixes #862 

With this change, the MODIS Web Mercator endpoint works when added via Add Data:
http://map1.vis.earthdata.nasa.gov/wmts-webmerc/wmts.cgi
