### PR TITLE
Made WebMapServiceCatalogItem get legend url from first Style tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ Change Log
 * The default style for CSV files is now 7 color bins with CK means method.
 * Improve the display of legends for CSV files, accordingly.
 * Support color palettes from Color Brewer (colorbrewer2.org). Within `tableStyle`, use a value like `"colorPalette": "10-class BrBG"`.
+* URLs for legends are now encapsulated in a `LegendUrl` model, which accepts a mime type that will affect how the
+  legend is rendered in the sidebar.
 
 ### 1.0.51
 

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -25,6 +25,7 @@ var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var AbsDataset = require('./AbsDataset');
 var AbsConcept = require('./AbsConcept');
 var AbsCode = require('./AbsCode');
+var LegendUrl = require('./LegendUrl');
 var naturalSort = require('javascript-natural-sort');
 
 /**
@@ -389,7 +390,7 @@ AbsIttCatalogItem.prototype._load = function() {
             function addTree(parent, codes) {
                 // Use natural sort for fields with included ages or incomes.
                 naturalSort.insensitive = true;
-                codes.sort(function(a,b) { 
+                codes.sort(function(a,b) {
                     return naturalSort(a.description.replace(',',''), b.description.replace(',',''));
                 } );
 
@@ -572,7 +573,7 @@ function updateAbsResults(absItem) {
     function doUpdate() {
         var me = when(updateAbsDataCsvText(absItem)).then(function() {
             return when(absItem._csvCatalogItem.dynamicUpdate(absItem._absDataText)).then(function() {
-                absItem.legendUrl = absItem._absDataText === '' ? '' : absItem._csvCatalogItem.legendUrl;
+                absItem.legendUrl = absItem._absDataText === '' ? '' : new LegendUrl(absItem._csvCatalogItem.legendUrl);
                 absItem.terria.currentViewer.notifyRepaintRequired();
                 if (me === absItem._updateResultsPromise) {
                     absItem._updateResultsPromise = undefined;

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -26,6 +26,7 @@ var ModelError = require('./ModelError');
 var overrideProperty = require('../Core/overrideProperty');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var unionRectangleArray = require('../Map/unionRectangleArray');
+var LegendUrl = require('./LegendUrl');
 
 /**
  * A {@link ImageryLayerCatalogItem} representing a layer from an Esri ArcGIS MapServer.
@@ -103,7 +104,7 @@ var ArcGisMapServerCatalogItem = function(terria) {
             if (defined(this._legendUrl)) {
                 return this._legendUrl;
             }
-            return cleanUrl(this.url) + '/legend';
+            return new LegendUrl(cleanUrl(this.url) + '/legend');
         },
         set : function(value) {
             this._legendUrl = value;

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -14,6 +14,7 @@ var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var arraysAreEqual = require('../Core/arraysAreEqual');
 var Metadata = require('./Metadata');
+var LegendUrl = require('./LegendUrl');
 var CatalogMember = require('./CatalogMember');
 var inherit = require('../Core/inherit');
 var raiseErrorOnRejectedPromise = require('./raiseErrorOnRejectedPromise');
@@ -56,7 +57,7 @@ var CatalogItem = function(terria) {
     /**
      * Gets or sets the URL of the legend for this data item, or undefined if this data item does not have a legend.
      * This property is observable.
-     * @type {String}
+     * @type {LegendUrl}
      */
     this.legendUrl = undefined;
 
