### PR TITLE
Automatically run test suite as part of Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,12 @@
 language: node_js
 node_js:
 - '0.10'
-addons:
-  sauce_connect:
-    username: "kevin-nationalmap"
-    access_key:
-      secure: "cPJsPEUvRWVqtbJCFVB0fChHxBaXfh97UUE/LhEPfgf1kZQtASLJ2hPvjjGAGrvyUUsdzFNL08l+ZY1p914qRmGYcV7ibCgkjwVROquqoT1s8UpXWOEvBKosX8++1Lm63WthazJqg65xqEVJJgKSk763mwcyVKkiTpCGQ2awkr0="
 script:
 - gulp lint docs release
 - npm start &
 - sleep 5
 - karma start
-#deploy:
-#  provider: s3
-#  access_key_id: AKIAJI2CLEK7CFXORVWA
-#  secret_access_key:
-#    secure: Q3E6wps0GOEAtHXiylkVIbZTjZCWMwYA4LG0ofaFdKTSa9Qzfu75rubuiDRInmK+Fhj+mXL1HbMKhSWfrmE49RIcuS8ntcYT+dop3JnOnH+ikaMDYN6NwhsnXsgF0sChV5hW+9M0K/0Ev0L/5DBF6366v1IivHJtTf16gsB6Akk=
-#  bucket: nationalmap-build-artifacts
-#  local-dir: public
-#  upload-dir: $TRAVIS_BRANCH/$TRAVIS_BUILD_NUMBER
-#  acl: public_read
-#  region: ap-southeast-2
-#  endpoint: s3-ap-southeast-2.amazonaws.com
-#  skip_cleanup: true
-#  on:
-#    repo: NICTA/nationalmap
-#    all_branches: true
+env:
+  global:
+  - secure: C3MD7bL3aPhBQga5DfUV9f2fH5oqYd6sP9NasqYuEYAP6zFdKBtXNzpC97RNWjihB+LIizq+NKWYN5H3vNXxW79CGdEOeTluD56VtlmY0jF9doHuEQZb/lnRyrwFypgxsK+MD5XIVgPTs3s49ETdTcsFuKM7N/51pDE75NkAbSY=
+  - secure: gzSiFfm+cog4Kl7kxh997UwuIIbthm5cbbwDWSJE8EnqAGuHP6XJsVnu+c1Ql+nuVidY0hCeenjdGuRMt5jSWCES6jAT1RR2j46PrCE0tLRDZIcY5m2rt9uRtAGG/Wvsk0tRdg/TPMc50f/3c4zX8iMmD4Hd1qB/G/debE6PDBE=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: node_js
 node_js:
 - '0.10'
+addons:
+  sauce_connect:
+    username: kevin-nationalmap
+    access_key:
+      secure: "hKffu7D30VljdS2/5E38MI10FE97brk/bH7dgbpmABT9gLed98paQBFYjyul/l6g03QHCjvXRHyU1Vrlw2EJZMMfuwap4oK6DcrHQ8hwPL/StWFfxn1kz7Lx3maAPKpOE6LaaZtHyXs6nauNjbntchkGmkEj1NZIbsuTmfSIZm0="
 script:
 - gulp lint docs release
+- npm start &
+- sleep 5
+- karma start
 #deploy:
 #  provider: s3
 #  access_key_id: AKIAJI2CLEK7CFXORVWA

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ node_js:
 - '0.10'
 addons:
   sauce_connect:
-    username: kevin-nationalmap
+    username: "kevin-nationalmap"
     access_key:
