### PR TITLE
Support parameters.feature_count for backwards compatibility

### DIFF
--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -439,17 +439,15 @@ WebMapServiceCatalogItem.prototype._createImageryProvider = function(time) {
     parameters = combine(parameters, WebMapServiceCatalogItem.defaultParameters);
     // request one more feature than we will show, so that we can tell the user if there are more not shown
     if (defined(parameters.feature_count)) {
-        throw new ModelError({
-            sender: this,
-            title: 'Do not set feature_count parameter directly',
-            message: '\
-An error occurred while setting up the WebMapServiceCatalogItem ' + this.name + '.  \
-<p>You should not set parameters.feature_count directly. Please set maximumShownFeatureInfos instead.</p> \
-<p>parameters.feature_count will be automatically set to one greater than this value.</p>'
-        });
-
+        console.log('Using parameters.feature_count to override maximumShownFeatureInfos');
+        if (parameters.feature_count === 1) {
+            this.maximumShownFeatureInfos = 1;
+        } else {
+            this.maximumShownFeatureInfos = parameters.feature_count - 1;
+        }
+    } else {
+        parameters.feature_count = this.maximumShownFeatureInfos + 1;
     }
-    parameters.feature_count = this.maximumShownFeatureInfos + 1;
 
     var maximumLevel;
 

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -439,7 +439,7 @@ WebMapServiceCatalogItem.prototype._createImageryProvider = function(time) {
     parameters = combine(parameters, WebMapServiceCatalogItem.defaultParameters);
     // request one more feature than we will show, so that we can tell the user if there are more not shown
     if (defined(parameters.feature_count)) {
-        console.log('Using parameters.feature_count to override maximumShownFeatureInfos');
+        console.log(this.name + ': using parameters.feature_count (' + parameters.feature_count + ') to override maximumShownFeatureInfos (' + this.maximumShownFeatureInfos + ').');
         if (parameters.feature_count === 1) {
             this.maximumShownFeatureInfos = 1;
         } else {


### PR DESCRIPTION
Fixes #1056.

Does not throw an error if feature_count is set. Instead, logs to console and intelligently overrides maximumShownFeatureInfos.
