### PR TITLE
Add Progress Bar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 
 * Fixed a typo that prevent clearing the search query
 * Add support for Nominatim search API hosted by OpenStreetMap (http://wiki.openstreetmap.org/wiki/Nominatim). This work by merging to 2 queries : one with the bounding parameter for nearest results, the other without the bounding parameter. `countrycodes` values could be used into the catalog item parameters to limit the result to a set of specific countries.
+* Added `MapProgressBarViewModel`.  When added to the user interface with `MapProgressBarViewModel.create`, it shows a bar at the top of the map window indicating tile load progress.
 
 ### 1.0.50
 

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -23,6 +23,7 @@ var ScreenSpaceEventType = require('terriajs-cesium/Source/Core/ScreenSpaceEvent
 var TaskProcessor = require('terriajs-cesium/Source/Core/TaskProcessor');
 var Transforms = require('terriajs-cesium/Source/Core/Transforms');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
+var EventHelper = require('terriajs-cesium/Source/Core/EventHelper');
 
 var CesiumSelectionIndicator = require('../Map/CesiumSelectionIndicator');
 var GlobeOrMap = require('./GlobeOrMap');
@@ -42,13 +43,7 @@ var ViewerMode = require('./ViewerMode');
  * @param {Viewer} viewer The Cesium viewer instance.
  */
 var Cesium = function(terria, viewer) {
-    GlobeOrMap.call(this);
-
-    /**
-     * Gets or sets the Terria instance.
-     * @type {Terria}
-     */
-    this.terria = terria;
+    GlobeOrMap.call(this, terria);
 
     /**
      * Gets or sets the Cesium {@link Viewer} instance.
@@ -171,8 +166,10 @@ var Cesium = function(terria, viewer) {
         return result;
     };
 
+    this.eventHelper = new EventHelper();
+
     // If the render loop crashes, inform the user and then switch to 2D.
-    this.scene.renderError.addEventListener(function(scene, error) {
+    this.eventHelper.add(this.scene.renderError, function(scene, error) {
          this.terria.error.raiseEvent(new ModelError({
             sender: this,
             title: 'Error rendering in 3D',
@@ -185,6 +182,8 @@ technical details below.  Thank you!</p><pre>' + formatError(error) + '</pre>'
 
          this.terria.viewerMode = ViewerMode.Leaflet;
     }, this);
+
+    this.eventHelper.add(this.scene.globe.tileLoadProgressEvent, this.updateTilesLoadingCount.bind(this));
 };
 
 inherit(GlobeOrMap, Cesium);
@@ -238,10 +237,13 @@ Cesium.prototype.destroy = function() {
 
     this.viewer.canvas.removeEventListener(this._wheelEvent, this._boundNotifyRepaintRequired, false);
 
+
     window.removeEventListener('resize', this._boundNotifyRepaintRequired, false);
 
     loadWithXhr.load = this._originalLoadWithXhr;
     TaskProcessor.prototype.scheduleTask = this._originalScheduleTask;
+
+    this.eventHelper.removeAll();
 
     return destroyObject(this);
 };

--- a/lib/Models/GlobeOrMap.js
+++ b/lib/Models/GlobeOrMap.js
@@ -12,18 +12,61 @@ require('./ImageryLayerFeatureInfo'); // overrides Cesium's prototype.configureD
  * @constructor
  * @alias GlobeOrMap
  *
+ * @param {Terria} terria The Terria instance.
+ *
  * @see Cesium
  * @see Leaflet
  */
-var GlobeOrMap = function() {
+var GlobeOrMap = function(terria) {
+    /**
+     * Gets or sets the Terria instance.
+     * @type {Terria}
+     */
+    this.terria = terria;
+
+    this._tilesLoadingCountMax = 0;
+};
+/**
+ * Creates an {@see Entity} from a {@see ImageryLayerFeatureInfo}.
+ * @param {ImageryLayerFeatureInfo} feature The feature for which to create an entity.
+ * @return {Entity} The created entity.
+ * @protected
+ */
+GlobeOrMap.prototype._createEntityFromImageryLayerFeature = function(feature) {
+    var entity = new Entity({
+        id : feature.name,
+    });
+    entity.name = feature.name;
+    entity.description = feature.description;  // already defined by the new Entity
+
+    if (entity.propertyNames.indexOf('properties') === -1) {  // not defined yet, but could be in future
+        entity.addProperty('properties');
+    }
+    entity.properties = feature.properties;
+
+
+    entity.imageryLayer = feature.imageryLayer;
+    entity.position = Ellipsoid.WGS84.cartographicToCartesian(feature.position);
+
+    return entity;
 };
 
-GlobeOrMap.prototype.destroy = function() {
-    throw new DeveloperError('destroy must be implemented in the derived class.');
+GlobeOrMap.prototype.updateTilesLoadingCount = function(tilesLoadingCount) {
+    if (tilesLoadingCount > this._tilesLoadingCountMax) {
+        this._tilesLoadingCountMax = tilesLoadingCount;
+    } else if (tilesLoadingCount === 0) {
+        this._tilesLoadingCountMax = 0;
+    }
+
+    this.terria.tileLoadProgressEvent.raiseEvent(tilesLoadingCount, this._tilesLoadingCountMax);
 };
 
 GlobeOrMap.prototype.isDestroyed = function() {
     return false;
+};
+
+GlobeOrMap.prototype.destroy = function() {
+    throw new DeveloperError('destroy must be implemented in the derived class.');
 };
 
 /**
@@ -31,7 +74,7 @@ GlobeOrMap.prototype.isDestroyed = function() {
  * @return {Rectangle} The current visible extent.
  */
 GlobeOrMap.prototype.getCurrentExtent = function() {
-    throw new DeveloperError('destroy must be implemented in the derived class.');
+    throw new DeveloperError('getCurrentExtent must be implemented in the derived class.');
 };
 
 /**
@@ -70,35 +113,10 @@ GlobeOrMap.prototype.computePositionOnScreen = function(position, result) {
 };
 
 /**
- * Creates an {@see Entity} from a {@see ImageryLayerFeatureInfo}.
- * @param {ImageryLayerFeatureInfo} feature The feature for which to create an entity.
- * @return {Entity} The created entity.
- * @protected
- */
-GlobeOrMap.prototype._createEntityFromImageryLayerFeature = function(feature) {
-    var entity = new Entity({
-        id: feature.name,
-    });
-    entity.name = feature.name;
-    entity.description = feature.description;  // already defined by the new Entity
-
-    if (entity.propertyNames.indexOf('properties') === -1) {  // not defined yet, but could be in future
-        entity.addProperty('properties');
-    }
-    entity.properties = feature.properties;
-
-
-    entity.imageryLayer = feature.imageryLayer;
-    entity.position = Ellipsoid.WGS84.cartographicToCartesian(feature.position);
-
-    return entity;
-};
-
-/**
  * Adds an attribution to the globe or map.
  * @param {Credit} attribution The attribution to add.
  */
-GlobeOrMap.prototype.addAttribution = function(attribution){
+GlobeOrMap.prototype.addAttribution = function(attribution) {
     throw new DeveloperError('addAttribution must be implemented in the derived class.');
 };
 
@@ -106,7 +124,7 @@ GlobeOrMap.prototype.addAttribution = function(attribution){
  * Removes an attribution from the globe or map.
  * @param {Credit} attribution The attribution to remove.
  */
-GlobeOrMap.prototype.removeAttribution = function(attribution){
+GlobeOrMap.prototype.removeAttribution = function(attribution) {
     throw new DeveloperError('removeAttribution must be implemented in the derived class.');
 };
 

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -104,15 +104,7 @@ Leaflet.prototype._initProgressEvent = function() {
     this.map.on('layeradd', function(evt) {
         // This check makes sure we only watch tile layers, and also protects us if this private variable gets removed.
         if (typeof evt.layer._tilesToLoad !== 'undefined') {
-            evt.layer.on('tileloadstart', function() {
-                onTileLoadChange();
-            });
-            evt.layer.on('tileload', function() {
-                onTileLoadChange();
-            });
-            evt.layer.on('loaded', function() {
-                onTileLoadChange();
-            });
+            evt.layer.on('tileloadstart tileload loaded', onTileLoadChange);
         }
     }.bind(this));
 };

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -94,11 +94,11 @@ Leaflet.prototype._initProgressEvent = function() {
 
         this.map.eachLayer(function(layer) {
             if (layer._tilesToLoad) {
-                tilesLoadingCount += layer._tilesToLoad - 1; // -1 because _tilesToLoad doesn't update until after this runs
+                tilesLoadingCount += layer._tilesToLoad;
             }
         });
 
-        this.updateTilesLoadingCount(tilesLoadingCount);
+        this.updateTilesLoadingCount(Math.max(tilesLoadingCount - 1, 0));// -1 because _tilesToLoad doesn't update until after this runs
     }.bind(this);
 
     this.map.on('layeradd', function(evt) {

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -56,13 +56,13 @@ var Leaflet = function(terria, map) {
 
     this._pickedFeatures = undefined;
     this._selectionIndicator = L.marker([0, 0], {
-        icon : L.divIcon({
-            className : '',
-            html : '<img src="' + this.terria.baseUrl + 'images/NM-LocationTarget.svg" width="50" height="50" alt="" />',
-            iconSize : L.point(50, 50)
+        icon: L.divIcon({
+            className: '',
+            html: '<img src="' + this.terria.baseUrl + 'images/NM-LocationTarget.svg" width="50" height="50" alt="" />',
+            iconSize: L.point(50, 50)
         }),
-        clickable : false,
-        keyboard : false
+        clickable: false,
+        keyboard: false
     });
     this._selectionIndicator.addTo(this.map);
     this._selectionIndicatorDomElement = this._selectionIndicator._icon.children[0];
@@ -153,7 +153,7 @@ Leaflet.prototype.zoomTo = function(viewOrExtent, flightDurationSeconds) {
     }
 
     this.map.fitBounds(rectangleToLatLngBounds(extent), {
-        animate : flightDurationSeconds > 0.0
+        animate: flightDurationSeconds > 0.0
     });
 };
 
@@ -171,8 +171,8 @@ Leaflet.prototype.captureScreenshot = function() {
 
     try {
         html2canvas(this.map.getContainer(), {
-            useCORS : true,
-            onrendered : function(canvas) {
+            useCORS: true,
+            onrendered: function(canvas) {
                 var dataUrl;
 
                 try {
@@ -259,8 +259,8 @@ Leaflet.prototype.updateLayerOrder = function() {
     // Set the current z-index of all layers.
     var items = this.terria.nowViewing.items;
     var currZIndex = {
-        reorderable : 100, // an arbitrary place to start
-        fixed : 1000000 // fixed layers go on top of reorderable ones
+        reorderable: 100, // an arbitrary place to start
+        fixed: 1000000 // fixed layers go on top of reorderable ones
     };
     var i, j, currentItem, subItem;
 
@@ -457,26 +457,26 @@ function animateSelectionIndicatorAppear(leaflet) {
 
     leaflet._selectionIndicatorIsAppearing = true;
     leaflet._selectionIndicatorTween = leaflet._tweens.add({
-        startObject : {
-            scale : 2.0,
-            opacity : 0.0,
-            rotate : -180
+        startObject: {
+            scale: 2.0,
+            opacity: 0.0,
+            rotate: -180
         },
-        stopObject : {
-            scale : 1.0,
-            opacity : 1.0,
-            rotate : 0
+        stopObject: {
+            scale: 1.0,
+            opacity: 1.0,
+            rotate: 0
         },
-        duration : 0.8,
-        easingFunction : EasingFunction.EXPONENTIAL_OUT,
-        update : function(value) {
+        duration: 0.8,
+        easingFunction: EasingFunction.EXPONENTIAL_OUT,
+        update: function(value) {
             style.opacity = value.opacity;
             style.transform = 'scale(' + (value.scale) + ') rotate(' + value.rotate + 'deg)';
         },
-        complete : function() {
+        complete: function() {
             leaflet._selectionIndicatorTween = undefined;
         },
-        cancel : function() {
+        cancel: function() {
             leaflet._selectionIndicatorTween = undefined;
         }
     });
@@ -498,24 +498,24 @@ function animateSelectionIndicatorDepart(leaflet) {
 
     leaflet._selectionIndicatorIsAppearing = false;
     leaflet._selectionIndicatorTween = leaflet._tweens.add({
-        startObject : {
-            scale : 1.0,
-            opacity : 1.0
+        startObject: {
+            scale: 1.0,
+            opacity: 1.0
         },
-        stopObject : {
-            scale : 1.5,
-            opacity : 0.0
+        stopObject: {
+            scale: 1.5,
+            opacity: 0.0
         },
-        duration : 0.8,
-        easingFunction : EasingFunction.EXPONENTIAL_OUT,
-        update : function(value) {
+        duration: 0.8,
+        easingFunction: EasingFunction.EXPONENTIAL_OUT,
+        update: function(value) {
             style.opacity = value.opacity;
             style.transform = 'scale(' + value.scale + ') rotate(0deg)';
         },
-        complete : function() {
+        complete: function() {
             leaflet._selectionIndicatorTween = undefined;
         },
-        cancel : function() {
+        cancel: function() {
             leaflet._selectionIndicatorTween = undefined;
         }
     });

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -36,12 +36,10 @@ window.html2canvas = html2canvas;
  * @extends GlobeOrMap
  *
  * @param {Terria} terria The Terria instance.
- * @param {Viewer} viewer The leaflet viewer instance.
+ * @param {Viewer} map The leaflet viewer instance.
  */
 var Leaflet = function(terria, map) {
-    GlobeOrMap.call(this);
-
-    this.terria = terria;
+    GlobeOrMap.call(this, terria);
 
     /**
      * Gets or sets the Leaflet {@link Map} instance.
@@ -57,14 +55,14 @@ var Leaflet = function(terria, map) {
     this._selectionIndicatorIsAppearing = undefined;
 
     this._pickedFeatures = undefined;
-    this._selectionIndicator = L.marker([0,0], {
-        icon: L.divIcon({
-            className: '',
-            html: '<img src="' + this.terria.baseUrl + 'images/NM-LocationTarget.svg" width="50" height="50" alt="" />',
-            iconSize: L.point(50, 50)
+    this._selectionIndicator = L.marker([0, 0], {
+        icon : L.divIcon({
+            className : '',
+            html : '<img src="' + this.terria.baseUrl + 'images/NM-LocationTarget.svg" width="50" height="50" alt="" />',
+            iconSize : L.point(50, 50)
         }),
-        clickable: false,
-        keyboard: false
+        clickable : false,
+        keyboard : false
     });
     this._selectionIndicator.addTo(this.map);
     this._selectionIndicatorDomElement = this._selectionIndicator._icon.children[0];
@@ -81,12 +79,43 @@ var Leaflet = function(terria, map) {
         pickFeatures(that, e.latlng);
     });
 
-    this._selectedFeatureSubscription = knockout.getObservable( this.terria, 'selectedFeature').subscribe(function() {
+    this._selectedFeatureSubscription = knockout.getObservable(this.terria, 'selectedFeature').subscribe(function() {
         selectFeature(this);
     }, this);
+
+    this._initProgressEvent();
 };
 
 inherit(GlobeOrMap, Leaflet);
+
+Leaflet.prototype._initProgressEvent = function() {
+    var onTileLoadChange = function() {
+        var tilesLoadingCount = 0;
+
+        this.map.eachLayer(function(layer) {
+            if (layer._tilesToLoad) {
+                tilesLoadingCount += layer._tilesToLoad - 1; // -1 because _tilesToLoad doesn't update until after this runs
+            }
+        });
+
+        this.updateTilesLoadingCount(tilesLoadingCount);
+    }.bind(this);
+
+    this.map.on('layeradd', function(evt) {
+        // This check makes sure we only watch tile layers, and also protects us if this private variable gets removed.
+        if (typeof evt.layer._tilesToLoad !== 'undefined') {
+            evt.layer.on('tileloadstart', function() {
+                onTileLoadChange();
+            });
+            evt.layer.on('tileload', function() {
+                onTileLoadChange();
+            });
+            evt.layer.on('loaded', function() {
+                onTileLoadChange();
+            });
+        }
+    }.bind(this));
+};
 
 Leaflet.prototype.destroy = function() {
     if (defined(this._selectedFeatureSubscription)) {
@@ -112,7 +141,7 @@ Leaflet.prototype.getCurrentExtent = function() {
  * @param {CameraView|Rectangle} viewOrExtent The view or extent to which to zoom.
  * @param {Number} [flightDurationSeconds=3.0] The length of the flight animation in seconds.  Leaflet ignores the actual value,
  *                                             but will use an animated transition when this value is greater than 0.
-*/
+ */
 Leaflet.prototype.zoomTo = function(viewOrExtent, flightDurationSeconds) {
     if (!defined(viewOrExtent)) {
         throw new DeveloperError('viewOrExtent is required.');
@@ -132,7 +161,7 @@ Leaflet.prototype.zoomTo = function(viewOrExtent, flightDurationSeconds) {
     }
 
     this.map.fitBounds(rectangleToLatLngBounds(extent), {
-        animate: flightDurationSeconds > 0.0
+        animate : flightDurationSeconds > 0.0
     });
 };
 
@@ -150,8 +179,8 @@ Leaflet.prototype.captureScreenshot = function() {
 
     try {
         html2canvas(this.map.getContainer(), {
-            useCORS: true,
-            onrendered: function(canvas) {
+            useCORS : true,
+            onrendered : function(canvas) {
                 var dataUrl;
 
                 try {
@@ -205,8 +234,8 @@ Leaflet.prototype.computePositionOnScreen = function(position, result) {
  * Adds an attribution to the map.
  * @param {Credit} attribution The attribution to add.
  */
-Leaflet.prototype.addAttribution = function(attribution){
-    if(attribution){
+Leaflet.prototype.addAttribution = function(attribution) {
+    if (attribution) {
         this.map.attributionControl.addAttribution(createLeafletCredit(attribution));
     }
 };
@@ -215,8 +244,8 @@ Leaflet.prototype.addAttribution = function(attribution){
  * Removes an attribution from the map.
  * @param {Credit} attribution The attribution to remove.
  */
-Leaflet.prototype.removeAttribution = function(attribution){
-    if(attribution){
+Leaflet.prototype.removeAttribution = function(attribution) {
+    if (attribution) {
         this.map.attributionControl.removeAttribution(createLeafletCredit(attribution));
     }
 };
@@ -238,8 +267,8 @@ Leaflet.prototype.updateLayerOrder = function() {
     // Set the current z-index of all layers.
     var items = this.terria.nowViewing.items;
     var currZIndex = {
-        reorderable: 100, // an arbitrary place to start
-        fixed: 1000000 // fixed layers go on top of reorderable ones
+        reorderable : 100, // an arbitrary place to start
+        fixed : 1000000 // fixed layers go on top of reorderable ones
     };
     var i, j, currentItem, subItem;
 
@@ -295,7 +324,7 @@ Leaflet.prototype.lowerToBottom = function(item) {
  * @param {Credit} attribution the original attribution object for leaflet to display as text or link
  * @return {String} The sanitized HTML for the credit.
  */
-function createLeafletCredit(attribution){
+function createLeafletCredit(attribution) {
     var element;
 
     if (defined(attribution.link)) {
@@ -345,7 +374,8 @@ function pickFeatures(leaflet, latlng) {
     // promise until we're sure all the click handlers have run, by waiting on a runLater.
     var promises = [];
     var imageryLayers = [];
-    promises.push(runLater(function() {}));
+    promises.push(runLater(function() {
+    }));
     imageryLayers.push(" ");
 
     if (defined(latlng)) {
@@ -355,7 +385,7 @@ function pickFeatures(leaflet, latlng) {
         var pickPosition = Ellipsoid.WGS84.cartographicToCartesian(pickedLocation);
         leaflet._pickedFeatures.pickPosition = pickPosition;
 
-        for (var i = 0; i < dataSources.length ; ++i) {
+        for (var i = 0; i < dataSources.length; ++i) {
             var dataSource = dataSources[i];
             if (dataSource.isEnabled && dataSource.isShown && defined(dataSource.imageryLayer) && defined(dataSource.imageryLayer.pickFeatures)) {
                 promises.push(dataSource.imageryLayer.pickFeatures(leaflet.map, CesiumMath.toRadians(latlng.lng), CesiumMath.toRadians(latlng.lat)));
@@ -435,26 +465,26 @@ function animateSelectionIndicatorAppear(leaflet) {
 
     leaflet._selectionIndicatorIsAppearing = true;
     leaflet._selectionIndicatorTween = leaflet._tweens.add({
-        startObject: {
-            scale: 2.0,
-            opacity: 0.0,
-            rotate: -180
+        startObject : {
+            scale : 2.0,
+            opacity : 0.0,
+            rotate : -180
         },
-        stopObject: {
-            scale: 1.0,
-            opacity: 1.0,
-            rotate: 0
+        stopObject : {
+            scale : 1.0,
+            opacity : 1.0,
+            rotate : 0
         },
-        duration: 0.8,
-        easingFunction: EasingFunction.EXPONENTIAL_OUT,
-        update: function(value) {
+        duration : 0.8,
+        easingFunction : EasingFunction.EXPONENTIAL_OUT,
+        update : function(value) {
             style.opacity = value.opacity;
             style.transform = 'scale(' + (value.scale) + ') rotate(' + value.rotate + 'deg)';
         },
-        complete: function() {
+        complete : function() {
             leaflet._selectionIndicatorTween = undefined;
         },
-        cancel: function() {
+        cancel : function() {
             leaflet._selectionIndicatorTween = undefined;
         }
     });
@@ -476,24 +506,24 @@ function animateSelectionIndicatorDepart(leaflet) {
 
     leaflet._selectionIndicatorIsAppearing = false;
     leaflet._selectionIndicatorTween = leaflet._tweens.add({
-        startObject: {
-            scale: 1.0,
-            opacity: 1.0
+        startObject : {
+            scale : 1.0,
+            opacity : 1.0
         },
-        stopObject: {
-            scale: 1.5,
-            opacity: 0.0
+        stopObject : {
+            scale : 1.5,
+            opacity : 0.0
         },
-        duration: 0.8,
-        easingFunction: EasingFunction.EXPONENTIAL_OUT,
-        update: function(value) {
+        duration : 0.8,
+        easingFunction : EasingFunction.EXPONENTIAL_OUT,
+        update : function(value) {
             style.opacity = value.opacity;
             style.transform = 'scale(' + value.scale + ') rotate(0deg)';
         },
-        complete: function() {
+        complete : function() {
             leaflet._selectionIndicatorTween = undefined;
         },
-        cancel: function() {
+        cancel : function() {
             leaflet._selectionIndicatorTween = undefined;
         }
     });

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -5,6 +5,7 @@ var URI = require('urijs');
 
 var buildModuleUrl = require('terriajs-cesium/Source/Core/buildModuleUrl');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');
+var EventHelper = require('terriajs-cesium/Source/Core/EventHelper');
 var Clock = require('terriajs-cesium/Source/Core/Clock');
 var combine = require('terriajs-cesium/Source/Core/combine');
 var DataSourceCollection = require('terriajs-cesium/Source/DataSources/DataSourceCollection');
@@ -272,6 +273,14 @@ var Terria = function(options) {
      * @type {Object}
      */
     this.urlShortener = undefined;
+
+    /**
+     * Event that tracks changes to the progress in loading new tiles from either Cesium or Leaflet - events will be
+     * raised with the number of tiles that still need to load.
+     *
+     * @type {CesiumEvent}
+     */
+    this.tileLoadProgressEvent = new CesiumEvent();
 
     knockout.track(this, ['viewerMode', 'baseMap', 'baseMapName', '_initialView', 'homeView', 'pickedFeatures', 'selectedFeature', 'configParameters', 'showTimeline']);
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -5,7 +5,6 @@ var URI = require('urijs');
 
 var buildModuleUrl = require('terriajs-cesium/Source/Core/buildModuleUrl');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');
-var EventHelper = require('terriajs-cesium/Source/Core/EventHelper');
 var Clock = require('terriajs-cesium/Source/Core/Clock');
 var combine = require('terriajs-cesium/Source/Core/combine');
 var DataSourceCollection = require('terriajs-cesium/Source/DataSources/DataSourceCollection');

--- a/lib/Styles/MapProgressBar.less
+++ b/lib/Styles/MapProgressBar.less
@@ -1,0 +1,30 @@
+.map-progress-bar {
+    z-index: 1;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: rgba(255, 255, 255, 0.8);
+    height: 5px;
+    transition: opacity 200ms linear, width 200ms linear, visibility 400ms linear;
+}
+
+.map-progress-bar.complete {
+    animation-duration: 400ms;
+    animation-name: complete;
+}
+
+@keyframes complete {
+    from {
+        opacity: 1;
+    }
+
+    50% {
+        width: 100%;
+        opacity: 1;
+    }
+
+    to {
+        opacity: 0;
+        width: 100%;
+    }
+}

--- a/lib/ViewModels/MapProgressBarViewModel.js
+++ b/lib/ViewModels/MapProgressBarViewModel.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/*global require*/
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var loadView = require('../Core/loadView');
+var EventHelper = require('terriajs-cesium/Source/Core/EventHelper');
+
+/**
+ * A simple progress bar that adjusts its width based on the current number of tiles being loaded by Cesium or Leaflet.
+ * Will automatically react to viewer changes (Cesium -> Leaflet and vice versa) without the need to re-initialise.
+ *
+ * @param options.terria {Terria} the terria instance to track
+ * @constructor
+ */
+var MapProgressBarViewModel = function(options) {
+    this.terria = options.terria;
+    this._eventHelper = new EventHelper();
+
+    this._eventHelper.add(this.terria.tileLoadProgressEvent, this._setProgress.bind(this));
+
+    // Clear progress when the viewer changes so we're not left with an invalid progress bar hanging on the screen.
+    this._eventHelper.add(this.terria.beforeViewerChanged, this._setProgress.bind(this, 0, 0));
+
+    // 100% loaded = view invisible.
+    this.percentage = 100;
+    knockout.track(this, ['percentage']);
+};
+
+/**
+ * Updates this view with the current progress. Rather than receive a fraction or percentage of how much has been
+ * loaded, this receives the raw information of how many tiles are waiting to be loaded, and the total tiles that have
+ * to be loaded (this includes the value in remaining).
+ *
+ * @param remaining The number of tiles remaining to be loaded
+ * @param total The total number of tiles, including those that have been loaded and are still waiting to be loaded.
+ */
+MapProgressBarViewModel.prototype._setProgress = function(remaining, max) {
+    var percentage = (1 - (remaining / max)) * 100;
+    this.percentage = Math.floor(remaining > 0 ? percentage : 100);
+};
+
+MapProgressBarViewModel.prototype.show = function(container) {
+    loadView(require('fs').readFileSync(__dirname + '/../Views/MapProgressBar.html', 'utf8'), container, this);
+};
+
+MapProgressBarViewModel.create = function(options) {
+    var viewModel = new MapProgressBarViewModel(options);
+    viewModel.show(options.container);
+    return viewModel;
+};
+
+module.exports = MapProgressBarViewModel;

--- a/lib/Views/MapProgressBar.html
+++ b/lib/Views/MapProgressBar.html
@@ -1,0 +1,11 @@
+<div
+    class="map-progress-bar"
+    data-bind="style: {
+        width: percentage + '%',
+        visibility: percentage < 100 ? 'visible' : 'hidden'
+    },
+    css: {
+        complete: percentage === 100
+    }">
+</div>
+

--- a/test/Models/CesiumSpec.js
+++ b/test/Models/CesiumSpec.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/*global require,describe,it,expect,beforeEach*/
+var Cesium = require('../../lib/Models/Cesium');
+var Terria = require('../../lib/Models/Terria');
+var CesiumWidget = require('terriajs-cesium/Source/Widgets/CesiumWidget/CesiumWidget');
+
+describe('Cesium Model', function() {
+    var terria;
+    var cesium;
+    var container;
+
+    beforeEach(function() {
+        terria = new Terria({
+            baseUrl : './'
+        });
+        container = document.createElement('div');
+        container.id = 'container';
+        document.body.appendChild(container);
+
+        spyOn(terria.tileLoadProgressEvent, 'raiseEvent');
+
+        cesium = new Cesium(terria, new CesiumWidget(container, {}));
+    });
+
+    afterEach(function() {
+        document.body.removeChild(container);
+    });
+
+    it('should trigger terria.tileLoadProgressEvent on globe tileLoadProgressEvent', function() {
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
+
+        expect(terria.tileLoadProgressEvent.raiseEvent).toHaveBeenCalledWith(3, 3);
+    });
+
+    it('should retain the maximum length of tiles to be loaded', function() {
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(7);
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(4);
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(2);
+
+        expect(terria.tileLoadProgressEvent.raiseEvent).toHaveBeenCalledWith(2, 7);
+    });
+
+    it('should reset maximum length when the number of tiles to be loaded reaches 0', function() {
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(7);
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(4);
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(0);
+
+        expect(terria.tileLoadProgressEvent.raiseEvent.calls.mostRecent().args).toEqual([0, 0]);
+
+        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(2);
+
+        expect(terria.tileLoadProgressEvent.raiseEvent.calls.mostRecent().args).toEqual([2, 2]);
+    });
+});

--- a/test/Models/LeafletSpec.js
+++ b/test/Models/LeafletSpec.js
@@ -5,7 +5,7 @@ var Leaflet = require('../../lib/Models/Leaflet');
 var Terria = require('../../lib/Models/Terria');
 var L = require('leaflet');
 
-describe('Leaflet', function() {
+describe('Leaflet Model', function() {
     var terria;
     var leaflet;
     var container, map, layers;
@@ -19,32 +19,95 @@ describe('Leaflet', function() {
         document.body.appendChild(container);
         map = L.map('container').setView([-28.5, 135], 5);
 
-        leaflet = new Leaflet(terria, map);
-
         spyOn(terria.tileLoadProgressEvent, 'raiseEvent');
 
         layers = [
-            new L.TileLayer(),
-            new L.TileLayer(),
-            {}
+            new L.TileLayer('http://example.com'),
+            new L.TileLayer('http://example.com'),
+            // Make sure there's a non-tile layer in there to make sure we're able to handle those.
+            new L.ImageOverlay('http://example.com', L.latLngBounds([1, 1], [3, 3]))
         ];
-
-        layers.forEach(function(layer) {
-            map.addLayer(layer);
-        });
     });
 
     afterEach(function() {
         document.body.removeChild(container);
     });
 
+    function initLeaflet() {
+        leaflet = new Leaflet(terria, map);
+        layers.forEach(function(layer) {
+            map.addLayer(layer);
+        });
+    }
+
     describe('should trigger a tileLoadProgressEvent', function() {
         ['tileloadstart', 'tileload', 'loaded'].forEach(function(event) {
             it('on ' + event, function() {
+                initLeaflet();
+
                 layers[0].fire(event);
 
                 expect(terria.tileLoadProgressEvent.raiseEvent).toHaveBeenCalled();
             });
         });
+    });
+
+    it('should trigger a tileLoadProgressEvent with the total number of tiles to be loaded for all layers', function() {
+        initLeaflet();
+
+        layers[0]._tilesToLoad = 4;
+        layers[1]._tilesToLoad = 3;
+
+        layers[1].fire('tileload');
+
+        // We're looking for 6 because Leaflet decrements _tilesToLoad AFTER the event fires.
+        expect(terria.tileLoadProgressEvent.raiseEvent).toHaveBeenCalledWith(6, 6);
+    });
+
+    it('shouldn\'t trigger anything if the _tilesToLoad private API gets removed', function() {
+        map.on('layeradd', function(evt) {
+            delete evt.layer._tilesToLoad;
+        });
+
+        initLeaflet();
+
+        layers[1].fire('tileload');
+
+        expect(terria.tileLoadProgressEvent.raiseEvent).not.toHaveBeenCalled();
+    });
+
+    describe('should change the max', function() {
+        it('to whatever the highest count of loading tiles so far was', function() {
+            initLeaflet();
+
+            changeTileLoadingCount(3);
+            changeTileLoadingCount(6);
+            changeTileLoadingCount(8);
+            changeTileLoadingCount(2);
+
+            expect(terria.tileLoadProgressEvent.raiseEvent.calls.mostRecent().args).toEqual([1, 7]);
+        });
+
+        it('to 0 when loading tile count reaches 1', function() {
+            // Once again, 1 instead of 0 because the _tilesToLoad count doesn't reach 0 until after the event's fired.
+            initLeaflet();
+
+            changeTileLoadingCount(3);
+            changeTileLoadingCount(6);
+            changeTileLoadingCount(8);
+            changeTileLoadingCount(1);
+
+            expect(terria.tileLoadProgressEvent.raiseEvent.calls.mostRecent().args).toEqual([0, 0]);
+
+            changeTileLoadingCount(3);
+
+            expect(terria.tileLoadProgressEvent.raiseEvent.calls.mostRecent().args).toEqual([2, 2]);
+        });
+
+        function changeTileLoadingCount(count) {
+            layers[0]._tilesToLoad = count;
+            layers[1]._tilesToLoad = 0;
+            layers[0].fire('tileload');
+        }
     });
 });

--- a/test/Models/LeafletSpec.js
+++ b/test/Models/LeafletSpec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/*global require,describe,it,expect,beforeEach*/
+var Leaflet = require('../../lib/Models/Leaflet');
+var Terria = require('../../lib/Models/Terria');
+var L = require('leaflet');
+
+describe('Leaflet', function() {
+    var terria;
+    var leaflet;
+    var container, map, layers;
+
+    beforeEach(function() {
+        terria = new Terria({
+            baseUrl : './'
+        });
+        container = document.createElement('div');
+        container.id = 'container';
+        document.body.appendChild(container);
+        map = L.map('container').setView([-28.5, 135], 5);
+
+        leaflet = new Leaflet(terria, map);
+
+        spyOn(terria.tileLoadProgressEvent, 'raiseEvent');
+
+        layers = [
+            new L.TileLayer(),
+            new L.TileLayer(),
+            {}
+        ];
+
+        layers.forEach(function(layer) {
+            map.addLayer(layer);
+        });
+    });
+
+    afterEach(function() {
+        document.body.removeChild(container);
+    });
+
+    describe('should trigger a tileLoadProgressEvent', function() {
+        ['tileloadstart', 'tileload', 'loaded'].forEach(function(event) {
+            it('on ' + event, function() {
+                layers[0].fire(event);
+
+                expect(terria.tileLoadProgressEvent.raiseEvent).toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/test/ViewModels/MapProgressBarViewModelSpec.js
+++ b/test/ViewModels/MapProgressBarViewModelSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/*global require,describe,it,expect,beforeEach,afterEach*/
+/*global require,describe,it,expect,beforeEach*/
 var MapProgressBarViewModel = require('../../lib/ViewModels/MapProgressBarViewModel');
 var Terria = require('../../lib/Models/Terria');
 

--- a/test/ViewModels/MapProgressBarViewModelSpec.js
+++ b/test/ViewModels/MapProgressBarViewModelSpec.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/*global require,describe,it,expect,beforeEach,afterEach*/
+var MapProgressBarViewModel = require('../../lib/ViewModels/MapProgressBarViewModel');
+var Terria = require('../../lib/Models/Terria');
+
+describe('MapProgressBarViewModel', function() {
+    var terria;
+    var progressBarView;
+
+    beforeEach(function() {
+        terria = new Terria({
+            baseUrl : './'
+        });
+        progressBarView = new MapProgressBarViewModel({
+            terria: terria
+        });
+    });
+
+    it('sets progress to the percentage of tiles not loaded', function() {
+        terria.tileLoadProgressEvent.raiseEvent(1, 2);
+        expect(progressBarView.percentage).toBe(50);
+    });
+
+    it('always uses the floor percentage', function() {
+        terria.tileLoadProgressEvent.raiseEvent(1, 3);
+        expect(progressBarView.percentage).toBe(66);
+    });
+
+    it('sets progress to 100 if remaining tiles === 0 for all values of max tiles', function() {
+        terria.tileLoadProgressEvent.raiseEvent(0, 0);
+        expect(progressBarView.percentage).toBe(100);
+
+        terria.tileLoadProgressEvent.raiseEvent(0, 1);
+        expect(progressBarView.percentage).toBe(100);
+
+        terria.tileLoadProgressEvent.raiseEvent(0, Number.MAX_VALUE);
+        expect(progressBarView.percentage).toBe(100);
+    });
+
+    it('resets progress to 100 on beforeViewerChanged', function() {
+        // First make sure progress isn't 100 already.
+        terria.tileLoadProgressEvent.raiseEvent(1, 2);
+        expect(progressBarView.percentage).not.toBe(100);
+
+        // Trigger the event.
+        terria.beforeViewerChanged.raiseEvent();
+
+        expect(progressBarView.percentage).toBe(100);
+    });
+});


### PR DESCRIPTION
Fixes #539.

Adds a `MapProgressBar` that can be added to the `cesiumContainer` in order to display a simple progressive loading bar as per the design in #539, that reflects tile loads in both Cesium and Leaflet. The `MapProgressBar` needs to be specifically added by the app that uses Terria.

As part of the infrastructure for the progress bar, adds a `terria.tileLoadProgressEvent` that raises events with the current number of tiles to be loading and the maximum number loading, so that other incremental progress bars can be plugged in.