-      secure: "hKffu7D30VljdS2/5E38MI10FE97brk/bH7dgbpmABT9gLed98paQBFYjyul/l6g03QHCjvXRHyU1Vrlw2EJZMMfuwap4oK6DcrHQ8hwPL/StWFfxn1kz7Lx3maAPKpOE6LaaZtHyXs6nauNjbntchkGmkEj1NZIbsuTmfSIZm0="
+      secure: "cPJsPEUvRWVqtbJCFVB0fChHxBaXfh97UUE/LhEPfgf1kZQtASLJ2hPvjjGAGrvyUUsdzFNL08l+ZY1p914qRmGYcV7ibCgkjwVROquqoT1s8UpXWOEvBKosX8++1Lm63WthazJqg65xqEVJJgKSk763mwcyVKkiTpCGQ2awkr0="
 script:
 - gulp lint docs release
 - npm start &

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -93,7 +93,8 @@ module.exports = function(config) {
     concurrency: Infinity,
 
     sauceLabels: {
-        testName: 'TerriaJS Unit Tests'
+        testName: 'TerriaJS Unit Tests',
+        tunnelIdentifier: process.env.TRAVIS_BUILD_NUMBER
     }
   })
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,6 +4,8 @@
 module.exports = function(config) {
   config.set({
 
+    browserNoActivityTimeout: 100000000,
+
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: 'wwwroot',
 
@@ -41,11 +43,23 @@ module.exports = function(config) {
     preprocessors: {
     },
 
+    customLaunchers: {
+        'PhantomJS_debug': {
+            base: 'PhantomJS',
+            debug: true
+        },
+        sl_chrome: {
+              base: 'SauceLabs',
+              browserName: 'chrome',
+              platform: 'Windows 7',
+              version: '46'
+        }
+    },
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+    reporters: ['progress', 'saucelabs'],
 
 
     // web server port
@@ -67,7 +81,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
+    browsers: ['sl_chrome'],
 
 
     // Continuous Integration mode
@@ -76,6 +90,10 @@ module.exports = function(config) {
 
     // Concurrency level
     // how many browser should be started simultanous
-    concurrency: Infinity
+    concurrency: Infinity,
+
+    sauceLabels: {
+        testName: 'TerriaJS Unit Tests'
+    }
   })
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -44,15 +44,35 @@ module.exports = function(config) {
     },
 
     customLaunchers: {
-        'PhantomJS_debug': {
-            base: 'PhantomJS',
-            debug: true
-        },
         sl_chrome: {
               base: 'SauceLabs',
               browserName: 'chrome',
               platform: 'Windows 7',
-              version: '46'
+              version: '46.0'
+        },
+        sl_safari9: {
+            base: 'SauceLabs',
+            browserName: 'safari',
+            platform: 'OS X 10.11',
+            version: '9.0'
+        },
+        sl_ie9: {
+            base: 'SauceLabs',
+            browserName: 'internet explorer',
+            platform: 'Windows 7',
+            version: '9.0'
+        },
+        sl_firefox42: {
+            base: 'SauceLabs',
+            browserName: 'firefox',
+            platform: 'Windows 7',
+            version: '42.0'
+        },
+        sl_firefox38esr: {
+            base: 'SauceLabs',
+            browserName: 'firefox',
+            platform: 'Windows 7',
+            version: '38.0'
         }
     },
 
@@ -81,7 +101,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['sl_chrome'],
+    browsers: ['sl_chrome', 'sl_safari9', 'sl_firefox42', 'sl_firefox38esr'],
 
 
     // Continuous Integration mode

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,81 @@
+// Karma configuration
+// Generated on Tue Dec 22 2015 11:24:15 GMT+1100 (AEDT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: 'wwwroot',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'build/TerriaJS-specs.js',
+      {
+        pattern: 'build/Cesium/**',
+        watched: false,
+        included: false,
+        served: true
+      }
+    ],
+
+    proxies: {
+        '/data': 'http://localhost:3002/data',
+        '/images': 'http://localhost:3002/images',
+        '/test': 'http://localhost:3002/test',
+        '/build': 'http://localhost:3002/build'
+    },
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+
+    // Concurrency level
+    // how many browser should be started simultanous
+    concurrency: Infinity
+  })
+}

