### PR TITLE
Remove gulp-shell dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,8 +55,8 @@ gulp.task('lint', function(){
         .pipe(jshint.reporter('fail'));
 });
 
-gulp.task('docs', function() {
-    child_exec('node ./node_modules/jsdoc/jsdoc.js ./lib -c ./jsdoc.json');
+gulp.task('docs', function(done) {
+    child_exec('node ./node_modules/jsdoc/jsdoc.js ./lib -c ./jsdoc.json', undefined, done);
 });
 
 gulp.task('prepare-cesium', ['copy-cesium-assets']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ var transform = require('vinyl-transform');
 var source = require('vinyl-source-stream');
 var watchify = require('watchify');
 var resolve = require('resolve');
-var shell = require('gulp-shell');
+var child_exec = require('child_process').exec;  // child_process is built in to node
 
 var specJSName = 'TerriaJS-specs.js';
 var sourceGlob = ['./lib/**/*.js', '!./lib/ThirdParty/**/*.js'];
@@ -55,9 +55,9 @@ gulp.task('lint', function(){
         .pipe(jshint.reporter('fail'));
 });
 
-gulp.task('docs', shell.task([
-    'node ./node_modules/jsdoc/jsdoc.js ./lib -c ./jsdoc.json'
-]));
+gulp.task('docs', function() {
+    child_exec('node ./node_modules/jsdoc/jsdoc.js ./lib -c ./jsdoc.json');
+});
 
 gulp.task('prepare-cesium', ['copy-cesium-assets']);
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "gulp-jasmine": "^2.0.1",
     "gulp-jshint": "^1.10.0",
     "gulp-less": "^3.0.2",
-    "gulp-shell": "^0.5.1",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.4",


### PR DESCRIPTION
`gulp-shell` (used for building the docs with jsdoc) is on the [gulp blacklist](https://github.com/gulpjs/plugins/blob/master/src/blackList.json#L15). Replacing with node's built in [child_process](https://nodejs.org/api/child_process.html).
