### PR TITLE
Need to check attribution exists in Leaflet

### DIFF
--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -206,7 +206,9 @@ Leaflet.prototype.computePositionOnScreen = function(position, result) {
  * @param {Credit} attribution The attribution to add.
  */
 Leaflet.prototype.addAttribution = function(attribution){
-    this.map.attributionControl.addAttribution(createLeafletCredit(attribution));
+    if(attribution){
+        this.map.attributionControl.addAttribution(createLeafletCredit(attribution));
+    }
 };
 
 /**
@@ -214,7 +216,9 @@ Leaflet.prototype.addAttribution = function(attribution){
  * @param {Credit} attribution The attribution to remove.
  */
 Leaflet.prototype.removeAttribution = function(attribution){
-    this.map.attributionControl.removeAttribution(createLeafletCredit(attribution));
+    if(attribution){
+        this.map.attributionControl.removeAttribution(createLeafletCredit(attribution));
+    }
 };
 
 /**


### PR DESCRIPTION
Fixing a bug introduced by my previous commit #944 : need to check if attribution exists before trying to create credit in Leaflet. 
