### PR TITLE
Show "NoData" tiles by default.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.40
+
+* `ArcGisMapServerCatalogItem` now shows "NoData" tiles by default even after showing the popup message saying that max zoom is exceeded.  This can be disabled by setting its `showTilesAfterMessage` property to false.
+
 ### 1.0.39
 
 * Fixed a race condition in `AbsIttCatalogItem` that could cause the legend and map to show different state than the Now Viewing UI suggested.

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -71,7 +71,15 @@ var ArcGisMapServerCatalogItem = function(terria) {
      */
     this.maximumScaleBeforeMessage = undefined;
 
-    knockout.track(this, ['url', 'layers', 'maximumScale', '_legendUrl', 'maximumScaleBeforeMessage']);
+    /**
+     * Gets or sets a value indicating whether to continue showing tiles when the {@link ArcGisMapServerCatalogItem#maximumScaleBeforeMessage}
+     * is exceeded.  This property is observable.
+     * @type {Boolean}
+     * @default true
+     */
+    this.showTilesAfterMessage = true;
+
+    knockout.track(this, ['url', 'layers', 'maximumScale', '_legendUrl', 'maximumScaleBeforeMessage', 'showTilesAfterMessage']);
 
     // metadataUrl and legendUrl are derived from url if not explicitly specified.
     overrideProperty(this, 'metadataUrl', {
@@ -154,7 +162,7 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
             serviceUrl = cleanAndProxyUrl(terria, this.url) + '?f=json';
             layersUrl = cleanAndProxyUrl(terria, this.url) + '/layers?f=json';
         }
- 
+
         var serviceMetadata = this.mapServerData || loadJson(serviceUrl);
         var layersMetadata = this.mapServerLayersData || loadJson(layersUrl);
 
@@ -195,12 +203,15 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
                     that.terria.error.raiseEvent(new ModelError({
                         title: 'Dataset will not be shown at this scale',
                         message: '\
-The "' + that.name + '" dataset will not be shown when zoomed in this close to the map because the data custodian has deemed it to be too inaccurate \
-to show at this scale.  Click the dataset\'s Info button on the Now Viewing tab for more information about the dataset and the data custodian.'
+The "' + that.name + '" dataset will not be shown when zoomed in this close to the map because the data custodian has indicated that the data is not intended or suitable \
+for display at this scale.  Click the dataset\'s Info button on the Now Viewing tab for more information about the dataset and the data custodian.'
                     }));
                     messageDisplayed = true;
                 }
-                return ImageryProvider.loadImage(imageryProvider, that.terria.baseUrl + 'images/blank.png');
+
+                if (!that.showTilesAfterMessage) {
+                    return ImageryProvider.loadImage(imageryProvider, that.terria.baseUrl + 'images/blank.png');
+                }
             }
             return realRequestImage.call(imageryProvider, x, y, level);
         };


### PR DESCRIPTION
`ArcGisMapServerCatalogItem` now shows "NoData" tiles by default even after showing the popup message saying that max zoom is exceeded.  This can be disabled by setting its `showTilesAfterMessage` property to false.

Also tweaked the wording of the modal popup.

So the default behavior is to show a modal popup saying: "The [data set name] dataset will not be shown when zoomed in this close to the map because the data custodian has indicated that the data is not intended or suitable for display at this scale.  Click the dataset's Info button on the Now Viewing tab for more information about the dataset and the data custodian."

And also show whatever tile image the server returns for the tile, which may be a blank tile with a message like "This service does not contain data at this zoom level" written across it, or it may be an entirely blank tile.
