### PR TITLE
Revert html2canvas to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "repository": {
@@ -10,7 +10,7 @@
   "dependencies": {
     "brfs": "^1.4.0",
     "hammerjs": "^2.0.4",
-    "html2canvas": "0.5.0-alpha2",
+    "html2canvas": "0.4.1",
     "javascript-natural-sort": "^0.7.1",
     "leaflet": "0.7.3",
     "less": "^2.5.0",


### PR DESCRIPTION
Since 0.5.0-alpha is broken, revert to 0.4.1.   I realize this PR might not be the right approach, but if it is, great!
