### PR TITLE
Add Urthecast API as catalog member type

### DIFF
--- a/lib/Models/UrthecastCatalogGroup.js
+++ b/lib/Models/UrthecastCatalogGroup.js
@@ -1,0 +1,140 @@
+'use strict';
+
+/*global require*/
+var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+
+var ModelError = require('./ModelError');
+var raiseErrorToUser = require('../Models/raiseErrorToUser');
+var CatalogGroup = require('./CatalogGroup');
+var inherit = require('../Core/inherit');
+var UrthecastCatalogItem = require('./UrthecastCatalogItem');
+var urthecastClient = require('urthecast');
+
+/**
+ * A {@link CatalogGroup} representing a collection of avalible Urthecast sensor platforms.
+ *
+ * @alias UrthecastCatalogGroup
+ * @constructor
+ * @extends CatalogGroup
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+var UrthecastCatalogGroup = function(terria) {
+    CatalogGroup.call(this, terria);
+
+    /**
+     * Gets or sets a hash of names of blacklisted data layers.  A layer that appears in this hash
+     * will not be shown to the user.  In this hash, the keys should be the Title of the layers to blacklist,
+     * and the values should be "true".  This property is observable.
+     * @type {Object}
+     */
+    this.blacklist = undefined;
+
+    knockout.track(this, ['blacklist']);
+};
+
+inherit(CatalogGroup, UrthecastCatalogGroup);
+
+defineProperties(UrthecastCatalogGroup.prototype, {
+    /**
+     * Gets the type of data member represented by this instance.
+     * @memberOf UrthecastCatalogGroup.prototype
+     * @type {String}
+     */
+    type : {
+        get : function() {
+            return 'urthecast-group';
+        }
+    },
+
+    /**
+     * Gets a human-readable name for this type of data source, such as 'Urthcast Sensor Platforms'.
+     * @memberOf UrthecastCatalogGroup.prototype
+     * @type {String}
+     */
+    typeName : {
+        get : function() {
+            return 'Urthcast Sensor Platforms';
+        }
+    },
+});
+
+UrthecastCatalogGroup.prototype._load = function() {
+    var catalogGroup = this;
+    var apiKey = catalogGroup.terria.configParameters.urthecastApiKey;
+    var apiSecret = catalogGroup.terria.configParameters.urthecastApiSecret;
+    var urthecast = urthecastClient(apiKey, apiSecret);
+
+    urthecast.v1.satellite_tracker('/sensor_platforms', {}, function(err, res) {
+        if (err) {
+            raiseErrorToUser(catalogGroup.terria, createModelError(catalogGroup.terria, res.body.messages[0]));
+
+            return;
+        }
+
+        createSensorPlatformsGroup(catalogGroup, res.body.payload);
+    });
+};
+
+function createSensorPlatformsGroup(catalogGroup, sensorPlatforms) {
+    var sensorPlatformsGroup = new CatalogGroup(catalogGroup.terria);
+
+    sensorPlatformsGroup.name = 'Sensor Platforms';
+
+    for (var i = 0; i < sensorPlatforms.length; i++) {
+        var sensor = sensorPlatforms[i];
+
+        if (catalogGroup.blacklist && catalogGroup.blacklist[sensor.name]) {
+            console.log('Provider Feedback: Filtering out ' + sensor.name + ' because it is blacklisted.');
+        } else {
+            var result = new CatalogGroup(catalogGroup.terria);
+
+            result.name = sensor.name;
+            sensorPlatformsGroup.items.push(result);
+
+            createCatalogItem(result, sensor);
+        }
+    }
+
+    catalogGroup.items.push(sensorPlatformsGroup);
+}
+
+function createCatalogItem(catalogGroup, sensor) {
+    // NOTE there is no Urthecast API that returns available renderers.
+    // See https://developers.urthecast.com/docs/map-tiles#service-url for renderer list.
+    var renderers = [
+      { name: 'True RGB', id: 'rgb' },
+      { name: 'Normalized Difference Vegetation Index (NDVI)', id: 'ndvi' },
+      { name: 'Enhanced Vegetation Index (EVI)', id: 'evi' },
+      { name: 'Normalized Difference Water Index (NDWI)', id: 'ndwi' },
+      { name: 'False-color NIR', id: 'false-color-nir' },
+    ];
+
+    for (var i = 0; i < renderers.length; i++ ) {
+        var item = new UrthecastCatalogItem(catalogGroup.terria);
+
+        item.name = renderers[i].name;
+        item.platform = sensor.key;
+        item.renderer = renderers[i].id;
+        item.description = true;
+
+        catalogGroup.items.push(item);
+    }
+}
+
+function createModelError(terria, title) {
+    var message = 'An error occurred while retrieving available sensor platforms from the Urthecast API.';
+
+    message += '<p>';
+    message += 'This error may indicate that the group you opened is temporarily unavailable or there is a problem with your internet connection. Try opening the group again, and if the problem persists, please report it by sending an email to ';
+    message += '<a href="mailto:' + terria.supportEmail + '">' + terria.supportEmail + '</a>.';
+    message += '</p>';
+
+    return new ModelError({
+        title: title,
+        message: message
+    });
+}
+
+module.exports = UrthecastCatalogGroup;

