### PR TITLE
Tools updates for ga datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Added `CswCatalogGroup` for populating a catalog by querying an OGC CSW service.
 * Fixed a bug that prevented WMTS layers with a single `TileMatrixSetLink` from working correctly.
 * Added support for WMTS layers that can only provide tiles in JPEG format.
+* Fixed testing and caching of ArcGis layers from tools and addde More information option for imagery layers.
 
 ### 1.0.36
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Change Log
 * Added `CswCatalogGroup` for populating a catalog by querying an OGC CSW service.
 * Fixed a bug that prevented WMTS layers with a single `TileMatrixSetLink` from working correctly.
 * Added support for WMTS layers that can only provide tiles in JPEG format.
-* Fixed testing and caching of ArcGis layers from tools and addde More information option for imagery layers.
+* Fixed testing and caching of ArcGis layers from tools and added More information option for imagery layers.
 
 ### 1.0.36
 

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -246,7 +246,7 @@ function getAllRequests(types, mode, requests, group, promises, blacklistGroup) 
         }
         return false;
     }
-    function generateReguest(item, group, blacklistGroup) {
+    function generateRequest(item, group, blacklistGroup) {
         return function() {
             var enabledHere = false;
             if (!item.isEnabled) {
@@ -283,7 +283,7 @@ function getAllRequests(types, mode, requests, group, promises, blacklistGroup) 
 
             if (!alreadyInRequests(item)) {
                     //this provides closure for the for loop inside the promise chain
-                var promise = when(item.load()).then( ( generateReguest ) (item, group, blacklistGroup) );
+                var promise = when(item.load()).then( ( generateRequest ) (item, group, blacklistGroup) );
 
                 promises.push(promise);
             }

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -36,6 +36,7 @@ var ToolsPanelViewModel = function(options) {
     this.useWmsTileCache = true;
     this.useProxyCache = false;
     this.purgeProxyCache = false;
+    this.moreImageryInfo = false;
 
     this.ckanFilter = 'opened';
     this.ckanUrl = 'http://localhost';
@@ -43,7 +44,7 @@ var ToolsPanelViewModel = function(options) {
 
     this.absFilter = 'opened';
 
-    knockout.track(this, ['cacheFilter', 'minZoomLevel', 'maxZoomLevel', 'useWmsTileCache', 'useProxyCache', 'purgeProxyCache', 'ckanFilter', 'ckanUrl', 'ckanApiKey', 'absFilter']);
+    knockout.track(this, ['cacheFilter', 'minZoomLevel', 'maxZoomLevel', 'useWmsTileCache', 'moreImageryInfo', 'useProxyCache', 'purgeProxyCache', 'ckanFilter', 'ckanUrl', 'ckanApiKey', 'absFilter']);
 };
 
 ToolsPanelViewModel.prototype.show = function(container) {
@@ -519,6 +520,14 @@ function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
               'Max: ' + Math.round(last.stat.success.max) + 'ms</span>)';
             popup.message += '</div>';
 
+            if (toolsPanel.moreImageryInfo) {
+                var uri = new URI(last.url);
+                var params = uri.search(true);
+                uri.search('');
+                popup.message += '<div>Server=' + uri.toString() + '</div>';
+                popup.message += '<div>Layers=' + params.layers + '</div>';
+            }
+ 
             failedRequests += last.stat.error.number;
 
             if (average > maxAverage || last.stat.success.max > maxMaximum) {

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -283,7 +283,7 @@ function getAllRequests(types, mode, requests, group, promises, blacklistGroup) 
 
             if (!alreadyInRequests(item)) {
                     //this provides closure for the for loop inside the promise chain
-                var promise = when(item._load()).then( ( generateReguest ) (item, group, blacklistGroup) );
+                var promise = when(item.load()).then( ( generateReguest ) (item, group, blacklistGroup) );
 
                 promises.push(promise);
             }

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -69,7 +69,7 @@ ToolsPanelViewModel.prototype.closeIfClickOnBackground = function(viewModel, e) 
 ToolsPanelViewModel.prototype.cacheTiles = function() {
     var requests = [];
     var promises = [];
-    getAllRequests(['wms', 'esri-mapServer'], this.cacheFilter, requests,  this.terria.catalog.group, promises);
+    getAllRequests(['wms', 'esri-mapServer'], this.cacheFilter, requests, this.terria.catalog.group, promises);
 
     var that = this;
     when.all(promises, function() {
@@ -257,25 +257,31 @@ function getAllRequests(types, mode, requests, group, promises, blacklistGroup) 
             }
         } else if ((types.indexOf(item.type) !== -1) && (mode !== 'enabled' || item.isEnabled)) {
 
-
             if (!alreadyInRequests(item)) {
-                var enabledHere = false;
-                if (!item.isEnabled) {
-                    enabledHere = true;
-                    item._enable();
-                }
-                var imageryProvider;
-                if (defined(item._imageryLayer)) {
-                    imageryProvider = item._imageryLayer.imageryProvider;
-                    promises.push(whenImageryProviderIsReady(imageryProvider));
-                }
-                requests.push({
-                    item : item,
-                    blacklistGroup : blacklistGroup,
-                    group : group.name,
-                    enabledHere : enabledHere,
-                    provider : imageryProvider
-                });
+                    //this provides closure for the for loop inside the promise chain
+                var promise = when(item._load()).then( (function(item, group, blacklistGroup) {
+                    return function() {
+                        var enabledHere = false;
+                        if (!item.isEnabled) {
+                            enabledHere = true;
+                            item._enable();
+                        }
+                        var imageryProvider;
+                        if (defined(item._imageryLayer)) {
+                            imageryProvider = item._imageryLayer.imageryProvider;
+                        }
+                        requests.push({
+                            item : item,
+                            blacklistGroup : blacklistGroup,
+                            group : group.name,
+                            enabledHere : enabledHere,
+                            provider : imageryProvider
+                        });
+                        return whenImageryProviderIsReady(imageryProvider);
+                    }
+                }) (item, group, blacklistGroup) );
+
+                promises.push(promise);
             }
         }
     }
@@ -283,7 +289,7 @@ function getAllRequests(types, mode, requests, group, promises, blacklistGroup) 
 
 function whenImageryProviderIsReady(imageryProvider) {
     return pollToPromise(function() {
-        return imageryProvider.ready;
+        return defined(imageryProvider) ? imageryProvider.ready : undefined;
     }, { timeout: 60000, pollInterval: 100 }).otherwise(function() {
     });
 }

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -246,6 +246,29 @@ function getAllRequests(types, mode, requests, group, promises, blacklistGroup) 
         }
         return false;
     }
+    function generateReguest(item, group, blacklistGroup) {
+        return function() {
+            var enabledHere = false;
+            if (!item.isEnabled) {
+                enabledHere = true;
+                item._enable();
+            }
+            var imageryProvider;
+            if (defined(item._imageryLayer)) {
+                imageryProvider = item._imageryLayer.imageryProvider;
+            }
+            requests.push({
+                item : item,
+                blacklistGroup : blacklistGroup,
+                group : group.name,
+                enabledHere : enabledHere,
+                provider : imageryProvider
+            });
+            return whenImageryProviderIsReady(imageryProvider);
+        };
+    }
+
+
     for (var i = 0; i < group.items.length; ++i) {
         var item = group.items[i];
         if (item instanceof CatalogGroup) {
@@ -260,27 +283,7 @@ function getAllRequests(types, mode, requests, group, promises, blacklistGroup) 
 
             if (!alreadyInRequests(item)) {
                     //this provides closure for the for loop inside the promise chain
-                var promise = when(item._load()).then( (function(item, group, blacklistGroup) {
-                    return function() {
-                        var enabledHere = false;
-                        if (!item.isEnabled) {
-                            enabledHere = true;
-                            item._enable();
-                        }
-                        var imageryProvider;
-                        if (defined(item._imageryLayer)) {
-                            imageryProvider = item._imageryLayer.imageryProvider;
-                        }
-                        requests.push({
-                            item : item,
-                            blacklistGroup : blacklistGroup,
-                            group : group.name,
-                            enabledHere : enabledHere,
-                            provider : imageryProvider
-                        });
-                        return whenImageryProviderIsReady(imageryProvider);
-                    }
-                }) (item, group, blacklistGroup) );
+                var promise = when(item._load()).then( ( generateReguest ) (item, group, blacklistGroup) );
 
                 promises.push(promise);
             }

--- a/lib/Views/ToolsPanel.html
+++ b/lib/Views/ToolsPanel.html
@@ -31,6 +31,12 @@
                         Use WMS tile cache
                     </label>
                     <label class="tools-content-type">
+                        <input type="checkbox" data-bind="checked: moreImageryInfo" />
+                        Show more imagery layer info
+                    </label>
+                </div>
+                <div>
+                    <label class="tools-content-type">
                         <input type="checkbox" data-bind="checked: useProxyCache" />
                         Use proxy cache
                     </label>


### PR DESCRIPTION
Updated the request loader to wait for the dataset to load before enabling.
- note: this can make the caching take longer to start since it has to query layers info from all the arcgis servers

Also added 'more info' option in data testing to return server and layers for a request.
