### PR TITLE
WIP Add a CatalogItem for Cesium buildings

### DIFF
--- a/00_Building_test.json
+++ b/00_Building_test.json
@@ -1,0 +1,37 @@
+{
+  "catalog": [
+    {
+      "items": [
+        {
+          "items": [
+            {
+              "nowViewingMessage": "Look here for the *legend* and to *interactively filter* the data.",
+              "name": "Buildings",
+              "description": "Layer description goes here",
+              "dataCustodian": "oslandia",
+              "rectangle": [
+                "112.93529999999998",
+                "-38.208809999082796",
+                "152.06206",
+                "-11.05104999964455"
+              ],
+              "type": "twfs",
+              "url": "http://ks29236.kimsufi.com/cgi-bin/tinyows",
+              "typeNames": "tows:lyongeom"
+            }
+          ],
+          "isOpen": true,
+          "type": "group",
+          "name": "Cesium buildings demo (Selected Datasets)"
+        }
+      ],
+      "initialMessage": {
+        "key": "AbsDataProviderWarning",
+        "content": "This is an experimental section ",
+        "title": "Data Provider Information"
+      },
+      "type": "group",
+      "name": "Buildings demo"
+    }
+  ]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,19 +28,19 @@ if (!fs.existsSync('wwwroot/build')) {
     fs.mkdirSync('wwwroot/build');
 }
 
-gulp.task('build-specs', ['prepare-cesium'], function() {
+gulp.task('build-specs', ['prepare-cesium', 'prepare-cesium-buildings'], function() {
     return build(specJSName, glob.sync(testGlob), false);
 });
 
 gulp.task('build', ['build-specs']);
 
-gulp.task('release-specs', ['prepare-cesium'], function() {
+gulp.task('release-specs', ['prepare-cesium', 'prepare-cesium-buildings'], function() {
     return build(specJSName, glob.sync(testGlob), true);
 });
 
 gulp.task('release', ['release-specs']);
 
-gulp.task('watch-specs', ['prepare-cesium'], function() {
+gulp.task('watch-specs', ['prepare-cesium', 'prepare-cesium-buildings'], function() {
     return watch(specJSName, glob.sync(testGlob), false);
 });
 
@@ -78,6 +78,24 @@ gulp.task('copy-cesium-assets', function() {
         ], { base: cesium })
         .pipe(gulp.dest('wwwroot/build/Cesium'));
 });
+
+gulp.task('prepare-cesium-buildings', ['copy-cesium-buildings-assets']);
+
+gulp.task('copy-cesium-buildings-assets', function() {
+    var cesium_buildings = resolve.sync('terriajs-cesium-buildings/wwwroot/build', {
+        basedir: __dirname,
+        extentions: ['.'],
+        isFile: function(file) {
+            try { return fs.statSync(file).isDirectory(); }
+            catch (e) { return false; }
+        }
+    });
+    return gulp.src([
+            cesium_buildings + '/createWfsGeometry.js'
+        ], { base: cesium_buildings })
+        .pipe(gulp.dest('wwwroot/build'));
+});
+
 
 gulp.task('default', ['lint', 'build']);
 

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -42,6 +42,7 @@ var CesiumTileLayer = L.TileLayer.extend({
         var oldLoad = ImageryProvider.loadImage;
 
         var tileUrl = this.options.errorTileUrl;
+        console.log('getTileUrl ', tileUrl);
         ImageryProvider.loadImage = function(imageryProvider, url) {
             tileUrl = url;
         };

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -457,6 +457,21 @@ function pickObject(cesium, e) {
         }
         if (id instanceof Entity) {
             result.features.push(id);
+        } else if (defined(id) 
+                && defined(picked[i].primitive) 
+                && defined(picked[i].primitive.properties)){
+            var props = picked[i].primitive.properties[id];
+            var entity = new Entity({
+                id: defined(props.name) ? props.name: "unnamed"
+            });
+            entity.name = entity.id;
+            entity.properties = props;
+            entity.description = {
+                getValue : function(time) {
+                    return defined(props.description) ? props.description : "no description";
+                }
+            };
+            result.features.push(entity);
         }
     }
 

--- a/lib/Models/TiledWebFeatureServiceCatalogItem.js
+++ b/lib/Models/TiledWebFeatureServiceCatalogItem.js
@@ -13,6 +13,9 @@ var sampleTerrain = require('terriajs-cesium/Source/Core/sampleTerrain');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var RectanglePrimitive = require('terriajs-cesium/Source/Scene/RectanglePrimitive');
+var QuadtreePrimitive = require('terriajs-cesium/Source/Scene/QuadtreePrimitive');
+
+var WfsTileProvider = require("cesium-buildings/lib/WfsTileProvider");
 
 var Metadata = require('./Metadata');
 var ModelError = require('./ModelError');
@@ -46,20 +49,21 @@ var TiledWebFeatureServiceCatalogItem =  function(terria, url) {
      * @type {String}
      */
     this.url = url;
-    console.log("TiledWebFeatureServiceCatalogItem dataUrl", this.dataUrl);
+    console.log("TiledWebFeatureServiceCatalogItem dataUrl", this.url);
 
 
-    //var tileProvider = new WfsTileProvider(
-    //                   'http://ks29236.kimsufi.com/cgi-bin/tinyows',
-    //                   'tows:lyongeom', 
-    //                   'http://ks29236.kimsufi.com/cesium-buildings-data',
-    //                   rectangle, 500, 3);
-    //this._quadTreePrimitive = new Cesium.QuadtreePrimitive({tileProvider : tileProvider});
-    this._quadTreePrimitive = new RectanglePrimitive({
-            rectangle : Rectangle.fromDegrees(120, -30.0, 150.0, -15.0)
-        });
+    this._tileProvider = new WfsTileProvider({
+                       url: 'http://37.187.164.233/cgi-bin/tinyows_australia',
+                       layerName: 'tows:goldcoast',
+                       zOffset: 30
+                       });
+    this._quadTreePrimitive = new QuadtreePrimitive({tileProvider : this._tileProvider});
+    //this._quadTreePrimitive = new RectanglePrimitive({
+    //        rectangle : Rectangle.fromDegrees(120, -30.0, 150.0, -15.0)
+    //    });
 
     knockout.track(this, ['url']);
+    console.log("TiledWebFeatureServiceCatalogItem dataUrl", this.url);
 };
 
 inherit(CatalogItem, TiledWebFeatureServiceCatalogItem);
@@ -110,12 +114,12 @@ TiledWebFeatureServiceCatalogItem.prototype._show = function() {
         throw new DeveloperError('This data source is not enabled.');
     }
 
-    var primitives = this.terria.cesium.scene.primitives;
-    if (primitives.contains(this._quadTreePrimitive)) {
-        throw new DeveloperError('This data source is already shown.');
+    var primitives = this._terria.cesium.scene.primitives;
+    if (!primitives.contains(this._quadTreePrimitive)) {
+        primitives.add(this._quadTreePrimitive);
     }
 
-    primitives.add(this._quadTreePrimitive, false);
+    this._tileProvider.show = true;
 };
 
 TiledWebFeatureServiceCatalogItem.prototype._hide = function() {
@@ -123,12 +127,7 @@ TiledWebFeatureServiceCatalogItem.prototype._hide = function() {
         throw new DeveloperError('This data source is not enabled.');
     }
 
-    var primitives =  this.terria.cesium.scene.primitives;
-    if (!primitives.contains(this._quadTreePrimitive)) {
-        throw new DeveloperError('This data source is not shown.');
-    }
-
-    primitives.remove(this._quadTreePrimitive, false);
+    this._tileProvider.show = false;
 };
 
 module.exports = TiledWebFeatureServiceCatalogItem;

--- a/lib/Models/TiledWebFeatureServiceCatalogItem.js
+++ b/lib/Models/TiledWebFeatureServiceCatalogItem.js
@@ -11,6 +11,8 @@ var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var PolygonHierarchy = require('terriajs-cesium/Source/Core/PolygonHierarchy');
 var sampleTerrain = require('terriajs-cesium/Source/Core/sampleTerrain');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
+var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
+var RectanglePrimitive = require('terriajs-cesium/Source/Scene/RectanglePrimitive');
 
 var Metadata = require('./Metadata');
 var ModelError = require('./ModelError');
@@ -47,12 +49,15 @@ var TiledWebFeatureServiceCatalogItem =  function(terria, url) {
     console.log("TiledWebFeatureServiceCatalogItem dataUrl", this.dataUrl);
 
 
-    var tileProvider = new WfsTileProvider(
-                       'http://ks29236.kimsufi.com/cgi-bin/tinyows',
-                       'tows:lyongeom', 
-                       'http://ks29236.kimsufi.com/cesium-buildings-data',
-                       rectangle, 500, 3);
-    this._quadTreePrimitive = new Cesium.QuadtreePrimitive({tileProvider : tileProvider});
+    //var tileProvider = new WfsTileProvider(
+    //                   'http://ks29236.kimsufi.com/cgi-bin/tinyows',
+    //                   'tows:lyongeom', 
+    //                   'http://ks29236.kimsufi.com/cesium-buildings-data',
+    //                   rectangle, 500, 3);
+    //this._quadTreePrimitive = new Cesium.QuadtreePrimitive({tileProvider : tileProvider});
+    this._quadTreePrimitive = new RectanglePrimitive({
+            rectangle : Rectangle.fromDegrees(120, -30.0, 150.0, -15.0)
+        });
 
     knockout.track(this, ['url']);
 };
@@ -105,7 +110,7 @@ TiledWebFeatureServiceCatalogItem.prototype._show = function() {
         throw new DeveloperError('This data source is not enabled.');
     }
 
-    var primitives =  this.terria.cesium.primitives;
+    var primitives = this.terria.cesium.scene.primitives;
     if (primitives.contains(this._quadTreePrimitive)) {
         throw new DeveloperError('This data source is already shown.');
     }
@@ -118,7 +123,7 @@ TiledWebFeatureServiceCatalogItem.prototype._hide = function() {
         throw new DeveloperError('This data source is not enabled.');
     }
 
-    var primitives =  this.terria.cesium.primitives;
+    var primitives =  this.terria.cesium.scene.primitives;
     if (!primitives.contains(this._quadTreePrimitive)) {
         throw new DeveloperError('This data source is not shown.');
     }

--- a/lib/Models/TiledWebFeatureServiceCatalogItem.js
+++ b/lib/Models/TiledWebFeatureServiceCatalogItem.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/*global require,Document*/
+
+var defined = require('terriajs-cesium/Source/Core/defined');
+var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
+var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
+var KmlDataSource = require('terriajs-cesium/Source/DataSources/KmlDataSource');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var PolygonHierarchy = require('terriajs-cesium/Source/Core/PolygonHierarchy');
+var sampleTerrain = require('terriajs-cesium/Source/Core/sampleTerrain');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
+
+var Metadata = require('./Metadata');
+var ModelError = require('./ModelError');
+var CatalogItem = require('./CatalogItem');
+var inherit = require('../Core/inherit');
+var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
+var readXml = require('../Core/readXml');
+
+/**
+ * A {@link CatalogItem} representing WFS feature data that will be tiled.
+ *
+ * This uses Cesium.QuadtreePrimitive to display potentially massive datasets.
+ *
+ *
+ * @alias TiledWebFeatureServiceCatalogItem
+ * @constructor
+ * @extends CatalogItem
+ *
+ * @param {Terria} terria The Terria instance.
+ * @param {String} [url] The URL from which to retrieve the KML or KMZ data.
+ */
+var TiledWebFeatureServiceCatalogItem =  function(terria, url) {
+     CatalogItem.call(this, terria);
+
+    this._kmlDataSource = undefined;
+    this._terria = terria;
+
+    /**
+     * Gets or sets the URL from which to retrieve data.
+     * This property is observable.
+     * @type {String}
+     */
+    this.url = url;
+    console.log("TiledWebFeatureServiceCatalogItem dataUrl", this.dataUrl);
+
+
+    var tileProvider = new WfsTileProvider(
+                       'http://ks29236.kimsufi.com/cgi-bin/tinyows',
+                       'tows:lyongeom', 
+                       'http://ks29236.kimsufi.com/cesium-buildings-data',
+                       rectangle, 500, 3);
+    this._quadTreePrimitive = new Cesium.QuadtreePrimitive({tileProvider : tileProvider});
+
+    knockout.track(this, ['url']);
+};
+
+inherit(CatalogItem, TiledWebFeatureServiceCatalogItem);
+
+defineProperties(TiledWebFeatureServiceCatalogItem.prototype, {
+    /**
+     * Gets the type of data member represented by this instance.
+     * @memberOf TiledWebFeatureServiceCatalogItem.prototype
+     * @type {String}
+     */
+    type : {
+        get : function() {
+            return 'twfs';
+        }
+    },
+
+    /**
+     * Gets a human-readable name for this type of data source, 'KML'.
+     * @memberOf TiledWebFeatureServiceCatalogItem.prototype
+     * @type {String}
+     */
+    typeName : {
+        get : function() {
+            return 'Tiled WFS';
+        }
+    },
+
+});
+
+TiledWebFeatureServiceCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
+    return [this.url];
+};
+
+/**
+ * _load base implementation (do nothing) is sufficient
+ * since the QuadtreePrimitive handles the actual loading depending on the camera
+ * position
+ */
+
+TiledWebFeatureServiceCatalogItem.prototype._enable = function() {
+};
+
+TiledWebFeatureServiceCatalogItem.prototype._disable = function() {
+};
+
+TiledWebFeatureServiceCatalogItem.prototype._show = function() {
+    if (!defined(this._quadTreePrimitive)) {
+        throw new DeveloperError('This data source is not enabled.');
+    }
+
+    var primitives =  this.terria.cesium.primitives;
+    if (primitives.contains(this._quadTreePrimitive)) {
+        throw new DeveloperError('This data source is already shown.');
+    }
+
+    primitives.add(this._quadTreePrimitive, false);
+};
+
+TiledWebFeatureServiceCatalogItem.prototype._hide = function() {
+    if (!defined(this._quadTreePrimitive)) {
+        throw new DeveloperError('This data source is not enabled.');
+    }
+
+    var primitives =  this.terria.cesium.primitives;
+    if (!primitives.contains(this._quadTreePrimitive)) {
+        throw new DeveloperError('This data source is not shown.');
+    }
+
+    primitives.remove(this._quadTreePrimitive, false);
+};
+
+module.exports = TiledWebFeatureServiceCatalogItem;

--- a/lib/Models/TiledWebFeatureServiceCatalogItem.js
+++ b/lib/Models/TiledWebFeatureServiceCatalogItem.js
@@ -1,28 +1,18 @@
 'use strict';
 
-/*global require,Document*/
-
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
-var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
-var KmlDataSource = require('terriajs-cesium/Source/DataSources/KmlDataSource');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
-var PolygonHierarchy = require('terriajs-cesium/Source/Core/PolygonHierarchy');
-var sampleTerrain = require('terriajs-cesium/Source/Core/sampleTerrain');
-var when = require('terriajs-cesium/Source/ThirdParty/when');
-var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
-var RectanglePrimitive = require('terriajs-cesium/Source/Scene/RectanglePrimitive');
 var QuadtreePrimitive = require('terriajs-cesium/Source/Scene/QuadtreePrimitive');
 
-var WfsTileProvider = require("cesium-buildings/lib/WfsTileProvider");
+var WfsTileProvider = require("terriajs-cesium-buildings/lib/WfsTileProvider");
 
-var Metadata = require('./Metadata');
-var ModelError = require('./ModelError');
+//var Metadata = require('./Metadata');
+//var ModelError = require('./ModelError');
 var CatalogItem = require('./CatalogItem');
 var inherit = require('../Core/inherit');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
-var readXml = require('../Core/readXml');
 
 /**
  * A {@link CatalogItem} representing WFS feature data that will be tiled.
@@ -37,10 +27,13 @@ var readXml = require('../Core/readXml');
  * @param {Terria} terria The Terria instance.
  * @param {String} [url] The URL from which to retrieve the KML or KMZ data.
  */
-var TiledWebFeatureServiceCatalogItem =  function(terria, url) {
+var TiledWebFeatureServiceCatalogItem =  function(terria) {
      CatalogItem.call(this, terria);
 
-    this._kmlDataSource = undefined;
+    this._dataUrl = undefined;
+    this._dataUrlType = undefined;
+    this._metadataUrl = undefined;
+
     this._terria = terria;
 
     /**
@@ -48,22 +41,14 @@ var TiledWebFeatureServiceCatalogItem =  function(terria, url) {
      * This property is observable.
      * @type {String}
      */
-    this.url = url;
-    console.log("TiledWebFeatureServiceCatalogItem dataUrl", this.url);
+    this.url = '';
+    this.typeNames = '';
 
 
-    this._tileProvider = new WfsTileProvider({
-                       url: 'http://37.187.164.233/cgi-bin/tinyows_australia',
-                       layerName: 'tows:goldcoast',
-                       zOffset: 30
-                       });
-    this._quadTreePrimitive = new QuadtreePrimitive({tileProvider : this._tileProvider});
-    //this._quadTreePrimitive = new RectanglePrimitive({
-    //        rectangle : Rectangle.fromDegrees(120, -30.0, 150.0, -15.0)
-    //    });
-
+    this._tileProvider = undefined;
+    
     knockout.track(this, ['url']);
-    console.log("TiledWebFeatureServiceCatalogItem dataUrl", this.url);
+    console.log("TiledWebFeatureServiceCatalogItem", this.__dataUrl);
 };
 
 inherit(CatalogItem, TiledWebFeatureServiceCatalogItem);
@@ -94,7 +79,7 @@ defineProperties(TiledWebFeatureServiceCatalogItem.prototype, {
 });
 
 TiledWebFeatureServiceCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
-    return [this.url];
+    return [this.url, this.typeNames];
 };
 
 /**
@@ -110,8 +95,14 @@ TiledWebFeatureServiceCatalogItem.prototype._disable = function() {
 };
 
 TiledWebFeatureServiceCatalogItem.prototype._show = function() {
-    if (!defined(this._quadTreePrimitive)) {
-        throw new DeveloperError('This data source is not enabled.');
+    if (!defined(this._tileProvider)) {
+        this._tileProvider = new WfsTileProvider({
+                           url: this.url,
+                           layerName: this.typeNames,
+                           zOffset: 30,
+                           workerDir: 'build/TerriaJS/build'
+                           });
+        this._quadTreePrimitive = new QuadtreePrimitive({tileProvider : this._tileProvider});
     }
 
     var primitives = this._terria.cesium.scene.primitives;
@@ -129,5 +120,17 @@ TiledWebFeatureServiceCatalogItem.prototype._hide = function() {
 
     this._tileProvider.show = false;
 };
+
+function cleanAndProxyUrl(catalogItem, url) {
+    return proxyCatalogItemUrl(catalogItem, cleanUrl(url));
+}
+
+function cleanUrl(url) {
+    // Strip off the search portion of the URL
+    var uri = new URI(url);
+    uri.search('');
+    return uri.toString();
+}
+
 
 module.exports = TiledWebFeatureServiceCatalogItem;

--- a/lib/Models/WebFeatureServiceCatalogGroup.js
+++ b/lib/Models/WebFeatureServiceCatalogGroup.js
@@ -250,6 +250,8 @@ function createWfsDataSource(wfsGroup, featureType, supportsJsonGetFeature, data
 
     result.description = '';
 
+    console.log('createWfsDataSource', wfsGroup.ur, featureType.Name);
+
     var wfsGroupHasDescription = defined(wfsGroup.description) && wfsGroup.description.length > 0;
     var layerHasAbstract = defined(featureType.Abstract) && featureType.Abstract.length > 0;
 

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -18,6 +18,7 @@ var WebMapServiceCatalogGroup = require('./WebMapServiceCatalogGroup');
 var WebMapServiceCatalogItem = require('./WebMapServiceCatalogItem');
 var WebMapTileServiceCatalogGroup = require('./WebMapTileServiceCatalogGroup');
 var WebMapTileServiceCatalogItem = require('./WebMapTileServiceCatalogItem');
+var TiledWebFeatureServiceCatalogItem = require('./TiledWebFeatureServiceCatalogItem');
 
 var OpenStreetMapCatalogItem = require('./OpenStreetMapCatalogItem');
 
@@ -52,6 +53,7 @@ var registerCatalogMembers = function() {
     createCatalogMemberFromType.register('open-street-map', OpenStreetMapCatalogItem);
     createCatalogMemberFromType.register('abs-itt', AbsIttCatalogItem);
     createCatalogMemberFromType.register('abs-itt-dataset-list', AbsIttCatalogGroup);
+    createCatalogMemberFromType.register('twfs', TiledWebFeatureServiceCatalogItem);
 
     createCatalogItemFromUrl.register(matchesExtension('csv'), CsvCatalogItem);
     createCatalogItemFromUrl.register(matchesExtension('czm'), CzmlCatalogItem);

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -753,12 +753,12 @@ function populateCkan(requests, server, apiKey) {
             }
             var bboxString = getCkanRect(requests[i].item.rectangle);
             var extrasList = [ { "key": "geo_coverage", "value":  bboxString} ];
-            if (defined(requests[i].item.dataUrlType) && requests[i].item.dataUrlType !== 'wfs') {
+            if (defined(requests[i].item.dataUrlType) && requests[i].item.dataUrlType !== 'wfs' && requests[i].item.dataUrlType !== 'twfs') {
                 extrasList.push({ "key": "data_url_type", "value":  requests[i].item.dataUrlType});
             }
             if (defined(requests[i].item.dataUrl)) {
                 var dataUrl = "";
-                if (requests[i].item.dataUrlType === 'wfs') {
+                if (requests[i].item.dataUrlType === 'wfs' || requests[i].item.dataUrlType === 'twfs') {
                     var baseUrl = cleanUrl(requests[i].item.dataUrl);
                     if ((baseUrl !== requests[i].item.url)) {
                         dataUrl = baseUrl;

--- a/lib/Views/CatalogItemInfo.html
+++ b/lib/Views/CatalogItemInfo.html
@@ -85,7 +85,7 @@
                 <h2>Metadata URL</h2>
                 <a class="catalog-item-info-description" data-bind="attr: { href: catalogItem.metadataUrl }, text: catalogItem.metadataUrl" target="_blank"></a>
             </div>
-            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wfs' || catalogItem.dataUrlType === 'wfs-complete'">
+            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wfs' || catalogItem.dataUrlType === 'wfs-complete'|| catalogItem.dataUrlType === 'twfs'">
                 <h2>Data URL</h2>
                 <div class="catalog-item-info-description">
                     Use the link below to download the data.  See the

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
     "terriajs-cesium": "1.11.1",
+    "terriajs-cesium-buildings": "0.0.1",
     "togeojson": "^0.9.0",
     "hammerjs": "^2.0.4"
   },


### PR DESCRIPTION
Hi @kring, this is a draft version for the integration of tiled 3D WFS datasources in terriajs related to #673 

What I'm looking for at the moment are **comments on the names** (for the class and the catalog type "twfs") and **advices to avoid a hardcoded dependency on terriajs-cesium in cesium-building**.

You have a POC [here](http://37.187.164.233/nationalmap/) where you can zoom on Gold Coast city an see some "buildings", don't be bothered by the apparent motion of the buildings when the point of view changes, it's just due to the fact that the buildings are not at the appropriate altitude (they are not the appropriate height either, I just extruded some public dataset for testing).

To have this demo working, you will need to:
- clone [cesium-buildings terriajs branch](https://github.com/Oslandia/cesium-buildings/tree/terriajs)
- `cd  cesium-buildings` and `sudo npm link`
-  `ce terriajs` checkout this branch for terriajs and `npm link cesium-buildings`
- copy the included 00_Building_test.json into your nationalmap /datasource directory
- `cd nationalmap` and `npm link cesium-buildings` (I believe it's necessary, and I assume you have a linked terriajs in there too)
- `gulp` and lastly `mkdir wwwroot/js/; browserify node_modules/cesium-building/lib/createWfsGeometry.js > wwwroot/js/createWfsGeometry.js` (this is a web worker)

I'm working on the build process to have the last steps integrated. 

I also want to base cesium-buildings apps build process on gulp, such that the terriajs branch can be merged in master.

I'm not familiar with leaflet, so I'll need a hand if a leaflet support is required for integration in terriajs master. We can use the same web worker and worker pool for both interfaces, but I have no clue about the leaflet equivalent of Cesium.QuadTreePrimitive and the associated tile provider. 
