### PR TITLE
Created option for setting leaflet's maximum zoom level. Closes #939

### DIFF
--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -506,6 +506,10 @@ is invalid.  The catalogue item has been hidden from the map.  You may re-show i
             bounds : catalogItem.clipToRectangle && catalogItem.rectangle ? rectangleToLatLngBounds(catalogItem.rectangle) : undefined
         };
 
+        if (defined(catalogItem.terria.leaflet.map.options.maxZoom)) {
+            options.maxZoom = catalogItem.terria.leaflet.map.options.maxZoom;
+        }
+
         result = new CesiumTileLayer(imageryProvider, options);
 
         result.errorEvent.addEventListener(function(sender, message) {

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -63,11 +63,14 @@ BingMapsApi.defaultKey = undefined;
  * @param {String|TerrainProvider} [options.terrain] The terrain to use in the 3D view.  This may be a string, in which case it is loaded using
  *                                 `CesiumTerrainProvider`, or it may be a `TerrainProvider`.  If this property is undefined, STK World Terrain
  *                                 is used.
+ * @param {Integer} [options.maximumLeafletZoomLevel] The maximum level to which to allow Leaflet to zoom to.
+                    If this property is undefined, Leaflet defaults to level 18.
  */
 var TerriaViewer = function(terria, options) {
     options = defaultValue(options, {});
 
     this._developerAttribution = options.developerAttribution;
+    this.maximumLeafletZoomLevel = options.maximumLeafletZoomLevel;
 
     if ((terria.viewerMode === ViewerMode.CesiumTerrain || terria.viewerModel === ViewerMode.CesiumEllipsoid) && !supportsWebgl()) {
         PopupMessageViewModel.open('ui', {
@@ -490,7 +493,8 @@ TerriaViewer.prototype.selectViewer = function(bCesium) {
         map = L.map('cesiumContainer', {
             worldCopyJump: true,
             zoomControl: false,
-            attributionControl: false
+            attributionControl: false,
+            maxZoom: this.maximumLeafletZoomLevel
         }).setView([-28.5, 135], 5);
 
         map.attributionControl = L.control.attribution({


### PR DESCRIPTION
Added the option `maximumLeafletZoomLevel` to `TerriaViewer`. If left undefined, leaflet's behaviour is unchanged and the max zoom level remains at 18.

Happy to rework this if anyone has a better way.
