### PR TITLE
The URIjs package name has changed to urijs. Technically it still wor…

### DIFF
--- a/lib/Core/corsProxy.js
+++ b/lib/Core/corsProxy.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var defined = require('terriajs-cesium/Source/Core/defined');
 

--- a/lib/Models/AbsIttCatalogGroup.js
+++ b/lib/Models/AbsIttCatalogGroup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var csv = require('../ThirdParty/csv');
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');

--- a/lib/Models/ArcGisCatalogGroup.js
+++ b/lib/Models/ArcGisCatalogGroup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var ArcGisMapServerImageryProvider = require('terriajs-cesium/Source/Scene/ArcGisMapServerImageryProvider');
 var Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3');

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');

--- a/lib/Models/CswCatalogGroup.js
+++ b/lib/Models/CswCatalogGroup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var ArcGisMapServerCatalogItem = require('./ArcGisMapServerCatalogItem');
 var CatalogGroup = require('./CatalogGroup');

--- a/lib/Models/OpenStreetMapCatalogItem.js
+++ b/lib/Models/OpenStreetMapCatalogItem.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var OpenStreetMapImageryProvider = require('terriajs-cesium/Source/Scene/OpenStreetMapImageryProvider');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var buildModuleUrl = require('terriajs-cesium/Source/Core/buildModuleUrl');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');

--- a/lib/Models/WebFeatureServiceCatalogGroup.js
+++ b/lib/Models/WebFeatureServiceCatalogGroup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');

--- a/lib/Models/WebFeatureServiceCatalogItem.js
+++ b/lib/Models/WebFeatureServiceCatalogItem.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var combine = require('terriajs-cesium/Source/Core/combine');

--- a/lib/Models/WebMapTileServiceCatalogGroup.js
+++ b/lib/Models/WebMapTileServiceCatalogGroup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');

--- a/lib/Models/WebMapTileServiceCatalogItem.js
+++ b/lib/Models/WebMapTileServiceCatalogItem.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');

--- a/lib/ViewModels/SharePopupViewModel.js
+++ b/lib/ViewModels/SharePopupViewModel.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var CesiumMath = require('terriajs-cesium/Source/Core/Math');
 var defined = require('terriajs-cesium/Source/Core/defined');

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -7,7 +7,7 @@
 
 /*global require,console*/
 var L = require('leaflet');
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var BingMapsApi = require('terriajs-cesium/Source/Core/BingMapsApi');
 var Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3');

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*global require*/
-var URI = require('URIjs');
+var URI = require('urijs');
 
 var CatalogGroup = require('../Models/CatalogGroup');
 var corsProxy = require('../Core/corsProxy');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/TerriaJS/terriajs"
   },
   "dependencies": {
-    "URIjs": "^1.15.0",
+    "urijs": "^1.16.0",
     "brfs": "^1.4.0",
     "html2canvas": "^0.5.0-alpha2",
     "javascript-natural-sort": "^0.7.1",


### PR DESCRIPTION
…ks to require('URIjs')

but it's better to use the correct module name.
