### PR TITLE
Fix documentation of Cesium.updateLayerOrderToKeepOnTop

### DIFF
--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -424,7 +424,7 @@ Cesium.prototype.computePositionOnScreen = function(position, result) {
 };
 
 /**
- * Updates the order of layers, moving layers marked {@link CatalogItem#keepOnTop} to the top.
+ * Updates the order of layers, moving layers where {@link CatalogItem#keepOnTop} is true to the top.
  */
 Cesium.prototype.updateLayerOrderToKeepOnTop = function() {
     // move alwaysOnTop layers to the top

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -424,7 +424,7 @@ Cesium.prototype.computePositionOnScreen = function(position, result) {
 };
 
 /**
- * Updates the order of layers to match the order in the Now Viewing pane.
+ * Updates the order of layers, moving layers marked {@link CatalogItem#keepOnTop} to the top.
  */
 Cesium.prototype.updateLayerOrderToKeepOnTop = function() {
     // move alwaysOnTop layers to the top


### PR DESCRIPTION
Fixes #1125.

Slightly incorrect documentation on one function.
