### PR TITLE
Fix HTTPS-related problems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ Change Log
 * Use `PolylineGraphics` instead of `PolygonGraphics` for unfilled polygons with an outline width greater than 1.  This works around the fact that Cesium does not support polygons with outline width great than 1 on Windows due to a WebGL limitation.
 * Sorted ABS age variables numerically, not alphabetically.
 * Removed extra space at the bottom of base map buttons.
+* Fixed a bug that prevented region mapping from working over HTTPS.
+* The proxy is now used to avoid a mixed content warning when accessing an HTTP dataset from an HTTPS deployment of TerriaJS.
 
 ### 1.0.49
 

--- a/lib/Core/corsProxy.js
+++ b/lib/Core/corsProxy.js
@@ -41,7 +41,7 @@ corsProxy.shouldUseProxy = function(url) {
     }
 
     if (corsProxy.pageIsHttps && uri.protocol() === 'http') {
-        // if we're accessing an http resource from and https page, always proxy in order to avoid a mixed content error.
+        // if we're accessing an http resource from an https page, always proxy in order to avoid a mixed content error.
         return true;
     }
 

--- a/lib/Core/corsProxy.js
+++ b/lib/Core/corsProxy.js
@@ -14,7 +14,7 @@ var corsProxy = {
     proxyDomains : [],     // domains that should be proxied for, as set by config files
     corsDomains : [],      // domains that are known to support CORS, as set by config files
     alwaysUseProxy : false, // use proxy on all domains, for browsers that don't support CORS
-    isHttps : typeof window !== 'undefined' && defined(window.location) && defined(window.location.href) && new URI(window.location.href).protocol() === 'https'
+    pageIsHttps : typeof window !== 'undefined' && defined(window.location) && defined(window.location.href) && new URI(window.location.href).protocol() === 'https'
 };
 
 /**
@@ -40,7 +40,7 @@ corsProxy.shouldUseProxy = function(url) {
         return true;
     }
 
-    if (corsProxy.isHttps && uri.protocol() === 'http') {
+    if (corsProxy.pageIsHttps && uri.protocol() === 'http') {
         // if we're accessing an http resource from and https page, always proxy in order to avoid a mixed content error.
         return true;
     }

--- a/lib/Core/corsProxy.js
+++ b/lib/Core/corsProxy.js
@@ -13,7 +13,8 @@ var corsProxy = {
     },
     proxyDomains : [],     // domains that should be proxied for, as set by config files
     corsDomains : [],      // domains that are known to support CORS, as set by config files
-    alwaysUseProxy : false // use proxy on all domains, for browsers that don't support CORS
+    alwaysUseProxy : false, // use proxy on all domains, for browsers that don't support CORS
+    isHttps : typeof window !== 'undefined' && defined(window.location) && defined(window.location.href) && new URI(window.location.href).protocol() === 'https'
 };
 
 /**
@@ -27,15 +28,20 @@ corsProxy.shouldUseProxy = function(url) {
         // eg. no url may be passed if all data is embedded
         return false;
     }
-    
+
     var uri = new URI(url);
-    var host = uri.host();  
-    
+    var host = uri.host();
+
     if (!hostInDomains(host, corsProxy.proxyDomains)) {
         // we're not willing to proxy for this host
         return false;
     }
     if (corsProxy.alwaysUseProxy) {
+        return true;
+    }
+
+    if (corsProxy.isHttps && uri.protocol() === 'http') {
+        // if we're accessing an http resource from and https page, always proxy in order to avoid a mixed content error.
         return true;
     }
 
@@ -56,7 +62,7 @@ function hostInDomains(host, domains) {
 
     host = host.toLowerCase();
     for (var i = 0; i < domains.length; i++) {
-        if (host.match("(^|\.)" + domains[i] + "$")) {
+        if (host.match("(^|\\.)" + domains[i] + "$")) {
             return true;
         }
     }

--- a/lib/Map/RegionProvider.js
+++ b/lib/Map/RegionProvider.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /*global require*/
+var corsProxy = require('../Core/corsProxy');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
@@ -24,7 +25,7 @@ Responsibilities:
 
 /**
  * Instantiate a region provider by giving it an entry from the region mapping JSON file.
- * 
+ *
  * @alias RegionProvider
  * @constructor
  * @param {String} regionType Unique text identifier.
@@ -37,9 +38,9 @@ var RegionProvider = function(regionType, properties) {
      */
     this.regionType = regionType;
 
