### PR TITLE
Don't show duplicate search results

### DIFF
--- a/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
+++ b/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
@@ -161,12 +161,7 @@ function findMatchingItemsRecursively(viewModel, searchInProgress, searchExpress
 
         // Match non-top-level items whose name contain the search text.
         if (searchExpression.test(item.name) && itemMatchesFilters(item, searchFilters)) {
-            viewModel.searchResults.push(new SearchResultViewModel({
-                name: item.name,
-                isImportant: true,
-                catalogItem: item,
-                tooltip: pathToTooltip(path)
-            }));
+            addSearchResult(viewModel.searchResults, item, path);
         }
 
         if (defined(item.items)) {
@@ -193,6 +188,33 @@ function findItemsInLoadedGroup(viewModel, searchInProgress, searchExpression, i
 }
 
 function ignoreLoadErrors() {
+}
+
+function addSearchResult(searchResults, item, path) {
+    // Get the index of an existing search result that refers to the same catalog item (or -1)
+    var index = -1;
+    for (var j = 0; j < searchResults.length; ++j) {
+        if (item === searchResults[j].catalogItem) {
+            index = j;
+            break;
+        }
+    }
+
+    // If a search result for item already exists, modify the tooltip of that search result
+    var prefix = 'In multiple locations including: ';
+    if (index >= 0) {
+        if (searchResults[index].tooltip.indexOf(prefix) !== 0) {
+            searchResults[index].tooltip = searchResults[index].tooltip.replace(/^In /, prefix)
+        }
+    }
+    else { // Otherwise, create a new search result
+        searchResults.push(new SearchResultViewModel({
+            name: item.name,
+            isImportant: true,
+            catalogItem: item,
+            tooltip: pathToTooltip(path)
+        }));
+    }
 }
 
 function pathToTooltip(path) {

--- a/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
+++ b/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
@@ -204,7 +204,7 @@ function addSearchResult(searchResults, item, path) {
     var prefix = 'In multiple locations including: ';
     if (index >= 0) {
         if (searchResults[index].tooltip.indexOf(prefix) !== 0) {
-            searchResults[index].tooltip = searchResults[index].tooltip.replace(/^In /, prefix)
+            searchResults[index].tooltip = searchResults[index].tooltip.replace(/^In /, prefix);
         }
     }
     else { // Otherwise, create a new search result


### PR DESCRIPTION
Search results no longer contain duplicate results. Instead of showing duplicate results for an item with multiple locations, the tooltip is now updated to indicate that the catalog item exists in multiple locations as well as showing the location of the first result (of the duplicates) the search found.

For testing, search for "cfa" in the search tab.

Fixes #1131.
