### PR TITLE
Fixes #1107. Click propagation from animation controls and timeline disabled.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Legend URLs are now accessed via the proxy, if applicable.
 * Fixed a bug that prevented feature scaling by value.
 * Added support for [Urthecast](https://www.urthecast.com/) with `UrthecastCatalogGroup`.
+* Fixed a bug with Leaflet 2D map where clicks on animation controls or timeline would also register on the map underneath causing undesired feature selection and, when double clicked, zooming (also removed an old hack that disabled dragging while using the timeline slider)
 
 ### 1.0.48
 

--- a/lib/ViewModels/AnimationViewModel.js
+++ b/lib/ViewModels/AnimationViewModel.js
@@ -1,6 +1,8 @@
 'use strict';
 
 /*global require*/
+var L = require('leaflet');
+
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 
@@ -126,6 +128,12 @@ function formatDateTime(d, locale) {
 
 function setupTimeline(viewModel) {
     var timelineContainer = document.getElementsByClassName('animation-timeline')[0];
+    var controlsContainer = document.getElementsByClassName('animation-controls')[0];
+    
+    L.DomEvent.disableClickPropagation(timelineContainer);
+    L.DomEvent.disableClickPropagation(controlsContainer);
+    
+    
     var timeline = new Timeline(timelineContainer, viewModel.terria.clock);
     viewModel.timeline = timeline;
 
@@ -143,13 +151,6 @@ function setupTimeline(viewModel) {
     };
 
     timeline.scrubFunction = function(e) {
-        var leaflet = viewModel.terria.leaflet;
-        if (defined(leaflet) && defined(leaflet.map) && leaflet.map.dragging.enabled()) {
-            leaflet.map.dragging.disable();
-            leaflet.map.on('mouseup', function(e) {
-                leaflet.map.dragging.enable();
-            });
-        }
         var clock = e.clock;
         clock.currentTime = e.timeJulian;
         clock.shouldAnimate = false;


### PR DESCRIPTION
@kring Fixes #1107. Also removed what looks like a hack to disable dragging the map while adjusting the slider on the timeline.
