### PR TITLE
Don't allow picking of the Australian Topo layer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+### 1.0.48
+
+* Added the ability to disable feature picking for `ArcGisMapServerCatalogItem`.
+* Disabled feature picking for the Australian Topography and Australian Hydrography base layers created by `createAustraliaBaseMapOptions`.
+
 ### 1.0.47
 
 * Make it possible to disable CSV region mapping warnings with the `showWarnings` init parameter.

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -5,6 +5,7 @@ var URI = require('urijs');
 
 var ArcGisMapServerImageryProvider = require('terriajs-cesium/Source/Scene/ArcGisMapServerImageryProvider');
 var Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3');
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var definedNotNull = require('terriajs-cesium/Source/Core/definedNotNull');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
@@ -74,7 +75,14 @@ var ArcGisMapServerCatalogItem = function(terria) {
      */
     this.showTilesAfterMessage = true;
 
-    knockout.track(this, ['layers', 'maximumScale', '_legendUrl', 'maximumScaleBeforeMessage', 'showTilesAfterMessage']);
+    /**
+     * Gets or sets a value indicating whether features in this catalog item can be selected by clicking them on the map.
+     * @type {Boolean}
+     * @default true
+     */
+    this.allowFeaturePicking = true;
+
+    knockout.track(this, ['layers', 'maximumScale', '_legendUrl', 'maximumScaleBeforeMessage', 'showTilesAfterMessage', 'allowFeaturePicking']);
 
     // metadataUrl and legendUrl are derived from url if not explicitly specified.
     overrideProperty(this, 'metadataUrl', {
@@ -207,7 +215,8 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
         layers: getLayerList(this),
         tilingScheme: new WebMercatorTilingScheme(),
         maximumLevel: maximumLevel,
-        mapServerData: this.mapServerData
+        mapServerData: this.mapServerData,
+        enablePickFeatures: defaultValue(this.allowFeaturePicking, true)
     });
 
     var maximumLevelBeforeMessage = maximumScaleToLevel(this.maximumScaleBeforeMessage);

--- a/lib/ViewModels/createAustraliaBaseMapOptions.js
+++ b/lib/ViewModels/createAustraliaBaseMapOptions.js
@@ -26,12 +26,14 @@ var createAustraliaBaseMapOptions = function(terria) {
     australianTopo.opacity = 1.0;
     australianTopo.isRequiredForRendering = true;
     australianTopo.name = 'Australian Topography';
+    australianTopo.allowFeaturePicking = false;
 
     var australianHydroOverlay = new ArcGisMapServerCatalogItem(terria);
     australianHydroOverlay.name = 'Australian Hydrography';
     australianHydroOverlay.url = 'http://www.ga.gov.au/gis/rest/services/topography/AusHydro_WM/MapServer';
     australianHydroOverlay.opacity = 1.0;
     australianHydroOverlay.isRequiredForRendering = true;
+    australianHydroOverlay.allowFeaturePicking = false;
 
     var australianHydro = new CompositeCatalogItem(terria, [naturalEarthII, australianHydroOverlay]);
     australianHydro.name = 'Australian Hydrography';


### PR DESCRIPTION
- Added the ability to disable feature picking for `ArcGisMapServerCatalogItem`.
- Disabled feature picking for the Australian Topography and Australian Hydrography base layers created by `createAustraliaBaseMapOptions`.

CC @stevage 