@@ -168,7 +169,7 @@ var CatalogItem = function(terria) {
     knockout.defineProperty(this, 'legendUrls', {
         get: function() {
             if (!defined(this._legendUrls) || this._legendUrls.length === 0) {
-                if (defined(this.legendUrl) && this.legendUrl.length > 0) {
+                if (defined(this.legendUrl) && defined(this.legendUrl.url) && this.legendUrl.url.length > 0) {
                     return [this.legendUrl];
                 }
             }
@@ -235,8 +236,6 @@ var CatalogItem = function(terria) {
 
 inherit(CatalogMember, CatalogItem);
 
-var imageUrlRegex = /[.\/](png|jpg|jpeg|gif)/i;
-
 defineProperties(CatalogItem.prototype, {
     /**
      * Gets a value indicating whether this data item, when enabled, can be reordered with respect to other data items.
@@ -266,25 +265,9 @@ defineProperties(CatalogItem.prototype, {
      * @memberOf CatalogItem.prototype
      * @type {Boolean}
      */
-    hasLegend : {
-        get : function() {
-            return defined(this.legendUrl) && this.legendUrl.length > 0;
-        }
-    },
-
-    /**
-     * Gets a value indicating whether this data item's legend is an image in a
-     * browser-supported format such as JPEG, PNG, or GIF.
-     * @memberOf CatalogItem.prototype
-     * @type {Boolean}
-     */
-    legendIsImage : {
-        get : function() {
-            if (!defined(this.legendUrl) || this.legendUrl.length === 0) {
-                return false;
-            }
-
-            return this.legendUrl.match(imageUrlRegex);
+    hasLegend: {
+        get: function() {
+            return defined(this.legendUrl);
         }
     },
 
@@ -375,6 +358,22 @@ CatalogItem.defaultUpdaters.attribution = function(catalogItem, json, prototypeN
         }
     }
 };
+
+CatalogItem.defaultUpdaters.legendUrl = function(catalogItem, json, prototypeName) {
+    if (defined(json.legendUrl)) {
+        var url, mimeType;
+
+        if (typeof json.legendUrl === 'string') {
+            url = json.legendUrl;
+        } else {
+            url = json.legendUrl.url;
+            mimeType = json.legendUrl.mimeType;
+        }
+
+        catalogItem.legendUrl = new LegendUrl(url, mimeType);
+    }
+};
+
 freezeObject(CatalogItem.defaultUpdaters);
 
 /**

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -23,7 +23,7 @@ var updateFromJson = require('../Core/updateFromJson');
  */
 var CatalogMember = function(terria) {
     if (!defined(terria)) {
-         throw new DeveloperError('terria is required');
+        throw new DeveloperError('terria is required');
     }
 
     this._terria = terria;

--- a/lib/Models/CompositeCatalogItem.js
+++ b/lib/Models/CompositeCatalogItem.js
@@ -20,13 +20,13 @@ var compositeType = 'composite';
 /**
  * A {@link CatalogItem} composed of multiple other catalog items.  When this item is enabled or shown, the composed items are
  * enabled or shown as well.  Other properties, including {@link CatalogItem#rectangle},
- * {@link CatalogItem#clock}, and {@link CatalogItem#legendUrl}, are not composed in any way, so you should manually set those
+ * {@link CatalogItem#clock}, and {@link CatalogItem#legendUrls}, are not composed in any way, so you should manually set those
  * properties on this object as appropriate.
  *
  * @alias CompositeCatalogItem
  * @constructor
  * @extends CatalogItem
- * 
+ *
  * @param {Terria} terria The Terria instance.
  * @param {CatalogItem[]} [items] The items to compose.
  */

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -26,7 +26,7 @@ var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var readText = require('../Core/readText');
 var TableDataSource = require('../Map/TableDataSource');
 var TileLayerFilter = require('../ThirdParty/TileLayer.Filter');
-
+var LegendUrl = require('./LegendUrl');
 
 var RegionProviderList = require('../Map/RegionProviderList');
 var ImageryProviderHooks = require('../Map/ImageryProviderHooks');
@@ -133,7 +133,7 @@ var CsvCatalogItem = function(terria, url) {
 
                 updateTableStyle(that, tableStyle);
 
-                that.legendUrl = source.getLegendGraphic();
+                that.legendUrl = new LegendUrl(source.getLegendGraphic(), 'image/png');
                 that.terria.currentViewer.notifyRepaintRequired();
             };
             return [displayVariablesConcept];
@@ -590,7 +590,7 @@ function finishTableLoad(csvItem) {
     if (!defined(csvItem.rectangle)) {
         csvItem.rectangle = csvItem._tableDataSource.dataset.getExtent();
     }
-    csvItem.legendUrl = csvItem._tableDataSource.getLegendGraphic();
+    csvItem.legendUrl = new LegendUrl(csvItem._tableDataSource.getLegendGraphic(), 'image/png');
     csvItem.terria.currentViewer.notifyRepaintRequired();
 }
 

--- a/lib/Models/LegendUrl.js
+++ b/lib/Models/LegendUrl.js
@@ -1,0 +1,43 @@
+"use strict";
+
+/** A lookup map for displayable mime types */
+var DISPLAYABLE_MIME_TYPES = ['image/jpeg', 'image/gif', 'image/png', 'image/svg+xml', 'image/bmp', 'image/x-bmp']
+    .reduce(function(acc, mimeType) {
+        acc[mimeType] = true;
+        return acc;
+    }, {});
+var IMAGE_URL_REGEX = /[.\/](png|jpg|jpeg|gif)/i;
+
+/**
+ * A simple object that represents a legend for a map layer.
+ *
+ * @param url The URL of the legend
+ * @param mimeType The mime type of the legend - this will be used by the UI to determine how the legend should be shown
+ *      (usually an img tag or a link)
+ * @constructor
+ */
+var LegendUrl = function(url, mimeType) {
+    this.url = url;
+    this.mimeType = mimeType;
+};
+
+/**
+ * Determines whether this url links to an image by inspecting the mime type, or if none is specified, the file
+ * extension.
+ *
+ * @returns {boolean}
+ */
+LegendUrl.prototype.isImage = function() {
+    if (this.mimeType) {
+        return !!DISPLAYABLE_MIME_TYPES[this.mimeType];
+    }
+
+    return !!this.url.match(IMAGE_URL_REGEX);
+};
+
+/** Simple check for whether the url is valid - currently valid is simply defined and length > 0. */
+LegendUrl.prototype.isValid = function() {
+    return this.url && this.url.length;
+};
+
+module.exports = LegendUrl;

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -32,6 +32,7 @@ var overrideProperty = require('../Core/overrideProperty');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var unionRectangleArray = require('../Map/unionRectangleArray');
 var xml2json = require('../ThirdParty/xml2json');
+var LegendUrl = require('./LegendUrl');
 
 /**
  * A {@link ImageryLayerCatalogItem} representing a layer from a Web Map Service (WMS) server.
@@ -140,7 +141,8 @@ var WebMapServiceCatalogItem = function(terria) {
                 return undefined;
             }
             var layer = this.layers.split(',')[0];
-            return cleanUrl(this.url) + '?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image/png&layer=' + layer;
+            return new LegendUrl(cleanUrl(this.url) +
+                '?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image/png&layer=' + layer, 'image/png');
         },
         set : function(value) {
             this._legendUrl = value;
@@ -365,6 +367,19 @@ WebMapServiceCatalogItem.prototype.updateFromCapabilities = function(capabilitie
     // Show the service abstract if there is one, and if it isn't the Geoserver default "A compliant implementation..."
     if (!containsAny(service.Abstract, WebMapServiceCatalogItem.abstractsToIgnore) && service.Abstract !== thisLayer.Abstract) {
         updateInfoSection(this, overwrite, 'Service Description', service.Abstract);
+    }
+
+    if (thisLayer.Style) {
+        // There can be multiple styles - just get the first if so.
+        var style = Array.isArray(thisLayer.Style) ? thisLayer.Style[0] : thisLayer.Style;
+
+        if (style.LegendURL) {
+            // According to the WMS schema, LegendURL is unbounded.
+            var legendUrl = Array.isArray(style.LegendURL) ? style.LegendURL[0] : style.LegendURL;
+            var legend = new LegendUrl(legendUrl.OnlineResource['xlink:href'], legendUrl.Format);
+
+            updateValue(this, overwrite, '_legendUrl', legend);
+        }
     }
 
     // Show the Access Constraints if it isn't "none" (because that's the default, and usually a lie).

--- a/lib/Models/WebMapTileServiceCatalogItem.js
+++ b/lib/Models/WebMapTileServiceCatalogItem.js
@@ -26,6 +26,7 @@ var inherit = require('../Core/inherit');
 var overrideProperty = require('../Core/overrideProperty');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var xml2json = require('../ThirdParty/xml2json');
+var LegendUrl = require('./LegendUrl');
 
 /**
  * A {@link ImageryLayerCatalogItem} representing a layer from a Web Map Tile Service (WMTS) server.
@@ -388,7 +389,6 @@ WebMapTileServiceCatalogItem.prototype.updateFromCapabilities = function(capabil
         }
 
         var defaultStyle;
-        var legendUrl;
 
         for (i = 0; i < styles.length; ++i) {
             var style = styles[i];
@@ -403,7 +403,7 @@ WebMapTileServiceCatalogItem.prototype.updateFromCapabilities = function(capabil
                         legendData = legendData[0];
                     }
 
-                    legendUrl = legendData.href;
+                    this.legendUrl = new LegendUrl(legendData.href, legendData.format);
                 }
                 break;
             }

--- a/lib/ViewModels/LegendSectionViewModel.js
+++ b/lib/ViewModels/LegendSectionViewModel.js
@@ -7,13 +7,28 @@ var proxyCatalogItemUrl = require('../Models/proxyCatalogItemUrl');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 
 var LegendSectionViewModel = function(nowViewingTab, catalogMember) {
-    this.nowViewingTab = nowViewingTab;
+    this.nowViewingTab = nowViewingTab; // This is used by LegendSection.html
     this.catalogMember = catalogMember;
+
+    var onImageError = function() {
+        this.imageHasError = true;
+    };
 
     knockout.defineProperty(this, 'proxiedLegendUrls', {
         get: function() {
-            return this.catalogMember.legendUrls.map(function(legendUrl) { // Proxy each legend Url
-                return proxyCatalogItemUrl(this, legendUrl);
+            return this.catalogMember.legendUrls &&
+                this.catalogMember.legendUrls.length &&
+                this.catalogMember.legendUrls.map(function(legend) {
+                var viewModelLegend = {
+                    url: proxyCatalogItemUrl(this.catalogMember, legend.url),
+                    isImage: legend.isImage(),
+                    imageHasError: false,
+                    onImageError: onImageError
+                };
+
+                knockout.track(viewModelLegend, ['imageHasError']);
+
+                return viewModelLegend;
             }, this);
         }
     });
@@ -30,16 +45,5 @@ LegendSectionViewModel.createForCatalogMember = function(nowViewingTab, catalogM
 LegendSectionViewModel.prototype.show = function(container) {
     loadView(require('fs').readFileSync(__dirname + '/../Views/LegendSection.html', 'utf8'), container, this);
 };
-
-var imageUrlRegex = /[.\/](png|jpg|jpeg|gif)/i;
-
-LegendSectionViewModel.prototype.urlIsImage = function(url) {
-    if (!defined(url) || url.length === 0) {
-        return false;
-    }
-
-    return url.match(imageUrlRegex);
-};
-
 
 module.exports = LegendSectionViewModel;

--- a/lib/Views/LegendSection.html
+++ b/lib/Views/LegendSection.html
@@ -1,14 +1,16 @@
 <div data-bind="foreach: proxiedLegendUrls || []">
-    <!-- ko if: $root.urlIsImage($data) -->
-    <a data-bind="attr: { href: $data , tabindex: $root.nowViewingTab.isActive ? 0 : -1 }" target="_blank">
+    <!-- ko if: $data.isImage -->
+    <a data-bind="attr: { href: $data.url , tabindex: $root.nowViewingTab.isActive ? 0 : -1 }" target="_blank">
         <div class="now-viewing-legend-image">
-            <img class="now-viewing-legend-image-background" data-bind="attr: { src: $data }" />
+            <img class="now-viewing-legend-image-background"
+                 data-bind="event: { error : $data.onImageError }, attr: { src: $data.url }, visible: !$data.imageHasError"/>
         </div>
     </a>
     <!-- /ko -->
 
-    <!-- ko if: !$root.urlIsImage($data) -->
-    <a class="now-viewing-legend-text" data-bind="attr: { href: $data }" target="_blank">Open legend in a separate tab</a>
+    <!-- ko if: !$data.isImage -->
+    <a class="now-viewing-legend-text" data-bind="attr: { href: $data.url }" target="_blank">Open legend in a separate
+        tab</a>
     <!-- /ko -->
 </div>
 

--- a/test/Models/ArcGisMapServerCatalogItemSpec.js
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.js
@@ -5,6 +5,7 @@
 var Terria = require('../../lib/Models/Terria');
 var loadWithXhr = require('terriajs-cesium/Source/Core/loadWithXhr');
 var ArcGisMapServerCatalogItem = require('../../lib/Models/ArcGisMapServerCatalogItem');
+var LegendUrl = require('../../lib/Models/LegendUrl');
 
 var terria;
 var item;
@@ -67,7 +68,7 @@ describe('ArcGisMapServerCatalogItem', function() {
             showTilesAfterMessage: false
         });
 
-        expect(item.legendUrl).toBe('http://legend.com');
+        expect(item.legendUrl).toEqual(new LegendUrl('http://legend.com'));
         expect(item.dataUrlType).toBeUndefined();
         expect(item.dataUrl).toBeUndefined();
         expect(item.metadataUrl).toBe('http://my.metadata.com');
@@ -76,6 +77,15 @@ describe('ArcGisMapServerCatalogItem', function() {
         expect(item.maximumScale).toEqual(100);
         expect(item.maximumScaleBeforeMessage).toEqual(10);
         expect(item.showTilesAfterMessage).toBe(false);
+    });
+
+    it('falls back to /legend if no legendUrl provided in json', function() {
+        item.updateFromJson({
+            metadataUrl: 'http://my.metadata.com',
+            url: 'http://my.arcgis.com/abc'
+        });
+
+        expect(item.legendUrl).toEqual(new LegendUrl('http://my.arcgis.com/abc/legend'));
     });
 
     it('can load json', function(done) {

--- a/test/Models/CompositeCatalogItemSpec.js
+++ b/test/Models/CompositeCatalogItemSpec.js
@@ -5,10 +5,13 @@ var CatalogGroup = require('../../lib/Models/CatalogGroup');
 var CompositeCatalogItem = require('../../lib/Models/CompositeCatalogItem');
 var createCatalogMemberFromType = require('../../lib/Models/createCatalogMemberFromType');
 var Terria = require('../../lib/Models/Terria');
+var LegendUrl = require('../../lib/Models/LegendUrl');
+var WMSCatalogItem = require('../../lib/Models/WebMapServiceCatalogItem');
 
 describe('CompositeCatalogItem', function() {
     var terria;
     var composite;
+
     beforeEach(function() {
         terria = new Terria({
             baseUrl: './'
@@ -16,6 +19,7 @@ describe('CompositeCatalogItem', function() {
         composite = new CompositeCatalogItem(terria);
         createCatalogMemberFromType.register('composite', CompositeCatalogItem);
         createCatalogMemberFromType.register('group', CatalogGroup);
+        createCatalogMemberFromType.register('wms', WMSCatalogItem);
     });
 
     it('updates from json, preserving order', function(done) {
@@ -40,4 +44,21 @@ describe('CompositeCatalogItem', function() {
         }).then(done).otherwise(fail);
     });
 
+    it('concatenates legends', function(done) {
+        composite.updateFromJson({
+            type: 'composite',
+            items: [
+                {
+                    type: 'wms',
+                    legendUrl: 'http://not.valid'
+                },
+                {
+                    type: 'wms',
+                    legendUrl: 'http://not.valid.either'
+                }
+            ]
+        }).then(function() {
+            expect(composite.legendUrls.slice()).toEqual([new LegendUrl('http://not.valid'), new LegendUrl('http://not.valid.either')]);
+        }).then(done).otherwise(fail);
+    });
 });

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -24,7 +24,7 @@ beforeEach(function() {
     csvItem = new CsvCatalogItem(terria);
 
     greenTableStyle = new TableStyle ({
-        "colorMap": [ 
+        "colorMap": [
         {
             "offset": 0,
             "color": "rgba(0, 64, 0, 1.00)"
@@ -123,6 +123,15 @@ describe('CsvCatalogItem', function() {
         }).otherwise(fail).then(done);
     });
 
+    it('is able to generate a Legend', function(done) {
+        csvItem.url = 'test/csv/minimal.csv';
+        csvItem.load().then(function() {
+            expect(csvItem.legendUrl).toBeDefined();
+            expect(csvItem.legendUrl.mimeType).toBe('image/png');
+            expect(csvItem.legendUrl.url).toBeDefined();
+        }).otherwise(fail).then(done);
+    });
+
     it('identifies "lat" and "lon" fields', function(done) {
         csvItem.updateFromJson( { data: 'lat,lon,value\n-37,145,10' });
         csvItem.load().then(function() {
@@ -195,7 +204,7 @@ describe('CsvCatalogItem', function() {
 
 
     it('respects tableStyle color ramping for regions', function(done) {
-        csvItem.updateFromJson( { 
+        csvItem.updateFromJson( {
             data: 'lga_name,value\nCity of Melbourne,0\nGreater Geelong,5\nSydney (S),10',
             tableStyle: greenTableStyle });
         csvItem.load().then(function() {
@@ -212,7 +221,7 @@ describe('CsvCatalogItem', function() {
     it('uses the requested region mapping column, not just the first one', function(done) {
         greenTableStyle.regionType = 'poa';
         greenTableStyle.regionVariable = 'postcode';
-        csvItem.updateFromJson( { 
+        csvItem.updateFromJson( {
             url: 'test/csv/postcode_lga_val_enum.csv',
             tableStyle: greenTableStyle });
         csvItem.load().then(function() {
@@ -451,7 +460,7 @@ describe('CsvCatalogItem', function() {
             expect(desc(1)).toContain('boots');
         }).otherwise(fail).then(done);
     });
-    
+
     it('is less than 2000 charecters when serialised to JSON then URLEncoded', function(done) {
         csvItem.url = 'test/csv/postcode_enum.csv';
         csvItem.load().then(function() {
@@ -490,7 +499,7 @@ describe('CsvCatalogItem', function() {
             // again, we don't specify the base size, but x10 things should be twice as big as x5 things.
             expect(maxPix).toEqual(csvItem._maxPix * 2);
             expect(minPix).toEqual(csvItem._minPix * 2);
-        })            
+        })
         .otherwise(fail).then(done);
     });
     // Removed: not clear that this is correct behaviour, and it's failing.
@@ -504,5 +513,5 @@ describe('CsvCatalogItem', function() {
             done();
         });
     });
-    
+
 });

--- a/test/Models/LegendUrlSpec.js
+++ b/test/Models/LegendUrlSpec.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var LegendUrl = require('../../lib/Models/LegendUrl');
+
+describe('LegendUrl', function() {
+    describe('isImage', function() {
+        it('should be true for a png mime type', function() {
+            var legend = new LegendUrl('http://example.com', 'image/png');
+            expect(legend.isImage()).toBe(true);
+        });
+
+        it('should be false for no mime type', function() {
+            var legend = new LegendUrl('http://example.com');
+            expect(legend.isImage()).toBe(false);
+        });
+
+        it('should be false for non-image mime type', function() {
+            var legend = new LegendUrl('http://example.com', 'application/json');
+            expect(legend.isImage()).toBe(false);
+        });
+
+        it('should be true for no mime type but .png extension', function() {
+            var legend = new LegendUrl('http://example.com/image.png');
+            expect(legend.isImage()).toBe(true);
+        });
+
+        it('should be true for png mime type and extension', function() {
+            var legend = new LegendUrl('http://example.com/image.png', 'image/png');
+            expect(legend.isImage()).toBe(true);
+        });
+
+        it('should be false for non-image mime type but .png extension', function() {
+            var legend = new LegendUrl('http://example.com/image.png', 'application/json');
+            expect(legend.isImage()).toBe(false);
+        });
+
+        it('should be false for non-png extension', function() {
+            var legend = new LegendUrl('http://example.com/image.exe');
+            expect(legend.isImage()).toBe(false);
+        });
+    });
+});

--- a/test/ViewModels/LegendSectionViewModelSpec.js
+++ b/test/ViewModels/LegendSectionViewModelSpec.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/*global require,describe,it,expect,beforeEach*/
+var LegendSectionViewModel = require('../../lib/ViewModels/LegendSectionViewModel');
+var Terria = require('../../lib/Models/Terria');
+var CatalogItem = require('../../lib/Models/CatalogItem');
+var CompositeCatalogItem = require('../../lib/Models/CompositeCatalogItem');
+var LegendUrl = require('../../lib/Models/LegendUrl');
+
+describe('LegendSectionViewModel', function() {
+    var terria, catalogItem;
+    var legendSectionViewModel;
+
+    beforeEach(function() {
+        terria = new Terria({
+            baseUrl: './'
+        });
+        delete terria.corsProxy;
+        catalogItem = new CatalogItem(terria);
+    });
+
+    function initSingle(url, mimeType) {
+        catalogItem.legendUrl = new LegendUrl(url, mimeType);
+        legendSectionViewModel = new LegendSectionViewModel({}, catalogItem);
+    }
+
+    describe('createForCatalogMember', function() {
+        it('returns undefined if CatalogGroup has no legendUrls', function() {
+            expect(LegendSectionViewModel.createForCatalogMember(undefined, catalogItem)).toBeUndefined();
+        });
+
+        it('returns a LegendSectionViewModel if CatalogGroup has legendUrls', function() {
+            catalogItem.legendUrl = new LegendUrl('http://example.com');
+
+            expect(LegendSectionViewModel.createForCatalogMember(undefined, catalogItem)).not.toBeUndefined();
+        });
+    });
+
+    describe('for a single legend', function() {
+        beforeEach(function() {
+            initSingle('http://example.com/legend', 'image/png');
+        });
+
+        it('correctly passes the url', function() {
+            expect(legendSectionViewModel.proxiedLegendUrls[0].url).toBe('http://example.com/legend');
+        });
+
+        it('correctly passes that the url is an image', function() {
+            expect(legendSectionViewModel.proxiedLegendUrls[0].isImage).toBe(true);
+        });
+
+        it('correctly passes that the url is not an image', function() {
+            initSingle('http://example.com/legend', 'text/html');
+            expect(legendSectionViewModel.proxiedLegendUrls[0].isImage).toBe(false);
+        });
+
+        it('correctly reflects an image error', function() {
+            expect(legendSectionViewModel.proxiedLegendUrls[0].imageHasError).toBe(false);
+
+            legendSectionViewModel.proxiedLegendUrls[0].onImageError();
+
+            expect(legendSectionViewModel.proxiedLegendUrls[0].imageHasError).toBe(true);
+        });
+    });
+
+    describe('for multiple legends', function() {
+        var compCatalogItem;
+
+        beforeEach(function() {
+            var catalogItem1 = new CatalogItem(terria);
+            catalogItem1.legendUrls = [
+                new LegendUrl('http://example.com/legend1'),
+                new LegendUrl('http://example.com/legend2')
+            ];
+
+            var catalogItem2 = new CatalogItem(terria);
+            catalogItem2.legendUrls = [
+                new LegendUrl('http://example.com/legend3')
+            ];
+
+            compCatalogItem = new CompositeCatalogItem(terria, [catalogItem1, catalogItem2]);
+
+            legendSectionViewModel = new LegendSectionViewModel({}, compCatalogItem);
+        });
+
+        it('shows all urls correctly', function() {
+            expect(legendSectionViewModel.proxiedLegendUrls[0].url).toBe('http://example.com/legend1');
+            expect(legendSectionViewModel.proxiedLegendUrls[1].url).toBe('http://example.com/legend2');
+            expect(legendSectionViewModel.proxiedLegendUrls[2].url).toBe('http://example.com/legend3');
+        });
+
+        it('correctly handles an error event on a single legend', function() {
+            legendSectionViewModel.proxiedLegendUrls[1].onImageError();
+
+            expect(legendSectionViewModel.proxiedLegendUrls[0].imageHasError).toBe(false);
+            expect(legendSectionViewModel.proxiedLegendUrls[1].imageHasError).toBe(true);
+            expect(legendSectionViewModel.proxiedLegendUrls[2].imageHasError).toBe(false);
+        });
+    });
+
+    it('should generate urls with catalog item proxy', function() {
+        terria.corsProxy = {
+            shouldUseProxy: function() { return true; },
+            getURL: function() { return 'http://proxy/example.com'; }
+        };
+
+        initSingle('http://notproxy/example.com');
+
+        expect(legendSectionViewModel.proxiedLegendUrls[0].url).toBe('http://proxy/example.com');
+    });
+
+    it('should handle no legends as !proxiedLegendUrls', function() {
+        legendSectionViewModel = new LegendSectionViewModel({}, catalogItem);
+
+        expect(legendSectionViewModel.proxiedLegendUrls).toBeFalsy();
+    });
+});

--- a/wwwroot/test/WMS/bad_datetime.xml
+++ b/wwwroot/test/WMS/bad_datetime.xml
@@ -5,11 +5,12 @@
         <Title>wms Server</Title>
         <Abstract></Abstract>
         <KeywordList>
-            
+
             <Keyword></Keyword>
-            
+
         </KeywordList>
-        <OnlineResource href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <OnlineResource href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"/>
         <ContactInformation>
             <ContactPersonPrimary>
                 <ContactPerson></ContactPerson>
@@ -36,7 +37,9 @@
                 <DCPType>
                     <HTTP>
                         <Get>
-                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                            <OnlineResource
+                                xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities"
+                                xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
                         </Get>
                     </HTTP>
                 </DCPType>
@@ -46,7 +49,9 @@
                 <DCPType>
                     <HTTP>
                         <Get>
-                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                            <OnlineResource
+                                xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities"
+                                xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
                         </Get>
                     </HTTP>
                 </DCPType>
@@ -58,7 +63,9 @@
                 <DCPType>
                     <HTTP>
                         <Get>
-                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                            <OnlineResource
+                                xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities"
+                                xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
                         </Get>
                     </HTTP>
                 </DCPType>
@@ -68,7 +75,9 @@
                 <DCPType>
                     <HTTP>
                         <Get>
-                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                            <OnlineResource
+                                xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities"
+                                xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink"/>
                         </Get>
                     </HTTP>
                 </DCPType>
@@ -82,28 +91,33 @@
             <Abstract>Test data set</Abstract>
             <SRS>EPSG:3857</SRS>
             <SRS>MERCATOR</SRS>
-            
+
             <Layer opaque="0" queryable="1">
                 <Name>single_period</Name>
                 <Title>average_data</Title>
                 <Abstract></Abstract>
                 <SRS>EPSG:3857</SRS>
-                <LatLonBoundingBox maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
-                <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
-                <Dimension name="time" units="ISO8601" />
-                
-                    <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00/PBAD</Extent>
+                <LatLonBoundingBox maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868"
+                                   miny="-124.177688599"/>
+                <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868"
+                             miny="-124.177688599"/>
+                <Dimension name="time" units="ISO8601"/>
+
+                <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00/PBAD</Extent>
 
                 <Style>
                     <Name>jet</Name>
                     <Title>jet</Title>
                     <Abstract></Abstract>
-                    <LegendURL height="80" width="50">
-                        <Format>image/png</Format>
+                    <LegendURL width="72" height="72">
+                        <Format>image/gif</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        xlink:type="simple"
+                                        xlink:href="http://www.example.com"/>
                     </LegendURL>
                 </Style>
             </Layer>
-            
+
         </Layer>
     </Capability>
 </WMT_MS_Capabilities>

--- a/wwwroot/test/WMS/multiple_style_legend_url.xml
+++ b/wwwroot/test/WMS/multiple_style_legend_url.xml
@@ -92,7 +92,7 @@
                 <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
                 <Dimension name="time" units="ISO8601" />
 
-                    <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00</Extent>
+                    <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00/PT15M</Extent>
 
                 <Style>
                     <Name>jet</Name>
@@ -102,7 +102,19 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com"/>
+                                        xlink:href="http://www.example.com/legendUrl"/>
+                    </LegendURL>
+                </Style>
+
+                <Style>
+                    <Name>jet2</Name>
+                    <Title>jet2</Title>
+                    <Abstract></Abstract>
+                    <LegendURL width="72" height="72">
+                        <Format>image/gif</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        xlink:type="simple"
+                                        xlink:href="http://www.example.com/wrongLegendUrl"/>
                     </LegendURL>
                 </Style>
             </Layer>

--- a/wwwroot/test/WMS/no_legend_url.xml
+++ b/wwwroot/test/WMS/no_legend_url.xml
@@ -92,18 +92,12 @@
                 <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
                 <Dimension name="time" units="ISO8601" />
 
-                    <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00</Extent>
+                    <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00/PT15M</Extent>
 
                 <Style>
                     <Name>jet</Name>
                     <Title>jet</Title>
                     <Abstract></Abstract>
-                    <LegendURL width="72" height="72">
-                        <Format>image/gif</Format>
-                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
-                                        xlink:type="simple"
-                                        xlink:href="http://www.example.com"/>
-                    </LegendURL>
                 </Style>
             </Layer>
 

--- a/wwwroot/test/WMS/period_datetimes.xml
+++ b/wwwroot/test/WMS/period_datetimes.xml
@@ -5,9 +5,9 @@
         <Title>wms Server</Title>
         <Abstract></Abstract>
         <KeywordList>
-            
+
             <Keyword></Keyword>
-            
+
         </KeywordList>
         <OnlineResource href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
         <ContactInformation>
@@ -82,7 +82,7 @@
             <Abstract>Test data set</Abstract>
             <SRS>EPSG:3857</SRS>
             <SRS>MERCATOR</SRS>
-            
+
             <Layer opaque="0" queryable="1">
                 <Name>single_period</Name>
                 <Title>average_data</Title>
@@ -91,19 +91,22 @@
                 <LatLonBoundingBox maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
                 <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
                 <Dimension name="time" units="ISO8601" />
-                
+
                     <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00/PT15M</Extent>
 
                 <Style>
                     <Name>jet</Name>
                     <Title>jet</Title>
                     <Abstract></Abstract>
-                    <LegendURL height="80" width="50">
-                        <Format>image/png</Format>
+                    <LegendURL width="72" height="72">
+                        <Format>image/gif</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        xlink:type="simple"
+                                        xlink:href="http://www.example.com"/>
                     </LegendURL>
                 </Style>
             </Layer>
-            
+
         </Layer>
     </Capability>
 </WMT_MS_Capabilities>

--- a/wwwroot/test/WMS/single_style_legend_url.xml
+++ b/wwwroot/test/WMS/single_style_legend_url.xml
@@ -92,7 +92,7 @@
                 <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
                 <Dimension name="time" units="ISO8601" />
 
-                    <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00</Extent>
+                    <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00/PT15M</Extent>
 
                 <Style>
                     <Name>jet</Name>
@@ -102,7 +102,7 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com"/>
+                                        xlink:href="http://www.example.com/legendUrl"/>
                     </LegendURL>
                 </Style>
             </Layer>

--- a/wwwroot/test/WMS/single_style_multiple_legend_urls.xml
+++ b/wwwroot/test/WMS/single_style_multiple_legend_urls.xml
@@ -92,7 +92,7 @@
                 <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
                 <Dimension name="time" units="ISO8601" />
 
-                    <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00</Extent>
+                    <Extent name="time">2015-04-27T16:15:00/2015-04-27T18:45:00/PT15M</Extent>
 
                 <Style>
                     <Name>jet</Name>
@@ -102,7 +102,13 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com"/>
+                                        xlink:href="http://www.example.com/legendUrl"/>
+                    </LegendURL>
+                    <LegendURL width="72" height="72">
+                        <Format>image/gif</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        xlink:type="simple"
+                                        xlink:href="http://www.example.com/wrongLegendUrl"/>
                     </LegendURL>
                 </Style>
             </Layer>


### PR DESCRIPTION
If any style tag is present in the Capabilities of a WMS layer with a LegendURL, this will be used by default for the legend image. If multiple <Style>s or <LegendURL>s are present, the first one will be used. If none are present, the legend URL will revert back to a default constructed url based on the WMS standard, as it currently does now.

As far as I can understand this _should_ fix #699, although the original use case in that issue is no longer valid because that dataset uses ArcGis now and it has a custom legend url set.

I did test against the distance from powerlines dataset in AREMI, which uses WMS, and it works with that - although the legend image is the same despite now coming from a different URL.
