### PR TITLE
Opacity UI enhancement for tablets and smartphones devices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 
 ### 1.0.50
 
+* Move opacity by 10% instead of 1%, put a select box opacity for tablets and smartphones devices
 * Put a white background behind legend images to fix legend images with transparent background being nearly invisible.
 * Search entries are no longer duplicated for catalog items that appear in multiple places in the Data Catalogue
 * Fixed the layer order changing in Cesium when a CSV variable is chosen.

--- a/lib/ViewModels/OpacitySectionViewModel.js
+++ b/lib/ViewModels/OpacitySectionViewModel.js
@@ -3,10 +3,13 @@
 /*global require*/
 var defined = require('terriajs-cesium/Source/Core/defined');
 var loadView = require('../Core/loadView');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 
 var OpacitySectionViewModel = function(nowViewingTab, catalogMember) {
     this.nowViewingTab = nowViewingTab;
     this.catalogMember = catalogMember;
+
+    this.opacityChoices = knockout.observableArray([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
 };
 
 OpacitySectionViewModel.createForCatalogMember = function(nowViewingTab, catalogMember) {

--- a/lib/Views/OpacitySection.html
+++ b/lib/Views/OpacitySection.html
@@ -1,4 +1,8 @@
 <div class="now-viewing-item-opacity">
-    OPACITY: <span data-bind="text: Math.round(catalogMember.opacity * 100) + '%'"></span>
-    <input class="now-viewing-opacity-slider" type="range" min="0" max="1" step="0.01" data-bind="value: catalogMember.opacity, valueUpdate: 'input', attr: {tabindex: nowViewingTab.isActive ? 0 : -1 }" />
+  OPACITE: <select style="display: inline-block;" data-bind="options: opacityChoices,
+			      optionsText: function(item) {
+			        return Math.round(item * 100) + '%';
+			      },
+			      value: catalogMember.opacity"></select>
+    <input class="now-viewing-opacity-slider" type="range" min="0" max="1" step="0.1" data-bind="value: catalogMember.opacity, valueUpdate: 'input', attr: {tabindex: nowViewingTab.isActive ? 0 : -1 }" />
 </div>


### PR DESCRIPTION
I had some issues with my IPad and Smartphone with the opacity slider so I've added a select box. I've reduced the opacity slider granularity for 0.01 to 0.1 in order to match the select box entries but this can be easily changed

Fabien