-    /** 
+    /**
     * WMS attribute whose value will correspond to each region's code.
-    * @type {String} 
+    * @type {String}
     */
     this.regionProp = properties.regionProp;
     /**
@@ -72,13 +73,13 @@ var RegionProvider = function(regionType, properties) {
     this.serverReplacements = properties.serverReplacements instanceof Array ? properties.serverReplacements.map(function(r) {
         return [ r[0], r[1].toLowerCase(), new RegExp(r[0].toLowerCase(), 'gi') ];
     }) : [];
-    
+
     /**
      * Array of [regex, replacement] arrays which will be applied to each user-provided ID element before matching
      * is attempted. For example, [ [ ' \(.\)$' ], '' ] will convert 'Baw Baw (S)' to 'Baw Baw'
      * @type {Array[]}
      */
-    
+
     this.dataReplacements = properties.dataReplacements instanceof Array ? properties.dataReplacements.map(function(r) {
         return [ r[0], r[1].toLowerCase(), new RegExp(r[0].toLowerCase(), 'gi') ];
     }) : [];
@@ -89,7 +90,7 @@ var RegionProvider = function(regionType, properties) {
     /** The property within the same WFS region that can be used for disambiguation. */
     this.disambigProp = properties.disambigProp;
 
-    /** 
+    /**
      * Returns the name of a field which uniquely identifies each region. This field is not necessarily used for matching, or
      * of interest to the user, but is needed for reverse lookups. This field must count from zero, and features must be
      * returned in sorted order.
@@ -97,7 +98,7 @@ var RegionProvider = function(regionType, properties) {
      */
     this.uniqueIdProp = defaultValue(properties.uniqueIdProp, 'FID');
 
-    /** 
+    /**
      * Whether this region type uses text codes, rather than numeric. It matters because numeric codes are treated differently by the
      * CSV handling models.
      * @type {Boolean}
@@ -146,7 +147,7 @@ RegionProvider.prototype.loadRegionsFromXML = function(xml, propertyName, replac
         var exception = defined(obj.Exception) ? ('<br/><br/>' + obj.Exception.ExceptionText) : '';
         throw new ModelError({ title: 'CSV region mapping', message: 'Couldn\'t load region boundaries for region ' + this.regionProp + exception});
     }
-    
+
     if (!(obj.member instanceof Array)) {
         obj.member = [obj.member];
     }
@@ -178,9 +179,9 @@ RegionProvider.prototype.loadRegionsFromXML = function(xml, propertyName, replac
     }
 };
 
-/** 
+/**
  * Given an entry from the region mapping config, contact our WFS server to get the list of all IDs of that type.
- * 
+ *
  * @return {Object} Promise that returns true if IDs were loaded for the first time, or false if already loaded.
  */
 RegionProvider.prototype.loadRegionIDs = function() {
@@ -189,10 +190,10 @@ RegionProvider.prototype.loadRegionIDs = function() {
     }
     if (this.server === undefined) {
         throw (new DeveloperError('No server for region mapping defined: ' + this.regionType));
-    }            
+    }
     var that = this;
 
-    var baseuri = URI(this.server).addQuery({ 
+    var baseuri = URI(this.server).addQuery({
         service: 'wfs',
         version: '2.0',
         request: 'getPropertyValue',
@@ -201,7 +202,11 @@ RegionProvider.prototype.loadRegionIDs = function() {
     // get the list of IDs that we will attempt to match against for this column
     var promises = [];
     var url = baseuri.setQuery('valueReference', this.regionProp).toString();
-    // note: currently region requests are never proxied.
+
+    if (corsProxy.shouldUseProxy(url)) {
+        url = corsProxy.getURL(url);
+    }
+
     promises.push(loadText(url)
         .then(function(xml) {
             that.loadRegionsFromXML(xml, undefined, "serverReplacements");
@@ -235,9 +240,9 @@ RegionProvider.prototype.applyReplacements = function (s, replacementsProp) {
     }
 
     if (this._appliedReplacements[replacementsProp][r] !== undefined) {
-        return this._appliedReplacements[replacementsProp][s]; // [r]? 
+        return this._appliedReplacements[replacementsProp][s]; // [r]?
     }
-    
+
     replacements.forEach(function(rep) {
         r = r.replace(rep[2], rep[1]);
     });
@@ -277,12 +282,12 @@ RegionProvider.prototype.codeMatchesRegionID = function(id, processedCode, disam
 
 /**
  * Given a region code, try to find a region that matches it, using replacements, disambiguation and other wizardry.
- * 
+ *
  * @param {String} code Code to search for.
  * @returns {Number} Zero-based index in list of regions if successful, or -1.
  */
 RegionProvider.prototype.findRegionIndex = function(code, disambigCode) {
-    if (typeof code === 'number') 
+    if (typeof code === 'number')
         code = String(code);
     var processedCode  = this.applyReplacements(code.toLowerCase(), 'dataReplacements');
 
@@ -295,7 +300,7 @@ RegionProvider.prototype.findRegionIndex = function(code, disambigCode) {
     for (var i = 0; i < this.regions.length; i++) {
         var dabId;
         if (defined(disambigCode) && defined(this.disambigProp)) {
-            dabId =  this.regions[i][this.disambigProp];    
+            dabId =  this.regions[i][this.disambigProp];
         }
         if (this.codeMatchesRegionID(this.regions[i].id, processedCode, dabId, processedDisambigCode)) {
             return i;
@@ -376,9 +381,9 @@ RegionProvider.prototype.getRegionValues = function (dataset, regionVariable, di
 
 /**
  * Pre-generates a function which quickly turns a value into a colour.
- * 
+ *
  * @param {Number[]} regionValues Array of values.
- * @param {Function} colorFunc should be function(val) { return [r,g,b,a]; } 
+ * @param {Function} colorFunc should be function(val) { return [r,g,b,a]; }
  * @returns {Function} Function of type f(regionIndex) { return [r,g,b,a]; } which may return undefined.
  */
 RegionProvider.prototype.getColorLookupFunc = function(regionValues, colorFunc) {
@@ -393,7 +398,7 @@ function findVariableForAliases(varNames, aliases) {
         var re = new RegExp('^' + aliases[j] + '$', 'i');
         for (var i = 0; i < varNames.length; i++) {
             if (re.test(varNames[i])) {
-                return varNames[i]; 
+                return varNames[i];
             }
         }
     }

--- a/test/Core/corsProxySpec.js
+++ b/test/Core/corsProxySpec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/*global require*/
+var corsProxy = require('../../lib/Core/corsProxy');
+
+describe('corsProxy', function() {
+    beforeEach(function() {
+        corsProxy.pageIsHttps = false;
+        corsProxy.proxyDomains.length = 0;
+        corsProxy.corsDomains.length = 0;
+    });
+
+    it('does not proxy CORS requests', function() {
+        corsProxy.proxyDomains.push('example.com');
+        corsProxy.corsDomains.push('example.com');
+        expect(corsProxy.shouldUseProxy('http://www.example.com/foo')).toBe(false);
+    });
+
+    it('proxies non-CORS http requests on https sites', function() {
+        corsProxy.pageIsHttps = true;
+        corsProxy.proxyDomains.push('example.com');
+        expect(corsProxy.shouldUseProxy('http://www.example.com/foo')).toBe(true);
+    });
+
+    it('proxies CORS http requests on https sites', function() {
+        corsProxy.pageIsHttps = true;
+        corsProxy.proxyDomains.push('example.com');
+        corsProxy.corsDomains.push('example.com');
+        expect(corsProxy.shouldUseProxy('http://www.example.com/foo')).toBe(true);
+    });
+});


### PR DESCRIPTION
The WFS request used in region mapping wasn't set up to ever go through the proxy.  Now it will do so when necessary.

Also, `corsProxy.shouldUseProxy` now returns true whenever the URL's protocol is `http` and the page's protocol is `https` (assuming we're allowed to proxy for the host at all).  This avoids a mixed-content warning.