--- a/lib/Core/supportsWebGL.js
+++ b/lib/Core/supportsWebGL.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/*global require*/
+var defined = require('terriajs-cesium/Source/Core/defined');
+
+var result;
+
+/**
+ * Determines if the current browser supports WebGL.
+ * @return {Boolean|String} False if WebGL is not supported at all, 'slow' if WebGL is supported
+ *                          but it has a major performance caveat (e.g. software rendering), and True
+ *                          if WebGL is available without a major performance caveat.
+ */
+function supportsWebGL() {
+    if (defined(result)) {
+        return result;
+    }
+
+    //Check for webgl support and if not, then fall back to leaflet
+    if (!window.WebGLRenderingContext) {
+        // Browser has no idea what WebGL is. Suggest they
+        // get a new browser by presenting the user with link to
+        // http://get.webgl.org
+        result = false;
+        return result;
+    }
+    var canvas = document.createElement( 'canvas' );
+
+    var webglOptions = {
+        alpha : false,
+        stencil : false,
+        failIfMajorPerformanceCaveat : true
+    };
+
+    var gl = canvas.getContext("webgl", webglOptions) || canvas.getContext("experimental-webgl", webglOptions);
+    if (!gl) {
+        // We couldn't get a WebGL context without a major performance caveat.  Let's see if we can get one at all.
+        webglOptions.failIfMajorPerformanceCaveat = false;
+        gl = canvas.getContext("webgl", webglOptions) || canvas.getContext("experimental-webgl", webglOptions);
+        if (!gl) {
+            // No WebGL at all.
+            result = false;
+        } else {
+            // We can do WebGL, but only with software rendering (or similar).
+            result = 'slow';
+        }
+    } else {
+        // WebGL is good to go!
+        result = true;
+    }
+
+    return result;
+}
+
+module.exports = supportsWebGL;

