### PR TITLE
Prevent timeseries data from skipping after Cesium has been in paused…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.0.44
+
+* Fixed a bug that could cause timeseries animation to "jump" when resuming play after it was paused.
+
 ### 1.0.43
 
 * Fixed a bug that prevent the opened/closed state of groups from being preserved when sharing.

--- a/lib/ViewModels/AnimationViewModel.js
+++ b/lib/ViewModels/AnimationViewModel.js
@@ -59,6 +59,7 @@ var AnimationViewModel = function(options) {
         that.showAnimation = (showTimeline > 0);
         //default to playing and looping when shown unless told otherwise
         if (that.showAnimation && that.autoPlay) {
+            that.terria.clock.tick();
             that.terria.clock.shouldAnimate = true;
         }
         that.terria.clock.clockRange = ClockRange.LOOP_STOP;
@@ -174,6 +175,7 @@ AnimationViewModel.prototype.gotoStart = function() {
 AnimationViewModel.prototype.togglePlay = function() {
     this.terria.analytics.logEvent('navigation', 'click', 'togglePlay');
 
+    this.terria.clock.tick();
     if (this.terria.clock.multiplier < 0) {
         this.terria.clock.multiplier = -this.terria.clock.multiplier;
     }
@@ -186,6 +188,7 @@ AnimationViewModel.prototype.togglePlay = function() {
 AnimationViewModel.prototype.playSlower = function() {
     this.terria.analytics.logEvent('navigation', 'click', 'playSlower');
 
+    this.terria.clock.tick();
     this.terria.clock.multiplier /= 2;
     this.terria.clock.shouldAnimate = true;
     this.isPlaying = true;
@@ -196,6 +199,7 @@ AnimationViewModel.prototype.playSlower = function() {
 AnimationViewModel.prototype.playFaster = function() {
     this.terria.analytics.logEvent('navigation', 'click', 'playFaster');
 
+    this.terria.clock.tick();
     this.terria.clock.multiplier *= 2;
     this.terria.clock.shouldAnimate = true;
     this.isPlaying = true;


### PR DESCRIPTION
… state by always tick()'ing before resuming timeseries play.

Fixes TerriaJS/terriajs#917.
