### PR TITLE
Expand tab for layers added via URL hash

### DIFF
--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -133,6 +133,9 @@ Catalog.prototype.updateFromJson = function(json, options) {
             existingGroup = createCatalogMemberFromType(group.type,  this.terria);
 
             this.group.add(existingGroup);
+        } else {
+            // updating an existing group - expand to show context of the update
+            existingGroup.isOpen = true;
         }
 
         promises.push(existingGroup.updateFromJson(group, options));

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -202,6 +202,8 @@ CatalogGroup.defaultUpdaters.items = function(catalogGroup, json, propertyName, 
 
                 existingItem = createCatalogMemberFromType(item.type, catalogGroup.terria);
                 catalogGroup.add(existingItem);
+            } else {
+                existingItem.isOpen = true;
             }
 
             promises.push(existingItem.updateFromJson(item, options));


### PR DESCRIPTION
When users share a map (via the 'share' button), the resulting map
should have any pre-selected layers expanded in the Catalog
control. This will provide context to the user indicating which layers
are already activated.

Resolves: https://github.com/TerriaJS/terriajs/issues/902
