### PR TITLE
Limit how many features are shown in the featureInfoPanel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
   * Added support for the glTF extensions [KHR_binary_glTF](https://github.com/KhronosGroup/glTF/tree/master/extensions/Khronos/KHR_binary_glTF) and [KHR_materials_common](https://github.com/KhronosGroup/glTF/tree/KHR_materials_common/extensions/Khronos/KHR_materials_common).
   * `ImageryLayerFeatureInfo` now has an `imageryLayer` property, indicating the layer that contains the feature.
   * Make KML invalid coordinate processing match Google Earth behavior. [#3124](https://github.com/AnalyticalGraphicsInc/cesium/pull/3124)
+* Show information for all WMS features when a location is clicked.
 
 ### 1.0.46
 

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -149,6 +149,13 @@ var CatalogItem = function(terria) {
      */
     this.featureInfoTemplate = undefined;
 
+    /**
+     * The maximum number of features whose information can be shown at one time in the FeatureInfoPanelViewModel, from this item.
+     * Defaults to terria.configParameters.defaultMaximumShownFeatureInfos
+     * @type {Number}
+     */
+    this.maximumShownFeatureInfos = terria.configParameters.defaultMaximumShownFeatureInfos;
+
     this._legendUrls = [];
     this._dataUrl = undefined;
     this._dataUrlType = undefined;

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -28,6 +28,10 @@ var Services = require('./Services');
 var ViewerMode = require('./ViewerMode');
 var NoViewer = require('./NoViewer');
 
+var defaultConfigParameters = {
+    defaultMaximumShownFeatureInfos: 100
+};
+
 /**
  * The overall model for TerriaJS.
  * @alias Terria
@@ -244,7 +248,7 @@ var Terria = function(options) {
      * Gets or sets the configuration parameters set at startup.
      * @type {Object}
      */
-    this.configParameters = {};
+    this.configParameters = defaultConfigParameters;
 
     /**
      * Gets or sets the file path for the region mapping definitions.
@@ -316,7 +320,7 @@ Terria.prototype.start = function(options) {
     var that = this;
     return loadJson(options.configUrl).then(function(config) {
         if (defined(config.parameters)) {
-            that.configParameters = config.parameters;
+            that.configParameters = combine(config.parameters, that.configParameters);
         }
 
         corsProxy.proxyDomains.push.apply(corsProxy.proxyDomains, config.proxyDomains);

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -437,6 +437,8 @@ WebMapServiceCatalogItem.prototype._createImageryProvider = function(time) {
     }
 
     parameters = combine(parameters, WebMapServiceCatalogItem.defaultParameters);
+    // request one more feature than we will show, so that we can tell the user if there are more not shown
+    parameters.feature_count = this.maximumShownFeatureInfos + 1;
 
     var maximumLevel;
 
@@ -470,8 +472,7 @@ WebMapServiceCatalogItem.defaultParameters = {
     format: 'image/png',
     exceptions: 'application/vnd.ogc.se_xml',
     styles: '',
-    tiled: true,
-    feature_count: 1000000000
+    tiled: true
 };
 
 function cleanAndProxyUrl(catalogItem, url) {

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -470,7 +470,8 @@ WebMapServiceCatalogItem.defaultParameters = {
     format: 'image/png',
     exceptions: 'application/vnd.ogc.se_xml',
     styles: '',
-    tiled: true
+    tiled: true,
+    feature_count: 1000
 };
 
 function cleanAndProxyUrl(catalogItem, url) {

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -438,6 +438,17 @@ WebMapServiceCatalogItem.prototype._createImageryProvider = function(time) {
 
     parameters = combine(parameters, WebMapServiceCatalogItem.defaultParameters);
     // request one more feature than we will show, so that we can tell the user if there are more not shown
+    if (defined(parameters.feature_count)) {
+        throw new ModelError({
+            sender: this,
+            title: 'Do not set feature_count parameter directly',
+            message: '\
+An error occurred while setting up the WebMapServiceCatalogItem ' + this.name + '.  \
+<p>You should not set parameters.feature_count directly. Please set maximumShownFeatureInfos instead.</p> \
+<p>parameters.feature_count will be automatically set to one greater than this value.</p>'
+        });
+
+    }
     parameters.feature_count = this.maximumShownFeatureInfos + 1;
 
     var maximumLevel;

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -471,7 +471,7 @@ WebMapServiceCatalogItem.defaultParameters = {
     exceptions: 'application/vnd.ogc.se_xml',
     styles: '',
     tiled: true,
-    feature_count: 1000
+    feature_count: 1000000000
 };
 
 function cleanAndProxyUrl(catalogItem, url) {

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -23,14 +23,13 @@ var htmlTagRegex = /(<html(.|\s)*>(.|\s)*<\/html>|<body(.|\s)*>(.|\s)*<\/body>|<
  * @param {Terria} terria Terria instance.
  * @param {Cesium.Entity} feature The feature to display.
 */
-var FeatureInfoPanelSectionViewModel = function(terria, feature) {
+var FeatureInfoPanelSectionViewModel = function(terria, feature, catalogItem) {
     this.terria = terria;
     this._clockSubscription = undefined;
     this.feature = feature;
     this.template = defined(feature.imageryLayer) ? feature.imageryLayer.featureInfoTemplate : undefined;
     this.name = feature.name ? feature.name : feature.id;
     this.info = htmlFromFeature(this, terria.clock);
-    var catalogItem = calculateCatalogItem(terria.nowViewing, feature);
     this.catalogItemName = defined(catalogItem) ? catalogItem.name : '';
     configureHtmlUpdater(this);
 
@@ -115,35 +114,5 @@ function configureHtmlUpdater(viewModel) {
     }
 }
 
-function calculateCatalogItem(nowViewing, feature) {
-    // some data sources (czml, geojson, kml) have an entity collection defined on the entity
-    // (and therefore the feature)
-    // then match up the data source on the feature with a now-viewing item's data source
-    var result, i;
-    if (defined(feature.entityCollection) && defined(feature.entityCollection.owner)) {
-        var dataSource = feature.entityCollection.owner;
-        for (i = nowViewing.items.length - 1; i >= 0; i--) {
-            if (nowViewing.items[i].dataSource === dataSource) {
-                result = nowViewing.items[i];
-                break;
-            }
-        }
-        return result;
-    }
-    // If there is no data source, but there is an imagery layer (eg. ArcGIS)
-    // we can match up the imagery layer on the feature with a now-viewing item.
-    if (defined(feature.imageryLayer)) {
-        var imageryLayer = feature.imageryLayer;
-        for (i = nowViewing.items.length - 1; i >= 0; i--) {
-            if (nowViewing.items[i].imageryLayer === imageryLayer) {
-                result = nowViewing.items[i];
-                break;
-            }
-        }
-        return result;
-    }
-    // otherwise, no luck
-    return undefined;
-}
 
 module.exports = FeatureInfoPanelSectionViewModel;

--- a/lib/ViewModels/FeatureInfoPanelViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelViewModel.js
@@ -128,8 +128,8 @@ FeatureInfoPanelViewModel.prototype.resetNameAndMessage = function(name, message
     this.message = defaultValue(message, '');
 };
 
-function newSectionfromFeature(panel, feature) {
-    return new FeatureInfoPanelSectionViewModel(panel.terria, feature);
+function newSectionfromFeature(panel, feature, catalogItem) {
+    return new FeatureInfoPanelSectionViewModel(panel.terria, feature, catalogItem);
 }
 
 FeatureInfoPanelViewModel.prototype.showFeatures = function(features) {
@@ -172,13 +172,45 @@ FeatureInfoPanelViewModel.prototype.showFeatures = function(features) {
         that.resetNameAndMessage();
         that.resetSections();
         that.terria.selectedFeature = features.features[0];
+        var counts = [];
         features.features.forEach(function(feature) {
             if (!defined(feature.position)) {
                 feature.position = features.pickPosition;
             }
-            that.addSection(newSectionfromFeature(that, feature));
+            var catalogItem = calculateCatalogItem(that.terria.nowViewing, feature);
 
+            var newItem = true;
+            var countOfCatalogItem = 0;
+            // only show features from each catalog item up to their maximumShownFeatureInfos
+            for (var i = counts.length - 1; i >= 0; i--) {
+                if (catalogItem === counts[i].catalogItem) {
+                    newItem = false;
+                    countOfCatalogItem = counts[i].count;
+                    counts[i].count = countOfCatalogItem + 1;
+                }
+            }
+            if (newItem) {
+                counts.push({catalogItem: catalogItem, count: 1});
+            }
+            if (countOfCatalogItem < catalogItem.maximumShownFeatureInfos) {
+                that.addSection(newSectionfromFeature(that, feature, catalogItem));
+            }
         });
+        // were any counts exceeded?
+        for (var i = counts.length - 1; i >= 0; i--) {
+            var numberShown = counts[i].catalogItem.maximumShownFeatureInfos;
+            var hiddenNumber = counts[i].count - numberShown;
+            if (hiddenNumber === 1) {
+                // if only one more, there may be more hidden layers that were not requested, so don't specify the exact total number
+                that.message += '<p>More than ' + numberShown + ' ' + counts[i].catalogItem.name + ' features were found. ' + 
+                'The first ' + numberShown + ' are shown below.</p>';
+            }
+            if (hiddenNumber > 1) {
+                that.message += '<p>' + counts[i].count + ' ' + counts[i].catalogItem.name + ' features were found. ' + 
+                'The first ' + numberShown + ' are shown below.</p>';
+            }
+        }
+
         that.isVisible = true;
     }, function() {
         that.terria.selectedFeature = undefined;
@@ -190,5 +222,36 @@ FeatureInfoPanelViewModel.prototype.showFeatures = function(features) {
 FeatureInfoPanelViewModel.create = function(options) {
     return new FeatureInfoPanelViewModel(options);
 };
+
+function calculateCatalogItem(nowViewing, feature) {
+    // some data sources (czml, geojson, kml) have an entity collection defined on the entity
+    // (and therefore the feature)
+    // then match up the data source on the feature with a now-viewing item's data source
+    var result, i;
+    if (defined(feature.entityCollection) && defined(feature.entityCollection.owner)) {
+        var dataSource = feature.entityCollection.owner;
+        for (i = nowViewing.items.length - 1; i >= 0; i--) {
+            if (nowViewing.items[i].dataSource === dataSource) {
+                result = nowViewing.items[i];
+                break;
+            }
+        }
+        return result;
+    }
+    // If there is no data source, but there is an imagery layer (eg. ArcGIS)
+    // we can match up the imagery layer on the feature with a now-viewing item.
+    if (defined(feature.imageryLayer)) {
+        var imageryLayer = feature.imageryLayer;
+        for (i = nowViewing.items.length - 1; i >= 0; i--) {
+            if (nowViewing.items[i].imageryLayer === imageryLayer) {
+                result = nowViewing.items[i];
+                break;
+            }
+        }
+        return result;
+    }
+    // otherwise, no luck
+    return undefined;
+}
 
 module.exports = FeatureInfoPanelViewModel;

--- a/lib/ViewModels/FeatureInfoPanelViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelViewModel.js
@@ -178,22 +178,25 @@ FeatureInfoPanelViewModel.prototype.showFeatures = function(features) {
                 feature.position = features.pickPosition;
             }
             var catalogItem = calculateCatalogItem(that.terria.nowViewing, feature);
-
-            var newItem = true;
-            var countOfCatalogItem = 0;
-            // only show features from each catalog item up to their maximumShownFeatureInfos
-            for (var i = counts.length - 1; i >= 0; i--) {
-                if (catalogItem === counts[i].catalogItem) {
-                    newItem = false;
-                    countOfCatalogItem = counts[i].count;
-                    counts[i].count = countOfCatalogItem + 1;
+            if (!defined(catalogItem)) {
+                that.addSection(newSectionfromFeature(that, feature));
+            } else {
+                var newItem = true;
+                var countOfCatalogItem = 0;
+                // only show features from each catalog item up to their maximumShownFeatureInfos
+                for (var i = counts.length - 1; i >= 0; i--) {
+                    if (catalogItem === counts[i].catalogItem) {
+                        newItem = false;
+                        countOfCatalogItem = counts[i].count;
+                        counts[i].count = countOfCatalogItem + 1;
+                    }
                 }
-            }
-            if (newItem) {
-                counts.push({catalogItem: catalogItem, count: 1});
-            }
-            if (countOfCatalogItem < catalogItem.maximumShownFeatureInfos) {
-                that.addSection(newSectionfromFeature(that, feature, catalogItem));
+                if (newItem) {
+                    counts.push({catalogItem: catalogItem, count: 1});
+                }
+                if (countOfCatalogItem < catalogItem.maximumShownFeatureInfos) {
+                    that.addSection(newSectionfromFeature(that, feature, catalogItem));
+                }
             }
         });
         // were any counts exceeded?
@@ -228,6 +231,10 @@ function calculateCatalogItem(nowViewing, feature) {
     // (and therefore the feature)
     // then match up the data source on the feature with a now-viewing item's data source
     var result, i;
+    if (!defined(nowViewing)) {
+        // so that specs do not need to define a nowViewing
+        return undefined;
+    }
     if (defined(feature.entityCollection) && defined(feature.entityCollection.owner)) {
         var dataSource = feature.entityCollection.owner;
         for (i = nowViewing.items.length - 1; i >= 0; i--) {

--- a/lib/ViewModels/FeatureInfoPanelViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelViewModel.js
@@ -172,48 +172,7 @@ FeatureInfoPanelViewModel.prototype.showFeatures = function(features) {
         that.resetNameAndMessage();
         that.resetSections();
         that.terria.selectedFeature = features.features[0];
-        var counts = [];
-        features.features.forEach(function(feature) {
-            if (!defined(feature.position)) {
-                feature.position = features.pickPosition;
-            }
-            var catalogItem = calculateCatalogItem(that.terria.nowViewing, feature);
-            if (!defined(catalogItem)) {
-                that.addSection(newSectionfromFeature(that, feature));
-            } else {
-                var newItem = true;
-                var countOfCatalogItem = 0;
-                // only show features from each catalog item up to their maximumShownFeatureInfos
-                for (var i = counts.length - 1; i >= 0; i--) {
-                    if (catalogItem === counts[i].catalogItem) {
-                        newItem = false;
-                        countOfCatalogItem = counts[i].count;
-                        counts[i].count = countOfCatalogItem + 1;
-                    }
-                }
-                if (newItem) {
-                    counts.push({catalogItem: catalogItem, count: 1});
-                }
-                if (countOfCatalogItem < catalogItem.maximumShownFeatureInfos) {
-                    that.addSection(newSectionfromFeature(that, feature, catalogItem));
-                }
-            }
-        });
-        // were any counts exceeded?
-        for (var i = counts.length - 1; i >= 0; i--) {
-            var numberShown = counts[i].catalogItem.maximumShownFeatureInfos;
-            var hiddenNumber = counts[i].count - numberShown;
-            if (hiddenNumber === 1) {
-                // if only one more, there may be more hidden layers that were not requested, so don't specify the exact total number
-                that.message += '<p>More than ' + numberShown + ' ' + counts[i].catalogItem.name + ' features were found. ' + 
-                'The first ' + numberShown + ' are shown below.</p>';
-            }
-            if (hiddenNumber > 1) {
-                that.message += '<p>' + counts[i].count + ' ' + counts[i].catalogItem.name + ' features were found. ' + 
-                'The first ' + numberShown + ' are shown below.</p>';
-            }
-        }
-
+        addSectionsForFeatures(that, features.features);
         that.isVisible = true;
     }, function() {
         that.terria.selectedFeature = undefined;
@@ -225,6 +184,52 @@ FeatureInfoPanelViewModel.prototype.showFeatures = function(features) {
 FeatureInfoPanelViewModel.create = function(options) {
     return new FeatureInfoPanelViewModel(options);
 };
+
+function addSectionsForFeatures(viewModel, features) {
+    // Only show sections up to a limit for each catalog item.
+
+    var counts = []; // an array of {catalogItem: , count: } objects
+    features.forEach(function(feature) {
+        if (!defined(feature.position)) {
+            feature.position = features.pickPosition;
+        }
+        var catalogItem = calculateCatalogItem(viewModel.terria.nowViewing, feature);
+        if (!defined(catalogItem)) {
+            viewModel.addSection(newSectionfromFeature(viewModel, feature));
+        } else {
+            var newItem = true;
+            var countOfCatalogItem = 0;
+            // only show features from each catalog item up to their maximumShownFeatureInfos
+            for (var i = counts.length - 1; i >= 0; i--) {
+                if (catalogItem === counts[i].catalogItem) {
+                    newItem = false;
+                    countOfCatalogItem = counts[i].count;
+                    counts[i].count = countOfCatalogItem + 1;
+                }
+            }
+            if (newItem) {
+                counts.push({catalogItem: catalogItem, count: 1});
+            }
+            if (countOfCatalogItem < catalogItem.maximumShownFeatureInfos) {
+                viewModel.addSection(newSectionfromFeature(viewModel, feature, catalogItem));
+            }
+        }
+    });
+    // if any counts were exceeded, add a message to the view model
+    for (var i = counts.length - 1; i >= 0; i--) {
+        var numberShown = counts[i].catalogItem.maximumShownFeatureInfos;
+        var hiddenNumber = counts[i].count - numberShown;
+        if (hiddenNumber === 1) {
+            // if only one more, there may be more hidden layers viewModel were not requested, so don't specify the exact total number
+            viewModel.message += '<p>More than ' + numberShown + ' ' + counts[i].catalogItem.name + ' features were found. ' + 
+            'The first ' + numberShown + ' are shown below.</p>';
+        }
+        if (hiddenNumber > 1) {
+            viewModel.message += '<p>' + counts[i].count + ' ' + counts[i].catalogItem.name + ' features were found. ' + 
+            'The first ' + numberShown + ' are shown below.</p>';
+        }
+    }
+}
 
 function calculateCatalogItem(nowViewing, feature) {
     // some data sources (czml, geojson, kml) have an entity collection defined on the entity

--- a/lib/Views/FeatureInfoPanel.html
+++ b/lib/Views/FeatureInfoPanel.html
@@ -9,7 +9,7 @@
                 <div class="feature-info-panel-sections" data-bind="style: { 'max-height': maxHeight + 'px' }">
                     <div class="feature-info-panel-section" data-bind="if: message">
                         <div class="feature-info-panel-section">
-                            <div class="feature-info-panel-section-content" data-bind="text: message"></div>
+                            <div class="feature-info-panel-section-content" data-bind="html: message"></div>
                         </div>
                     </div>
                     <div class="feature-info-panel-section" data-bind="foreach: sections">


### PR DESCRIPTION
Fixes #1010. It limits the number of features in the featureInfoPanel to 100 per catalog item. If the limit is exceeded, a message appears at the top of the panel.

The limit of 100 is configurable in two ways: globally and per catalog item.

To change it globally, add to your `config.json` a line like `"defaultMaximumShownFeatureInfos": 25` inside `parameters`.

To change it for a single catalog item, add a property "maximumShownFeatureInfos", eg.:

```
    {
      "name": "my item",
      "url": "http://example.com/geoserver/wms",
      "type": "wms",
      "maximumShownFeatureInfos": 1000,
      "parameters": {
        "tiled": true
      }
```

Note an error is now thrown if WMS sets `parameters.feature_count` directly, since this would conflict with the new parameter.

Finally, for the record, we thought about setting the limit very high instead (eg. 1,000,000,000), and letting the catalogItem itself restrict the number if relevant, but we want the UI to work in a reasonable way out of the box.
