### PR TITLE
Fix issue #958 embedded czml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Added the `attribution` property to catalog items.  The attribution is displayed on the map when the catalog item is enabled.
 * Remove an unnecessary instance of the Cesium InfoBox class when viewing in 2D
 * Fixed a bug that prevented `AbsIttCatalogGroup` from successfully loading its list of catalog items.
+* Allow missing URLs on embedded data (eg. embedded czml data)
 
 ### 1.0.43
 

--- a/lib/Core/corsProxy.js
+++ b/lib/Core/corsProxy.js
@@ -23,6 +23,11 @@ var corsProxy = {
  * @return {Boolean} true if the proxy should be used, false if not.
  */
 corsProxy.shouldUseProxy = function(url) {
+    if (typeof url === 'undefined') {
+        // eg. no url may be passed if all data is embedded
+        return false;
+    }
+    
     var uri = new URI(url);
     var host = uri.host();  
     

--- a/lib/Core/corsProxy.js
+++ b/lib/Core/corsProxy.js
@@ -23,7 +23,7 @@ var corsProxy = {
  * @return {Boolean} true if the proxy should be used, false if not.
  */
 corsProxy.shouldUseProxy = function(url) {
-    if (typeof url === 'undefined') {
+    if (!defined(url)) {
         // eg. no url may be passed if all data is embedded
         return false;
     }

--- a/test/Models/CzmlCatalogItemSpec.js
+++ b/test/Models/CzmlCatalogItemSpec.js
@@ -49,6 +49,28 @@ describe('CzmlCatalogItem', function() {
                 });
             });
         });
+
+    });
+
+    describe('embedding CZML', function() {
+        it('works with dataSourceUrl', function(done) {
+            czml.data = JSON.parse('[{"id": "document", "version": "1.0"}, {"position": {"cartographicDegrees": [133.0, -25.0, 0.0]}}]');
+            czml.dataSourceUrl = 'something.czml';
+            czml.load().then(function() {
+                expect(czml._czmlDataSource.entities.values.length).toBeGreaterThan(0);
+                done();
+            });
+        });
+
+        it('works without dataSourceUrl', function(done) {
+            czml.data = JSON.parse('[{"id": "document", "version": "1.0"}, {"position": {"cartographicDegrees": [133.0, -25.0, 0.0]}}]');
+            expect(czml.dataSourceUrl).toBeUndefined();
+            czml.load().then(function() {
+                expect(czml._czmlDataSource.entities.values.length).toBeGreaterThan(0);
+                done();
+            });
+        });
+
     });
 
     describe('loading a CZML file with a moving vehicle', function() {
@@ -113,6 +135,7 @@ describe('CzmlCatalogItem', function() {
                 });
             });
         });
+
     });
 
     describe('error handling', function(done) {


### PR DESCRIPTION
Allow missing URLs in data, which allows eg. czml embedded in the init file to load. Added tests.
fixes #958 
