### PR TITLE
Fix typo preventing open state of groups from being serialized.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.43
+
+* Fixed a bug that prevent the opened/closed state of groups from being preserved when sharing.
+
 ### 1.0.42
 
 * Added a `cacheDuration` property to all catalog items.  The new property is used to specify, using Varnish-like notation (e.g. '1d', '10000s') the default length of time to cache URLs related to the catalog item.

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -246,7 +246,7 @@ freezeObject(CatalogGroup.defaultSerializers);
  */
 CatalogGroup.defaultPropertiesForSharing = clone(CatalogMember.defaultPropertiesForSharing);
 CatalogGroup.defaultPropertiesForSharing.push('items');
-CatalogGroup.defaultPropertiesForSharing.push('isOpened');
+CatalogGroup.defaultPropertiesForSharing.push('isOpen');
 
 freezeObject(CatalogGroup.defaultPropertiesForSharing);
 


### PR DESCRIPTION
As a result, the opened/closed state of groups was not being preserved.

Fixes #909 
