### PR TITLE
Dispose of feature info panel sections after close

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 1.0.49
+
+* Fixed a bug that caused poor performance when clicking a point on the map with lots of features and then closing the feature information panel.
+
 ### 1.0.48
 
 * Added the ability to disable feature picking for `ArcGisMapServerCatalogItem`.

--- a/lib/ViewModels/FeatureInfoPanelViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelViewModel.js
@@ -100,8 +100,12 @@ FeatureInfoPanelViewModel.prototype.closeIfClickOnBackground = function(viewMode
 };
 
 FeatureInfoPanelViewModel.prototype.close = function() {
-    // no need to remove sections yet (and that would briefly flash an empty feature info panel as it closes)
     this.isVisible = false;
+    var that = this;
+    // wait a moment for animations to finish, then dispose of the panel sections - they may have clock subscriptions
+    setTimeout(function() {
+        that.resetSections();
+    }, 400);
 };
 
 FeatureInfoPanelViewModel.prototype.destroy = function() {


### PR DESCRIPTION
This fixes this issue: "We have an interesting thing happen on our OSX laptops using Chrome, when viewing ACMA, after having clicked somewhere so the "more than feature_count" warning message is shown, after you close the feature info box the globe rendering speed drops to about 1fps..."

It's not an issue while the feature info box is open - only after you close it, and only if there were lots of features shown (but not necessarily the full feature_count). Reopening the info box fixes it. And it's happening without any clock listeners.
