### PR TITLE
Show Feature Info properties using linkify, not markdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 ### 1.0.49
 
 * Fixed a bug that caused poor performance when clicking a point on the map with lots of features and then closing the feature information panel.
+* Apply linkify, instead of markdown, to properties shown in the Feature Info Panel.
 
 ### 1.0.48
 

--- a/lib/Core/formatPropertyValue.js
+++ b/lib/Core/formatPropertyValue.js
@@ -1,7 +1,9 @@
 "use strict";
 
 /*global require*/
-var markdownToHtml = require('../Core/markdownToHtml');
+var linkifyContent = require('./linkifyContent');
+var defined = require('terriajs-cesium/Source/Core/defined');
+
 
 function numberWithCommas(x) {
     var str = x.toString();
@@ -29,7 +31,11 @@ function formatPropertyValue(value) {
     if (typeof value === 'number') {
         return numberWithCommas(value);
     } else if (typeof value === 'string') {
-        return markdownToHtml(value, true);
+        // do not linkify if it contains html elements, which we detect by looking for <x...>
+        // this could catch some non-html strings such as "a<3 && b>1", but not linkifying those is no big deal
+        if (!/<[a-z][\s\S]*>/i.test(value)) {
+            return linkifyContent(value);
+        }
     }
     return value;
 }

--- a/lib/Core/formatPropertyValue.js
+++ b/lib/Core/formatPropertyValue.js
@@ -2,7 +2,6 @@
 
 /*global require*/
 var linkifyContent = require('./linkifyContent');
-var defined = require('terriajs-cesium/Source/Core/defined');
 
 
 function numberWithCommas(x) {

--- a/lib/Core/linkifyContent.js
+++ b/lib/Core/linkifyContent.js
@@ -5,7 +5,7 @@ var linkify = require('linkify-it')();
 
 
 function linkifyContent(content) {
-    
+
     var matches = linkify.match(content),
             result  = [],
             last;

--- a/lib/Core/linkifyContent.js
+++ b/lib/Core/linkifyContent.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/*global require*/
+var linkify = require('linkify-it')();
+
+
+function linkifyContent(content) {
+    
+    var matches = linkify.match(content),
+            result  = [],
+            last;
+
+    if (matches) {
+        last = 0;
+        matches.forEach(function (match) {
+            if (last < match.index) {
+                result.push(content.slice(last, match.index).replace(/\r?\n/g, '<br>'));
+            }
+            result.push('<a target="_blank" href="');
+            result.push(match.url);
+            result.push('">');
+            result.push(match.text);
+            result.push('</a>');
+            last = match.lastIndex;
+        });
+        if (last < content.length) {
+            result.push(content.slice(last).replace(/\r?\n/g, '<br>'));
+        }
+        content = result.join('');
+    }
+
+    return content;
+}
+
+module.exports = linkifyContent;

--- a/lib/Styles/Core.less
+++ b/lib/Styles/Core.less
@@ -206,9 +206,11 @@ select {
     margin-top: 0;
     margin-bottom: 1rem;
   }
-  p:last-child {		
+  
+  p:last-child {
     margin-bottom: 0;
   }
+  
   strong { font-weight: bold }
   em { font-style: italic }
   small {font-size: 80%;}

--- a/lib/Styles/Core.less
+++ b/lib/Styles/Core.less
@@ -206,11 +206,11 @@ select {
     margin-top: 0;
     margin-bottom: 1rem;
   }
-  
+
   p:last-child {
     margin-bottom: 0;
   }
-  
+
   strong { font-weight: bold }
   em { font-style: italic }
   small {font-size: 80%;}

--- a/lib/Styles/Core.less
+++ b/lib/Styles/Core.less
@@ -204,11 +204,7 @@ select {
 
   p {
     margin-top: 0;
-    margin-bottom: 1rem;
-  }
-
-  p:last-child {
-    margin-bottom: 0;
+    margin-bottom: 0; // 1rem;
   }
 
   strong { font-weight: bold }

--- a/lib/Styles/Core.less
+++ b/lib/Styles/Core.less
@@ -204,9 +204,11 @@ select {
 
   p {
     margin-top: 0;
-    margin-bottom: 0; // 1rem;
+    margin-bottom: 1rem;
   }
-
+  p:last-child {		
+    margin-bottom: 0;
+  }
   strong { font-weight: bold }
   em { font-style: italic }
   small {font-size: 80%;}


### PR DESCRIPTION
Fixes #1084.
Note the `linkify-it` package doesn't explicitly include a function to linkify a string. The `linkifyContent` function I define below is based on the example they provide in their [demo](http://markdown-it.github.io/linkify-it/index.js).
