### PR TITLE
Use html2canvas v0.5.0-alpha2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "brfs": "^1.4.0",
     "hammerjs": "^2.0.4",
-    "html2canvas": "^0.5.0-alpha2",
+    "html2canvas": "0.5.0-alpha2",
     "javascript-natural-sort": "^0.7.1",
     "leaflet": "^0.7.3",
     "less": "^2.5.0",


### PR DESCRIPTION
The next version after that, 0.5.0-beta3, is broken or perhaps incompatible with our version of node or npm.
