### PR TITLE
Avoid breaking change in Google Analytics refactoring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,13 +3,13 @@ Change Log
 
 ### 1.0.37
 
-* Breaking changes:
-  * TerriaJS no longer automatically logs events to Google Analytics.  With no changes to client applications, events will now be logged to the console instead.  To use Google Analytics, create an instance of `GoogleAnalytics` and pass it as the `analytics` parameter to the `Terria` constructor.  The Google Analytics key may be given as a `GoogleAnalytics` constructor parameter, or specified as the `parameters.googleAnalyticsKey` property in `config.json`.
 * Added `CswCatalogGroup` for populating a catalog by querying an OGC CSW service.
 * Added `CatalogMember.infoSectionOrder` property, to allow the order of info sections to be configured per catalog item when necessary.
 * Fixed a bug that prevented WMTS layers with a single `TileMatrixSetLink` from working correctly.
 * Added support for WMTS layers that can only provide tiles in JPEG format.
 * Fixed testing and caching of ArcGis layers from tools and added More information option for imagery layers.
+* TerriaJS no longer requires Google Analytics.  If a global `ga` function exists, it is used just as before.  Otherwise, events are, by default, logged to the console.
+* The default event analytics behavior can be specified by passing an instance of `ConsoleAnalytics` or `GoogleAnalytics` to the `Terria` constructor.  The API key to use with `GoogleAnalytics` can be specified explicitly to its constructor, or it can be specified in the `parameter.googleAnalyticsKey` property in `config.json`.
 
 ### 1.0.36
 

--- a/lib/Core/ConsoleAnalytics.js
+++ b/lib/Core/ConsoleAnalytics.js
@@ -4,7 +4,7 @@
 var defined = require('terriajs-cesium/Source/Core/defined');
 
 var ConsoleAnalytics = function() {
-    this.logToConsole = true;
+    this.logToConsole = false;
 };
 
 ConsoleAnalytics.prototype.start = function(userParameters) {

--- a/lib/Core/ConsoleAnalytics.js
+++ b/lib/Core/ConsoleAnalytics.js
@@ -3,17 +3,17 @@
 /*global require*/
 var defined = require('terriajs-cesium/Source/Core/defined');
 
-var Analytics = function() {
+var ConsoleAnalytics = function() {
     this.logToConsole = true;
 };
 
-Analytics.prototype.start = function(userParameters) {
+ConsoleAnalytics.prototype.start = function(userParameters) {
     if (defined(userParameters.logToConsole)) {
         this.logToConsole = userParameters.logAnalyticsToConsole;
     }
 };
 
-Analytics.prototype.logEvent = function(category, action, label, value) {
+ConsoleAnalytics.prototype.logEvent = function(category, action, label, value) {
     if (this.logToConsole) {
         var labelString = defined(label) ? ' Label: ' + label : '';
         var valueString = defined(value) ? ' Value: ' + value : '';
@@ -21,4 +21,4 @@ Analytics.prototype.logEvent = function(category, action, label, value) {
     }
 };
 
-module.exports = Analytics;
+module.exports = ConsoleAnalytics;

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -22,6 +22,7 @@ var Analytics = require('../Core/Analytics');
 var CameraView = require('./CameraView');
 var Catalog = require('./Catalog');
 var corsProxy = require('../Core/corsProxy');
+var GoogleAnalytics = require('../Core/GoogleAnalytics');
 var NowViewing = require('./NowViewing');
 var Services = require('./Services');
 var ViewerMode = require('./ViewerMode');
@@ -62,11 +63,19 @@ var Terria = function(options) {
     }
     buildModuleUrl.setBaseUrl(cesiumBaseUrl);
 
+    /**
+     * Gets or sets the instance to which to report Google Analytics-style log events.
+     * If a global `ga` function is defined, this defaults to `GoogleAnalytics`.  Otherwise, it defaults
+     * to `Analytics`.
+     * @type {Analytics}
+     */
     this.analytics = options.analytics;
     if (!defined(this.analytics)) {
-        this.analytics = new Analytics({
-            logToConsole: true
-        });
+        if (typeof window !== 'undefined' && defined(window.ga)) {
+            this.analytics = new GoogleAnalytics();
+        } else {
+            this.analytics = new Analytics();
+        }
     }
 
     /**

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -18,9 +18,9 @@ var queryToObject = require('terriajs-cesium/Source/Core/queryToObject');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 
-var Analytics = require('../Core/Analytics');
 var CameraView = require('./CameraView');
 var Catalog = require('./Catalog');
+var ConsoleAnalytics = require('../Core/ConsoleAnalytics');
 var corsProxy = require('../Core/corsProxy');
 var GoogleAnalytics = require('../Core/GoogleAnalytics');
 var NowViewing = require('./NowViewing');
@@ -74,7 +74,7 @@ var Terria = function(options) {
         if (typeof window !== 'undefined' && defined(window.ga)) {
             this.analytics = new GoogleAnalytics();
         } else {
-            this.analytics = new Analytics();
+            this.analytics = new ConsoleAnalytics();
         }
     }
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -66,8 +66,8 @@ var Terria = function(options) {
     /**
      * Gets or sets the instance to which to report Google Analytics-style log events.
      * If a global `ga` function is defined, this defaults to `GoogleAnalytics`.  Otherwise, it defaults
-     * to `Analytics`.
-     * @type {Analytics}
+     * to `ConsoleAnalytics`.
+     * @type {ConsoleAnalytics|GoogleAnalytics}
      */
     this.analytics = options.analytics;
     if (!defined(this.analytics)) {


### PR DESCRIPTION
If the `ga` function is defined in `index.html` (as it is in current versions of TerriaJS apps), an instance of `GoogleAnalytics` is created and used, so the app will work just as it did before.

Apps without a global `ga` function will get the console event logger, unless they explicitly pass something else as the `analytics` parameter to `Terria`.