--- a/lib/Models/UrthecastCatalogGroup.js
+++ b/lib/Models/UrthecastCatalogGroup.js
@@ -80,13 +80,16 @@ UrthecastCatalogGroup.prototype._load = function() {
 
     urthecastClient(apiKey, apiSecret).v1.satellite_tracker('/sensor_platforms', {}, function(err, res) {
         if (err) {
-            raiseErrorToUser(catalogGroup.terria, createModelError(catalogGroup.terria, res.body.messages[0]));
+            deferred.reject(createModelError(catalogGroup.terria, res.body.messages[0]));
 
             return;
         }
 
         createSensorPlatformsGroup(catalogGroup, res.body.payload);
+        deferred.resolve();
     });
+
+    return deferred.promise;
 };
 
 function createSensorPlatformsGroup(catalogGroup, sensorPlatforms) {

--- a/lib/Models/UrthecastCatalogGroup.js
+++ b/lib/Models/UrthecastCatalogGroup.js
@@ -3,6 +3,7 @@
 /*global require*/
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var ModelError = require('./ModelError');
 var raiseErrorToUser = require('../Models/raiseErrorToUser');
@@ -62,11 +63,22 @@ defineProperties(UrthecastCatalogGroup.prototype, {
 
 UrthecastCatalogGroup.prototype._load = function() {
     var catalogGroup = this;
+    var deferred = when.defer();
     var apiKey = catalogGroup.terria.configParameters.urthecastApiKey;
     var apiSecret = catalogGroup.terria.configParameters.urthecastApiSecret;
-    var urthecast = urthecastClient(apiKey, apiSecret);
 
-    urthecast.v1.satellite_tracker('/sensor_platforms', {}, function(err, res) {
+    if (!apiKey || !apiSecret) {
+        deferred.reject(createModelError(
+                catalogGroup.terria,
+                'Please Provide an Urthecast API Key and Secret',
+                'Visit [developers.urthecast.com](https://developers.urthecast.com) to obatin your Urthecast API key and secret. If you already have an API key and secret and are having trouble please visit [support.urthecast.com](https://support.urthecast.com) for more information.'
+            )
+        );
+
+        return deferred.promise;
+    }
+
+    urthecastClient(apiKey, apiSecret).v1.satellite_tracker('/sensor_platforms', {}, function(err, res) {
         if (err) {
             raiseErrorToUser(catalogGroup.terria, createModelError(catalogGroup.terria, res.body.messages[0]));
 
@@ -123,18 +135,25 @@ function createCatalogItem(catalogGroup, sensor) {
     }
 }
 
-function createModelError(terria, title) {
-    var message = 'An error occurred while retrieving available sensor platforms from the Urthecast API.';
-
-    message += '<p>';
-    message += 'This error may indicate that the group you opened is temporarily unavailable or there is a problem with your internet connection. Try opening the group again, and if the problem persists, please report it by sending an email to ';
-    message += '<a href="mailto:' + terria.supportEmail + '">' + terria.supportEmail + '</a>.';
-    message += '</p>';
+function createModelError(terria, title, message) {
+    if (!message) {
+        message = getDefaultErrorMessage(terria);
+    }
 
     return new ModelError({
         title: title,
         message: message
     });
+}
+
+function getDefaultErrorMessage(terria) {
+    var message = '<p>';
+
+    message += 'This error may indicate that the group you opened is temporarily unavailable or there is a problem with your internet connection. Try opening the group again, and if the problem persists, please report it by sending an email to ';
+    message += '<a href="mailto:' + terria.supportEmail + '">' + terria.supportEmail + '</a>.';
+    message += '</p>';
+
+    return message;
 }
 
 module.exports = UrthecastCatalogGroup;

--- a/lib/Models/UrthecastCatalogItem.js
+++ b/lib/Models/UrthecastCatalogItem.js
@@ -1,0 +1,159 @@
+'use strict';
+
+/*global require*/
+var UrlTemplateImageryProvider = require('terriajs-cesium/Source/Scene/UrlTemplateImageryProvider');
+var defined = require('terriajs-cesium/Source/Core/defined');
+var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+
+var ImageryLayerCatalogItem = require('./ImageryLayerCatalogItem');
+var inherit = require('../Core/inherit');
+var Metadata = require('./Metadata');
+var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
+
+/**
+ * A {@link ImageryLayerCatalogItem} representing a layer of Urthecast Imagrey.
+ *
+ * @alias UrthecastServerCatalogItem
+ * @constructor
+ * @extends ImageryLayerCatalogItem
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+var UrthecastServerCatalogItem = function(terria) {
+    ImageryLayerCatalogItem.call(this, terria);
+};
+
+inherit(ImageryLayerCatalogItem, UrthecastServerCatalogItem);
+
+defineProperties(UrthecastServerCatalogItem.prototype, {
+    /**
+     * Gets the type of data item represented by this instance.
+     * @memberOf UrthecastServerCatalogItem.prototype
+     * @type {String}
+     */
+    type : {
+        get : function() {
+            return 'urthecast';
+        }
+    },
+
+    /**
+     * Gets a human-readable name for this type of data source, 'Urthecast Map Tiles Service'.
+     * @memberOf UrthecastServerCatalogItem.prototype
+     * @type {String}
+     */
+    typeName : {
+        get : function() {
+            return 'Urthecast Map Tiles Service Renderer';
+        }
+    },
+
+    /**
+     * Gets the metadata associated with this data source and the server that provided it, if applicable.
+     * @memberOf WebMapServiceCatalogItem.prototype
+     * @type {Metadata}
+     */
+    metadata : {
+        get : function() {
+            if (!defined(this._metadata)) {
+                addInfoSections(this, [
+                  {
+                      name: this.name,
+                      content: getMapTileServiceRendererInfo(this.renderer)
+                  },
+                  {
+                      name: 'Sensor Platform',
+                      content: getSensorPlatformInfo(this.platform)
+                  }
+                ]);
+
+                this._metadata = createMetaData();
+
+                return this._metadata;
+            } else {
+                return this._metadata;
+            }
+        }
+    },
+});
+
+UrthecastServerCatalogItem.prototype._createImageryProvider = function() {
+    var url = proxyCatalogItemUrl(this, createMapTileServiceUrl(this));
+
+    return new UrlTemplateImageryProvider({
+        url: url,
+        subdomains: 'abcdefgh',
+    });
+};
+
+function createMapTileServiceUrl(catalogItem) {
+    var url = 'https://tile-{s}.urthecast.com/v1/' + catalogItem.renderer + '/{z}/{x}/{y}';
+
+    url += '?api_key=' + catalogItem.terria.configParameters.urthecastApiKey;
+    url += '&api_secret=' + catalogItem.terria.configParameters.urthecastApiSecret;
+    url += '&sensor_platform=' + catalogItem.platform;
+
+    // NOTE this will yield the best data for all sensor platforms.
+    url += '&cloud_coverage_lte=20';
+
+    return url;
+}
+
+function createMetaData() {
+    var result = new Metadata();
+
+    result.isLoading = false;
+
+    return result;
+}
+
+function addInfoSections(catalogItem, sections) {
+    for (var i = 0; i < sections.length; i++) {
+        catalogItem.info.push({
+            name: sections[i].name,
+            content: sections[i].content
+        });
+    }
+}
+
+// NOTE there is no good way to get this info via API.
+// Content is pulled from the following sources:
+// https://www.urthecast.com/enterprise/cameras
+// http://www.deimos-imaging.com/satellites
+// http://landsat.usgs.gov/landsat8.php
+function getSensorPlatformInfo(sensorPlatform) {
+    var sensorPlatforms = {
+        'landsat-8': 'Landsat 8 carries two instruments: [The Operational Land Imager (OLI)](http://landsat.usgs.gov/ldcm_vs_previous.php) sensor includes refined heritage bands, along with three new bands: a deep blue band for coastal/aerosol studies, a shortwave infrared band for cirrus detection*, and a [Quality Assessment band](http://landsat.usgs.gov/L8_QA_band.php). The [Thermal Infrared Sensor (TIRS)](http://landsat.usgs.gov/ldcm_vs_previous.php) provides two thermal bands. These sensors both provide improved signal-to-noise (SNR) radiometric performance quantized over a 12-bit dynamic range. (This translates into 4096 potential grey levels in an image compared with only 256 grey levels in previous 8-bit instruments.) Improved signal to noise performance enable better characterization of land cover state and condition. Products are delivered as 16-bit images (scaled to 55,000 grey levels).',
+        'theia': '[Urthecast\'s](https://developers.urthecast.com) Medium-Resolution Camera (MRC), Theia, is a conventional linear Charge-Coupled Device (CCD) pushbroom camera. It produces strips of medium-resolution, 4-channel multispectral imagery with a GSD of approximately 5 m and a swath width of approximately 50 km.',
+
+        'iris': 'The High-Resolution Camera (HRC), Iris, is mounted on a biaxial pointing platform that allows for the tracking of targeted Areas of Interest (AOI). Iris uses a CMOS detector to capture full color, Ultra High-Definition (UHD) videos with a Ground Sample Distance (GSD) as fine as 1-meter and a duration of up to 60-seconds.',
+
+        'deimos-1': 'The DEIMOS-1, owned and operated by Deimos Imaging, is the first Spanish Earth Observation Satellite. With a mass of 100 kg, it was launched in 2009, and provides 22m, 3-band imagery with a very wide (650-km) swath. It has been specifically designed to assure very-high-frequency revisit on large areas (every 3 days on average for any mid-latitude region), with precision agriculture and forestry monitoring applications in mind. DEIMOS-1 is member of the Disaster Monitoring Constellation (DMC), and it is nowadays one of the leading sources of high-resolution data worldwide.',
+
+        'deimos-2': 'The DEIMOS-2, owned and operated by Deimos Imaging, is an agile satellite for cost-effective, dependable very-high-resolution EO applications. It provides 75-cm pan-sharpened images with a 12-km swath from its orbital altitude of 620 km. The DEIMOS-2 is operated 24/7, with a network of four ground stations which assures a contact every orbit, and therefore the capacity of commanding the satellite and downloading data every 90 minutes. Launched in June 2014, it entered Initial Operational Capability in November 2014 and Full Operational Capability in May 2015.'
+
+    };
+
+    return sensorPlatforms[sensorPlatform];
+}
+
+// NOTE there is no good way to get this info via API.
+// Content is pulled from the following sources:
+// https://developers.urthecast.com/docs/map-tiles#renderers
+function getMapTileServiceRendererInfo(renderer) {
+    var renderers = {
+        'rgb': 'True RGB (rgb) - this is a traditional mapping of the red, green, and blue spectral bands to the red, green, and blue image channels. This produces a satellite image that looks "normal" to the human eye. True RGB is available for both the Theia and Landsat8 sensors.',
+
+        'ndvi': 'Normalized Difference Vegetation Index (ndvi) is an index that uses the [near-infrared](https://en.wikipedia.org/wiki/NIR) and red spectral bands to calculate a vegetation "health" index. This index is mapped from a red to green hue, where green pixels indicate good crop health and red pixels indicate poor crop health or an absence of vegetation. This index can be used to provide insight into the health of crops and vegetation. It is available for both the Theia and Landsat8 sensors.',
+
+        'evi': 'Enhanced Vegetation Index (evi) is another vegetation index that can be used to help determine the health of crops and vegetation. It differs from NDVI in that the EVI index is more sensitive to variations in canopy structure, canopy type, and canopy architecture ([Wikipedia](https://en.wikipedia.org/wiki/Enhanced_vegetation_index)). In addition, it has an increased ability to eliminate background and atmospheric noises.',
+
+        'ndwi': 'Normalized Difference Water Index (ndwi) uses the near-infrared and green bands to help detect the presence of water in vegetation. The calculated pixel values range from blue to purple - where blue indicates the presence of water, and purple indicates dryer land. It is another tool to determine crop health and condition.',
+
+        'false-color-nir': 'False-color NIR (false-color-nir) is an algorithm that substitutes the red band for the near-infrared band, the red band for the green band, and the green band for the blue band. This provides an alternate view of the image where the (typically) invisible near-infrared light will appear as shades of red.'
+    };
+
+    return renderers[renderer] + ' See [https://developers.urthecast.com/docs/map-tiles](https://developers.urthecast.com/docs/map-tiles) for more information.';
+}
+
+module.exports = UrthecastServerCatalogItem;

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -19,8 +19,6 @@ var WebMapServiceCatalogItem = require('./WebMapServiceCatalogItem');
 var WebMapTileServiceCatalogGroup = require('./WebMapTileServiceCatalogGroup');
 var WebMapTileServiceCatalogItem = require('./WebMapTileServiceCatalogItem');
 var WfsFeaturesCatalogGroup = require('./WfsFeaturesCatalogGroup');
-var UrthecastCatalogGroup = require('./UrthecastCatalogGroup');
-var UrthecastCatalogItem = require('./UrthecastCatalogItem');
 
 var OpenStreetMapCatalogItem = require('./OpenStreetMapCatalogItem');
 
@@ -40,8 +38,6 @@ var registerCatalogMembers = function() {
     createCatalogMemberFromType.register('czml', CzmlCatalogItem);
     createCatalogMemberFromType.register('esri-mapServer', ArcGisMapServerCatalogItem);
     createCatalogMemberFromType.register('esri-mapServer-group', ArcGisCatalogGroup);
-    createCatalogMemberFromType.register('urthecast', UrthecastCatalogItem);
-    createCatalogMemberFromType.register('urthecast-group', UrthecastCatalogGroup);
     createCatalogMemberFromType.register('esri-group', ArcGisCatalogGroup);
     createCatalogMemberFromType.register('geojson', GeoJsonCatalogItem);
     createCatalogMemberFromType.register('gpx', GpxCatalogItem);

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -19,6 +19,8 @@ var WebMapServiceCatalogItem = require('./WebMapServiceCatalogItem');
 var WebMapTileServiceCatalogGroup = require('./WebMapTileServiceCatalogGroup');
 var WebMapTileServiceCatalogItem = require('./WebMapTileServiceCatalogItem');
 var WfsFeaturesCatalogGroup = require('./WfsFeaturesCatalogGroup');
+var UrthecastCatalogGroup = require('./UrthecastCatalogGroup');
+var UrthecastCatalogItem = require('./UrthecastCatalogItem');
 
 var OpenStreetMapCatalogItem = require('./OpenStreetMapCatalogItem');
 
@@ -38,6 +40,8 @@ var registerCatalogMembers = function() {
     createCatalogMemberFromType.register('czml', CzmlCatalogItem);
     createCatalogMemberFromType.register('esri-mapServer', ArcGisMapServerCatalogItem);
     createCatalogMemberFromType.register('esri-mapServer-group', ArcGisCatalogGroup);
+    createCatalogMemberFromType.register('urthecast', UrthecastCatalogItem);
+    createCatalogMemberFromType.register('urthecast-group', UrthecastCatalogGroup);
     createCatalogMemberFromType.register('esri-group', ArcGisCatalogGroup);
     createCatalogMemberFromType.register('geojson', GeoJsonCatalogItem);
     createCatalogMemberFromType.register('gpx', GpxCatalogItem);

--- a/lib/Models/registerUrthecastCatalogItems.js
+++ b/lib/Models/registerUrthecastCatalogItems.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/*global require*/
+
+var createCatalogMemberFromType = require('./createCatalogMemberFromType');
+var UrthecastCatalogGroup = require('./UrthecastCatalogGroup');
+var UrthecastCatalogItem = require('./UrthecastCatalogItem');
+
+function registerUrthecastCatalogItems() {
+    createCatalogMemberFromType.register('urthecast', UrthecastCatalogItem);
+    createCatalogMemberFromType.register('urthecast-group', UrthecastCatalogGroup);
+}
+
+module.exports = registerUrthecastCatalogItems;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "sanitize-caja": "^0.1.3",
     "terriajs-cesium": "1.15.2",
     "togeojson": "^0.9.0",
-    "urijs": "^1.16.0"
+    "urijs": "^1.16.0",
+    "hammerjs": "^2.0.4",
+    "urthecast": "^1.0.0"
   },
   "devDependencies": {
     "browserify": "^9.0.8",
@@ -46,7 +48,8 @@
     "vinyl-source-stream": "^1.1.0",
     "vinyl-transform": "^1.0.0",
     "watchify": "^3.1.1",
-    "yargs": "^3.7.2"
+    "yargs": "^3.7.2",
+    "sinon": "^1.17.2"
   },
   "scripts": {
     "prepublish": "bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\"",

--- a/test/Models/UrthecastCatalogGroupSpec.js
+++ b/test/Models/UrthecastCatalogGroupSpec.js
@@ -3,7 +3,6 @@
 /*global require,describe,beforeEach,it,afterEach,expect*/
 var Terria = require('../../lib/Models/Terria');
 var UrthecastCatalogGroup = require('../../lib/Models/UrthecastCatalogGroup');
-var loadWithXhr = require('terriajs-cesium/Source/Core/loadWithXhr');
 var sinon = require('sinon');
 
 describe('UrthecastCatalogGroup', function() {
@@ -41,6 +40,8 @@ describe('UrthecastCatalogGroup', function() {
     });
 
     it('creates hierarchy of catalog items', function(done) {
+        terria.configParameters.urthecastApiKey = 111;
+        terria.configParameters.urthecastApiSecret = 111;
         group = new UrthecastCatalogGroup(terria);
 
         group.load().then(function() {
@@ -56,6 +57,18 @@ describe('UrthecastCatalogGroup', function() {
             var groupItems = group.items[0].items[0].items;
             expect(groupItems.length).toBe(5);
             expect(groupItems[0].name).toContain('True RGB');
+
+            done();
+        });
+    });
+
+    it('raises an error when no API key or secret is provided', function(done) {
+        terria.configParameters.urthecastApiKey = null;
+        terria.configParameters.urthecastApiSecret = null;
+
+        group = new UrthecastCatalogGroup(terria);
+        group.load().otherwise(function(modelError) {
+            expect(modelError.title).toBe('Please Provide an Urthecast API Key and Secret');
 
             done();
         });

--- a/test/Models/UrthecastCatalogGroupSpec.js
+++ b/test/Models/UrthecastCatalogGroupSpec.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/*global require,describe,beforeEach,it,afterEach,expect*/
+var Terria = require('../../lib/Models/Terria');
+var UrthecastCatalogGroup = require('../../lib/Models/UrthecastCatalogGroup');
+var loadWithXhr = require('terriajs-cesium/Source/Core/loadWithXhr');
+var sinon = require('sinon');
+
+describe('UrthecastCatalogGroup', function() {
+    var terria;
+    var group;
+    var requests = [];
+    var sensorPlatformResponse = {
+        status: 200,
+        messages: [],
+        payload: [{
+            name: "Landsat 8",
+            platform: "landsat-8",
+            key: "landsat-8",
+        },
+        {
+            name: "Theia (MRC)",
+            platform: "iss",
+            key: "theia",
+        }]
+    };
+
+    beforeEach(function() {
+        terria = new Terria({
+            baseUrl: './'
+        });
+
+        this.xhr = sinon.useFakeXMLHttpRequest();
+        this.xhr.onCreate = function (xhr) {
+            requests.push(xhr);
+        };
+    });
+
+    afterEach(function() {
+        this.xhr.restore();
+    });
+
+    it('creates hierarchy of catalog items', function(done) {
+        group = new UrthecastCatalogGroup(terria);
+
+        group.load().then(function() {
+            requests[0].respond(200, { "Content-Type": "application/json" }, JSON.stringify(sensorPlatformResponse));
+
+            // Sensor platforms group
+            expect(group.items.length).toBe(1);
+
+            // Sensor platforms
+            expect(group.items[0].items.length).toBe(2);
+
+            // Map tile service renderers
+            var groupItems = group.items[0].items[0].items;
+            expect(groupItems.length).toBe(5);
+            expect(groupItems[0].name).toContain('True RGB');
+
+            done();
+        });
+    });
+});

--- a/test/Models/UrthecastCatalogItemSpec.js
+++ b/test/Models/UrthecastCatalogItemSpec.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/*global require,describe,it,expect,beforeEach*/
+
+var Terria = require('../../lib/Models/Terria');
+var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
+var UrthecastCatalogItem = require('../../lib/Models/UrthecastCatalogItem');
+
+var terria;
+var urthecastCatalogItem;
+
+beforeEach(function() {
+    terria = new Terria({
+        baseUrl: './'
+    });
+
+    urthecastCatalogItem = new UrthecastCatalogItem(terria);
+
+    urthecastCatalogItem.name = 'True RGB';
+    urthecastCatalogItem.platform = 'theia';
+    urthecastCatalogItem.renderer = 'rgb';
+});
+
+describe('UrthecastCatalogItem', function() {
+    it('has sensible type and typeName', function() {
+        expect(urthecastCatalogItem.type).toBe('urthecast');
+        expect(urthecastCatalogItem.typeName).toBe('Urthecast Map Tiles Service Renderer');
+    });
+
+    it('can be constructed', function() {
+        expect(urthecastCatalogItem).toBeDefined();
+    });
+
+    it('is derived from ImageryLayerDataItemViewModel', function() {
+        expect(urthecastCatalogItem instanceof ImageryLayerCatalogItem).toBe(true);
+    });
+
+    it('contains correct info sections', function() {
+        expect(urthecastCatalogItem.metadata).toBeDefined();
+
+        expect(urthecastCatalogItem.info.length).toBe(2);
+
+        // Renderer info section
+        expect(urthecastCatalogItem.info[0].name).toBe(urthecastCatalogItem.name);
+
+        // Sensor platform info section
+        expect(urthecastCatalogItem.info[1].content.indexOf('Theia')).not.toBe(-1);
+    });
+});

--- a/wwwroot/test/init/urthecast.json
+++ b/wwwroot/test/init/urthecast.json
@@ -1,0 +1,8 @@
+{
+  "catalog": [
+    {
+      "name": "Urthecast",
+      "type": "urthecast-group"
+    }
+  ]
+}


### PR DESCRIPTION
Add Urthecast catalog group that contains available sensor platforms
(theia, landsat 8) and available map tile service renderers as catalog
items.
- Add Urthecast API client as a dependency
- Add sinon.js as a dependency to help mock XHR

resolves #964
