### PR TITLE
Modify GeoJsonCatalogItem error messages

### DIFF
--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -221,9 +221,9 @@ GeoJsonCatalogItem.prototype._load = function() {
                     sender: that,
                     title: 'Error loading GeoJSON',
                     message: '\
-            An error occurred while loading a GeoJSON file.  This may indicate that the file is invalid or that it \
-            is not supported by '+that.terria.appName+'.  If you would like assistance or further information, please email us \
-            at <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.supportEmail+'</a>.'
+An error occurred while loading a GeoJSON file.  This may indicate that the file is invalid or that it \
+is not supported by '+that.terria.appName+'.  If you would like assistance or further information, please email us \
+at <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.supportEmail+'</a>.'
                 });
             });
         });

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -204,9 +204,9 @@ GeoJsonCatalogItem.prototype._load = function() {
                         sender: that,
                         title: 'Error loading GeoJSON',
                         message: '\
-            An error occurred parsing the provided data as JSON.  This may indicate that the file is invalid or that it \
-            is not supported by '+that.terria.appName+'.  If you would like assistance or further information, please email us \
-            at <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.supportEmail+'</a>.'
+An error occurred parsing the provided data as JSON.  This may indicate that the file is invalid or that it \
+is not supported by '+that.terria.appName+'.  If you would like assistance or further information, please email us \
+at <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.supportEmail+'</a>.'
                     });
                 }
             } else {


### PR DESCRIPTION
Fixes #1122.

Error messages in GeoJsonCatalogItem currently have more than 4 spaces in front of the first line, causing Markdown to treat them as lines of code, hence displaying the error message in a small blue box in plaintext without links.
