### PR TITLE
Add getContainer() to GlobeOrMap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 1.0.52
+
+* Add a `getContainer()` method to Terria's `currentViewer`.
+
 ### 1.0.51
 
 * Fixed a typo that prevented clearing the search query

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -328,6 +328,14 @@ Cesium.prototype.getCurrentExtent = function() {
 };
 
 /**
+ * Gets the current container element.
+ * @return {Element} The current container element.
+ */
+Cesium.prototype.getContainer = function() {
+    return this.viewer.container;
+};
+
+/**
  * Zooms to a specified camera view or extent with a smooth flight animation.
  *
  * @param {CameraView|Rectangle} viewOrExtent The view or extent to which to zoom.

--- a/lib/Models/GlobeOrMap.js
+++ b/lib/Models/GlobeOrMap.js
@@ -78,6 +78,15 @@ GlobeOrMap.prototype.getCurrentExtent = function() {
 };
 
 /**
+ * Gets the current container element.
+ * @return {Element} The current container element.
+ */
+GlobeOrMap.prototype.getContainer = function() {
+    throw new DeveloperError('getContainer must be implemented in the derived class.');
+};
+
+
+/**
  * Zooms to a specified camera view or extent with a smooth flight animation.
  *
  * @param {CameraView|Rectangle} viewOrExtent The view or extent to which to zoom.

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -128,6 +128,14 @@ Leaflet.prototype.getCurrentExtent = function() {
 };
 
 /**
+ * Gets the current container element.
+ * @return {Element} The current container element.
+ */
+Leaflet.prototype.getContainer = function() {
+    return this.map.getContainer();
+};
+
+/**
  * Zooms to a specified camera view or extent.
  *
  * @param {CameraView|Rectangle} viewOrExtent The view or extent to which to zoom.

--- a/lib/Models/NoViewer.js
+++ b/lib/Models/NoViewer.js
@@ -36,6 +36,14 @@ NoViewer.prototype.getCurrentExtent = function() {
 };
 
 /**
+ * Gets the current container element.
+ * @return {Element} The current container element.
+ */
+NoViewer.prototype.getContainer = function() {
+    return undefined;
+};
+
+/**
  * Zooms to a specified camera view or extent with a smooth flight animation.
  *
  * @param {CameraView|Rectangle} viewOrExtent The view or extent to which to zoom.

--- a/test/Models/CesiumSpec.js
+++ b/test/Models/CesiumSpec.js
@@ -27,6 +27,10 @@ describe('Cesium Model', function() {
         document.body.removeChild(container);
     });
 
+    it('should be able to reference its container', function() {
+        expect(cesium.getContainer()).toBe(container);
+    });
+
     it('should trigger terria.tileLoadProgressEvent on globe tileLoadProgressEvent', function() {
         cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
 

--- a/test/Models/LeafletSpec.js
+++ b/test/Models/LeafletSpec.js
@@ -52,6 +52,11 @@ describe('Leaflet Model', function() {
         });
     });
 
+    it('should be able to reference its container', function() {
+        initLeaflet();
+        expect(leaflet.getContainer()).toBe(container);
+    });
+
     it('should trigger a tileLoadProgressEvent with the total number of tiles to be loaded for all layers', function() {
         initLeaflet();
 


### PR DESCRIPTION
This unifies the interface for referring to the containing DOM element. We'll need this for the charts panel.