--- a/lib/Models/KmlCatalogItem.js
+++ b/lib/Models/KmlCatalogItem.js
@@ -112,7 +112,6 @@ KmlCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
 var kmzRegex = /\.kmz$/i;
 
 KmlCatalogItem.prototype._load = function() {
-    debugger;
     var dataSource = new KmlDataSource();
     this._dataSource = dataSource;
 

--- a/lib/Models/KmlCatalogItem.js
+++ b/lib/Models/KmlCatalogItem.js
@@ -112,6 +112,7 @@ KmlCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
 var kmzRegex = /\.kmz$/i;
 
 KmlCatalogItem.prototype._load = function() {
+    debugger;
     var dataSource = new KmlDataSource();
     this._dataSource = dataSource;
 

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -47,6 +47,7 @@ var Cesium = require('../Models/Cesium');
 var Leaflet = require('../Models/Leaflet');
 var PopupMessageViewModel = require('../ViewModels/PopupMessageViewModel');
 var LeafletVisualizer = require('../Map/LeafletVisualizer');
+var supportsWebGL = require('../Core/supportsWebGL');
 var ViewerMode = require('../Models/ViewerMode');
 
 //use our own bing maps key
@@ -662,41 +663,6 @@ that option from the Maps button at the top of the screen.'
     changeBaseMap(this,  this.terria.baseMap);
 
 };
-
-// Check for WebGL support
-function supportsWebGL() {
-    //Check for webgl support and if not, then fall back to leaflet
-    if (!window.WebGLRenderingContext) {
-        // Browser has no idea what WebGL is. Suggest they
-        // get a new browser by presenting the user with link to
-        // http://get.webgl.org
-        return false;
-    }
-    var canvas = document.createElement( 'canvas' );
-
-    var webglOptions = {
-        alpha : false,
-        stencil : false,
-        failIfMajorPerformanceCaveat : true
-    };
-
-    var gl = canvas.getContext("webgl", webglOptions) || canvas.getContext("experimental-webgl", webglOptions);
-    if (!gl) {
-        // We couldn't get a WebGL context without a major performance caveat.  Let's see if we can get one at all.
-        webglOptions.failIfMajorPerformanceCaveat = false;
-        gl = canvas.getContext("webgl", webglOptions) || canvas.getContext("experimental-webgl", webglOptions);
-        if (!gl) {
-            // No WebGL at all.
-            return false;
-        } else {
-            // We can do WebGL, but only with software rendering (or similar).
-            return 'slow';
-        }
-    }
-
-    // WebGL is good to go!
-    return true;
-}
 
 TerriaViewer.prototype._getDisclaimer = function() {
     var d = this.terria.configParameters.disclaimer;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "karma-chrome-launcher": "^0.2.2",
     "karma-jasmine": "^0.3.6",
     "karma-sauce-launcher": "^0.3.0",
-    "phantomjs": "^2.0.0-alpha",
     "sinon": "^1.17.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,14 +43,18 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.4",
     "gulp-watch": "^4.2.4",
+    "jasmine-core": "^2.4.1",
     "jsdoc": "^3.3.3",
     "jshint": "2.8.x",
+    "karma": "^0.13.15",
+    "karma-chrome-launcher": "^0.2.2",
+    "karma-jasmine": "^0.3.6",
+    "sinon": "^1.17.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "vinyl-transform": "^1.0.0",
     "watchify": "^3.1.1",
-    "yargs": "^3.7.2",
-    "sinon": "^1.17.2"
+    "yargs": "^3.7.2"
   },
   "scripts": {
     "prepublish": "bash -c \"if [ ! -d \"./wwwroot/build\" ]; then gulp prepare-cesium; fi\"",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "karma": "^0.13.15",
     "karma-chrome-launcher": "^0.2.2",
     "karma-jasmine": "^0.3.6",
+    "karma-sauce-launcher": "^0.3.0",
+    "phantomjs": "^2.0.0-alpha",
     "sinon": "^1.17.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "jsdoc": "^3.3.3",
     "jshint": "2.8.x",
     "karma": "^0.13.15",
-    "karma-chrome-launcher": "^0.2.2",
     "karma-jasmine": "^0.3.6",
     "karma-sauce-launcher": "^0.3.0",
     "sinon": "^1.17.2",

--- a/test/Models/CesiumSpec.js
+++ b/test/Models/CesiumSpec.js
@@ -4,54 +4,57 @@
 var Cesium = require('../../lib/Models/Cesium');
 var Terria = require('../../lib/Models/Terria');
 var CesiumWidget = require('terriajs-cesium/Source/Widgets/CesiumWidget/CesiumWidget');
+var supportsWebGL = require('../../lib/Core/supportsWebGL');
 
-describe('Cesium Model', function() {
-    var terria;
-    var cesium;
-    var container;
+if (supportsWebGL()) {
+    describe('Cesium Model', function() {
+        var terria;
+        var cesium;
+        var container;
 
-    beforeEach(function() {
-        terria = new Terria({
-            baseUrl : './'
+        beforeEach(function() {
+            terria = new Terria({
+                baseUrl : './'
+            });
+            container = document.createElement('div');
+            container.id = 'container';
+            document.body.appendChild(container);
+
+            spyOn(terria.tileLoadProgressEvent, 'raiseEvent');
+
+            cesium = new Cesium(terria, new CesiumWidget(container, {}));
         });
-        container = document.createElement('div');
-        container.id = 'container';
-        document.body.appendChild(container);
 
-        spyOn(terria.tileLoadProgressEvent, 'raiseEvent');
+        afterEach(function() {
+            document.body.removeChild(container);
+        });
 
-        cesium = new Cesium(terria, new CesiumWidget(container, {}));
+        it('should trigger terria.tileLoadProgressEvent on globe tileLoadProgressEvent', function() {
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
+
+            expect(terria.tileLoadProgressEvent.raiseEvent).toHaveBeenCalledWith(3, 3);
+        });
+
+        it('should retain the maximum length of tiles to be loaded', function() {
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(7);
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(4);
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(2);
+
+            expect(terria.tileLoadProgressEvent.raiseEvent).toHaveBeenCalledWith(2, 7);
+        });
+
+        it('should reset maximum length when the number of tiles to be loaded reaches 0', function() {
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(7);
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(4);
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(0);
+
+            expect(terria.tileLoadProgressEvent.raiseEvent.calls.mostRecent().args).toEqual([0, 0]);
+
+            cesium.scene.globe.tileLoadProgressEvent.raiseEvent(2);
+
+            expect(terria.tileLoadProgressEvent.raiseEvent.calls.mostRecent().args).toEqual([2, 2]);
+        });
     });
-
-    afterEach(function() {
-        document.body.removeChild(container);
-    });
-
-    it('should trigger terria.tileLoadProgressEvent on globe tileLoadProgressEvent', function() {
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
-
-        expect(terria.tileLoadProgressEvent.raiseEvent).toHaveBeenCalledWith(3, 3);
-    });
-
-    it('should retain the maximum length of tiles to be loaded', function() {
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(7);
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(4);
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(2);
-
-        expect(terria.tileLoadProgressEvent.raiseEvent).toHaveBeenCalledWith(2, 7);
-    });
-
-    it('should reset maximum length when the number of tiles to be loaded reaches 0', function() {
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(3);
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(7);
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(4);
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(0);
-
-        expect(terria.tileLoadProgressEvent.raiseEvent.calls.mostRecent().args).toEqual([0, 0]);
-
-        cesium.scene.globe.tileLoadProgressEvent.raiseEvent(2);
-
-        expect(terria.tileLoadProgressEvent.raiseEvent.calls.mostRecent().args).toEqual([2, 2]);
-    });
-});
+}

--- a/test/Models/CzmlCatalogItemSpec.js
+++ b/test/Models/CzmlCatalogItemSpec.js
@@ -158,7 +158,7 @@ describe('CzmlCatalogItem', function() {
 
     });
 
-    describe('error handling', function(done) {
+    describe('error handling', function() {
         it('fails gracefully when the data at a URL is not JSON', function(done) {
             czml.url = 'test/KML/vic_police.kml';
             czml.load().then(function() {

--- a/test/Models/KmlCatalogItemSpec.js
+++ b/test/Models/KmlCatalogItemSpec.js
@@ -21,7 +21,6 @@ describe('KmlCatalogItem', function() {
     });
 
     it('can load a KML file by URL', function(done) {
-        debugger;
         kml.url = 'test/KML/vic_police.kml';
         kml.load().then(function() {
             expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);

--- a/test/Models/KmlCatalogItemSpec.js
+++ b/test/Models/KmlCatalogItemSpec.js
@@ -21,11 +21,11 @@ describe('KmlCatalogItem', function() {
     });
 
     it('can load a KML file by URL', function(done) {
+        debugger;
         kml.url = 'test/KML/vic_police.kml';
         kml.load().then(function() {
             expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('use provided dataUrl', function(done) {
@@ -34,8 +34,7 @@ describe('KmlCatalogItem', function() {
         kml.load().then(function() {
             expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
             expect(kml.dataUrl).toBe("test/test.html");
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('have default dataUrl and dataUrlType', function() {

--- a/test/Models/NowViewingSpec.js
+++ b/test/Models/NowViewingSpec.js
@@ -8,7 +8,7 @@ var CesiumWidget = require('terriajs-cesium/Source/Widgets/CesiumWidget/CesiumWi
 var Leaflet = require('../../lib/Models/Leaflet');
 var L = require('leaflet');
 var CatalogItem = require('../../lib/Models/CatalogItem');
-
+var supportsWebGL = require('../../lib/Core/supportsWebGL');
 
 describe('NowViewing without a viewer', function() {
 
@@ -34,7 +34,7 @@ describe('NowViewing without a viewer', function() {
 // only run these tests if the browser supports WebGL
 // the browser may still not show WebGL properly - see TerriaViewer.js for a more precise test if needed
 
-if (window.WebGLRenderingContext) {
+if (supportsWebGL()) {
 
     describe('NowViewing with a minimal Cesium viewer', function() {
         var container;
@@ -100,7 +100,7 @@ describe('NowViewing with a minimal Leaflet viewer', function() {
         });
         container = document.createElement('div');
         container.id = 'container';
-        document.body.appendChild(container);    
+        document.body.appendChild(container);
         var map = L.map('container').setView([-28.5, 135], 5);
 
         leaflet = new Leaflet(terria, map);


### PR DESCRIPTION
This pull request uses Karma and Sauce Labs to automatically run our unit tests on a bunch of browsers on each check-in / pull request.  Currently we run on:
- Chrome 46 on Windows 7
- Safari 9 on Mac OS X 10.11
- Firefox 42 on Windows 7
- Firefox 38 (the current extended support release) on Windows 7

We'll add some Internet Explorer flavors once the tests are in better shape there.  We can also add mobile devices, but I haven't tried it yet.  This handy tool can be used to configure more platforms:
https://wiki.saucelabs.com/display/DOCS/Platform+Configurator?_ga=1.115415494.1515790378.1415140375#/

As an open source project, we have a free Sauce Labs account that allows us to run on up to 5 VMs simultaneously.  I think I can create sub-accounts for anyone that wants to run the tests across browsers on their own system before committing.  Let me know if you want to try it.
