### PR TITLE
Loading indicator

### DIFF
--- a/lib/Styles/DataCatalogTab.less
+++ b/lib/Styles/DataCatalogTab.less
@@ -158,7 +158,13 @@
 	stroke-dasharray: 80;
 	stroke-dashoffset: 0;
 	animation: border-loading 1.25s linear;
+	-moz-animation: border-loading 1.25s linear;
+	-webkit-animation: border-loading 1.25s linear;
+	-o-animation: border-loading 1.25s linear;
 	animation-iteration-count: infinite;
+	-moz-animation-iteration-count: infinite;
+	-webkit-animation-iteration-count: infinite;
+	-o-animation-iteration-count: infinite;
 }
 
 .data-catalog-item-checkbox.loading path {
@@ -171,7 +177,13 @@
 	stroke-dasharray: 80;
 	stroke-dashoffset: 0;
 	animation: border-fill 0.25s ease-out;
+	-moz-animation: border-fill 0.25s ease-out;
+	-webkit-animation: border-fill 0.25s ease-out;
+	-o-animation: border-fill 0.25s ease-out;
 	animation-iteration-count: 1;
+	-moz-animation-iteration-count: 1;
+	-webkit-animation-iteration-count: 1;
+	-o-animation-iteration-count: 1;
 }
 
 .data-catalog-item-checkbox.checked path {
@@ -181,7 +193,13 @@
 	fill-opacity: 1;
 	fill: @catalog-enabled-item-text-color;
 	animation: check-fill 0.8s ease-out;
+	-moz-animation: check-fill 0.8s ease-out;
+	-webkit-animation: check-fill 0.8s ease-out;
+	-o-animation: check-fill 0.8s ease-out;
 	animation-iteration-count: 1;
+	-moz-animation-iteration-count: 1;
+	-webkit-animation-iteration-count: 1;
+	-o-animation-iteration-count: 1;
 }
 
 @keyframes border-loading {

--- a/lib/Styles/DataCatalogTab.less
+++ b/lib/Styles/DataCatalogTab.less
@@ -116,18 +116,115 @@
   fill: @catalog-group-text-color;
 }
 
-.data-catalog-item-checkbox {
-  position: relative;
-  top: 2px;
-  width: 15px;
-  height: 15px;
-  fill: @catalog-item-text-color;
-}
-
 .data-catalog-icon-holder {
     display: table-cell;
     width: 20px;
 }
