### PR TITLE
Fix two bugs in AbsIttCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.0.39
+
+* Fixed a race condition in `AbsIttCatalogItem` that could cause the legend and map to show different state than the Now Viewing UI suggested.
+* Fixed a bug where an ABS concept with a comma in its name (e.g. "South Eastern Europe,nfd(c)" in Country of Birth) would cause values for concept that follow to be misappropriated to the wrong concepts.
+
 ### 1.0.38
 
 * `AbsIttCatalogItem` now allows the region type to be set on demand rather than only at load time.

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -748,7 +748,7 @@ function updateAbsDataCsvText(absItem, serializeCalls) {
             var idx = getFilterDataIndex(currentFilterList[f].filter);
             if (idx !== -1) {
                 var colName = absItem._filterColumnMap[idx].colName;
-                finalCsvArray[0].push(currentFilterList[f].name);
+                finalCsvArray[0].push(csvEscape(currentFilterList[f].name));
                 cols.push(csvArray[0].indexOf(colName));
             }
         }
@@ -780,5 +780,21 @@ function updateAbsDataCsvText(absItem, serializeCalls) {
     });
 }
 
+function csvEscape(value) {
+    // Based on logic in http://tools.ietf.org/html/rfc4180, section 2
+    if (typeof value !== 'string' && !(value instanceof String)) {
+        // We only need to escape strings.
+        return value;
+    }
+
+    if (value.indexOf(',') < 0 && value.indexOf('"') < 0 && value.indexOf('\n') < 0 && value.indexOf('\r') < 0) {
+        // Value does not need to be escaped.
+        return value;
+    }
+
+    // Replace double quotes with double double quotes.
+    var escapedValue = value.replace('"', '""');
+    return '"' + escapedValue + '"';
+}
 
 module.exports = AbsIttCatalogItem;

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -32,7 +32,7 @@ var AbsCode = require('./AbsCode');
  * @alias AbsIttCatalogItem
  * @constructor
  * @extends CatalogItem
- * 
+ *
  * @param {Terria} terria The Terria instance.
  */
 var AbsIttCatalogItem = function(terria) {
@@ -47,6 +47,7 @@ var AbsIttCatalogItem = function(terria) {
 
     this._filterColumnMap = [];
 
+    this._updateResultsPromise = undefined;
 
     /**
      * Gets or sets the URL of the ABS ITT API, typically http://stat.abs.gov.au/itt/query.jsp.
@@ -64,7 +65,7 @@ var AbsIttCatalogItem = function(terria) {
     this.dataSetID = undefined;
 
     /**
-     * Gets or sets the ABS region type concept used with the region code to set the region type.  
+     * Gets or sets the ABS region type concept used with the region code to set the region type.
      * This property is observable.
      * @type {String}
      */
@@ -284,7 +285,7 @@ AbsIttCatalogItem.prototype._load = function() {
             that._filterColumnMap = json.filterColumnMap;
         }));
         this.regionConcept = this.regionConcept || 'region_id';
-    } 
+    }
     else {
         var baseUrl = cleanAndProxyUrl(this.terria, this.url);
         var parameters = {
@@ -304,7 +305,7 @@ AbsIttCatalogItem.prototype._load = function() {
     loadPromises.push(loadJson('data/abs_names.json').then(function(json) {
         conceptNameMap = json;
     }));
-    
+
     function updateConceptName(concept) {
         if (!defined(conceptNameMap[concept.name])) {
             return;
@@ -422,8 +423,8 @@ AbsIttCatalogItem.prototype._load = function() {
         return when.all(promises).then( function(results) {
             // put region type first and then sort after that
             var makeFirst = that.regionTypeConcept;
-            that.absDataset.items.sort(function(a, b){ 
-                return (a.code === makeFirst) ? -1 : ((b.code === makeFirst) ? 1 : (a.name > b.name ? 1 : -1)); 
+            that.absDataset.items.sort(function(a, b){
+                return (a.code === makeFirst) ? -1 : ((b.code === makeFirst) ? 1 : (a.name > b.name ? 1 : -1));
             });
 
             return when(updateAbsResults(that)).then(function() {
@@ -524,12 +525,26 @@ function updateAbsResults(absItem) {
         return;
     }
 
-    return when(updateAbsDataCsvText(absItem)).then(function() {
-        return when(absItem._csvCatalogItem.dynamicUpdate(absItem._absDataText)).then(function() {
-            absItem.legendUrl = absItem._absDataText === '' ? '' : absItem._csvCatalogItem.legendUrl;
-            absItem.terria.currentViewer.notifyRepaintRequired();
+    function doUpdate() {
+        var me = when(updateAbsDataCsvText(absItem)).then(function() {
+            return when(absItem._csvCatalogItem.dynamicUpdate(absItem._absDataText)).then(function() {
+                absItem.legendUrl = absItem._absDataText === '' ? '' : absItem._csvCatalogItem.legendUrl;
+                absItem.terria.currentViewer.notifyRepaintRequired();
+                if (me === absItem._updateResultsPromise) {
+                    absItem._updateResultsPromise = undefined;
+                }
+            });
         });
-    });
+        return me;
+    }
+
+    if (defined(absItem._updateResultsPromise)) {
+        absItem._updateResultsPromise = absItem._updateResultsPromise.then(doUpdate);
+    } else {
+        absItem._updateResultsPromise = doUpdate();
+    }
+
+    return absItem._updateResultsPromise;
 }
 
 


### PR DESCRIPTION
- Fixed a race condition in `AbsIttCatalogItem` that could cause the legend and map to show different state than the Now Viewing UI suggested.
- Fixed a bug where an ABS concept with a comma in its name (e.g. "South Eastern Europe,nfd(c)" in Country of Birth) would cause values for concept that follow to be misappropriated to the wrong concepts.

To see the bug in the second bullet, enable Country of Birth, then enable "South Eastern Europe,nfd(c)" and another after it in the list (e.g. Greece).  Then click on a region and you'll see something like this;

![image](https://cloud.githubusercontent.com/assets/924374/8999797/ac640eae-3782-11e5-87ce-fe040fa38229.png)

Note that TerriaJS has treated "South Eastern Europe,nfd(c)" as two separate columns and so all of the values that follow are misaligned and there's an "undefined" at the end.

Fixes NICTA/nationalmap#101
