### PR TITLE
better feature naming for TableDataSource

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 1.0.47
+
+* The `name` of a feature from a CSV file is now taken from a `name` or `title` column, if it exists.  Previously the name was always "Site Data".
+
 ### 1.0.46
 
 * Fixed an incorrect require (`URIjs` instead of `urijs`).

--- a/lib/Map/TableDataSource.js
+++ b/lib/Map/TableDataSource.js
@@ -369,10 +369,10 @@ TableDataSource.prototype.describe = function(properties) {
 };
 
 
-TableDataSource.prototype._czmlRecFromPoint = function (point) {
+TableDataSource.prototype._czmlRecFromPoint = function(point, name) {
 
     var rec = {
-        "name": "Site Data",
+        "name": name,
         "description": "empty",
         "position" : {
             "cartographicDegrees" : [0, 0, 0]
@@ -437,6 +437,21 @@ TableDataSource.prototype._czmlRecFromPoint = function (point) {
     return rec;
 };
 
+var potentialNameIdentifiers = ['name', 'station name', 'id'];
+var defaultName = 'Site Data';
+
+function chooseName(dataRow) {
+    var name = defaultName;
+    for (var key in dataRow) {
+        if (dataRow.hasOwnProperty(key)) {
+            if (potentialNameIdentifiers.indexOf(key.toLowerCase()) !== -1) {
+                name = dataRow[key];
+                continue;
+            }
+        }
+    }
+    return name;
+}
 
 /**
 * Get a list of display records for the current point list in czml format.
@@ -457,9 +472,11 @@ TableDataSource.prototype.getCzmlDataPointList = function () {
     }];
 
     for (var i = 0; i < pointList.length; i++) {
-            //set position, scale, color, and display time
-        var rec = this._czmlRecFromPoint(pointList[i]);
-        rec.description = this.describe(this.dataset.getDataRow(pointList[i].row));
+        //set position, scale, color, and display time
+        var dataRow = this.dataset.getDataRow(pointList[i].row);
+        var name = chooseName(dataRow);
+        var rec = this._czmlRecFromPoint(pointList[i], name);
+        rec.description = this.describe(dataRow);
         dispRecords.push(rec);
     }
     return dispRecords;

--- a/lib/Map/TableDataSource.js
+++ b/lib/Map/TableDataSource.js
@@ -11,6 +11,7 @@ var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var CzmlDataSource = require('terriajs-cesium/Source/DataSources/CzmlDataSource');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var definedNotNull = require('terriajs-cesium/Source/Core/definedNotNull');
 var destroyObject = require('terriajs-cesium/Source/Core/destroyObject');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var loadText = require('terriajs-cesium/Source/Core/loadText');
@@ -437,20 +438,50 @@ TableDataSource.prototype._czmlRecFromPoint = function(point, name) {
     return rec;
 };
 
-var potentialNameIdentifiers = ['name', 'station name', 'id'];
 var defaultName = 'Site Data';
 
-function chooseName(dataRow) {
-    var name = defaultName;
-    for (var key in dataRow) {
-        if (dataRow.hasOwnProperty(key)) {
-            if (potentialNameIdentifiers.indexOf(key.toLowerCase()) !== -1) {
-                name = dataRow[key];
-                continue;
+function chooseName(properties) {
+    // Choose a name by the same logic as Cesium's GeoJsonDataSource
+    // but fall back to the defaultName if none found.
+    var nameProperty;
+
+    // Check for the simplestyle specified name first.
+    var name = properties.title;
+    if (definedNotNull(name)) {
+        nameProperty = 'title';
+    } else {
+        //Else, find the name by selecting an appropriate property.
+        //The name will be obtained based on this order:
+        //1) The first case-insensitive property with the name 'title',
+        //2) The first case-insensitive property with the name 'name',
+        //3) The first property containing the word 'title'.
+        //4) The first property containing the word 'name',
+        var namePropertyPrecedence = Number.MAX_VALUE;
+        for (var key in properties) {
+            if (properties.hasOwnProperty(key) && properties[key]) {
+                var lowerKey = key.toLowerCase();
+                if (namePropertyPrecedence > 1 && lowerKey === 'title') {
+                    namePropertyPrecedence = 1;
+                    nameProperty = key;
+                    break;
+                } else if (namePropertyPrecedence > 2 && lowerKey === 'name') {
+                    namePropertyPrecedence = 2;
+                    nameProperty = key;
+                } else if (namePropertyPrecedence > 3 && /title/i.test(key)) {
+                    namePropertyPrecedence = 3;
+                    nameProperty = key;
+                } else if (namePropertyPrecedence > 4 && /name/i.test(key)) {
+                    namePropertyPrecedence = 4;
+                    nameProperty = key;
+                }
             }
         }
     }
-    return name;
+    if (defined(nameProperty)) {
+        return properties[nameProperty];
+    } else {
+        return defaultName;
+    }
 }
 
 /**


### PR DESCRIPTION
I noticed that the feature info box was just showing "Site Data" for the collapsible heading titles for any csv data.
It now looks for "name", "station name" and "id" fields in that order to use instead, falling back to "Site Data" if none found.
