### PR TITLE
Better fix for WMS layers with one time.

### DIFF
--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -333,7 +333,7 @@ ImageryLayerCatalogItem.prototype._enable = function() {
     var currentTimeIdentifier;
     var nextTimeIdentifier;
 
-    if (defined(this.intervals)) {
+    if (defined(this.intervals) && this.intervals.length > 0) {
         isTimeDynamic = true;
 
         var clock =  this.terria.clock;

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -668,11 +668,6 @@ function getIntervalsFromLayer(wmsItem, layer) {
         }
     }
 
-    if (result.length <= 1) {
-        // zero or one times, so treat this layer as non-time-varying.
-        return undefined;
-    }
-
     return result;
 }
 


### PR DESCRIPTION
This is a better version of #1036.  It fixes a failure in one of our tests, allows layers with a single _interval_ be to treated as time dynamic, and is less likely to allow a similar bug to creep in to other types of imagery layers (other than WMS) in the future.