+
+.data-catalog-item-checkbox {
+	position: relative;
+	top: 2px;
+	width: 15px;
+	height: 15px;
+	fill: none;
+	stroke: @catalog-item-text-color;
+	stroke-opacity: 1;
+	stroke-width: 2;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+	stroke-miterlimit: 4;
+}
+.data-catalog-item-checkbox rect {
+	fill-opacity: 0;
+	stroke: @catalog-item-text-color;
+	stroke-opacity: 1;
+	stroke-width: 2;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+	stroke-miterlimit: 4;
+}
+.data-catalog-item-checkbox path {
+	fill-opacity: 0;
+	stroke: @catalog-item-text-color;
+	stroke-opacity: 0;
+	stroke-width: 2;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+	stroke-miterlimit: 4;
+}
+
+.data-catalog-item-checkbox.loading rect {
+	stroke: @catalog-enabled-item-text-color;
+	stroke-dasharray: 80;
+	stroke-dashoffset: 0;
+	animation: border-loading 1.25s linear;
+	animation-iteration-count: infinite;
+}
+
+.data-catalog-item-checkbox.loading path {
+	stroke-opacity: 0;
+	fill-opacity: 0;
+}
+
+.data-catalog-item-checkbox.checked rect {
+	stroke: @catalog-enabled-item-text-color;
+	stroke-dasharray: 80;
+	stroke-dashoffset: 0;
+	animation: border-fill 0.25s ease-out;
+	animation-iteration-count: 1;
+}
+
+.data-catalog-item-checkbox.checked path {
+	stroke: @catalog-top-group-background-color; // this should be bg color
+	stroke-dashoffset: 0;
+	stroke-dasharray: 100;
+	fill-opacity: 1;
+	fill: @catalog-enabled-item-text-color;
+	animation: check-fill 0.8s ease-out;
+	animation-iteration-count: 1;
+}
+
+@keyframes border-loading {
+	from {
+		stroke-dasharray: 10, 70;
+	    stroke-dashoffset: 0;
+	}
+	to {
+		stroke-dasharray: 10, 70;
+	    stroke-dashoffset: 80;
+	}
+}
+
+@keyframes border-fill {
+	from {
+	    stroke-dashoffset: -40;
+	    stroke-dasharray: 10, 70;
+	}
+	to {
+	    stroke-dashoffset: 0;
+	    stroke-dasharray: 80,10;
+	}
+}
+
+@keyframes check-fill {
+	0% {
+	    fill: hsla(193, 85%, 35%, 0);
+	    stroke: hsla(193, 85%, 90%, 1);
+	    stroke-dashoffset: 100;
+	    stroke-dasharray: 100;
+	}
+	40% {
+	    fill: hsla(193, 85%, 35%, 0);
+	    stroke: hsla(193, 85%, 90%, 1);
+	    stroke-dashoffset: 0;
+	    stroke-dasharray: 100;
+	}
+	100% {
+	    fill: hsla(193, 85%, 35%, 1);
+	    stroke: hsla(212, 12%, 21%, 1);
+	}
+}
+
 
 .data-catalog-control {
     display: table-cell;

--- a/lib/ViewModels/DataCatalogTabViewModel.js
+++ b/lib/ViewModels/DataCatalogTabViewModel.js
@@ -64,6 +64,15 @@ DataCatalogTabViewModel.prototype.clickOpen = function(item) {
     }
 };
 
+DataCatalogTabViewModel.prototype.getCheckboxClass = function(item) {
+	if (defined(item.isLoading) && item.isLoading) {
+		return 'data-catalog-item-checkbox loading';
+	} else if (defined(item.isEnabled) && item.isEnabled) {
+		return 'data-catalog-item-checkbox checked';
+	}
+	return 'data-catalog-item-checkbox unchecked';
+};
+
 DataCatalogTabViewModel.prototype.getRightSideItemControls = function(item) {
     return CatalogItemControl.rightSideItemControls(item);
 };

--- a/lib/ViewModels/SearchTabViewModel.js
+++ b/lib/ViewModels/SearchTabViewModel.js
@@ -8,6 +8,7 @@ var CatalogItemInfoViewModel = require('./CatalogItemInfoViewModel');
 var ExplorerTabViewModel = require('./ExplorerTabViewModel');
 var inherit = require('../Core/inherit');
 var loadView = require('../Core/loadView');
+var defined = require('terriajs-cesium/Source/Core/defined');
 
 var svgArrowDown = require('../SvgPaths/svgArrowDown');
 var svgArrowRight = require('../SvgPaths/svgArrowRight');
