### PR TITLE
Issue 988 proxy Url for legend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * `CsvCatalogItem` and `AbsIttCatalogItem` now expose a `concepts` property that can be used to adjust the display.
 * Added `Terria.cesiumBaseUrl` property.
 * The user interface container DOM element may now be provided to `TerriaViewer` by specifying `uiContainer` in its options.  Previously it always used an element named `ui`.
+* Legend URLs are now accessed via the proxy, if applicable.
 
 ### 1.0.48
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,6 +17,7 @@ The following people have contributed to TerriaJS:
    * [Chloe Chen](https://github.com/chloeleichen)
    * [Arthur Street](https://github.com/racingtadpole)
    * [Mats Henrikson](https://github.com/meh9)
+   * [Stephen Davies](https://github.com/steve9164)
 * [Geoscience Australia](http://www.ga.gov.au/)
    * [Darren Reid](https://github.com/Layoric)
 * [Propeller Aerobotics](http://www.propelleraero.com.au/)

--- a/lib/ViewModels/LegendSectionViewModel.js
+++ b/lib/ViewModels/LegendSectionViewModel.js
@@ -18,12 +18,11 @@ LegendSectionViewModel.createForCatalogMember = function(catalogMember) {
 };
 
 LegendSectionViewModel.prototype.show = function(container) {
-	// Proxy legend Urls (should be in a function that is only called once - could be moved to constructor?)
-	
-	this.proxiedLegendUrls = this.catalogMember.legendUrls.map(function(legendUrl) { // Proxy each legend Url
-		return proxyCatalogItemUrl(this, legendUrl);
-	}, this);
-	
+	if (!defined(this.proxiedLegendUrls)) {
+		this.proxiedLegendUrls = this.catalogMember.legendUrls.map(function(legendUrl) { // Proxy each legend Url
+			return proxyCatalogItemUrl(this, legendUrl);
+		}, this);
+	}
     loadView(require('fs').readFileSync(__dirname + '/../Views/LegendSection.html', 'utf8'), container, this);
 };
 

--- a/lib/ViewModels/LegendSectionViewModel.js
+++ b/lib/ViewModels/LegendSectionViewModel.js
@@ -8,12 +8,12 @@ var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 
 var LegendSectionViewModel = function(catalogMember) {
     this.catalogMember = catalogMember;
-	
-	knockout.defineProperty(this, 'proxiedLegendUrls', {
+    
+    knockout.defineProperty(this, 'proxiedLegendUrls', {
         get: function() {
             return this.catalogMember.legendUrls.map(function(legendUrl) { // Proxy each legend Url
-				return proxyCatalogItemUrl(this, legendUrl);
-			}, this);
+                return proxyCatalogItemUrl(this, legendUrl);
+            }, this);
         }
     });
 };

--- a/lib/ViewModels/LegendSectionViewModel.js
+++ b/lib/ViewModels/LegendSectionViewModel.js
@@ -3,6 +3,7 @@
 /*global require*/
 var defined = require('terriajs-cesium/Source/Core/defined');
 var loadView = require('../Core/loadView');
+var proxyCatalogItemUrl = require('../Models/proxyCatalogItemUrl');
 
 var LegendSectionViewModel = function(catalogMember) {
     this.catalogMember = catalogMember;
@@ -17,6 +18,12 @@ LegendSectionViewModel.createForCatalogMember = function(catalogMember) {
 };
 
 LegendSectionViewModel.prototype.show = function(container) {
+	// Proxy legend Urls (should be in a function that is only called once - could be moved to constructor?)
+	
+	this.proxiedLegendUrls = this.catalogMember.legendUrls.map(function(legendUrl) { // Proxy each legend Url
+		return proxyCatalogItemUrl(this, legendUrl);
+	}, this);
+	
     loadView(require('fs').readFileSync(__dirname + '/../Views/LegendSection.html', 'utf8'), container, this);
 };
 

--- a/lib/ViewModels/LegendSectionViewModel.js
+++ b/lib/ViewModels/LegendSectionViewModel.js
@@ -4,25 +4,28 @@
 var defined = require('terriajs-cesium/Source/Core/defined');
 var loadView = require('../Core/loadView');
 var proxyCatalogItemUrl = require('../Models/proxyCatalogItemUrl');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 
 var LegendSectionViewModel = function(catalogMember) {
     this.catalogMember = catalogMember;
+	
+	knockout.defineProperty(this, 'proxiedLegendUrls', {
+        get: function() {
+            return this.catalogMember.legendUrls.map(function(legendUrl) { // Proxy each legend Url
+				return proxyCatalogItemUrl(this, legendUrl);
+			}, this);
+        }
+    });
 };
 
 LegendSectionViewModel.createForCatalogMember = function(catalogMember) {
     if (!defined(catalogMember.legendUrls) || catalogMember.legendUrls.length === 0) {
         return undefined;
     }
-
     return new LegendSectionViewModel(catalogMember);
 };
 
 LegendSectionViewModel.prototype.show = function(container) {
-	if (!defined(this.proxiedLegendUrls)) {
-		this.proxiedLegendUrls = this.catalogMember.legendUrls.map(function(legendUrl) { // Proxy each legend Url
-			return proxyCatalogItemUrl(this, legendUrl);
-		}, this);
-	}
     loadView(require('fs').readFileSync(__dirname + '/../Views/LegendSection.html', 'utf8'), container, this);
 };
 

--- a/lib/Views/LegendSection.html
+++ b/lib/Views/LegendSection.html
@@ -1,4 +1,4 @@
-<div data-bind="foreach: catalogMember.legendUrls || []">
+<div data-bind="foreach: proxiedLegendUrls || []">
     <!-- ko if: $root.urlIsImage($data) -->
     <a data-bind="attr: { href: $data }" target="_blank">
         <img class="now-viewing-legend-image" data-bind="attr: { src: $data }" />
@@ -10,7 +10,7 @@
     <!-- /ko -->
 </div>
 
-<div data-bind="if: !catalogMember.legendUrls || catalogMember.legendUrls.length === 0">
+<div data-bind="if: !proxiedLegendUrls || proxiedLegendUrls.length === 0">
     <!-- ko if: catalogMember.type !== 'abs-itt' -->
     <div class="now-viewing-legend-text">No legend available for this data item.</div>
     <!-- /ko -->


### PR DESCRIPTION
@kring issue https://github.com/TerriaJS/terriajs/issues/988. Legend Urls are proxied in LegendSectionViewModel.show(), but that could be moved to the constructor if that would be a better place.
