### PR TITLE
Fix trailing slash issue for CkanCatalogGroup, simplify proxying.

### DIFF
--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -345,8 +345,12 @@ CkanCatalogGroup.prototype._load = function() {
 
     var promises = [];
     for (var i = 0; i < this.filterQuery.length; i++) {
-        var url = cleanAndProxyUrl(this, this.url) + 'api/3/action/package_search?rows=100000&' + this.filterQuery[i];
-        var promise = loadJson(url);
+        var url = new URI(this.url)
+            .segment('api/3/action/package_search')
+            .addQuery({ rows: 100000 })
+            .toString();
+        url += '&' + this.filterQuery[i]; // filterQuery[i] is expected to be aleady URL-encoded and begin with a query like 'fq='
+        var promise = loadJson(proxyCatalogItemUrl(this, url, '1d'));
 
         promises.push(promise);
     }
@@ -676,15 +680,6 @@ function populateGroupFromResults(ckanGroup, json) {
             ckanGroup.items[i].items.sort(compareNames);
         }
     }
-}
-
-function cleanAndProxyUrl(catalogGroup, url) {
-    // Strip off the search portion of the URL
-    var uri = new URI(url);
-    uri.search('');
-
-    var cleanedUrl = uri.toString();
-    return proxyCatalogItemUrl(catalogGroup, cleanedUrl, '1d');
 }
 
 module.exports = CkanCatalogGroup;


### PR DESCRIPTION
Data.Vic stopped working, probably due to another fix to this same issue. Now we can comfortably handle CKAN URLs ending with slashes or without.
