### PR TITLE
abs fix for b35 and b33

### DIFF
--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -761,6 +761,7 @@ function updateAbsDataCsvText(absItem) {
         // A hack to deal with ABS returning an exception on some filters
         if (!defined(csvArray)) {
             csvArray = absItem._absTotalTable;
+            csvArray[0][0] = absItem.regionConcept;
         }
         if (!defined(csvArray) || csvArray.length === 0) {
             return;


### PR DESCRIPTION
These two default to a filter with no data, so this provides a placeholder until the user selects the filter.
