### PR TITLE
Improve WMS Title matching.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Supports FeatureInfoTemplates on all catalog item types (previously only available on ImageryLayers).
 * Apply markdown to properties shown in the Feature Info Panel.
 * Add `includeCzml` option to CkanCatalogGroup.
+* Fixed a bug that caused `WebMapServiceCatalogItem` to incorrectly populate the catalog item's metadata with data from GetCapabilities when another layer had a `Title` with the same value as the expected layer's `Name`.
 * Updated to [Cesium](http://cesiumjs.org) 1.15.  Significant changes relevant to TerriaJS users include:
   * Added support for the [glTF 1.0](https://github.com/KhronosGroup/glTF/blob/master/specification/README.md) draft specification.
   * Added support for the glTF extensions [KHR_binary_glTF](https://github.com/KhronosGroup/glTF/tree/master/extensions/Khronos/KHR_binary_glTF) and [KHR_materials_common](https://github.com/KhronosGroup/glTF/tree/KHR_materials_common/extensions/Khronos/KHR_materials_common).

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -332,6 +332,8 @@ WebMapServiceCatalogItem.prototype.updateFromCapabilities = function(capabilitie
                     thisLayer.splice(i, 1);
                     layers.splice(i, 1);
                     --i;
+                } else {
+                    layers[i] = thisLayer[i].Name;
                 }
             }
         }
@@ -339,6 +341,8 @@ WebMapServiceCatalogItem.prototype.updateFromCapabilities = function(capabilitie
         if (thisLayer.length === 0) {
             return;
         }
+
+        this.layers = layers.join(',');
     }
 
     this._rawMetadata = capabilities;
@@ -754,12 +758,12 @@ function requestMetadata(wmsItem) {
 /* Given a comma-separated string of layer names, returns the layer objects corresponding to them. */
 function findLayers(startLayer, names) {
     return names.split(',').map(function(i) {
-        return findLayer(startLayer, i);
+        return findLayer(startLayer, i, false) || findLayer(startLayer, i, true);
     });
 }
 
-function findLayer(startLayer, name) {
-    if (startLayer.Name === name || startLayer.Title === name) {
+function findLayer(startLayer, name, allowMatchByTitle) {
+    if (startLayer.Name === name || (allowMatchByTitle && startLayer.Title === name && defined(startLayer.Name))) {
         return startLayer;
     }
 
@@ -768,10 +772,10 @@ function findLayer(startLayer, name) {
         return undefined;
     }
 
-    var found = findLayer(layers, name);
+    var found = findLayer(layers, name, allowMatchByTitle);
     for (var i = 0; !found && i < layers.length; ++i) {
         var layer = layers[i];
-        found = findLayer(layer, name);
+        found = findLayer(layer, name, allowMatchByTitle);
     }
 
     return found;


### PR DESCRIPTION
`WebMapServiceCatalogItem` had some code to try to match each of its `layers` against either the `Name` or `Title` property in `GetCapabilities`.  This was intended to be a usability feature.  You can specify which layer to use by its human-oriented name rather than just by its identifier.  But it had some problems:
- It could match by `Title` even when a better match by `Name` existed (e.g. on a child layer).
- It didn't require that the matched-by-Title layer have a `Name` property.  Only layers with a `Name` are valid for `GetMap` requests.
- Upon finding a match by title, it wouldn't use the `Name` of the matched layer, so the `GetMap` would likely fail.

So this change does two things:
- It only tries for a match against `Title` when there is no match by `Name`, and it requires that the matched layer have a `Name` (even if it doesn't match).
- It uses the `Name` of the matched layers in later `GetMap` requests.

CC @meh9
