### PR TITLE
Set 'gulp watch' to poll less often. Frequent polling uses a lot of C…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,7 +130,7 @@ function watch(name, files, minify) {
         debug: true,
         cache: {},
         packageCache: {}
-    }));
+    }), { poll: 1000 } );
 
     function rebundle() {
         var start = new Date();


### PR DESCRIPTION
…PU on some platforms

(notably OSX), which makes working unplugged harder.

More info:
https://github.com/gulpjs/gulp/issues/634
