### PR TITLE
Use `parseFloat` instead of `Number.parseFloat`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Legend URLs are now accessed via the proxy, if applicable.
 * Fixed a bug that prevented feature scaling by value.
 * Added support for [Urthecast](https://www.urthecast.com/) with `UrthecastCatalogGroup`.
+* Fixed a bug that could cause an exception in some browsers (Internet Explorer, Safari) when loading a GeoJSON with embedded styles.
 
 ### 1.0.48
 

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -452,10 +452,10 @@ function loadGeoJson(geoJsonItem) {
 
     options.fill = defaultColor(style.fill, options.stroke.clone);
     if (defined(style['stroke-opacity'])) {
-        options.stroke.alpha = Number.parseFloat(style['stroke-opacity']);
+        options.stroke.alpha = parseFloat(style['stroke-opacity']);
     }
     if (defined(style['fill-opacity'])) {
-        options.fill.alpha = Number.parseFloat(style['fill-opacity']);
+        options.fill.alpha = parseFloat(style['fill-opacity']);
     } else {
         options.fill.alpha = 0.75;
     }
@@ -479,12 +479,12 @@ function loadGeoJson(geoJsonItem) {
                 });
                 if (defined (entity.properties['marker-opacity'])) {
                     // not part of SimpleStyle spec, but why not?
-                    entity.point.color.alpha = Number.parseFloat(entity.properties['marker-opacity']);
+                    entity.point.color.alpha = parseFloat(entity.properties['marker-opacity']);
                 }
                 entity.billboard = undefined;
             }
             if (defined(entity.billboard) && defined(entity.properties['marker-opacity'])) {
-                entity.billboard.color = new Color(1, 1, 1, Number.parseFloat(entity.properties['marker-opacity']));
+                entity.billboard.color = new Color(1, 1, 1, parseFloat(entity.properties['marker-opacity']));
             }
         }
     });


### PR DESCRIPTION
The latter is not supported on IE or Safari.