@@ -69,6 +70,16 @@ SearchTabViewModel.prototype.search = function() {
 SearchTabViewModel.prototype.activateFirstResult = function() {
     // When we have keyboard navigation for search results, this will move focus to the first result.
 };
+
+SearchTabViewModel.prototype.getCheckboxClass = function(item) {
+	if (defined(item.isLoading) && item.isLoading) {
+		return 'data-catalog-item-checkbox loading';
+	} else if (defined(item.isEnabled) && item.isEnabled) {
+		return 'data-catalog-item-checkbox checked';
+	}
+	return 'data-catalog-item-checkbox unchecked';
+};
+
 
 SearchTabViewModel.prototype.showInfo = function(item) {
     item.terria.analytics.logEvent('dataSource', 'info', item.name);

--- a/lib/Views/DataCatalogTab.html
+++ b/lib/Views/DataCatalogTab.html
@@ -4,7 +4,10 @@
             <div class="data-catalog-member-top-row">
                 <!-- ko if: isMappable -->
                 <div class="data-catalog-icon-holder clickable" data-bind="click: $root.clickEnabled">
-                    <div class="data-catalog-item-checkbox" data-bind="cesiumSvgPath: { path: isEnabled ? $root.svgCheckboxChecked : $root.svgCheckboxUnchecked, width: 32, height: 32 }, css: { 'data-catalog-enabled-item': isEnabled }"></div>
+				  <svg class="data-catalog-item-checkbox" data-bind="attr: { class: isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+					<rect y="6" x="6" height="20" width="20"></rect>
+					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
+				  </svg>
                 </div>
                 <!-- /ko -->
                 <!-- ko foreach: $root.getLeftSideItemControls($data) -->

--- a/lib/Views/DataCatalogTab.html
+++ b/lib/Views/DataCatalogTab.html
@@ -4,7 +4,7 @@
             <div class="data-catalog-member-top-row">
                 <!-- ko if: isMappable -->
                 <div class="data-catalog-icon-holder clickable" data-bind="click: $root.clickEnabled.bind($root)">
-				  <svg xmlns="http://www.w3.org/2000/svg"  class="data-catalog-item-checkbox" data-bind="attr: { class: typeof isLoading !== 'undefined' && isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+				  <svg xmlns="http://www.w3.org/2000/svg"  class="data-catalog-item-checkbox" data-bind="attr: { class: $root.getCheckboxClass($data) }" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
 					<rect y="6" x="6" height="20" width="20"></rect>
 					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
 				  </svg>

--- a/lib/Views/DataCatalogTab.html
+++ b/lib/Views/DataCatalogTab.html
@@ -4,7 +4,7 @@
             <div class="data-catalog-member-top-row">
                 <!-- ko if: isMappable -->
                 <div class="data-catalog-icon-holder clickable" data-bind="click: $root.clickEnabled.bind($root)">
-				  <svg class="data-catalog-item-checkbox" data-bind="attr: { class: isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+				  <svg xmlns="http://www.w3.org/2000/svg"  class="data-catalog-item-checkbox" data-bind="attr: { class: isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
 					<rect y="6" x="6" height="20" width="20"></rect>
 					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
 				  </svg>

--- a/lib/Views/DataCatalogTab.html
+++ b/lib/Views/DataCatalogTab.html
@@ -4,7 +4,7 @@
             <div class="data-catalog-member-top-row">
                 <!-- ko if: isMappable -->
                 <div class="data-catalog-icon-holder clickable" data-bind="click: $root.clickEnabled.bind($root)">
-				  <svg xmlns="http://www.w3.org/2000/svg"  class="data-catalog-item-checkbox" data-bind="attr: { class: isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+				  <svg xmlns="http://www.w3.org/2000/svg"  class="data-catalog-item-checkbox" data-bind="attr: { class: typeof isLoading !== 'undefined' && isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
 					<rect y="6" x="6" height="20" width="20"></rect>
 					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
 				  </svg>

--- a/lib/Views/NowViewingTab.html
+++ b/lib/Views/NowViewingTab.html
@@ -13,7 +13,7 @@
             <!-- /ko -->
             <!-- ko if: isSelectable -->
                 <div class="data-catalog-icon-holder clickable" data-bind="click: toggleActive">
-				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: typeof isLoading !== 'undefined' && isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
 					<rect y="6" x="6" height="20" width="20"></rect>
 					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
 				  </svg:svg>

--- a/lib/Views/NowViewingTab.html
+++ b/lib/Views/NowViewingTab.html
@@ -13,7 +13,7 @@
             <!-- /ko -->
             <!-- ko if: isSelectable -->
                 <div class="data-catalog-icon-holder clickable" data-bind="click: toggleActive">
-				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: typeof isLoading !== 'undefined' && isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: isActive ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
 					<rect y="6" x="6" height="20" width="20"></rect>
 					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
 				  </svg:svg>

--- a/lib/Views/NowViewingTab.html
+++ b/lib/Views/NowViewingTab.html
@@ -13,7 +13,10 @@
             <!-- /ko -->
             <!-- ko if: isSelectable -->
                 <div class="data-catalog-icon-holder clickable" data-bind="click: toggleActive">
-                    <div class="data-catalog-item-checkbox" data-bind="cesiumSvgPath: { path: isActive ? $root.svgCheckboxChecked : $root.svgCheckboxUnchecked, width: 32, height: 32 }, css: { 'data-catalog-enabled-item': isActive }"></div>
+				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+					<rect y="6" x="6" height="20" width="20"></rect>
+					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
+				  </svg:svg>
                 </div>
             <!-- /ko -->
             <div class="data-catalog-item-label now-viewing-abs-tighten" data-bind="text: name, css: { 'data-catalog-enabled-item': isSelectable && isActive }"></div>

--- a/lib/Views/SearchTab.html
+++ b/lib/Views/SearchTab.html
@@ -3,7 +3,7 @@
         <div class="data-catalog-member" data-bind="css: 'data-catalog-indent' + ($parents.length - 2)">
             <div class="data-catalog-member-top-row">
                 <div class="data-catalog-icon-holder clickable" data-bind="click: toggleEnabled">
-				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: typeof isLoading !== 'undefined' && isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: $root.getCheckboxClass($data) }" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
 					<rect y="6" x="6" height="20" width="20"></rect>
 					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
 				  </svg>

--- a/lib/Views/SearchTab.html
+++ b/lib/Views/SearchTab.html
@@ -3,7 +3,7 @@
         <div class="data-catalog-member" data-bind="css: 'data-catalog-indent' + ($parents.length - 2)">
             <div class="data-catalog-member-top-row">
                 <div class="data-catalog-icon-holder clickable" data-bind="click: toggleEnabled">
-				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: typeof isLoading !== 'undefined' && isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
 					<rect y="6" x="6" height="20" width="20"></rect>
 					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
 				  </svg>

--- a/lib/Views/SearchTab.html
+++ b/lib/Views/SearchTab.html
@@ -3,7 +3,10 @@
         <div class="data-catalog-member" data-bind="css: 'data-catalog-indent' + ($parents.length - 2)">
             <div class="data-catalog-member-top-row">
                 <div class="data-catalog-icon-holder clickable" data-bind="click: toggleEnabled">
-                    <div class="data-catalog-item-checkbox" data-bind="cesiumSvgPath: { path: isEnabled ? $root.svgCheckboxChecked : $root.svgCheckboxUnchecked, width: 32, height: 32 }, css: { 'data-catalog-enabled-item': isEnabled }"></div>
+				  <svg xmlns="http://www.w3.org/2000/svg" class="data-catalog-item-checkbox" data-bind="attr: { class: isLoading ? 'data-catalog-item-checkbox loading' : isEnabled ? 'data-catalog-item-checkbox checked' : 'data-catalog-item-checkbox unchecked'}" viewBox="0 0 32 32" preserveAspectRatio="xMinYMin">
+					<rect y="6" x="6" height="20" width="20"></rect>
+					<path d="M30,3.1C29,2.1 27.3,2.4 26.5,3.5L16,16 12.5,11.6c-1,-1 -2.4,-1.2 -3.5,-0.4 -1,1 -1,2.4 -0.4,3.5l5.5,6.9c0.5,0.6 1.2,1 2,1 0.8,0 1.5,-0.3 2,-1L30,6.5c0.6,-1 1,-2 0,-3.4z"></path>
+				  </svg>
                 </div>
                 <div class="data-catalog-item-label data-catalog-enabled-item clickable" data-bind="visible: isEnabled, text: name, click: zoomToAndUseClock" title="Change the map view to show the full extent of this data item."></div>
                 <div class="data-catalog-item-label" data-bind="visible: !isEnabled, text: name"></div>


### PR DESCRIPTION
This commit uses css to animate the checkbox associated with data
catalog items. It provides three states - unchecked, loading and
loading. The checkbox itself is created with SVG.

The loading animation animates the dash-offset property to provide the
motion. The checked property uses an animation to draw the stroke path
and then fade in the fill. It's a less-effective animation at smaller
sizes and may (or may not) require tweaking.
