### PR TITLE
Fix bug in AbsIttCataloGroup.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Add `mode=preview` option in the hash portion of the URL.  When present, it is assumed that TerriaJS is being used as a previewer and the "small screen warning" will not be shown.
 * Added `maximumLeafletZoomLevel` constructor option to `TerriaViewer`, which can be used to force Leaflet to allow zooming closer than its default of level 18.
 * Added the `attribution` property to catalog items.  The attribution is displayed on the map when the catalog item is enabled.
+* Fixed a bug that prevented `AbsIttCatalogGroup` from successfully loading its list of catalog items.
 
 ### 1.0.43
 

--- a/lib/Models/AbsIttCatalogGroup.js
+++ b/lib/Models/AbsIttCatalogGroup.js
@@ -159,7 +159,7 @@ AbsIttCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
 };
 
 AbsIttCatalogGroup.prototype._load = function() {
-    var baseUrl = cleanAndProxyUrl(this.terria, this.url);
+    var baseUrl = cleanAndProxyUrl(this, this.url);
     var parameters = {
         method: 'GetDatasetList',
         format: 'json'
@@ -235,13 +235,13 @@ sending an email to <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.
     });
 };
 
-function cleanAndProxyUrl(terria, url) {
+function cleanAndProxyUrl(catalogGroup, url) {
     // Strip off the search portion of the URL
     var uri = new URI(url);
     uri.search('');
 
     var cleanedUrl = uri.toString();
-    return proxyCatalogItemUrl(cleanedUrl, '1d');
+    return proxyCatalogItemUrl(catalogGroup, cleanedUrl, '1d');
 }
 
 function createItemForDataset(absGroup, dataset) {


### PR DESCRIPTION
When fixing up the caching, I introduced this bug that prevents `AbsIttCatalogGroup` from working at all.  This meant that the `ABS Data Service` group within `Australian Bureau of Statistics (BETA)` didn't work in NationalMap.
