### PR TITLE
Catalog members can now have stable ids set in config JSON

### DIFF
--- a/lib/Core/combineFilters.js
+++ b/lib/Core/combineFilters.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var combine = require('terriajs-cesium/Source/Core/combine');
+var defined = require('terriajs-cesium/Source/Core/defined');
+
+/**
+ * Combines a number of functions that return a boolean into a single function that executes all of them and returns
+ * true only if all them do. Maintains an internal index of filter functions, so if the same function is combined
+ * more than once, it is only executed one time. This index means that it is also safe to call combineFilters, then call
+ * it again to combine the result with another filter - the index of the previous call and the current call will simply
+ * be merged together so that only individual filter functions are executed.
+ *
+ * @param {Array} filters A number of functions to combine into one logical function.
+ * @returns {Function} The resulting function.
+ */
+function combineFilters(filters) {
+    var filterIndex, returnFn;
+
+    filterIndex = filters
+        .filter(function(filter) {
+            return defined(filter);
+        })
+        .reduce(function(indexSoFar, thisFilter) {
+            if (thisFilter._filterIndex) {
+                // If a filter is an instance of this function just pull that filter's index into this one's.
+                return combine(thisFilter._filterIndex, indexSoFar);
+            } else {
+                // Otherwise add it.
+                indexSoFar[thisFilter.toString()] = thisFilter;
+            }
+
+            return indexSoFar;
+        }, {});
+
+    returnFn = function() {
+        var outerArgs = arguments;
+
+        return Object.keys(filterIndex).reduce(function(soFar, fnKey) {
+            return soFar && filterIndex[fnKey].apply(this, outerArgs);
+        }.bind(this), true);
+    };
+    returnFn._filterIndex = filterIndex;
+
+    return returnFn;
+}
+
+module.exports = combineFilters;

--- a/lib/Core/combineFilters.js
+++ b/lib/Core/combineFilters.js
@@ -1,47 +1,52 @@
 'use strict';
 
-var combine = require('terriajs-cesium/Source/Core/combine');
 var defined = require('terriajs-cesium/Source/Core/defined');
 
 /**
  * Combines a number of functions that return a boolean into a single function that executes all of them and returns
- * true only if all them do. Maintains an internal index of filter functions, so if the same function is combined
- * more than once, it is only executed one time. This index means that it is also safe to call combineFilters, then call
- * it again to combine the result with another filter - the index of the previous call and the current call will simply
- * be merged together so that only individual filter functions are executed.
+ * true only if all them do. Maintains an set of filter functions, so if the same function is combined
+ * more than once, it is only executed one time. This means that it is also safe to call combineFilter on its own result
+ * to combine the result with another filter - the set of filters from the previous result will simply
+ * be merged into that of the new result so that only individual filter functions are executed.
  *
  * @param {Array} filters A number of functions to combine into one logical function.
  * @returns {Function} The resulting function.
  */
 function combineFilters(filters) {
-    var filterIndex, returnFn;
+    var allFilters, returnFn;
 
-    filterIndex = filters
+    allFilters = filters
         .filter(function(filter) {
             return defined(filter);
         })
-        .reduce(function(indexSoFar, thisFilter) {
+        .reduce(function(filtersSoFar, thisFilter) {
             if (thisFilter._filterIndex) {
                 // If a filter is an instance of this function just pull that filter's index into this one's.
-                return combine(thisFilter._filterIndex, indexSoFar);
+                thisFilter._filterIndex.forEach(addToListUnique.bind(undefined, filtersSoFar));
             } else {
                 // Otherwise add it.
-                indexSoFar[thisFilter.toString()] = thisFilter;
+                addToListUnique(filtersSoFar, thisFilter);
             }
 
-            return indexSoFar;
-        }, {});
+            return filtersSoFar;
+        }, []);
 
     returnFn = function() {
         var outerArgs = arguments;
 
-        return Object.keys(filterIndex).reduce(function(soFar, fnKey) {
-            return soFar && filterIndex[fnKey].apply(this, outerArgs);
-        }.bind(this), true);
+        return !allFilters.some(function(filter) {
+            return !filter.apply(this, outerArgs);
+        }, this);
     };
-    returnFn._filterIndex = filterIndex;
+    returnFn._filterIndex = allFilters;
 
     return returnFn;
+}
+
+function addToListUnique(list, filter) {
+    if (list.indexOf(filter) === -1) {
+        list.push(filter);
+    }
 }
 
 module.exports = combineFilters;

--- a/lib/Core/serializeToJson.js
+++ b/lib/Core/serializeToJson.js
@@ -17,7 +17,7 @@ function serializeToJson(target, filterFunction, options) {
     var result = {};
 
     for (var propertyName in target) {
-        if (target.hasOwnProperty(propertyName) && propertyName.length > 0 && propertyName[0] !== '_' && filterFunction(propertyName)) {
+        if (target.hasOwnProperty(propertyName) && propertyName.length > 0 && propertyName[0] !== '_' && filterFunction(propertyName, target)) {
             if (target.serializers && target.serializers[propertyName]) {
                 target.serializers[propertyName](target, result, propertyName, options);
             } else {

--- a/lib/Core/serializeToJson.js
+++ b/lib/Core/serializeToJson.js
@@ -17,7 +17,11 @@ function serializeToJson(target, filterFunction, options) {
     var result = {};
 
     for (var propertyName in target) {
-        if (target.hasOwnProperty(propertyName) && propertyName.length > 0 && propertyName[0] !== '_' && filterFunction(propertyName, target)) {
+        if (target.hasOwnProperty(propertyName) &&
+            propertyName.length > 0 &&
+            propertyName[0] !== '_' &&
+            propertyName !== 'parent' &&
+            filterFunction(propertyName, target)) {
             if (target.serializers && target.serializers[propertyName]) {
                 target.serializers[propertyName](target, result, propertyName, options);
             } else {

--- a/lib/Core/updateFromJson.js
+++ b/lib/Core/updateFromJson.js
@@ -4,7 +4,6 @@
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
-
 /**
  * Updates an object from a JSON representation of the object.  Only properties that actually exist on the object are read from the JSON,
  * and the object has the opportunity to inject specialized deserialization logic by providing an `updaters` property.
@@ -19,7 +18,7 @@ function updateFromJson(target, json, options) {
     var promises = [];
 
     for (var propertyName in target) {
-        if (target.hasOwnProperty(propertyName) && defined(json[propertyName]) && propertyName.length > 0 && propertyName[0] !== '_') {
+        if (target.hasOwnProperty(propertyName) && shouldBeUpdated(target, propertyName, json)) {
             if (target.updaters && target.updaters[propertyName]) {
                 promises.push(target.updaters[propertyName](target, json, propertyName, options));
             } else {
@@ -29,6 +28,16 @@ function updateFromJson(target, json, options) {
     }
 
     return when.all(promises);
+}
+
+/**
+ * Determines whether this property is valid for updating.
+ */
+function shouldBeUpdated(target, propertyName, json) {
+    return defined(json[propertyName]) && // Must have a value to update to
+        propertyName.length > 0 && // Must have a name to update
+        propertyName[0] !== '_' && // Must not be a private property
+        (propertyName !== 'id' || !defined(target.id)); // Must not be overwriting 'id'
 }
 
 module.exports = updateFromJson;

--- a/lib/Models/AbsIttCatalogGroup.js
+++ b/lib/Models/AbsIttCatalogGroup.js
@@ -12,6 +12,7 @@ var loadJson = require('terriajs-cesium/Source/Core/loadJson');
 var objectToQuery = require('terriajs-cesium/Source/Core/objectToQuery');
 
 var AbsIttCatalogItem = require('./AbsIttCatalogItem');
+var CatalogMember = require('./CatalogMember');
 var CatalogGroup = require('./CatalogGroup');
 var inherit = require('../Core/inherit');
 var TerriaError = require('../Core/TerriaError');
@@ -149,25 +150,7 @@ defineProperties(AbsIttCatalogGroup.prototype, {
  */
 AbsIttCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-AbsIttCatalogGroup.defaultSerializers.items = function(absGroup, json, propertyName, options) {
-    // Only serialize minimal properties in contained items, because other properties are loaded by querying ABS.Stat.
-    var previousSerializeForSharing = options.serializeForSharing;
-    options.serializeForSharing = true;
-
-    // Only serlize enabled items as well.  This isn't quite right - ideally we'd serialize any
-    // property of any item if the property's value is changed from what was loaded from GetCapabilities -
-    // but this gives us reasonable results for sharing and is a lot less work than the ideal
-    // solution.
-    var previousEnabledItemsOnly = options.enabledItemsOnly;
-    options.enabledItemsOnly = true;
-
-    var result = CatalogGroup.defaultSerializers.items(absGroup, json, propertyName, options);
-
-    options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeForSharing = previousSerializeForSharing;
-
-    return result;
-};
+AbsIttCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 freezeObject(AbsIttCatalogGroup.defaultSerializers);
 

--- a/lib/Models/AbsIttCatalogGroup.js
+++ b/lib/Models/AbsIttCatalogGroup.js
@@ -12,7 +12,6 @@ var loadJson = require('terriajs-cesium/Source/Core/loadJson');
 var objectToQuery = require('terriajs-cesium/Source/Core/objectToQuery');
 
 var AbsIttCatalogItem = require('./AbsIttCatalogItem');
-var CatalogMember = require('./CatalogMember');
 var CatalogGroup = require('./CatalogGroup');
 var inherit = require('../Core/inherit');
 var TerriaError = require('../Core/TerriaError');

--- a/lib/Models/AbsIttCatalogGroup.js
+++ b/lib/Models/AbsIttCatalogGroup.js
@@ -235,7 +235,7 @@ AbsIttCatalogGroup.prototype._load = function() {
                 continue;
             }
 
-            that.items.push(createItemForDataset(that, dataset));
+            that.add(createItemForDataset(that, dataset));
         }
 
     }).otherwise(function(e) {

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -287,9 +287,8 @@ defineProperties(AbsIttCatalogItem.prototype, {
     },
 
     /**
-     * Gets the set of names of the properties to be serialized for this object when {@link CatalogMember#serializeToJson} is called
-     * and the `serializeForSharing` flag is set in the options.
-     * @memberOf AbsIttCatalogItem.prototype
+     * Gets the set of names of the properties to be serialized for this object for a share link.
+     * @memberOf ImageryLayerCatalogItem.prototype
      * @type {String[]}
      */
     propertiesForSharing: {
@@ -314,8 +313,8 @@ defineProperties(AbsIttCatalogItem.prototype, {
 });
 
 /**
- * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object with the
- * `serializeForSharing` flag set in the options.
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived for a
+ * share link.
  * @type {String[]}
  */
 AbsIttCatalogItem.defaultPropertiesForSharing = clone(CsvCatalogItem.defaultPropertiesForSharing);

--- a/lib/Models/ArcGisCatalogGroup.js
+++ b/lib/Models/ArcGisCatalogGroup.js
@@ -108,25 +108,7 @@ defineProperties(ArcGisCatalogGroup.prototype, {
  */
 ArcGisCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-ArcGisCatalogGroup.defaultSerializers.items = function(wmsGroup, json, propertyName, options) {
-    // Only serialize minimal properties in contained items, because other properties are loaded from GetCapabilities.
-    var previousSerializeForSharing = options.serializeForSharing;
-    options.serializeForSharing = true;
-
-    // Only serlize enabled items as well.  This isn't quite right - ideally we'd serialize any
-    // property of any item if the property's value is changed from what was loaded from GetCapabilities -
-    // but this gives us reasonable results for sharing and is a lot less work than the ideal
-    // solution.
-    var previousEnabledItemsOnly = options.enabledItemsOnly;
-    options.enabledItemsOnly = true;
-
-    var result = CatalogGroup.defaultSerializers.items(wmsGroup, json, propertyName, options);
-
-    options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeForSharing = previousSerializeForSharing;
-
-    return result;
-};
+ArcGisCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 ArcGisCatalogGroup.defaultSerializers.isLoading = function(wmsGroup, json, propertyName, options) {};
 

--- a/lib/Models/ArcGisCatalogGroup.js
+++ b/lib/Models/ArcGisCatalogGroup.js
@@ -171,7 +171,7 @@ sending an email to <a href="mailto:'+terria.supportEmail+'">'+terria.supportEma
             dataCustodian = serviceJson.documentInfo.Author;
         }
 
-        addLayersRecursively(catalogGroup, serviceJson, layersJson, -1, layersJson.layers, catalogGroup.items, dataCustodian);
+        addLayersRecursively(catalogGroup, serviceJson, layersJson, -1, layersJson.layers, catalogGroup, dataCustodian);
     }).otherwise(function(e) {
         throw new TerriaError({
             sender: catalogGroup,
@@ -219,14 +219,14 @@ sending an email to <a href="mailto:'+terria.supportEmail+'">'+terria.supportEma
         var folders = serviceJson.folders;
         if (definedNotNull(folders)) {
             for (i = 0; i < folders.length; ++i) {
-                createGroup(catalogGroup, catalogGroup.items, basePath, folders[i]);
+                createGroup(catalogGroup, basePath, folders[i]);
             }
         }
 
         var services = serviceJson.services;
         if (definedNotNull(services)) {
             for (i = 0; i < services.length; ++i) {
-                createMapServer(catalogGroup, catalogGroup.items, basePath, services[i]);
+                createMapServer(catalogGroup, basePath, services[i]);
             }
         }
     }).otherwise(function(e) {
@@ -258,7 +258,7 @@ function cleanAndProxyUrl(catalogGroup, url) {
     return proxyCatalogItemUrl(catalogGroup, cleanedUrl, '1d');
 }
 
-function addLayersRecursively(mapServiceGroup, topLevelJson, topLevelLayersJson, parentID, layers, items, dataCustodian) {
+function addLayersRecursively(mapServiceGroup, topLevelJson, topLevelLayersJson, parentID, layers, thisGroup, dataCustodian) {
     if (!(layers instanceof Array)) {
         layers = [layers];
     }
@@ -280,10 +280,10 @@ function addLayersRecursively(mapServiceGroup, topLevelJson, topLevelLayersJson,
         if (layer.type === 'Group Layer') {
             var subGroup = new CatalogGroup(mapServiceGroup.terria);
             subGroup.name = layer.name;
-            items.push(subGroup);
-            addLayersRecursively(mapServiceGroup, topLevelJson, topLevelLayersJson, layer.id, layers, subGroup.items, dataCustodian);
+            thisGroup.add(subGroup);
+            addLayersRecursively(mapServiceGroup, topLevelJson, topLevelLayersJson, layer.id, layers, subGroup, dataCustodian);
         } else if (layer.type === 'Feature Layer' || layer.type === 'Raster Layer' || layer.type === 'Mosaic Layer') {
-            items.push(createDataSource(mapServiceGroup, topLevelJson, topLevelLayersJson, layer, dataCustodian));
+            thisGroup.add(createDataSource(mapServiceGroup, topLevelJson, topLevelLayersJson, layer, dataCustodian));
         }
     }
 }
@@ -306,7 +306,7 @@ function createDataSource(mapServiceGroup, topLevelJson, topLevelLayersJson, lay
     return result;
 }
 
-function createGroup(catalogGroup, items, basePath, folderJson) {
+function createGroup(catalogGroup, basePath, folderJson) {
     var localName = removePathFromName(basePath, folderJson);
 
     var newGroup = new ArcGisCatalogGroup(catalogGroup.terria);
@@ -319,11 +319,12 @@ function createGroup(catalogGroup, items, basePath, folderJson) {
         newGroup.updateFromJson(catalogGroup.itemProperties);
     }
 
-    items.push(newGroup);
+    catalogGroup.add(newGroup);
+
     return newGroup;
 }
 
-function createMapServer(catalogGroup, items, basePath, serviceJson) {
+function createMapServer(catalogGroup, basePath, serviceJson) {
     if (serviceJson.type !== 'MapServer') {
         return;
     }
@@ -344,7 +345,8 @@ function createMapServer(catalogGroup, items, basePath, serviceJson) {
         }
     }
 
-    items.push(mapServer);
+    catalogGroup.add(mapServer);
+
     return mapServer;
 }
 

--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -2,15 +2,10 @@
 
 /*global require*/
 
-var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
-var RuntimeError = require('terriajs-cesium/Source/Core/RuntimeError');
-var when = require('terriajs-cesium/Source/ThirdParty/when');
-
-var createCatalogMemberFromType = require('./createCatalogMemberFromType');
 var CatalogGroup = require('./CatalogGroup');
 
 /**
@@ -102,45 +97,8 @@ defineProperties(Catalog.prototype, {
  * @returns {Promise} A promise that resolves when the update is complete.
  */
 Catalog.prototype.updateFromJson = function(json, options) {
-    if (!(json instanceof Array)) {
-        throw new DeveloperError('JSON catalog description must be an array of groups.');
-    }
-
-    options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-    var onlyUpdateExistingItems = defaultValue(options.onlyUpdateExistingItems, false);
-
-    var promises = [];
-
-    for (var groupIndex = 0; groupIndex < json.length; ++groupIndex) {
-        var group = json[groupIndex];
-
-        if (!defined(group.name)) {
-            throw new RuntimeError('A group must have a name.');
-        }
-
-        // Find an existing group with the same name, if any.
-        var existingGroup = this.group.findFirstItemByName(group.name);
-        if (!defined(existingGroup)) {
-            // Skip this item entirely if we're not allowed to create it.
-            if (onlyUpdateExistingItems) {
-                continue;
-            }
-
-            if (!defined(group.type)) {
-                throw new RuntimeError('A group must have a type.');
-            }
-
-            existingGroup = createCatalogMemberFromType(group.type,  this.terria);
-
-            this.group.add(existingGroup);
-        }
-
-        promises.push(existingGroup.updateFromJson(group, options));
-    }
-
     var that = this;
-    return when.all(promises, function() {
-        that.group.sortItems();
+    return CatalogGroup.updateItems(json, options, this.group).then(function() {
         that.terria.nowViewing.sortByNowViewingIndices();
     });
 };
@@ -168,7 +126,7 @@ Catalog.prototype.updateFromJson = function(json, options) {
  * @return {Object} The serialized JSON object-literal.
  */
 Catalog.prototype.serializeToJson = function(options) {
-     this.terria.nowViewing.recordNowViewingIndices();
+    this.terria.nowViewing.recordNowViewingIndices();
 
     var json = {};
     CatalogGroup.defaultSerializers.items(this.group, json, 'items', options);

--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -3,6 +3,7 @@
 /*global require*/
 
 var defined = require('terriajs-cesium/Source/Core/defined');
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
@@ -98,7 +99,11 @@ defineProperties(Catalog.prototype, {
  */
 Catalog.prototype.updateFromJson = function(json, options) {
     var that = this;
-    return CatalogGroup.updateItems(json, options, this.group).then(function() {
+    options = defaultValue(options, {});
+
+    options.shareKeyIndex = this.group.generateShareKeyIndex();
+
+    return CatalogGroup.updateItems(json, options, this.group).then(function () {
         that.terria.nowViewing.sortByNowViewingIndices();
     });
 };

--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -8,6 +8,7 @@ var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var CatalogGroup = require('./CatalogGroup');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 /**
  * The view model for the geospatial data catalog.
@@ -135,5 +136,38 @@ Catalog.prototype.serializeToJson = function(options) {
 
     return this.group.serializeToJson(options).items;
 };
+
+/**
+ * Resolves items in the catalog based on the share keys provided, and enabled them along with all their ancestors in
+ * the catalog hierarchy. This is asynchronous, as to enable an item it must have finished loading first.
+ *
+ * Note that because of the lazily-loaded nature of the catalog, items within it may not be resolvable by shareKey until
+ * their parents have loaded. As a result this loads shareKeys in serial from left to right. If a catalog member is the
+ * child of an asynchronously-loaded catalog group (like a ckan or socrata group), then that group's shareKey precede the
+ * child member.
+ *
+ * @param {String[]} shareKeys An array of string-based share keys.
+ * @returns {Promise} A promise that will resolve when all the items have been loaded and enabled.
+ */
+Catalog.prototype.enableByShareKeys = function (shareKeys) {
+    var shareKeyIndex = this.shareKeyIndex;
+
+    return shareKeys.map(function(shareKey) {
+        return shareKeyIndex[shareKey];
+    }).filter(function (member) {
+        return defined(member);
+    }).map(function (member) {
+        var loadPromise = member.load() || when(); // load() sometimes returns undefined.
+
+        return loadPromise.then(function () {
+            member.enableWithParents();
+        });
+    }).reduce(function (aggregatedPromise, promise) {
+        return aggregatedPromise.then(function() {
+            return promise;
+        });
+    }, when());
+};
+
 
 module.exports = Catalog;

--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -151,24 +151,58 @@ Catalog.prototype.serializeToJson = function(options) {
  *      possible to pass an empty object if nothing needs updating.
  * @returns {Promise} A promise that will resolve when all the items have been loaded and enabled.
  */
-Catalog.prototype.updateByShareKeys = function (sharedObjects) {
-    var shareKeyIndex = this.shareKeyIndex;
+Catalog.prototype.updateByShareKeys = function(sharedObjects) {
+    return Object.keys(sharedObjects).reduce(function(aggregatedPromise, shareKey) {
+        var itemJson = sharedObjects[shareKey];
 
-    return Object.keys(sharedObjects).reduce(function (aggregatedPromise, shareKey) {
-        return aggregatedPromise.then(function() {
-            var existingMember = shareKeyIndex[shareKey];
-
-            if (existingMember) {
-                return existingMember.updateFromJson(sharedObjects[shareKey])
-                    .then(function () {
-                        return when(existingMember.load());
-                    }).then(function () {
-                        existingMember.enableWithParents();
-                    });
-            }
-        });
-    }, when());
+        return aggregatedPromise
+            .then(this._loadInSerial.bind(this, itemJson.parents || []))
+            .then(this._updateAndEnable.bind(this, shareKey, itemJson));
+    }.bind(this), when());
 };
 
+/**
+ * Calls {@link CatalogMember#load} on a number of catalog members, identified by their share key, one after the other
+ * from left to right. Doing this in serial is important because sometimes calling load() on a catalog group will
+ * reveal more catalog items under it, which will be added to the catalog's shareKeyIndex - if these were done in
+ * parallel, share keys towards the right of the array would not able to be resolved at all.
+ *
+ * @param shareKeys An array of catalog member share keys to use for resolving catalog members from the catalog
+ * @returns {Promise} A promise that will be resolved when all the catalog members have either loaded or failed to load.
+ * @private
+ */
+Catalog.prototype._loadInSerial = function(shareKeys) {
+    return shareKeys.reduce(function(aggregatedPromise, shareKey) {
+        return aggregatedPromise.then(function() {
+            if (this.shareKeyIndex[shareKey]) {
+                return this.shareKeyIndex[shareKey].load();
+            }
+        }.bind(this));
+    }.bind(this), when());
+};
+
+/**
+ * Finds the an item in the catalog with the passed shareKey, updates it with the passed itemJson, THEN calls load on
+ * the item, THEN enables it and all its parents. If no item for the passed shareKey can be found, logs a warning but
+ * proceeds without an exception.
+ *
+ * @returns {Promise} A promise that will be resolved when all of this is done.
+ * @private
+ */
+Catalog.prototype._updateAndEnable = function(shareKey, itemJson) {
+    var existingMember = this.shareKeyIndex[shareKey];
+
+    if (existingMember) {
+        // Update THEN load is the expected behaviour for some catalog items (e.g. CSV) - if these operations aren't
+        // executed in this order then bugs happen in auto-generated legends.
+
+        return existingMember.updateFromJson(itemJson)
+            .then(existingMember.load.bind(existingMember))
+            .then(existingMember.enableWithParents.bind(existingMember));
+    } else {
+        console.warn('Share link has a catalog member with shareKey ' + shareKey + ' but could not find ' +
+            'this in the catalog');
+    }
+};
 
 module.exports = Catalog;

--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -152,19 +152,15 @@ Catalog.prototype.serializeToJson = function(options) {
 Catalog.prototype.enableByShareKeys = function (shareKeys) {
     var shareKeyIndex = this.shareKeyIndex;
 
-    return shareKeys.map(function(shareKey) {
-        return shareKeyIndex[shareKey];
-    }).filter(function (member) {
-        return defined(member);
-    }).map(function (member) {
-        var loadPromise = member.load() || when(); // load() sometimes returns undefined.
-
-        return loadPromise.then(function () {
-            member.enableWithParents();
-        });
-    }).reduce(function (aggregatedPromise, promise) {
+    return shareKeys.reduce(function (aggregatedPromise, shareKey) {
         return aggregatedPromise.then(function() {
-            return promise;
+            var existingMember = shareKeyIndex[shareKey];
+
+            if (existingMember) {
+                return when(existingMember.load()).then(function() {
+                    existingMember.enableWithParents();
+                });
+            }
         });
     }, when());
 };

--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -138,28 +138,33 @@ Catalog.prototype.serializeToJson = function(options) {
 };
 
 /**
- * Resolves items in the catalog based on the share keys provided, and enabled them along with all their ancestors in
- * the catalog hierarchy. This is asynchronous, as to enable an item it must have finished loading first.
+ * Resolves items in the catalog based on the share keys provided, and updates them with the passed info and
+ * enables them along with all their ancestors in the catalog hierarchy. This is asynchronous as it may involve a number
+ * of CatalogItem#load calls.
  *
  * Note that because of the lazily-loaded nature of the catalog, items within it may not be resolvable by shareKey until
- * their parents have loaded. As a result this loads shareKeys in serial from left to right. If a catalog member is the
+ * their parents have loaded. As a result this loads sharedObjects in serial from left to right. If a catalog member is the
  * child of an asynchronously-loaded catalog group (like a ckan or socrata group), then that group's shareKey precede the
  * child member.
  *
- * @param {String[]} shareKeys An array of string-based share keys.
+ * @param {Object} sharedObjects A flat map of string-based share keys with data to update on the resolved object. It is
+ *      possible to pass an empty object if nothing needs updating.
  * @returns {Promise} A promise that will resolve when all the items have been loaded and enabled.
  */
-Catalog.prototype.enableByShareKeys = function (shareKeys) {
+Catalog.prototype.updateByShareKeys = function (sharedObjects) {
     var shareKeyIndex = this.shareKeyIndex;
 
-    return shareKeys.reduce(function (aggregatedPromise, shareKey) {
+    return Object.keys(sharedObjects).reduce(function (aggregatedPromise, shareKey) {
         return aggregatedPromise.then(function() {
             var existingMember = shareKeyIndex[shareKey];
 
             if (existingMember) {
-                return when(existingMember.load()).then(function() {
-                    existingMember.enableWithParents();
-                });
+                return existingMember.updateFromJson(sharedObjects[shareKey])
+                    .then(function () {
+                        return when(existingMember.load());
+                    }).then(function () {
+                        existingMember.enableWithParents();
+                    });
             }
         });
     }, when());

--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -23,6 +23,7 @@ var Catalog = function(terria) {
     }
 
     this._terria = terria;
+    this._shareKeyIndex = {};
 
     this._group = new CatalogGroup(terria);
     this._group.name = 'Root Group';
@@ -51,6 +52,7 @@ var Catalog = function(terria) {
             group = new CatalogGroup( this.terria);
             group.name = 'User-Added Data';
             group.description = 'The group for data that was added by the user via the Add Data panel.';
+            group.isUserSupplied = true;
             this.group.add(group);
 
             return group;
@@ -79,6 +81,18 @@ defineProperties(Catalog.prototype, {
         get : function() {
             return this._group;
         }
+    },
+
+    /**
+     * A flat index of all catalog member in this catalog by their share keys. Because items can have multiple share keys
+     * to preserve backwards compatibility, multiple entries in this index will lead to the same catalog member.
+     *
+     * @type {Object}
+     */
+    shareKeyIndex : {
+        get : function() {
+            return this._shareKeyIndex;
+        }
     }
 });
 
@@ -101,8 +115,6 @@ Catalog.prototype.updateFromJson = function(json, options) {
     var that = this;
     options = defaultValue(options, {});
 
-    options.shareKeyIndex = this.group.generateShareKeyIndex();
-
     return CatalogGroup.updateItems(json, options, this.group).then(function () {
         that.terria.nowViewing.sortByNowViewingIndices();
     });
@@ -112,30 +124,16 @@ Catalog.prototype.updateFromJson = function(json, options) {
  * Serializes the catalog to JSON.
  *
  * @param {Object} [options] Object with the following properties:
- * @param {Boolean} [options.enabledItemsOnly=false] true if only enabled data items (and their groups) should be serialized,
- *                  or false if all data items should be serialized.
- * @param {CatalogMember[]} [options.itemsSkippedBecauseTheyAreNotEnabled] An array that, if provided, is populated on return with
- *        all of the data items that were not serialized because they were not enabled.  The array will be empty if
- *        options.enabledItemsOnly is false.
- * @param {Boolean} [options.skipItemsWithLocalData=false] true if items with a serializable 'data' property should be skipped entirely.
- *                  This is useful to avoid creating a JSON data structure with potentially very large embedded data.
- * @param {CatalogMember[]} [options.itemsSkippedBecauseTheyHaveLocalData] An array that, if provided, is populated on return
- *        with all of the data items that were not serialized because they have a serializable 'data' property.  The array will be empty
- *        if options.skipItemsWithLocalData is false.
- * @param {Boolean} [options.serializeForSharing=false] true to only serialize properties that are typically necessary for sharing this member
- *                                                      with other users, such as {@link CatalogGroup#isOpen}, {@link CatalogItem#isEnabled},
- *                                                      {@link CatalogItem#isLegendVisible}, and {@link ImageryLayerCatalogItem#opacity},
- *                                                      rather than serializing all properties needed to completely recreate the catalog.
- * @param {Boolean} [options.userSuppliedOnly=false] true to only serialize catalog members (and their containing groups) that have been identified as having been
- *                  supplied by the user ({@link CatalogMember#isUserSupplied} is true); false to serialize all catalog members.
+ * @param {Function} [options.propertyFilter] Filter function that will be executed to determine whether a property
+ *          should be serialized.
+ * @param {Function} [options.itemFilter] Filter function that will be executed for each item in a group to determine
+ *          whether that item should be serialized.
  * @return {Object} The serialized JSON object-literal.
  */
 Catalog.prototype.serializeToJson = function(options) {
     this.terria.nowViewing.recordNowViewingIndices();
 
-    var json = {};
-    CatalogGroup.defaultSerializers.items(this.group, json, 'items', options);
-    return json.items;
+    return this.group.serializeToJson(options).items;
 };
 
 module.exports = Catalog;

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -18,6 +18,7 @@ var CatalogMember = require('./CatalogMember');
 var inherit = require('../Core/inherit');
 var raiseErrorOnRejectedPromise = require('./raiseErrorOnRejectedPromise');
 var runLater = require('../Core/runLater');
+var deprecationWarning = require('terriajs-cesium/Source/Core/deprecationWarning');
 
 var naturalSort = require('javascript-natural-sort');
 
@@ -101,7 +102,7 @@ var CatalogGroup = function(terria) {
         }
     });
 
-    this.setupItemListeners();
+    this._setupItemListeners();
 };
 
 inherit(CatalogMember, CatalogGroup);
@@ -237,7 +238,7 @@ CatalogGroup.defaultPropertiesForSharing.push('items');
 
 freezeObject(CatalogGroup.defaultPropertiesForSharing);
 
-CatalogGroup.prototype.setupItemListeners = function() {
+CatalogGroup.prototype._setupItemListeners = function() {
     var itemsChangeListeners = {
         added: function(item) {
             item.parent = this;
@@ -250,11 +251,11 @@ CatalogGroup.prototype.setupItemListeners = function() {
             }, this);
         }.bind(this),
         deleted: function(item) {
-            item.parent = undefined;
-
             item.allShareKeys.forEach(function(key) {
                 this.terria.catalog.shareKeyIndex[key] = undefined;
             }, this);
+
+            item.parent = undefined;
         }.bind(this)
     };
 
@@ -360,7 +361,7 @@ CatalogGroup.prototype.add = function(item) {
  * @param {CatalogMember} item The item to remove.
  */
 CatalogGroup.prototype.remove = function(item) {
-    this.items.remove(item);
+    this.items.remove(item); // available for knockout observable arrays.
 };
 
 /**
@@ -395,6 +396,9 @@ CatalogGroup.prototype.getChildForShareKey = function(key) {
  * with existing share links.
  */
 CatalogGroup.prototype.findFirstItemByName = function(name) {
+    deprecationWarning('findFirstItemByName', 'Use CatalogGroup.getChildForShareKey where possible, this is retained ' +
+        'for backwards compatibility with existing share links.');
+
     for (var i = 0; i < this.items.length; ++i) {
         if (this.items[i].name === name) {
             return this.items[i];

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -347,9 +347,11 @@ CatalogGroup.prototype.toggleOpen = function() {
  * @return {CatalogMember} The first item with the given key, or undefined if no item with that name exists.
  */
 CatalogGroup.prototype.getChildForShareKey = function(key) {
-    return this.items.find(function(item) {
-        return item.allShareKeys.indexOf(key) >= 0;
-    });
+    for (var i = 0; i < this.items.length; i++) {
+        if (this.items[i].allShareKeys.indexOf(key) >= 0) {
+            return this.items[i];
+        }
+    }
 };
 
 /**
@@ -401,6 +403,54 @@ CatalogGroup.prototype.sortItems = function(sortRecursively) {
 };
 
 /**
+ * Opens this CatalogGroup and all its parents.
+ */
+CatalogGroup.prototype.openWithAllParents = function() {
+    this.isOpen = true;
+
+    if (this.parent) {
+        this.parent.openWithAllParents();
+    }
+};
+
+/**
+ * Does a complete traversal of this CatalogGroup and any CatalogGroups under it and produces a flat map of each item's
+ * share key(s) to that item, using {@link CatalogMember#allShareKeys}. Will throw an Error if there are any duplicate
+ * keys, as this shouldn't ever occur.
+ *
+ * @returns {Object} a map of share keys to items.
+ */
+CatalogGroup.prototype.generateShareKeyIndex = function() {
+    return this.items.reduce(function(indexSoFar, item) {
+        item.allShareKeys.forEach(function(key) {
+            addToIndex(indexSoFar, key, item);
+        });
+
+        if (item.generateShareKeyIndex) {
+            var shareKeyIndex = item.generateShareKeyIndex();
+
+            Object.keys(shareKeyIndex).forEach(function(key) {
+                addToIndex(indexSoFar, key, shareKeyIndex[key]);
+            });
+        }
+
+        return indexSoFar;
+    }, {});
+};
+
+/**
+ * Adds an item to the provided index under the provided key, checking to make sure there's no item for that key already.
+ * Will throw an error if so.
+ */
+function addToIndex(indexSoFar, key, item) {
+    if (indexSoFar[key]) {
+        throw new DeveloperError('Duplicate shareKey: ' + key);
+    } else {
+        indexSoFar[key] = item;
+    }
+}
+
+/**
  * Reads an array of catalog members in JSON format (as objects, not strings) and transforms them into actual Terria
  * models (i.e. {@link CatalogMember} instances), and adds them to the {@link CatalogMember#items} property of the
  * supplied catalogGroup, or updates only the existing items in the catalogGroup.
@@ -412,6 +462,9 @@ CatalogGroup.prototype.sortItems = function(sortRecursively) {
  *                                                    may be created by this update.
  * @param {Boolean} [options.isUserSupplied] If specified, sets the {@link CatalogMember#isUserSupplied} property of updated catalog members
  *                                           to the given value.  If not specified, the property is left unchanged.
+ * @param {Object} [options.shareKeyIndex] An optional index of all catalog items by their share ids - this will be
+ *                                         used to match catalog items in itemsJson to their already-existing equivalents
+ *                                         even if those equivalents have been moved outside the catalogGroup specified.
  * @param {CatalogGroup} catalogGroup The catalogGroup to update.
  *
  * @returns {Promise} A promise that resolves when the update is complete.
@@ -435,7 +488,17 @@ CatalogGroup.updateItems = function (itemsJson, options, catalogGroup) {
 
         var existingItem;
         if (item.id) {
-            existingItem = catalogGroup.getChildForShareKey(item.id);
+            if (options.shareKeyIndex) {
+                existingItem = options.shareKeyIndex[item.id];
+
+                if (existingItem && existingItem.parent !== catalogGroup && item.isEnabled && !existingItem.isEnabled) {
+                    // We are enabling an existing item that has been moved since our itemsJson was generated
+                    // (probably an old share link) - make sure all its parents are open so it's visible.
+                    existingItem.parent.openWithAllParents();
+                }
+            } else {
+                existingItem = catalogGroup.getChildForShareKey(item.id);
+            }
         } else if (item.name) {
             existingItem = catalogGroup.findFirstItemByName(item.name);
         }
@@ -457,6 +520,9 @@ CatalogGroup.updateItems = function (itemsJson, options, catalogGroup) {
             existingItem = createCatalogMemberFromType(item.type, catalogGroup.terria);
 
             catalogGroup.add(existingItem);
+        } else {
+            // We only want to use the id for matching, not overwrite it.
+            delete item.id;
         }
 
         promises.push(existingItem.updateFromJson(item, options));

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -210,7 +210,6 @@ freezeObject(CatalogGroup.defaultUpdaters);
 CatalogGroup.defaultSerializers = clone(CatalogMember.defaultSerializers);
 
 CatalogGroup.defaultSerializers.items = function(catalogGroup, json, propertyName, options) {
-
     json.items = catalogGroup.items.filter(function(item) {
         return !defined(options.itemFilter) || options.itemFilter(item);
     }).map(function(item) {
@@ -220,6 +219,11 @@ CatalogGroup.defaultSerializers.items = function(catalogGroup, json, propertyNam
     });
 };
 
+/**
+ * Call {@link CatalogGroup#defaultSerializers#items}, filtering out non-shareable properties and non-enabled items.
+ * This is used when serializing a number of kinds of item groups where most details can be fetched from a URL and hence
+ * there's no need to serialize anything that can't be changed by the user.
+ */
 CatalogGroup.enabledShareableItemsSerializer = function(catalogGroup, json, propertyName, options) {
     return CatalogGroup.defaultSerializers.items(catalogGroup, json, propertyName, combine({
         propertyFilter: combineFilters([options.propertyFilter, CatalogMember.propertyFilters.sharedOnly]),
@@ -501,9 +505,6 @@ CatalogGroup.prototype.enableWithParents = function() {
  *                                                    may be created by this update.
  * @param {Boolean} [options.isUserSupplied] If specified, sets the {@link CatalogMember#isUserSupplied} property of updated catalog members
  *                                           to the given value.  If not specified, the property is left unchanged.
- * @param {Object} [options.shareKeyIndex] An optional index of all catalog items by their share ids - this will be
- *                                         used to match catalog items in itemsJson to their already-existing equivalents
- *                                         even if those equivalents have been moved outside the catalogGroup specified.
  * @param {CatalogGroup} catalogGroup The catalogGroup to update.
  *
  * @returns {Promise} A promise that resolves when the update is complete.

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -10,6 +10,7 @@ var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var RuntimeError = require('terriajs-cesium/Source/Core/RuntimeError');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
+var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 
 var arraysAreEqual = require('../Core/arraysAreEqual');
 var createCatalogMemberFromType = require('./createCatalogMemberFromType');
@@ -127,7 +128,7 @@ defineProperties(CatalogGroup.prototype, {
     },
 
     /**
-     * Gets a value that tells the UI whether this is a group. 
+     * Gets a value that tells the UI whether this is a group.
      * Groups, when clicked, expand to show their constituent items.
      * @memberOf CatalogGroup.prototype
      * @type {Boolean}
@@ -189,39 +190,7 @@ CatalogGroup.defaultUpdaters = clone(CatalogMember.defaultUpdaters);
 CatalogGroup.defaultUpdaters.items = function(catalogGroup, json, propertyName, options) {
     // Let the group finish loading first.  Otherwise, these changes could get clobbered by the load.
     return when(catalogGroup.load(), function() {
-        var promises = [];
-
-        // TODO: allow JSON to update the order of items as well.
-
-        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-        var onlyUpdateExistingItems = defaultValue(options.onlyUpdateExistingItems, false);
-
-        var items = json.items;
-        for (var itemIndex = 0; itemIndex < items.length; ++itemIndex) {
-            var item = items[itemIndex];
-
-            // Find an existing item with the same name
-            var existingItem = catalogGroup.findFirstItemByName(item.name);
-            if (!defined(existingItem)) {
-                // Skip this item entirely if we're not allowed to create it.
-                if (onlyUpdateExistingItems) {
-                    continue;
-                }
-
-                if (!defined(item.type)) {
-                    throw new RuntimeError('An item must have a type.');
-                }
-
-                existingItem = createCatalogMemberFromType(item.type, catalogGroup.terria);
-                catalogGroup.add(existingItem);
-            }
-
-            promises.push(existingItem.updateFromJson(item, options));
-        }
-
-        return when.all(promises, function() {
-            catalogGroup.sortItems();
-        });
+        return CatalogGroup.updateItems(json.items, options, catalogGroup);
     });
 };
 
@@ -346,6 +315,8 @@ CatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
  * @param {CatalogMember} item The item to add.
  */
 CatalogGroup.prototype.add = function(item) {
+    item.parent = this;
+
     this.items.push(item);
 };
 
@@ -355,6 +326,8 @@ CatalogGroup.prototype.add = function(item) {
  * @param {CatalogMember} item The item to remove.
  */
 CatalogGroup.prototype.remove = function(item) {
+    delete item.parent;
+
     this.items.remove(item);
 };
 
@@ -367,10 +340,25 @@ CatalogGroup.prototype.toggleOpen = function() {
 };
 
 /**
+ * Finds the first item in this group with a value in {@link CatalogItem#allShareKeys} that matches the given key.
+ * The search is case-sensitive.
+ *
+ * @param {String} key The key to search for.
+ * @return {CatalogMember} The first item with the given key, or undefined if no item with that name exists.
+ */
+CatalogGroup.prototype.getChildForShareKey = function(key) {
+    return this.items.find(function(item) {
+        return item.allShareKeys.indexOf(key) >= 0;
+    });
+};
+
+/**
  * Finds the first item in this group that has the given name.  The search is case-sensitive.
  *
  * @param {String} name The name of the item to find.
  * @return {CatalogMember} The first item with the given name, or undefined if no item with that name exists.
+ * @deprecated Use {@link CatalogGroup#getChildForShareKey} where possible, this is retained for backwards compatibility
+ * with existing share links.
  */
 CatalogGroup.prototype.findFirstItemByName = function(name) {
     for (var i = 0; i < this.items.length; ++i) {
@@ -410,6 +398,73 @@ CatalogGroup.prototype.sortItems = function(sortRecursively) {
             }
         }
     }
+};
+
+/**
+ * Reads an array of catalog members in JSON format (as objects, not strings) and transforms them into actual Terria
+ * models (i.e. {@link CatalogMember} instances), and adds them to the {@link CatalogMember#items} property of the
+ * supplied catalogGroup, or updates only the existing items in the catalogGroup.
+ *
+ * @param {Object} itemsJson The items as simple JSON data. The JSON should be in the form of an object literal, not a
+ *                 string.
+ * @param {Object} [options] Object with the following properties:
+ * @param {Boolean} [options.onlyUpdateExistingItems] true to only update existing items and never create new ones, or false is new items
+ *                                                    may be created by this update.
+ * @param {Boolean} [options.isUserSupplied] If specified, sets the {@link CatalogMember#isUserSupplied} property of updated catalog members
+ *                                           to the given value.  If not specified, the property is left unchanged.
+ * @param {CatalogGroup} catalogGroup The catalogGroup to update.
+ *
+ * @returns {Promise} A promise that resolves when the update is complete.
+ */
+CatalogGroup.updateItems = function (itemsJson, options, catalogGroup) {
+    if (!(itemsJson instanceof Array)) {
+        throw new DeveloperError('JSON catalog description must be an array of groups.');
+    }
+
+    options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+    var onlyUpdateExistingItems = defaultValue(options.onlyUpdateExistingItems, false);
+
+    var promises = [];
+
+    for (var itemIndex = 0; itemIndex < itemsJson.length; ++itemIndex) {
+        var item = itemsJson[itemIndex];
+
+        if (!defined(item.name) && !defined(item.id)) {
+            throw new RuntimeError('A catalog member must have a name or a id for matching.');
+        }
+
+        var existingItem;
+        if (item.id) {
+            existingItem = catalogGroup.getChildForShareKey(item.id);
+        } else if (item.name) {
+            existingItem = catalogGroup.findFirstItemByName(item.name);
+        }
+
+        if (!defined(existingItem)) {
+            // Skip this item entirely if we're not allowed to create it.
+            if (onlyUpdateExistingItems) {
+                continue;
+            }
+
+            if (!defined(item.name)) {
+                throw new RuntimeError('A newly created catalog member must have a name.');
+            }
+
+            if (!defined(item.type)) {
+                throw new RuntimeError('A catalog member must have a type.');
+            }
+
+            existingItem = createCatalogMemberFromType(item.type, catalogGroup.terria);
+
+            catalogGroup.add(existingItem);
+        }
+
+        promises.push(existingItem.updateFromJson(item, options));
+    }
+
+    return when.all(promises, function () {
+        catalogGroup.sortItems();
+    });
 };
 
 module.exports = CatalogGroup;

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -11,8 +11,10 @@ var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var RuntimeError = require('terriajs-cesium/Source/Core/RuntimeError');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
+var combine = require('terriajs-cesium/Source/Core/combine');
 
 var arraysAreEqual = require('../Core/arraysAreEqual');
+var combineFilters = require('../Core/combineFilters');
 var createCatalogMemberFromType = require('./createCatalogMemberFromType');
 var CatalogMember = require('./CatalogMember');
 var inherit = require('../Core/inherit');
@@ -171,8 +173,7 @@ defineProperties(CatalogGroup.prototype, {
     },
 
     /**
-     * Gets the set of names of the properties to be serialized for this object when {@link CatalogMember#serializeToJson} is called
-     * and the `serializeForSharing` flag is set in the options.
+     * Gets the set of names of the properties to be serialized for this object for a share link.
      * @memberOf CatalogGroup.prototype
      * @type {String[]}
      */
@@ -203,24 +204,27 @@ freezeObject(CatalogGroup.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
- * should expose this instance - cloned and modified if necesary - through their {@link CatalogMember#serializers} property.
+ * should expose this instance - cloned and modified if neccesary - through their {@link CatalogMember#serializers} property.
  * @type {Object}
  */
 CatalogGroup.defaultSerializers = clone(CatalogMember.defaultSerializers);
 
 CatalogGroup.defaultSerializers.items = function(catalogGroup, json, propertyName, options) {
-    var items = json.items = [];
 
-    for (var i = 0; i < catalogGroup.items.length; ++i) {
-        if (!defined(options.itemFilter) || options.itemFilter(catalogGroup.items[i])) {
-            var item = catalogGroup.items[i].serializeToJson(options);
+    json.items = catalogGroup.items.filter(function(item) {
+        return !defined(options.itemFilter) || options.itemFilter(item);
+    }).map(function(item) {
+        return item.serializeToJson(options);
+    }).filter(function(serializedItem) {
+        return defined(serializedItem);
+    });
+};
 
-            if (defined(item)) {
-                item.parent = undefined; // would create circular json
-                items.push(item);
-            }
-        }
-    }
+CatalogGroup.enabledShareableItemsSerializer = function(catalogGroup, json, propertyName, options) {
+    return CatalogGroup.defaultSerializers.items(catalogGroup, json, propertyName, combine({
+        propertyFilter: combineFilters([options.propertyFilter, CatalogMember.propertyFilters.sharedOnly]),
+        itemFilter: combineFilters([options.itemFilter, CatalogMember.itemFilters.enabled])
+    }, options));
 };
 
 CatalogGroup.defaultSerializers.isLoading = function(catalogGroup, json, propertyName, options) {};
@@ -228,8 +232,8 @@ CatalogGroup.defaultSerializers.isLoading = function(catalogGroup, json, propert
 freezeObject(CatalogGroup.defaultSerializers);
 
 /**
- * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object with the
- * `serializeForSharing` flag set in the options.
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
+ * for a share link.
  * @type {String[]}
  */
 CatalogGroup.defaultPropertiesForSharing = clone(CatalogMember.defaultPropertiesForSharing);
@@ -242,18 +246,17 @@ CatalogGroup.prototype._setupItemListeners = function() {
     var itemsChangeListeners = {
         added: function(item) {
             item.parent = this;
-            item.allShareKeys.forEach(function (key) {
-                if (this.terria.catalog.shareKeyIndex[key]) {
-                    throw new RuntimeError('Duplicate shareKey: ' + key);
-                } else {
-                    this.terria.catalog.shareKeyIndex[key] = item;
-                }
-            }, this);
+
+            // Only index this in catalog if it's actually connected to catalog, otherwise we get situations where an
+            // item is added to the index before its actually built up a correct path to use as a default id.
+            if (item.connectsWithRoot()) {
+                indexWithDescendants([item], this.terria.catalog.shareKeyIndex);
+            }
         }.bind(this),
         deleted: function(item) {
-            item.allShareKeys.forEach(function(key) {
-                this.terria.catalog.shareKeyIndex[key] = undefined;
-            }, this);
+            if (item.connectsWithRoot()) {
+                deIndexWithDescendants([item], this.terria.catalog.shareKeyIndex);
+            }
 
             item.parent = undefined;
         }.bind(this)
@@ -267,6 +270,46 @@ CatalogGroup.prototype._setupItemListeners = function() {
         });
     }, null, "arrayChange");
 };
+
+/**
+ * Adds all passed items to the passed index, and all the children of those items recursively.
+ *
+ * @param {CatalogMember[]} items
+ * @param {Object} index
+ */
+function indexWithDescendants(items, index) {
+    items.forEach(function(item) {
+        item.allShareKeys.forEach(function (key) {
+            if (index[key]) {
+                throw new RuntimeError('Duplicate shareKey: ' + key);
+            } else {
+                index[key] = item;
+            }
+        }, this);
+
+        if (defined(item.items)) {
+           indexWithDescendants(item.items, index);
+        }
+    });
+}
+
+/**
+ * Removes all passed items to the passed index, and all the children of those items recursively.
+ *
+ * @param {CatalogMember[]} items
+ * @param {Object} index
+ */
+function deIndexWithDescendants(items, index) {
+    items.forEach(function(item) {
+        item.allShareKeys.forEach(function (key) {
+            index[key] = undefined;
+        }, this);
+
+        if (defined(item.items)) {
+            deIndexWithDescendants(item.items, index);
+        }
+    });
+}
 
 /**
  * Loads the contents of this group, if the contents are not already loaded.  It is safe to
@@ -444,18 +487,6 @@ CatalogGroup.prototype.enableWithParents = function() {
     if (this.parent) {
         this.parent.enableWithParents();
     }
-};
-
-CatalogGroup.prototype.getDescendantsFlat = function() {
-    return this.items.reduce(function(prev, current) {
-        var descendants = [current];
-
-        if (defined(current.getDescendantsFlat)) {
-            descendants = descendants.concat(current.getDescendantsFlat());
-        }
-
-        return prev.concat(descendants);
-    }, []);
 };
 
 /**

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -100,6 +100,8 @@ var CatalogGroup = function(terria) {
             raiseErrorOnRejectedPromise( that.terria, that.load());
         }
     });
+
+    this.setupItemListeners();
 };
 
 inherit(CatalogMember, CatalogGroup);
@@ -235,6 +237,36 @@ CatalogGroup.defaultPropertiesForSharing.push('items');
 
 freezeObject(CatalogGroup.defaultPropertiesForSharing);
 
+CatalogGroup.prototype.setupItemListeners = function() {
+    var itemsChangeListeners = {
+        added: function(item) {
+            item.parent = this;
+            item.allShareKeys.forEach(function (key) {
+                if (this.terria.catalog.shareKeyIndex[key]) {
+                    throw new RuntimeError('Duplicate shareKey: ' + key);
+                } else {
+                    this.terria.catalog.shareKeyIndex[key] = item;
+                }
+            }, this);
+        }.bind(this),
+        deleted: function(item) {
+            item.parent = undefined;
+
+            item.allShareKeys.forEach(function(key) {
+                this.terria.catalog.shareKeyIndex[key] = undefined;
+            }, this);
+        }.bind(this)
+    };
+
+    knockout.getObservable(this, 'items').subscribe(function(changes) {
+        changes.forEach(function(change) {
+            if (!defined(change.moved)) {
+                itemsChangeListeners[change.status](change.value);
+            }
+        });
+    }, null, "arrayChange");
+};
+
 /**
  * Loads the contents of this group, if the contents are not already loaded.  It is safe to
  * call this method multiple times.  The {@link CatalogGroup#isLoading} flag will be set while the load is in progress.
@@ -317,28 +349,8 @@ CatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
  * Adds an item or group to this group.
  *
  * @param {CatalogMember} item The item to add.
- * @param {Promise} indexPromise A promise that if specified, will be waited for before the item is added to the catalog-wide index.
- *                               Allows for an item to be added immediately even if its contents haven't been loaded yet.
  */
-CatalogGroup.prototype.add = function(item, indexPromise) {
-    item.parent = this;
-
-    var addItemToIndex = function() {
-        item.allShareKeys.forEach(function (key) {
-            if (this.terria.catalog.shareKeyIndex[key]) {
-                throw new RuntimeError('Duplicate shareKey: ' + key);
-            } else {
-                this.terria.catalog.shareKeyIndex[key] = item;
-            }
-        }, this);
-    }.bind(this);
-
-    if (indexPromise) {
-        indexPromise.then(addItemToIndex);
-    } else {
-        addItemToIndex();
-    }
-
+CatalogGroup.prototype.add = function(item) {
     this.items.push(item);
 };
 
@@ -348,12 +360,6 @@ CatalogGroup.prototype.add = function(item, indexPromise) {
  * @param {CatalogMember} item The item to remove.
  */
 CatalogGroup.prototype.remove = function(item) {
-    item.parent = undefined;
-
-    item.allShareKeys.forEach(function(key) {
-        this.terria.catalog.shareKeyIndex[key] = undefined;
-    }, this);
-
     this.items.remove(item);
 };
 
@@ -510,18 +516,16 @@ CatalogGroup.updateItems = function (itemsJson, options, catalogGroup) {
             itemObject = createCatalogMemberFromType(itemJson.type, catalogGroup.terria);
         }
 
-        var loadPromise = itemObject.updateFromJson(itemJson, options);
+        promises.push(itemObject.updateFromJson(itemJson, options));
 
         if (!updating) {
-            catalogGroup.add(itemObject, loadPromise);
+            catalogGroup.add(itemObject);
         }
-
-        promises.push(loadPromise);
     }
 
-    return when.all(promises, function () {
-        catalogGroup.sortItems();
-    });
+    catalogGroup.sortItems();
+
+    return when.all(promises);
 };
 
 module.exports = CatalogGroup;

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -20,7 +20,6 @@ var CatalogMember = require('./CatalogMember');
 var inherit = require('../Core/inherit');
 var raiseErrorOnRejectedPromise = require('./raiseErrorOnRejectedPromise');
 var runLater = require('../Core/runLater');
-var deprecationWarning = require('terriajs-cesium/Source/Core/deprecationWarning');
 
 var naturalSort = require('javascript-natural-sort');
 
@@ -420,32 +419,17 @@ CatalogGroup.prototype.toggleOpen = function() {
 };
 
 /**
- * Finds the first item in this group with a value in {@link CatalogItem#allShareKeys} that matches the given key.
- * The search is case-sensitive.
- *
- * @param {String} key The key to search for.
- * @return {CatalogMember} The first item with the given key, or undefined if no item with that name exists.
- */
-CatalogGroup.prototype.getChildForShareKey = function(key) {
-    for (var i = 0; i < this.items.length; i++) {
-        if (this.items[i].allShareKeys.indexOf(key) >= 0) {
-            return this.items[i];
-        }
-    }
-};
-
-/**
  * Finds the first item in this group that has the given name.  The search is case-sensitive.
+ *
+ * Instead of using this function, consider using {@link Catalog#shareKeyIndex} to look the item up, as this works in
+ * constant time and allows lookups to continue working for items that have been renamed or moved as long as they have
+ * a stable shareKey set. This function is retained mainly for backwards-compatibility with existing share links that
+ * used names for matching.
  *
  * @param {String} name The name of the item to find.
  * @return {CatalogMember} The first item with the given name, or undefined if no item with that name exists.
- * @deprecated Use {@link CatalogGroup#getChildForShareKey} where possible, this is retained for backwards compatibility
- * with existing share links.
  */
 CatalogGroup.prototype.findFirstItemByName = function(name) {
-    deprecationWarning('findFirstItemByName', 'Use CatalogGroup.getChildForShareKey where possible, this is retained ' +
-        'for backwards compatibility with existing share links.');
-
     for (var i = 0; i < this.items.length; ++i) {
         if (this.items[i].name === name) {
             return this.items[i];

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -233,8 +233,8 @@ freezeObject(CatalogGroup.defaultSerializers);
  * @type {String[]}
  */
 CatalogGroup.defaultPropertiesForSharing = clone(CatalogMember.defaultPropertiesForSharing);
-CatalogGroup.defaultPropertiesForSharing.push('isOpen');
 CatalogGroup.defaultPropertiesForSharing.push('items');
+CatalogGroup.defaultPropertiesForSharing.push('isOpen');
 
 freezeObject(CatalogGroup.defaultPropertiesForSharing);
 

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -209,9 +209,13 @@ CatalogGroup.defaultSerializers.items = function(catalogGroup, json, propertyNam
     var items = json.items = [];
 
     for (var i = 0; i < catalogGroup.items.length; ++i) {
-        var item = catalogGroup.items[i].serializeToJson(options);
-        if (defined(item)) {
-            items.push(item);
+        if (!defined(options.itemFilter) || options.itemFilter(catalogGroup.items[i])) {
+            var item = catalogGroup.items[i].serializeToJson(options);
+
+            if (defined(item)) {
+                item.parent = undefined; // would create circular json
+                items.push(item);
+            }
         }
     }
 };
@@ -226,8 +230,8 @@ freezeObject(CatalogGroup.defaultSerializers);
  * @type {String[]}
  */
 CatalogGroup.defaultPropertiesForSharing = clone(CatalogMember.defaultPropertiesForSharing);
-CatalogGroup.defaultPropertiesForSharing.push('items');
 CatalogGroup.defaultPropertiesForSharing.push('isOpen');
+CatalogGroup.defaultPropertiesForSharing.push('items');
 
 freezeObject(CatalogGroup.defaultPropertiesForSharing);
 
@@ -313,9 +317,27 @@ CatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
  * Adds an item or group to this group.
  *
  * @param {CatalogMember} item The item to add.
+ * @param {Promise} indexPromise A promise that if specified, will be waited for before the item is added to the catalog-wide index.
+ *                               Allows for an item to be added immediately even if its contents haven't been loaded yet.
  */
-CatalogGroup.prototype.add = function(item) {
+CatalogGroup.prototype.add = function(item, indexPromise) {
     item.parent = this;
+
+    var addItemToIndex = function() {
+        item.allShareKeys.forEach(function (key) {
+            if (this.terria.catalog.shareKeyIndex[key]) {
+                throw new RuntimeError('Duplicate shareKey: ' + key);
+            } else {
+                this.terria.catalog.shareKeyIndex[key] = item;
+            }
+        }, this);
+    }.bind(this);
+
+    if (indexPromise) {
+        indexPromise.then(addItemToIndex);
+    } else {
+        addItemToIndex();
+    }
 
     this.items.push(item);
 };
@@ -326,7 +348,11 @@ CatalogGroup.prototype.add = function(item) {
  * @param {CatalogMember} item The item to remove.
  */
 CatalogGroup.prototype.remove = function(item) {
-    delete item.parent;
+    item.parent = undefined;
+
+    item.allShareKeys.forEach(function(key) {
+        this.terria.catalog.shareKeyIndex[key] = undefined;
+    }, this);
 
     this.items.remove(item);
 };
@@ -402,53 +428,25 @@ CatalogGroup.prototype.sortItems = function(sortRecursively) {
     }
 };
 
-/**
- * Opens this CatalogGroup and all its parents.
- */
-CatalogGroup.prototype.openWithAllParents = function() {
+CatalogGroup.prototype.enableWithParents = function() {
     this.isOpen = true;
 
     if (this.parent) {
-        this.parent.openWithAllParents();
+        this.parent.enableWithParents();
     }
 };
 
-/**
- * Does a complete traversal of this CatalogGroup and any CatalogGroups under it and produces a flat map of each item's
- * share key(s) to that item, using {@link CatalogMember#allShareKeys}. Will throw an Error if there are any duplicate
- * keys, as this shouldn't ever occur.
- *
- * @returns {Object} a map of share keys to items.
- */
-CatalogGroup.prototype.generateShareKeyIndex = function() {
-    return this.items.reduce(function(indexSoFar, item) {
-        item.allShareKeys.forEach(function(key) {
-            addToIndex(indexSoFar, key, item);
-        });
+CatalogGroup.prototype.getDescendantsFlat = function() {
+    return this.items.reduce(function(prev, current) {
+        var descendants = [current];
 
-        if (item.generateShareKeyIndex) {
-            var shareKeyIndex = item.generateShareKeyIndex();
-
-            Object.keys(shareKeyIndex).forEach(function(key) {
-                addToIndex(indexSoFar, key, shareKeyIndex[key]);
-            });
+        if (defined(current.getDescendantsFlat)) {
+            descendants = descendants.concat(current.getDescendantsFlat());
         }
 
-        return indexSoFar;
-    }, {});
+        return prev.concat(descendants);
+    }, []);
 };
-
-/**
- * Adds an item to the provided index under the provided key, checking to make sure there's no item for that key already.
- * Will throw an error if so.
- */
-function addToIndex(indexSoFar, key, item) {
-    if (indexSoFar[key]) {
-        throw new DeveloperError('Duplicate shareKey: ' + key);
-    } else {
-        indexSoFar[key] = item;
-    }
-}
 
 /**
  * Reads an array of catalog members in JSON format (as objects, not strings) and transforms them into actual Terria
@@ -480,52 +478,45 @@ CatalogGroup.updateItems = function (itemsJson, options, catalogGroup) {
     var promises = [];
 
     for (var itemIndex = 0; itemIndex < itemsJson.length; ++itemIndex) {
-        var item = itemsJson[itemIndex];
+        var itemJson = itemsJson[itemIndex];
 
-        if (!defined(item.name) && !defined(item.id)) {
+        if (!defined(itemJson.name) && !defined(itemJson.id)) {
             throw new RuntimeError('A catalog member must have a name or a id for matching.');
         }
 
-        var existingItem;
-        if (item.id) {
-            if (options.shareKeyIndex) {
-                existingItem = options.shareKeyIndex[item.id];
-
-                if (existingItem && existingItem.parent !== catalogGroup && item.isEnabled && !existingItem.isEnabled) {
-                    // We are enabling an existing item that has been moved since our itemsJson was generated
-                    // (probably an old share link) - make sure all its parents are open so it's visible.
-                    existingItem.parent.openWithAllParents();
-                }
-            } else {
-                existingItem = catalogGroup.getChildForShareKey(item.id);
-            }
-        } else if (item.name) {
-            existingItem = catalogGroup.findFirstItemByName(item.name);
+        var itemObject;
+        if (itemJson.id) {
+            itemObject = catalogGroup.terria.catalog.shareKeyIndex[itemJson.id];
+        } else if (itemJson.name) {
+            itemObject = catalogGroup.findFirstItemByName(itemJson.name);
         }
 
-        if (!defined(existingItem)) {
+        var updating = defined(itemObject);
+
+        if (!updating) {
             // Skip this item entirely if we're not allowed to create it.
             if (onlyUpdateExistingItems) {
                 continue;
             }
 
-            if (!defined(item.name)) {
+            if (!defined(itemJson.name)) {
                 throw new RuntimeError('A newly created catalog member must have a name.');
             }
 
-            if (!defined(item.type)) {
+            if (!defined(itemJson.type)) {
                 throw new RuntimeError('A catalog member must have a type.');
             }
 
-            existingItem = createCatalogMemberFromType(item.type, catalogGroup.terria);
-
-            catalogGroup.add(existingItem);
-        } else {
-            // We only want to use the id for matching, not overwrite it.
-            delete item.id;
+            itemObject = createCatalogMemberFromType(itemJson.type, catalogGroup.terria);
         }
 
-        promises.push(existingItem.updateFromJson(item, options));
+        var loadPromise = itemObject.updateFromJson(itemJson, options);
+
+        if (!updating) {
+            catalogGroup.add(itemObject, loadPromise);
+        }
+
+        promises.push(loadPromise);
     }
 
     return when.all(promises, function () {

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -919,4 +919,12 @@ function isShownChanged(catalogItem) {
     catalogItem.terria.currentViewer.notifyRepaintRequired();
 }
 
+CatalogItem.prototype.enableWithParents = function() {
+    this.isEnabled = true;
+
+    if (this.parent) {
+        this.parent.enableWithParents();
+    }
+};
+
 module.exports = CatalogItem;

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -329,8 +329,7 @@ defineProperties(CatalogItem.prototype, {
     },
 
     /**
-     * Gets the set of names of the properties to be serialized for this object when {@link CatalogMember#serializeToJson} is called
-     * and the `serializeForSharing` flag is set in the options.
+     * Gets the set of names of the properties to be serialized for this object for a share link.
      * @memberOf CatalogItem.prototype
      * @type {String[]}
      */
@@ -444,8 +443,8 @@ CatalogItem.defaultSerializers.dataUrlType = function(catalogItem, json, prototy
 freezeObject(CatalogItem.defaultSerializers);
 
 /**
- * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object with the
- * `serializeForSharing` flag set in the options.
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
+ * for a share link.
  * @type {String[]}
  */
 CatalogItem.defaultPropertiesForSharing = clone(CatalogMember.defaultPropertiesForSharing);

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -823,6 +823,14 @@ CatalogItem.prototype._hideInLeaflet = function() {
     throw new DeveloperError('_hideInLeaflet must be implemented in the derived class.');
 };
 
+CatalogItem.prototype.enableWithParents = function() {
+    this.isEnabled = true;
+
+    if (this.parent) {
+        this.parent.enableWithParents();
+    }
+};
+
 function isEnabledChanged(catalogItem) {
     var terria = catalogItem.terria;
     if (catalogItem.isEnabled) {
@@ -918,13 +926,5 @@ function isShownChanged(catalogItem) {
 
     catalogItem.terria.currentViewer.notifyRepaintRequired();
 }
-
-CatalogItem.prototype.enableWithParents = function() {
-    this.isEnabled = true;
-
-    if (this.parent) {
-        this.parent.enableWithParents();
-    }
-};
 
 module.exports = CatalogItem;

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -215,8 +215,8 @@ defineProperties(CatalogMember.prototype, {
     },
 
     /**
-     * Gets the set of names of the properties to be serialized for this object when {@link CatalogMember#serializeToJson} is called
-     * and the `serializeForSharing` flag is set in the options.
+     * Gets the set of names of the properties to be serialized for this object when {@link CatalogMember#serializeToJson}
+     * is called for a share link.
      * @memberOf CatalogMember.prototype
      * @type {String[]}
      */
@@ -292,11 +292,13 @@ CatalogMember.defaultSerializers = {
 freezeObject(CatalogMember.defaultSerializers);
 
 /**
- * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogMember}-derived object with the
- * `serializeForSharing` flag set in the options.
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogMember}-derived object
+ * for a share link.
  * @type {String[]}
  */
-CatalogMember.defaultPropertiesForSharing = [];
+CatalogMember.defaultPropertiesForSharing = [
+    'name'
+];
 
 freezeObject(CatalogMember.defaultPropertiesForSharing);
 
@@ -377,11 +379,48 @@ CatalogMember.prototype.findInfoSection = function(sectionName) {
 };
 
 /**
+ * Goes up the hierarchy and determines if this CatalogMember is connected with the root in terria.catalog, or whether it's
+ * part of a disconnected sub-tree.
+ */
+CatalogMember.prototype.connectsWithRoot = function() {
+    var item = this;
+    while (item.parent) {
+        item = item.parent;
+    }
+    return item === this.terria.catalog.group;
+};
+
+/**
  * "Enables" this catalog member in a way that makes sense for its implementation (e.g. isEnabled for items, isOpen for
  * groups, and all its parents and ancestors in the tree.
  */
 CatalogMember.prototype.enableWithParents = function() {
     throw new DeveloperError('Types derived from CatalogMember must implement a "enableWithParents" function.');
+};
+
+/** A collection of static filters functions used during serialization */
+CatalogMember.itemFilters = {
+    /** Item filter that returns true if the item is user supplied */
+    userSuppliedOnly: function(item) {
+        return item.isUserSupplied;
+    },
+    /** Item filter that returns true if the item is a {@link CatalogItem} that is enabled, or another kind of {@link CatalogMember}. */
+    enabled: function(item) {
+        return !defined(item.isEnabled) || item.isEnabled;
+    },
+    /** Item filter that returns true if an item has no local data. */
+    noLocalData: function(item) {
+        return !defined(item.data);
+    }
+};
+
+CatalogMember.propertyFilters = {
+    /**
+     * Property filter that returns true if the property is in that item's {@link CatalogMember#propertiesForSharing} array.
+     */
+    sharedOnly: function(property, item) {
+        return item.propertiesForSharing.indexOf(property) >= 0;
+    }
 };
 
 module.exports = CatalogMember;

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -340,8 +340,27 @@ CatalogMember.prototype.serializeToJson = function(options) {
     result.type = this.type;
     result.id = this.uniqueId;
 
+    result.parents = getParentIds(this).reverse();
+
     return result;
 };
+
+/**
+ * Gets the ids of all parents of a catalog member, ordered from the closest descendant to the most distant.
+ *
+ * @param catalogMember The catalog member to get parent ids for.
+ * @param parentIds A starting list of parent ids to add to (allows the function to work recursively).
+ * @returns {String[]}
+ */
+function getParentIds(catalogMember, parentIds) {
+    parentIds = defaultValue(parentIds, []);
+
+    if (catalogMember.parent) {
+        return getParentIds(catalogMember.parent, parentIds.concat([catalogMember.parent.uniqueId]));
+    }
+
+    return parentIds;
+}
 
 /**
  * Finds an {@link CatalogMember#info} section by name.

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -113,6 +113,20 @@ var CatalogMember = function(terria) {
      */
     this.customProperties = {};
 
+    /**
+     * A unique id for this member, that is stable across renames and moves.
+     * @type {String}
+     */
+    this.id = undefined;
+
+    /**
+     * An array of all possible keys that can be used to match to this catalog member when specified in a share link -
+     * used for maintaining backwards compatibility when adding or changing {@link CatalogMember#id}.
+     *
+     * @type {Array<String>}
+     */
+    this.shareKeys = undefined;
+
     knockout.track(this, ['name', 'info', 'infoSectionOrder', 'description', 'isUserSupplied', 'isPromoted', 'initialMessage', 'isHidden', 'cacheDuration', 'customProperties']);
 };
 
@@ -219,6 +233,26 @@ defineProperties(CatalogMember.prototype, {
                     return descriptionRegex.test(i.name);
                 }));
         }
+    },
+
+    uniqueId : {
+        get : function() {
+            if (this.id) {
+                return this.id;
+            }
+
+            var parentKey = this.parent ? this.parent.uniqueId + '/' : '';
+
+            return parentKey + this.name;
+        }
+    },
+
+    allShareKeys : {
+        get : function() {
+            var allShareKeys = [this.uniqueId];
+
+            return this.shareKeys ? allShareKeys.concat(this.shareKeys) : allShareKeys;
+        }
     }
 });
 
@@ -248,7 +282,7 @@ freezeObject(CatalogMember.defaultSerializers);
  * @type {String[]}
  */
 CatalogMember.defaultPropertiesForSharing = [
-    'name'
+    'uniqueId'
 ];
 
 freezeObject(CatalogMember.defaultPropertiesForSharing);
@@ -333,7 +367,9 @@ CatalogMember.prototype.serializeToJson = function(options) {
 
     var result = serializeToJson(this, filterFunction, options);
 
-    if (!options.serializeForSharing) {
+    if (options.serializeForSharing) {
+        result.id = this.uniqueId;
+    } else {
         result.type = this.type;
     }
 

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -123,7 +123,7 @@ var CatalogMember = function(terria) {
      * An array of all possible keys that can be used to match to this catalog member when specified in a share link -
      * used for maintaining backwards compatibility when adding or changing {@link CatalogMember#id}.
      *
-     * @type {Array<String>}
+     * @type {String[]}
      */
     this.shareKeys = undefined;
 
@@ -235,6 +235,11 @@ defineProperties(CatalogMember.prototype, {
         }
     },
 
+    /**
+     * The canonical unique id for this CatalogMember. Will be the id property if one is present, otherwise it will fall
+     * back to the uniqueId of this item's parent + this item's name. This means that if no id is set anywhere up the
+     * tree, the uniqueId will be a complete path of this member's location.
+     */
     uniqueId : {
         get : function() {
             if (this.id) {
@@ -247,6 +252,9 @@ defineProperties(CatalogMember.prototype, {
         }
     },
 
+    /**
+     * All keys that have historically been used to resolve this member - the current uniqueId + past shareKeys.
+     */
     allShareKeys : {
         get : function() {
             var allShareKeys = [this.uniqueId];
@@ -281,9 +289,7 @@ freezeObject(CatalogMember.defaultSerializers);
  * `serializeForSharing` flag set in the options.
  * @type {String[]}
  */
-CatalogMember.defaultPropertiesForSharing = [
-    'uniqueId'
-];
+CatalogMember.defaultPropertiesForSharing = [];
 
 freezeObject(CatalogMember.defaultPropertiesForSharing);
 
@@ -300,6 +306,9 @@ freezeObject(CatalogMember.defaultPropertiesForSharing);
  *                                                    may be created by this update.
  * @param {Boolean} [options.isUserSupplied] If specified, sets the {@link CatalogMember#isUserSupplied} property of updated catalog members
  *                                           to the given value.  If not specified, the property is left unchanged.
+ * @param {Object} [options.shareKeyIndex] An optional index of all catalog items by their share ids - this will be
+ *                                         used to match catalog items in itemsJson to their already-existing equivalents
+ *                                         even if those equivalents have been moved outside this catalogItem.
   * @returns {Promise} A promise that resolves when the update is complete.
 */
 CatalogMember.prototype.updateFromJson = function(json, options) {

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -65,9 +65,9 @@ var CatalogMember = function(terria) {
      * {@link Terria#initSources}.  User-supplied members must be serialized completely when, for example,
      * serializing enabled members for sharing.  This property is observable.
      * @type {Boolean}
-     * @default true
+     * @default false
      */
-    this.isUserSupplied = true;
+    this.isUserSupplied = false;
 
     /**
      * Gets or sets a value indicating whether this item is kept above other non-promoted items.
@@ -126,6 +126,13 @@ var CatalogMember = function(terria) {
      * @type {String[]}
      */
     this.shareKeys = undefined;
+
+    /**
+     * The parent {@link CatalogGroup} of this member.
+     *
+     * @type {CatalogGroup}
+     */
+    this.parent = undefined;
 
     knockout.track(this, ['name', 'info', 'infoSectionOrder', 'description', 'isUserSupplied', 'isPromoted', 'initialMessage', 'isHidden', 'cacheDuration', 'customProperties']);
 };
@@ -306,9 +313,6 @@ freezeObject(CatalogMember.defaultPropertiesForSharing);
  *                                                    may be created by this update.
  * @param {Boolean} [options.isUserSupplied] If specified, sets the {@link CatalogMember#isUserSupplied} property of updated catalog members
  *                                           to the given value.  If not specified, the property is left unchanged.
- * @param {Object} [options.shareKeyIndex] An optional index of all catalog items by their share ids - this will be
- *                                         used to match catalog items in itemsJson to their already-existing equivalents
- *                                         even if those equivalents have been moved outside this catalogItem.
   * @returns {Promise} A promise that resolves when the update is complete.
 */
 CatalogMember.prototype.updateFromJson = function(json, options) {
@@ -323,69 +327,18 @@ CatalogMember.prototype.updateFromJson = function(json, options) {
  * Serializes the data item to JSON.
  *
  * @param {Object} [options] Object with the following properties:
- * @param {Boolean} [options.enabledItemsOnly=false] true if only enabled data items (and their groups) should be serialized,
- *                  or false if all data items should be serialized.
- * @param {CatalogMember[]} [options.itemsSkippedBecauseTheyAreNotEnabled] An array that, if provided, is populated on return with
- *        all of the data items that were not serialized because they were not enabled.  The array will be empty if
- *        options.enabledItemsOnly is false.
- * @param {Boolean} [options.skipItemsWithLocalData=false] true if items with a serializable 'data' property should be skipped entirely.
- *                  This is useful to avoid creating a JSON data structure with potentially very large embedded data.
- * @param {CatalogMember[]} [options.itemsSkippedBecauseTheyHaveLocalData] An array that, if provided, is populated on return
- *        with all of the data items that were not serialized because they have a serializable 'data' property.  The array will be empty
- *        if options.skipItemsWithLocalData is false.
- * @param {Boolean} [options.serializeForSharing=false] true to only serialize properties that are typically necessary for sharing this member
- *                                                      with other users, such as {@link CatalogGroup#isOpen}, {@link CatalogItem#isEnabled},
- *                                                      {@link CatalogItem#isLegendVisible}, and {@link ImageryLayerCatalogItem#opacity},
- *                                                      rather than serializing all properties needed to completely recreate the catalog.  The set of properties
- *                                                      that is serialized when this property is true is given by each model's
- *                                                      {@link CatalogMember#propertiesForSharing} property.
- * @param {Boolean} [options.userSuppliedOnly=false] true to only serialize catalog members (and their containing groups) that have been identified as having been
- *                  supplied by the user ({@link CatalogMember#isUserSupplied} is true); false to serialize all catalog members.
+ * @param {Function} [options.propertyFilter] Filter function that will be executed to determine whether a property
+ *          should be serialized.
+ * @param {Function} [options.itemFilter] Filter function that will be executed for each item in a group to determine
+ *          whether that item should be serialized.
  * @return {Object} The serialized JSON object-literal.
  */
 CatalogMember.prototype.serializeToJson = function(options) {
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-    var enabledItemsOnly = defaultValue(options.enabledItemsOnly, false);
-
-    if (defaultValue(options.userSuppliedOnly, false) && !this.isUserSupplied) {
-        return undefined;
-    }
-
-    if (enabledItemsOnly && this.isEnabled === false) {
-        if (defined(options.itemsSkippedBecauseTheyAreNotEnabled)) {
-            options.itemsSkippedBecauseTheyAreNotEnabled.push(this);
-        }
-        return undefined;
-    }
-
-    if (defaultValue(options.skipItemsWithLocalData, false) && defined(this.data)) {
-        if (defined(options.itemsSkippedBecauseTheyHaveLocalData)) {
-            options.itemsSkippedBecauseTheyHaveLocalData.push(this);
-        }
-        return undefined;
-    }
-
-    var filterFunction = function() { return true; };
-    if (options.serializeForSharing) {
-        var that = this;
-        filterFunction = function(propertyName) {
-            return that.propertiesForSharing.indexOf(propertyName) >= 0;
-        };
-    }
-
-    var result = serializeToJson(this, filterFunction, options);
-
-    if (options.serializeForSharing) {
-        result.id = this.uniqueId;
-    } else {
-        result.type = this.type;
-    }
-
-    // Only serialize a group if the group has items in it.
-    if (enabledItemsOnly && defined(this.items) && (!defined(result.items) || result.items.length === 0)) {
-        return undefined;
-    }
+    var result = serializeToJson(this, options.propertyFilter, options);
+    result.type = this.type;
+    result.id = this.uniqueId;
 
     return result;
 };
@@ -402,6 +355,14 @@ CatalogMember.prototype.findInfoSection = function(sectionName) {
         }
     }
     return undefined;
+};
+
+/**
+ * "Enables" this catalog member in a way that makes sense for its implementation (e.g. isEnabled for items, isOpen for
+ * groups, and all its parents and ancestors in the tree.
+ */
+CatalogMember.prototype.enableWithParents = function() {
+    throw new DeveloperError('Types derived from CatalogMember must implement a "enableWithParents" function.');
 };
 
 module.exports = CatalogMember;

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -65,9 +65,9 @@ var CatalogMember = function(terria) {
      * {@link Terria#initSources}.  User-supplied members must be serialized completely when, for example,
      * serializing enabled members for sharing.  This property is observable.
      * @type {Boolean}
-     * @default false
+     * @default true
      */
-    this.isUserSupplied = false;
+    this.isUserSupplied = true;
 
     /**
      * Gets or sets a value indicating whether this item is kept above other non-promoted items.

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -295,25 +295,7 @@ freezeObject(CkanCatalogGroup.defaultUpdaters);
  */
 CkanCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-CkanCatalogGroup.defaultSerializers.items = function(ckanGroup, json, propertyName, options) {
-    // Only serialize minimal properties in contained items, because other properties are loaded from CKAN.
-    var previousSerializeForSharing = options.serializeForSharing;
-    options.serializeForSharing = true;
-
-    // Only serialize enabled items as well.  This isn't quite right - ideally we'd serialize any
-    // property of any item if the property's value is changed from what was loaded from CKAN -
-    // but this gives us reasonable results for sharing and is a lot less work than the ideal
-    // solution.
-    var previousEnabledItemsOnly = options.enabledItemsOnly;
-    options.enabledItemsOnly = true;
-
-    var result = CatalogGroup.defaultSerializers.items(ckanGroup, json, propertyName, options);
-
-    options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeForSharing = previousSerializeForSharing;
-
-    return result;
-};
+CkanCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 /* Serializes a regex like /.foo/i into ".foo"  */
 function regexSerializer (fieldName) {

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -483,7 +483,7 @@ function filterBasedOnGetCapabilitiesResponse(ckanGroup, wmsLayersSource, resour
     }
 }
 
-function createItemFromResource(resource, ckanGroup, item, extras) {
+function createItemFromResource(resource, ckanGroup, itemData, extras, parent) {
     if (resource.__filtered) {
         return;
     }
@@ -513,7 +513,7 @@ function createItemFromResource(resource, ckanGroup, item, extras) {
     // Remove the query portion of the WMS URL.
     var url = baseUrl;
 
-    var newItem = null;
+    var newItem;
     if (isWms) {
         if (!ckanGroup.includeWms) {
             return;
@@ -531,11 +531,11 @@ function createItemFromResource(resource, ckanGroup, item, extras) {
         uri.search('');
         url = uri.toString();
     } else {
-        [[ 'esriMapServerResourceFormat', 'includeEsriMapServer', ArcGisMapServerCatalogItem ],
-        [ 'kmlResourceFormat',            'includeKml',           KmlCatalogItem],
-        [ 'geoJsonResourceFormat',        'includeGeoJson',       GeoJsonCatalogItem],
-        [ 'czmlJsonResourceFormat',       'includeCzml',          CzmlCatalogItem],
-        [ 'csvResourceFormat',            'includeCsv',           CsvCatalogItem]].forEach(function(f) {
+        [['esriMapServerResourceFormat', 'includeEsriMapServer', ArcGisMapServerCatalogItem],
+            ['kmlResourceFormat', 'includeKml', KmlCatalogItem],
+            ['geoJsonResourceFormat', 'includeGeoJson', GeoJsonCatalogItem],
+            ['czmlJsonResourceFormat', 'includeCzml', CzmlCatalogItem],
+            ['csvResourceFormat', 'includeCsv', CsvCatalogItem]].forEach(function (f) {
             if (resource.format.match(ckanGroup[f[0]]) && ckanGroup[f[1]]) {
                 newItem = new f[2](ckanGroup.terria);
             }
@@ -548,18 +548,18 @@ function createItemFromResource(resource, ckanGroup, item, extras) {
     if (ckanGroup.useResourceName) {
         newItem.name = resource.name;
     } else {
-        newItem.name = item.title;
+        newItem.name = itemData.title;
     }
 
 
     var textDescription = '';
 
-    if (item.notes) {
-        textDescription = item.notes;
+    if (itemData.notes) {
+        textDescription = itemData.notes;
     }
 
-    if (item.license_url && (item.notes === null || item.notes.indexOf('[Licence]') === -1)) {
-        textDescription += '\n\n[Licence](' + item.license_url + ')';
+    if (itemData.license_url && (itemData.notes === null || itemData.notes.indexOf('[Licence]') === -1)) {
+        textDescription += '\n\n[Licence](' + itemData.license_url + ')';
     }
 
     newItem.info.push({
@@ -576,14 +576,14 @@ function createItemFromResource(resource, ckanGroup, item, extras) {
 
     newItem.url = url;
 
-    var bboxString = item.geo_coverage || extras.geo_coverage;
+    var bboxString = itemData.geo_coverage || extras.geo_coverage;
     if (defined(bboxString)) {
         var parts = bboxString.split(',');
         if (parts.length === 4) {
             newItem.rectangle = Rectangle.fromDegrees(parts[0], parts[1], parts[2], parts[3]);
         }
     }
-    newItem.dataUrl = ckanGroup.url + '/dataset/' + item.name;
+    newItem.dataUrl = ckanGroup.url + '/dataset/' + itemData.name;
     newItem.dataUrlType = 'direct';
 
     if (isWms) {
@@ -593,17 +593,18 @@ function createItemFromResource(resource, ckanGroup, item, extras) {
 
     if (defined(ckanGroup.dataCustodian)) {
         newItem.dataCustodian = ckanGroup.dataCustodian;
-    } else if (item.organization && item.organization.title) {
-        newItem.dataCustodian = item.organization.description || item.organization.title;
+    } else if (itemData.organization && itemData.organization.title) {
+        newItem.dataCustodian = itemData.organization.description || itemData.organization.title;
     }
 
     if (typeof(ckanGroup.itemProperties) === 'object') {
         newItem.updateFromJson(ckanGroup.itemProperties);
     }
 
+    newItem.id = parent.uniqueId + '/' + resource.id;
+
     return newItem;
 }
-
 function populateGroupFromResults(ckanGroup, json) {
     var items = json.result.results;
     for (var itemIndex = 0; itemIndex < items.length; ++itemIndex) {
@@ -626,15 +627,10 @@ function populateGroupFromResults(ckanGroup, json) {
         for (var resourceIndex = 0; resourceIndex < resources.length; ++resourceIndex) {
             var resource = resources[resourceIndex];
 
-            var newItem = createItemFromResource(resource, ckanGroup, item, extras);
-            if (!newItem) {
-                continue;
-            }
-
             var groups;
             if (ckanGroup.groupBy === 'group') {
                 groups = item.groups;
-            } else if (ckanGroup.groupBy === 'organization') {
+            } else if (ckanGroup.groupBy === 'organization' && item.organization) { // item.organization is sometimes null
                 groups = [item.organization];
             }
 
@@ -642,23 +638,29 @@ function populateGroupFromResults(ckanGroup, json) {
                 for (var groupIndex = 0; groupIndex < groups.length; ++groupIndex) {
                     var group = groups[groupIndex];
                     var groupName = group.display_name || group.title;
+                    var groupId = ckanGroup.uniqueId + '/' + group.id;
 
                     if (ckanGroup.blacklist && ckanGroup.blacklist[groupName]) {
                         continue;
                     }
 
-                    var existingGroup = ckanGroup.getChildForShareKey(groupName);
-                    if (!defined(existingGroup)) {
-                        existingGroup = new CatalogGroup(ckanGroup.terria);
-                        existingGroup.name = groupName;
-                        existingGroup.id = groupName;
-                        ckanGroup.add(existingGroup);
+                    var groupToAdd = ckanGroup.terria.catalog.shareKeyIndex[groupId];
+                    var updating = defined(groupToAdd);
+
+                    if (!defined(groupToAdd)) {
+                        groupToAdd = new CatalogGroup(ckanGroup.terria);
+                        groupToAdd.name = groupName;
+                        groupToAdd.id = groupId;
                     }
 
-                    existingGroup.add(newItem);
+                    addItem(resource, ckanGroup, item, extras, groupToAdd);
+
+                    if (!updating && groupToAdd.items.length) {
+                        ckanGroup.add(groupToAdd);
+                    }
                 }
             } else {
-                ckanGroup.add(newItem);
+                addItem(resource, ckanGroup, item, extras, ckanGroup);
             }
         }
     }
@@ -680,6 +682,28 @@ function populateGroupFromResults(ckanGroup, json) {
     for (var i = 0; i < ckanGroup.items.length; ++i) {
         if (defined(ckanGroup.items[i].items)) {
             ckanGroup.items[i].items.sort(compareNames);
+        }
+    }
+}
+
+/**
+ * Creates a catalog item from the supplied resource and adds it to the supplied parent if necessary..
+ *
+ * @param resource The Ckan resource
+ * @param rootCkanGroup The root group of all items in this Ckan hierarchy
+ * @param itemData The data of the item to build the catalog item from
+ * @param extras
+ * @param parent The parent group to add the item to once it's constructed - set this to rootCkanGroup for flat hierarchies.
+ */
+function addItem(resource, rootCkanGroup, itemData, extras, parent) {
+    var item = rootCkanGroup.terria.catalog.shareKeyIndex[parent.uniqueId + '/' + resource.id];
+    var alreadyExists = defined(item);
+
+    if (!alreadyExists) {
+        item = createItemFromResource(resource, rootCkanGroup, itemData, extras, parent);
+
+        if (item) {
+            parent.add(item);
         }
     }
 }

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -647,10 +647,11 @@ function populateGroupFromResults(ckanGroup, json) {
                         continue;
                     }
 
-                    var existingGroup = ckanGroup.findFirstItemByName(groupName);
+                    var existingGroup = ckanGroup.getChildForShareKey(groupName);
                     if (!defined(existingGroup)) {
                         existingGroup = new CatalogGroup(ckanGroup.terria);
                         existingGroup.name = groupName;
+                        existingGroup.id = groupName;
                         ckanGroup.add(existingGroup);
                     }
 

--- a/lib/Models/CompositeCatalogItem.js
+++ b/lib/Models/CompositeCatalogItem.js
@@ -113,7 +113,7 @@ defineProperties(CompositeCatalogItem.prototype, {
 
     /**
      * Gets the set of names of the properties to be serialized for this object when {@link CatalogMember#serializeToJson} is called
-     * and the `serializeForSharing` flag is set in the options.
+     * for a share link.
      * @memberOf CompositeCatalogItem.prototype
      * @type {String[]}
      */
@@ -202,8 +202,8 @@ CompositeCatalogItem.defaultSerializers.isLoading = function(compositeCatalogIte
 freezeObject(CompositeCatalogItem.defaultSerializers);
 
 /**
- * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object with the
- * `serializeForSharing` flag set in the options.
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
+ * for a share link.
  * @type {String[]}
  */
 CompositeCatalogItem.defaultPropertiesForSharing = clone(CatalogItem.defaultPropertiesForSharing);

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -270,8 +270,8 @@ defineProperties(CsvCatalogItem.prototype, {
 
     /**
      * Gets the set of names of the properties to be serialized for this object when {@link CatalogMember#serializeToJson} is called
-     * and the `serializeForSharing` flag is set in the options.
-     * @memberOf CsvCatalogItem.prototype
+     * for a share link.
+     * @memberOf ImageryLayerCatalogItem.prototype
      * @type {String[]}
      */
     propertiesForSharing: {
@@ -343,8 +343,8 @@ CsvCatalogItem.defaultSerializers.concepts = function() {
 freezeObject(CsvCatalogItem.defaultSerializers);
 
 /**
- * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object with the
- * `serializeForSharing` flag set in the options.
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
+ * for a share link.
  * @type {String[]}
  */
 CsvCatalogItem.defaultPropertiesForSharing = clone(CatalogItem.defaultPropertiesForSharing);

--- a/lib/Models/CswCatalogGroup.js
+++ b/lib/Models/CswCatalogGroup.js
@@ -323,7 +323,7 @@ CswCatalogGroup.prototype._load = function() {
 
                     var catalogItem = createItemForUri(that, record, uri);
                     if (defined(catalogItem)) {
-                        that.items.push(catalogItem);
+                        that.add(catalogItem);
                     }
 
                 }

--- a/lib/Models/CswCatalogGroup.js
+++ b/lib/Models/CswCatalogGroup.js
@@ -205,25 +205,7 @@ freezeObject(CswCatalogGroup.defaultUpdaters);
  */
 CswCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-CswCatalogGroup.defaultSerializers.items = function(cswGroup, json, propertyName, options) {
-    // Only serialize minimal properties in contained items, because other properties are loaded from CSW.
-    var previousSerializeForSharing = options.serializeForSharing;
-    options.serializeForSharing = true;
-
-    // Only serialize enabled items as well.  This isn't quite right - ideally we'd serialize any
-    // property of any item if the property's value is changed from what was loaded from CSW -
-    // but this gives us reasonable results for sharing and is a lot less work than the ideal
-    // solution.
-    var previousEnabledItemsOnly = options.enabledItemsOnly;
-    options.enabledItemsOnly = true;
-
-    var result = CatalogGroup.defaultSerializers.items(cswGroup, json, propertyName, options);
-
-    options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeForSharing = previousSerializeForSharing;
-
-    return result;
-};
+CswCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 /* Serializes a regex like /.foo/i into ".foo"  */
 function regexSerializer (fieldName) {

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -232,7 +232,7 @@ defineProperties(ImageryLayerCatalogItem.prototype, {
 
     /**
      * Gets the set of names of the properties to be serialized for this object when {@link CatalogMember#serializeToJson} is called
-     * and the `serializeForSharing` flag is set in the options.
+     * for a share link.
      * @memberOf ImageryLayerCatalogItem.prototype
      * @type {String[]}
      */
@@ -291,8 +291,8 @@ ImageryLayerCatalogItem.defaultSerializers.intervals = function(catalogItem, jso
 freezeObject(ImageryLayerCatalogItem.defaultSerializers);
 
 /**
- * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object with the
- * `serializeForSharing` flag set in the options.
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
+ * for a share link.
  * @type {String[]}
  */
 ImageryLayerCatalogItem.defaultPropertiesForSharing = clone(CatalogItem.defaultPropertiesForSharing);

--- a/lib/Models/SocrataCatalogGroup.js
+++ b/lib/Models/SocrataCatalogGroup.js
@@ -207,7 +207,7 @@ function populateGroupFromResults(socrataGroup, json) {
         var geo = item.metadata.geo;
         // Currently we only support spatial layers, which are identified by a geo {} object. TODO support other kinds of layers?
         if (!geo || !defined(item.childViews)) { // items without a 'childViews' seem to be themselves child views
-          continue;
+            continue;
         }
         var id = item.category ?
         socrataGroup.uniqueId + '/' + item.category + '/' + item.id :

--- a/lib/Models/SocrataCatalogGroup.js
+++ b/lib/Models/SocrataCatalogGroup.js
@@ -209,32 +209,40 @@ function populateGroupFromResults(socrataGroup, json) {
         if (!geo || !defined(item.childViews)) { // items without a 'childViews' seem to be themselves child views
           continue;
         }
+        var id = item.category ?
+        socrataGroup.uniqueId + '/' + item.category + '/' + item.id :
+        socrataGroup.uniqueId + '/' + item.id;
 
-        var newItem;
-        // Socrata is currently transitioning from a Geoserver/OWS tiling system to a "new backend" with GeoJSON download but no
-        // reliable public tiling endpoint.
-        if (item.newBackend) {
-            newItem = new GeoJsonCatalogItem(socrataGroup.terria);
-            // We have to choose a number of features to truncate to. We can go as high as 50,000 but in the case of Melbourne's
-            // urban forest canopies dataset, the file becomes 71MB.
-            newItem.url = socrataGroup.url + '/resource/' + item.childViews[0] + '.geojson' + '?$limit=10000';
-        } else {
-            newItem = new WebMapServiceCatalogItem(socrataGroup.terria);
-            newItem.url = socrataGroup.url + geo.owsUrl;
-            newItem.layers = geo.layers;
-            if (geo.namespace) {
-              // Socrata gives us a list of layers like 'geo_foo,geo_bar', but we need to prepend them with the WMS namespace.
-              newItem.layers = geo.namespace + ':' + newItem.layers.replace(/,/g, ',' + geo.namespace + ':');
-            }
-            if (geo.bboxCrs === 'EPSG:4326' && defined (geo.bbox)) {
-                var parts = geo.bbox.split(',');
-                if (parts.length === 4) {
-                    newItem.rectangle = Rectangle.fromDegrees(parts[0], parts[1], parts[2], parts[3]);
+        var newItem = socrataGroup.terria.catalog.shareKeyIndex[id];
+
+        var alreadyExists = defined(newItem);
+        if (!alreadyExists) {
+            // Socrata is currently transitioning from a Geoserver/OWS tiling system to a "new backend" with GeoJSON download but no
+            // reliable public tiling endpoint.
+            if (item.newBackend) {
+                newItem = new GeoJsonCatalogItem(socrataGroup.terria);
+                // We have to choose a number of features to truncate to. We can go as high as 50,000 but in the case of Melbourne's
+                // urban forest canopies dataset, the file becomes 71MB.
+                newItem.url = socrataGroup.url + '/resource/' + item.childViews[0] + '.geojson' + '?$limit=10000';
+            } else {
+                newItem = new WebMapServiceCatalogItem(socrataGroup.terria);
+                newItem.url = socrataGroup.url + geo.owsUrl;
+                newItem.layers = geo.layers;
+                if (geo.namespace) {
+                    // Socrata gives us a list of layers like 'geo_foo,geo_bar', but we need to prepend them with the WMS namespace.
+                    newItem.layers = geo.namespace + ':' + newItem.layers.replace(/,/g, ',' + geo.namespace + ':');
+                }
+                if (geo.bboxCrs === 'EPSG:4326' && defined(geo.bbox)) {
+                    var parts = geo.bbox.split(',');
+                    if (parts.length === 4) {
+                        newItem.rectangle = Rectangle.fromDegrees(parts[0], parts[1], parts[2], parts[3]);
+                    }
                 }
             }
         }
 
         newItem.name = item.name;
+        newItem.id = id;
 
         if (defined(item.description)) {
             newItem.info.push({

--- a/lib/Models/SocrataCatalogGroup.js
+++ b/lib/Models/SocrataCatalogGroup.js
@@ -135,21 +135,7 @@ freezeObject(SocrataCatalogGroup.defaultUpdaters);
  */
 SocrataCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-SocrataCatalogGroup.defaultSerializers.items = function(socrataGroup, json, propertyName, options) {
-    // duplicated from CkanCatalogGroup - see comments there.
-    var previousSerializeForSharing = options.serializeForSharing;
-    options.serializeForSharing = true;
-
-    var previousEnabledItemsOnly = options.enabledItemsOnly;
-    options.enabledItemsOnly = true;
-
-    var result = CatalogGroup.defaultSerializers.items(socrataGroup, json, propertyName, options);
-
-    options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeForSharing = previousSerializeForSharing;
-
-    return result;
-};
+SocrataCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 SocrataCatalogGroup.defaultSerializers.isLoading = function(socrataGroup, json, propertyName, options) {};
 

--- a/lib/Models/SocrataCatalogGroup.js
+++ b/lib/Models/SocrataCatalogGroup.js
@@ -20,7 +20,7 @@ var CatalogGroup = require('./CatalogGroup');
 var TerriaError = require('../Core/TerriaError');
 
 /**
- * A {@link CatalogGroup} representing a collection of layers from a [Socrata](http://Socrata.org) server. Only spatial layers with a defined Map 
+ * A {@link CatalogGroup} representing a collection of layers from a [Socrata](http://Socrata.org) server. Only spatial layers with a defined Map
  * visualisation are shown, using WMS.
  *
  * @alias SocrataCatalogGroup
@@ -39,10 +39,10 @@ var SocrataCatalogGroup = function(terria) {
     this.url = '';
     /**
      * Gets or sets the filter query to pass to Socrata when querying the available data sources and their groups.  Each string in the
-     * array is passed to Socrata as an independent search string and the results are concatenated to create the complete list. 
+     * array is passed to Socrata as an independent search string and the results are concatenated to create the complete list.
      * @type {String[]}
      */
-    this.filterQuery = ['limitTo=MAPS']; 
+    this.filterQuery = ['limitTo=MAPS'];
 
     /**
      * Gets or sets a description of the custodian of the data sources in this group.
@@ -211,13 +211,13 @@ function populateGroupFromResults(socrataGroup, json) {
         }
 
         var newItem;
-        // Socrata is currently transitioning from a Geoserver/OWS tiling system to a "new backend" with GeoJSON download but no 
+        // Socrata is currently transitioning from a Geoserver/OWS tiling system to a "new backend" with GeoJSON download but no
         // reliable public tiling endpoint.
         if (item.newBackend) {
             newItem = new GeoJsonCatalogItem(socrataGroup.terria);
             // We have to choose a number of features to truncate to. We can go as high as 50,000 but in the case of Melbourne's
             // urban forest canopies dataset, the file becomes 71MB.
-            newItem.url = socrataGroup.url + '/resource/' + item.childViews[0] + '.geojson' + '?$limit=10000'; 
+            newItem.url = socrataGroup.url + '/resource/' + item.childViews[0] + '.geojson' + '?$limit=10000';
         } else {
             newItem = new WebMapServiceCatalogItem(socrataGroup.terria);
             newItem.url = socrataGroup.url + geo.owsUrl;
@@ -232,7 +232,7 @@ function populateGroupFromResults(socrataGroup, json) {
                     newItem.rectangle = Rectangle.fromDegrees(parts[0], parts[1], parts[2], parts[3]);
                 }
             }
-        }        
+        }
 
         newItem.name = item.name;
 
@@ -245,8 +245,8 @@ function populateGroupFromResults(socrataGroup, json) {
         if (defined(item.license) && defined(item.license.name)) {
             newItem.info.push({
                 name:'Licence',
-                content: 
-                    (item.license.logoUrl ? '<img src=' + socrataGroup.url + '/' + item.license.logoUrl + ' /> &nbsp;' : '') + 
+                content:
+                    (item.license.logoUrl ? '<img src=' + socrataGroup.url + '/' + item.license.logoUrl + ' /> &nbsp;' : '') +
                     (item.license.termsLink ? '<a href="' + item.license.termsLink + '">' + item.license.name + '</a>' : item.license.name)
             });
         }
@@ -277,6 +277,7 @@ function populateGroupFromResults(socrataGroup, json) {
             if (!defined(existingGroup)) {
                 existingGroup = new CatalogGroup(socrataGroup.terria);
                 existingGroup.name = item.category;
+                existingGroup.id = item.category;
                 socrataGroup.add(existingGroup);
             }
             existingGroup.add(newItem);
@@ -284,6 +285,6 @@ function populateGroupFromResults(socrataGroup, json) {
             socrataGroup.add(newItem);
         }
     }
-} 
+}
 
 module.exports = SocrataCatalogGroup;

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -448,7 +448,11 @@ Terria.prototype.addInitSource = function(initSource) {
 
     // Populate the catalog
     if (defined(initSource.catalog)) {
-        promise = promise.then(this.catalog.updateFromJson.bind(this.catalog, initSource.catalog));
+        var isUserSupplied = !initSource.isFromExternalFile;
+
+        promise = promise.then(this.catalog.updateFromJson.bind(this.catalog, initSource.catalog, {
+            isUserSupplied: isUserSupplied
+        }));
     }
 
     if (defined(initSource.sharedCatalogMembers)) {

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -452,19 +452,7 @@ Terria.prototype.addInitSource = function(initSource) {
     }
 
     if (defined(initSource.sharedCatalogMembers)) {
-        initSource.sharedCatalogMembers.forEach(function(id) {
-            promise = promise.then(function () {
-                var sharedMember = this.catalog.shareKeyIndex[id];
-
-                if (defined(sharedMember)) {
-                    var memberLoadPromise = sharedMember.load() || when(); // load() sometimes returns undefined.
-
-                    return memberLoadPromise.then(function() {
-                        sharedMember.enableWithParents();
-                    });
-                }
-            }.bind(this));
-        }, this);
+        this.catalog.enableByShareKeys(initSource.sharedCatalogMembers);
     }
 
     return promise;

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -562,17 +562,25 @@ function generateInitializationUrl(url) {
 
 function loadInitSources(terria, initSources) {
     return when.all(initSources.map(loadInitSource.bind(undefined, terria)), function(initSources) {
-        var promises = [];
+        var promises = [], updateSources = [];
 
         for (var i = 0; i < initSources.length; ++i) {
             var initSource = initSources[i];
             if (!defined(initSource)) {
                 continue;
             }
-            promises.push(terria.addInitSource(initSource));
+
+            if (initSource.catalogOnlyUpdatesExistingItems) {
+                updateSources.push(initSource);
+            } else {
+                promises.push(terria.addInitSource(initSource));
+            }
         }
 
-        return when.all(promises);
+        // Execute init sources, then execute the sources that update them
+        return when.all(promises).then(function() {
+            return updateSources.map(terria.addInitSource.bind(terria));
+        });
     });
 }
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -456,7 +456,7 @@ Terria.prototype.addInitSource = function(initSource) {
     }
 
     if (defined(initSource.sharedCatalogMembers)) {
-        this.catalog.updateByShareKeys(initSource.sharedCatalogMembers);
+        promise = promise.then(this.catalog.updateByShareKeys.bind(this.catalog, initSource.sharedCatalogMembers));
     }
 
     return promise;

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -413,6 +413,8 @@ Terria.prototype.getUserProperty = function(propertyName) {
 };
 
 Terria.prototype.addInitSource = function(initSource) {
+    var promise = when();
+
     // Extract the list of CORS-ready domains.
     if (defined(initSource.corsDomains)) {
         corsProxy.corsDomains.push.apply(corsProxy.corsDomains, initSource.corsDomains);
@@ -446,22 +448,26 @@ Terria.prototype.addInitSource = function(initSource) {
 
     // Populate the catalog
     if (defined(initSource.catalog)) {
-        var isUserSupplied;
-        if (initSource.isFromExternalFile) {
-            isUserSupplied = false;
-        } else if (initSource.catalogOnlyUpdatesExistingItems) {
-            isUserSupplied = undefined;
-        } else {
-            isUserSupplied = true;
-        }
-
-        return this.catalog.updateFromJson(initSource.catalog, {
-            onlyUpdateExistingItems: initSource.catalogOnlyUpdatesExistingItems,
-            isUserSupplied: isUserSupplied
-        });
-    } else {
-        return when();
+        promise = promise.then(this.catalog.updateFromJson.bind(this.catalog, initSource.catalog));
     }
+
+    if (defined(initSource.sharedCatalogMembers)) {
+        initSource.sharedCatalogMembers.forEach(function(id) {
+            promise = promise.then(function () {
+                var sharedMember = this.catalog.shareKeyIndex[id];
+
+                if (defined(sharedMember)) {
+                    var memberLoadPromise = sharedMember.load() || when(); // load() sometimes returns undefined.
+
+                    return memberLoadPromise.then(function() {
+                        sharedMember.enableWithParents();
+                    });
+                }
+            }.bind(this));
+        }, this);
+    }
+
+    return promise;
 };
 
 Terria.prototype.getLocalProperty = function(key) {
@@ -562,7 +568,7 @@ function generateInitializationUrl(url) {
 
 function loadInitSources(terria, initSources) {
     return when.all(initSources.map(loadInitSource.bind(undefined, terria)), function(initSources) {
-        var promises = [], updateSources = [];
+        var promise = when();
 
         for (var i = 0; i < initSources.length; ++i) {
             var initSource = initSources[i];
@@ -570,17 +576,10 @@ function loadInitSources(terria, initSources) {
                 continue;
             }
 
-            if (initSource.catalogOnlyUpdatesExistingItems) {
-                updateSources.push(initSource);
-            } else {
-                promises.push(terria.addInitSource(initSource));
-            }
+            promise = promise.then(terria.addInitSource.bind(terria, initSource));
         }
 
-        // Execute init sources, then execute the sources that update them
-        return when.all(promises).then(function() {
-            return updateSources.map(terria.addInitSource.bind(terria));
-        });
+        return promise;
     });
 }
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -254,7 +254,7 @@ var Terria = function(options) {
 
     /**
      * Gets or sets the configuration parameters set at startup.
-     * Contains: 
+     * Contains:
      * * regionMappingDefinitionsUrl: URL of JSON file containing region mapping definitions
      * * conversionServiceBaseUrl: URL of OGR2OGR conversion service
      * * proj4ServiceBaseUrl: URL of proj4def lookup service
@@ -264,7 +264,7 @@ var Terria = function(options) {
     this.configParameters = defaultConfigParameters;
 
     if (defined(options.regionMappingDefinitionsUrl)) {
-        deprecationWarning('regionMappingDefinitionsUrl', 'terria.regionMappingDefinitionsUrl is deprecated. Set parameters: { regionMappingDefinitionsUrl: ...} in config.json, or accept the default (\'data/regionMapping.json\').'); 
+        deprecationWarning('regionMappingDefinitionsUrl', 'terria.regionMappingDefinitionsUrl is deprecated. Set parameters: { regionMappingDefinitionsUrl: ...} in config.json, or accept the default (\'data/regionMapping.json\').');
         this.configParameters.regionMappingDefinitionsUrl = options.regionMappingDefinitionsUrl;
     }
 
@@ -346,7 +346,7 @@ Terria.prototype.start = function(options) {
 
         corsProxy.proxyDomains.push.apply(corsProxy.proxyDomains, config.proxyDomains);
         corsProxy.baseProxyUrl = that.configParameters.corsProxyBaseUrl;
-        
+
         that.analytics.start(that.configParameters);
         that.analytics.logEvent('launch', 'url', defined(applicationUrl.href) ? applicationUrl.href : 'empty');
 
@@ -452,7 +452,7 @@ Terria.prototype.addInitSource = function(initSource) {
     }
 
     if (defined(initSource.sharedCatalogMembers)) {
-        this.catalog.enableByShareKeys(initSource.sharedCatalogMembers);
+        this.catalog.updateByShareKeys(initSource.sharedCatalogMembers);
     }
 
     return promise;
@@ -555,20 +555,15 @@ function generateInitializationUrl(url) {
 }
 
 function loadInitSources(terria, initSources) {
-    return when.all(initSources.map(loadInitSource.bind(undefined, terria)), function(initSources) {
-        var promise = when();
-
-        for (var i = 0; i < initSources.length; ++i) {
-            var initSource = initSources[i];
-            if (!defined(initSource)) {
-                continue;
-            }
-
-            promise = promise.then(terria.addInitSource.bind(terria, initSource));
-        }
-
-        return promise;
-    });
+    return initSources.reduce(function (promiseSoFar, initSource) {
+        return promiseSoFar
+            .then(loadInitSource.bind(undefined, terria, initSource))
+            .then(function (initSource) {
+                if (defined(initSource)) {
+                    return terria.addInitSource(initSource);
+                }
+            });
+    }, when());
 }
 
 function loadInitSource(terria, source) {

--- a/lib/Models/UrthecastCatalogGroup.js
+++ b/lib/Models/UrthecastCatalogGroup.js
@@ -111,7 +111,7 @@ function createSensorPlatformsGroup(catalogGroup, sensorPlatforms) {
         }
     }
 
-    catalogGroup.items.push(sensorPlatformsGroup);
+    catalogGroup.add(sensorPlatformsGroup);
 }
 
 function createCatalogItem(catalogGroup, sensor) {
@@ -133,7 +133,7 @@ function createCatalogItem(catalogGroup, sensor) {
         item.renderer = renderers[i].id;
         item.description = true;
 
-        catalogGroup.items.push(item);
+        catalogGroup.add(item);
     }
 }
 

--- a/lib/Models/WebFeatureServiceCatalogGroup.js
+++ b/lib/Models/WebFeatureServiceCatalogGroup.js
@@ -235,7 +235,7 @@ function addFeatureTypes(wfsGroup, featureTypes, items, parent, supportsJsonGetF
             continue;
         }
 
-        items.push(createWfsDataSource(wfsGroup, featureType, supportsJsonGetFeature, dataCustodian));
+        wfsGroup.add(createWfsDataSource(wfsGroup, featureType, supportsJsonGetFeature, dataCustodian));
     }
 }
 

--- a/lib/Models/WebFeatureServiceCatalogGroup.js
+++ b/lib/Models/WebFeatureServiceCatalogGroup.js
@@ -103,23 +103,7 @@ defineProperties(WebFeatureServiceCatalogGroup.prototype, {
  */
 WebFeatureServiceCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-WebFeatureServiceCatalogGroup.defaultSerializers.items = function(wfsGroup, json, propertyName, options) {
-    // Only serialize minimal properties in contained items, because other properties are loaded from GetCapabilities.
-    var previousSerializeForSharing = options.serializeForSharing;
-    options.serializeForSharing = true;
-
-    // Only serlize enabled items as well.  This isn't quite right - ideally we'd serialize any
-    // property of any item if the property's value is changed from what was loaded from GetCapabilities -
-    // but this gives us reasonable results for sharing and is a lot less work than the ideal
-    // solution.
-    var previousEnabledItemsOnly = options.enabledItemsOnly;
-    options.enabledItemsOnly = true;
-
-    CatalogGroup.defaultSerializers.items(wfsGroup, json, propertyName, options);
-
-    options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeForSharing = previousSerializeForSharing;
-};
+WebFeatureServiceCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 WebFeatureServiceCatalogGroup.defaultSerializers.isLoading = function(wfsGroup, json, propertyName, options) {};
 

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -131,25 +131,7 @@ defineProperties(WebMapServiceCatalogGroup.prototype, {
  */
 WebMapServiceCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-WebMapServiceCatalogGroup.defaultSerializers.items = function(wmsGroup, json, propertyName, options) {
-    // Only serialize minimal properties in contained items, because other properties are loaded from GetCapabilities.
-    var previousSerializeForSharing = options.serializeForSharing;
-    options.serializeForSharing = true;
-
-    // Only serlize enabled items as well.  This isn't quite right - ideally we'd serialize any
-    // property of any item if the property's value is changed from what was loaded from GetCapabilities -
-    // but this gives us reasonable results for sharing and is a lot less work than the ideal
-    // solution.
-    var previousEnabledItemsOnly = options.enabledItemsOnly;
-    options.enabledItemsOnly = true;
-
-    var result = CatalogGroup.defaultSerializers.items(wmsGroup, json, propertyName, options);
-
-    options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeForSharing = previousSerializeForSharing;
-
-    return result;
-};
+WebMapServiceCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;;
 
 WebMapServiceCatalogGroup.defaultSerializers.isLoading = function(wmsGroup, json, propertyName, options) {};
 

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -131,7 +131,7 @@ defineProperties(WebMapServiceCatalogGroup.prototype, {
  */
 WebMapServiceCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-WebMapServiceCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;;
+WebMapServiceCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 WebMapServiceCatalogGroup.defaultSerializers.isLoading = function(wmsGroup, json, propertyName, options) {};
 

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -196,7 +196,7 @@ sending an email to <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.
                 rootLayers = singleRoot.Layer;
             }
 
-            addLayersRecursively(that, json, rootLayers, that.items, parentLayer);
+            addLayersRecursively(that, that, json, rootLayers, parentLayer);
         }
     }).otherwise(function(e) {
         throw new TerriaError({
@@ -237,7 +237,7 @@ function getNameFromLayer(wmsGroup, layer) {
     }
 }
 
-function addLayersRecursively(wmsGroup, capabilities, layers, items, parent) {
+function addLayersRecursively(wmsGroup, parentGroup, capabilities, layers, parent) {
     if (!(layers instanceof Array)) {
         layers = [layers];
     }
@@ -254,13 +254,10 @@ function addLayersRecursively(wmsGroup, capabilities, layers, items, parent) {
         }
 
         if (defined(layer.Layer)) {
-            var recurseItems = items;
-
-            var group;
+            var group = parentGroup;
             if (!wmsGroup.flatten) {
                 // Create a group for this layer
                 group = createWmsSubGroup(wmsGroup, layer);
-                recurseItems = group.items;
             }
 
             // WMS 1.1.1 spec section 7.1.4.5.2 says any layer with a Name property can be used
@@ -275,22 +272,22 @@ function addLayersRecursively(wmsGroup, capabilities, layers, items, parent) {
                     all.name = allName + ' ' + all.name;
                 }
 
-                recurseItems.push(all);
+                group.add(all);
             }
 
-            addLayersRecursively(wmsGroup, capabilities, layer.Layer, recurseItems, layer);
+            addLayersRecursively(wmsGroup, group, capabilities, layer.Layer, layer);
 
             if (!wmsGroup.flatten) {
-                if (recurseItems.length === 1 && recurseItems[0].name.indexOf(allName) === 0) {
-                    recurseItems[0].name = originalNameForAll;
-                    items.push(recurseItems[0]);
-                } else if (recurseItems.length > 0) {
-                    items.push(group);
+                if (group.items.length === 1 && group.items[0].name.indexOf(allName) === 0) {
+                    group.items[0].name = originalNameForAll;
+                    parentGroup.add(group.items[0]);
+                } else if (group.items.length > 0) {
+                    parentGroup.add(group);
                 }
             }
         }
         else {
-            items.push(createWmsDataSource(wmsGroup, capabilities, layer));
+            parentGroup.add(createWmsDataSource(wmsGroup, capabilities, layer));
         }
     }
 }

--- a/lib/Models/WebMapTileServiceCatalogGroup.js
+++ b/lib/Models/WebMapTileServiceCatalogGroup.js
@@ -120,25 +120,7 @@ defineProperties(WebMapTileServiceCatalogGroup.prototype, {
  */
 WebMapTileServiceCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-WebMapTileServiceCatalogGroup.defaultSerializers.items = function(wmtsGroup, json, propertyName, options) {
-    // Only serialize minimal properties in contained items, because other properties are loaded from GetCapabilities.
-    var previousSerializeForSharing = options.serializeForSharing;
-    options.serializeForSharing = true;
-
-    // Only serlize enabled items as well.  This isn't quite right - ideally we'd serialize any
-    // property of any item if the property's value is changed from what was loaded from GetCapabilities -
-    // but this gives us reasonable results for sharing and is a lot less work than the ideal
-    // solution.
-    var previousEnabledItemsOnly = options.enabledItemsOnly;
-    options.enabledItemsOnly = true;
-
-    var result = CatalogGroup.defaultSerializers.items(wmtsGroup, json, propertyName, options);
-
-    options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeForSharing = previousSerializeForSharing;
-
-    return result;
-};
+WebMapTileServiceCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 WebMapTileServiceCatalogGroup.defaultSerializers.isLoading = function(wmtsGroup, json, propertyName, options) {};
 

--- a/lib/Models/WebMapTileServiceCatalogGroup.js
+++ b/lib/Models/WebMapTileServiceCatalogGroup.js
@@ -234,7 +234,7 @@ function createWmtsDataSource(wmtsGroup, capabilities, layer) {
         result.updateFromJson(wmtsGroup.itemProperties);
     }
 
-    wmtsGroup.items.push(result);
+    wmtsGroup.add(result);
 
     return result;
 }

--- a/lib/Models/WfsFeaturesCatalogGroup.js
+++ b/lib/Models/WfsFeaturesCatalogGroup.js
@@ -140,7 +140,7 @@ defineProperties(WfsFeaturesCatalogGroup.prototype, {
  */
 WfsFeaturesCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-WfsFeaturesCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;;
+WfsFeaturesCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 WfsFeaturesCatalogGroup.defaultSerializers.isLoading = function(wfsGroup, json, propertyName, options) {};
 

--- a/lib/Models/WfsFeaturesCatalogGroup.js
+++ b/lib/Models/WfsFeaturesCatalogGroup.js
@@ -140,23 +140,7 @@ defineProperties(WfsFeaturesCatalogGroup.prototype, {
  */
 WfsFeaturesCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 
-WfsFeaturesCatalogGroup.defaultSerializers.items = function(wfsGroup, json, propertyName, options) {
-    // Only serialize minimal properties in contained items, because other properties are loaded from GetCapabilities.
-    var previousSerializeForSharing = options.serializeForSharing;
-    options.serializeForSharing = true;
-
-    // Only serialize enabled items as well.  This isn't quite right - ideally we'd serialize any
-    // property of any item if the property's value is changed from what was loaded from GetCapabilities -
-    // but this gives us reasonable results for sharing and is a lot less work than the ideal
-    // solution.
-    var previousEnabledItemsOnly = options.enabledItemsOnly;
-    options.enabledItemsOnly = true;
-
-    CatalogGroup.defaultSerializers.items(wfsGroup, json, propertyName, options);
-
-    options.enabledItemsOnly = previousEnabledItemsOnly;
-    options.serializeForSharing = previousSerializeForSharing;
-};
+WfsFeaturesCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;;
 
 WfsFeaturesCatalogGroup.defaultSerializers.isLoading = function(wfsGroup, json, propertyName, options) {};
 

--- a/lib/Models/WfsFeaturesCatalogGroup.js
+++ b/lib/Models/WfsFeaturesCatalogGroup.js
@@ -234,10 +234,10 @@ sending an email to <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.
                 if (!defined(group)) {
                     group = groups[feature.properties[that.groupByProperty]] = new CatalogGroup(that.terria);
                     group.name = feature.properties[that.groupByProperty];
-                    that.items.push(group);
+                    that.add(group);
                 }
             }
-            group.items.push(item);
+            group.add(item);
         }
     }).otherwise(function(e) {
         throw new TerriaError({

--- a/lib/Models/addUserCatalogMember.js
+++ b/lib/Models/addUserCatalogMember.js
@@ -9,7 +9,7 @@ var TerriaError = require('../Core/TerriaError');
 
 /**
  * Adds a user's catalog item or group to the catalog.
- * 
+ *
  * @param  {Terria} terria The Terria instance to contain the catalog member.
  * @param {CatalogItem|Promise} newCatalogItemOrPromise The catalog member to add, or a promise for a catalog member.
  * @param {Object} [options] An object with the following members:
@@ -26,7 +26,9 @@ var addUserCatalogMember = function(terria, newCatalogMemberOrPromise, options) 
             return;
         }
 
-        terria.catalog.userAddedDataGroup.items.push(newCatalogItem);
+        newCatalogItem.isUserSupplied = true;
+
+        terria.catalog.userAddedDataGroup.add(newCatalogItem);
 
         if (defaultValue(options.open, true) && defined(newCatalogItem.isOpen)) {
             newCatalogItem.isOpen = true;

--- a/lib/ViewModels/SharePopupViewModel.js
+++ b/lib/ViewModels/SharePopupViewModel.js
@@ -10,7 +10,9 @@ var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 
 var inherit = require('../Core/inherit');
+var combineFilters = require('../Core/combineFilters');
 var TerriaError = require('../Core/TerriaError');
+var CatalogMember = require('../Models/CatalogMember');
 var PopupViewModel = require('./PopupViewModel');
 
 /**
@@ -90,14 +92,21 @@ inherit(PopupViewModel, SharePopupViewModel);
  * @private
  */
 SharePopupViewModel.prototype._addUserAddedCatalog = function(initSources) {
-    var localDataFilterRemembering = rememberRejections(localDataFilter);
+    var localDataFilterRemembering = rememberRejections(CatalogMember.itemFilters.noLocalData);
 
     var userAddedCatalog = this.terria.catalog.serializeToJson({
         itemFilter: combineFilters([
             localDataFilterRemembering.filter,
-            userSuppliedOnlyFilter
+            CatalogMember.itemFilters.userSuppliedOnly,
+            function(item) {
+                // If the parent has a URL then this item will just load from that, so don't bother serializing it.
+                // Properties that change when an item is enabled like opacity will be included in the shared members
+                // anyway.
+                return !item.parent || !item.parent.url;
+            }
         ])
     });
+
     this.itemsSkippedBecauseTheyHaveLocalData = localDataFilterRemembering.rejections;
 
     // Add an init source with user-added catalog members.
@@ -113,16 +122,15 @@ SharePopupViewModel.prototype._addUserAddedCatalog = function(initSources) {
  * @private
  */
 SharePopupViewModel.prototype._addSharedMembers = function(initSources) {
-    var catalogForSharing = flattenCatalog(this.terria.catalog.group.items)
-        .filter(combineFilters([
-            enabledFilter,
-            localDataFilter
-        ]))
-        .map(function(catalogItem) {
-            return catalogItem.serializeToJson({
-                propertyFilter: combineFilters([noRecursionFilter, sharedPropertyFilter])
-            });
-        });
+    var catalogForSharing = flattenCatalog(this.terria.catalog.serializeToJson({
+        itemFilter: combineFilters([
+            CatalogMember.itemFilters.noLocalData
+        ]),
+        propertyFilter: CatalogMember.propertyFilters.sharedOnly
+    })).filter(function(item) {
+        // Filter out groups.
+        return item.isEnabled;
+    });
 
     if (catalogForSharing.length > 0) {
         initSources.push({
@@ -229,55 +237,6 @@ SharePopupViewModel.open = function(options) {
 };
 
 /**
- * Combines a number of functions that take a single argument and return a boolean into a single function that executes
- * all of them and returns true only if all them do.
- *
- * @param {Array} fns A number of functions to combine into one logical function.
- * @returns {Function} The resulting function.
- */
-function combineFilters(fns) {
-    return function() {
-        var outerArgs = arguments;
-
-        return fns.reduce(function(soFar, fn) {
-            return soFar && fn.apply(this, outerArgs);
-        }, true);
-    };
-}
-
-/**
- * Item filter that true if an item has no local data.
- */
-function localDataFilter(item) {
-    return !defined(item.data);
-}
-
-/**
- * Property filter that returns true if the property is in that item's {@link CatalogMember#propertiesForSharing} array.
- */
-function sharedPropertyFilter(property, item) {
-    return item.propertiesForSharing.indexOf(property) >= 0;
-}
-
-/**
- * Property filter that ensures serializeToJson doesn't recurse into sub-items, and just flatly serializes a single
- * catalog member.
- */
-function noRecursionFilter(property) {
-    return property !== 'items';
-}
-
-/** Item filter that returns true if the item is user supplied */
-function userSuppliedOnlyFilter(item) {
-    return item.isUserSupplied;
-}
-
-/** Item filter that returns true if the item is an enabled {@link CatalogItem}. */
-function enabledFilter(item) {
-    return item.isEnabled;
-}
-
-/**
  * Wraps around a filter function and records all items that are excluded by it. Does not modify the function passed in.
  *
  * @param filterFn The fn to wrap around
@@ -311,10 +270,34 @@ function flattenCatalog(items) {
 
         if (item.items) {
             soFar = soFar.concat(flattenCatalog(item.items));
+            item.items = undefined;
         }
 
         return soFar;
     }, []);
+}
+
+/**
+ * Traverses a serialized version of the catalog, removing groups that have no items. This is done after serializeToJson
+ * is called because it cleans up groups that are left empty by the filters passed to that function. This function will
+ * mutate the items property of objects passed to it.
+ *
+ * @param items {Object[]} An array of serialized catalog members to filter. Will also go into the items property of
+ *      objects in this array and filter out empty groups in them too.
+ * @returns {Object[]} a trimmed array of serialized objects.
+ */
+function trimEmptyGroups(items) {
+    return items
+        .map(function(item) {
+            if (defined(item.items)) {
+                item.items = trimEmptyGroups(item.items);
+            }
+
+            return item;
+        })
+        .filter(function(item) {
+            return !defined(item.items) || item.items.length;
+        });
 }
 
 module.exports = SharePopupViewModel;

--- a/lib/ViewModels/SharePopupViewModel.js
+++ b/lib/ViewModels/SharePopupViewModel.js
@@ -113,22 +113,23 @@ SharePopupViewModel.prototype._addUserAddedCatalog = function(initSources) {
  * @private
  */
 SharePopupViewModel.prototype._addSharedMembers = function(initSources) {
-    var catalogForSharing = this.terria.catalog.serializeToJson({
-        itemFilter: combineFilters([
+    var catalogForSharing = flattenCatalog(this.terria.catalog.group.items)
+        .filter(combineFilters([
             enabledFilter,
-            localDataFilter,
-            populatedGroupsFilter
-        ]),
-        propertyFilter: sharedPropertyFilter
-    });
+            localDataFilter
+        ]))
+        .map(function(catalogItem) {
+            return catalogItem.serializeToJson({
+                propertyFilter: combineFilters([noRecursionFilter, sharedPropertyFilter])
+            });
+        });
 
     if (catalogForSharing.length > 0) {
         initSources.push({
-            sharedCatalogMembers: flattenSerializedItems(catalogForSharing)
-                .reduce(function(soFar, item) {
-                    soFar[item.id] = item;
-                    return soFar;
-                }, {})
+            sharedCatalogMembers: catalogForSharing.reduce(function(soFar, item) {
+                soFar[item.id] = item;
+                return soFar;
+            }, {})
         });
     }
 };
@@ -258,19 +259,22 @@ function sharedPropertyFilter(property, item) {
     return item.propertiesForSharing.indexOf(property) >= 0;
 }
 
+/**
+ * Property filter that ensures serializeToJson doesn't recurse into sub-items, and just flatly serializes a single
+ * catalog member.
+ */
+function noRecursionFilter(property) {
+    return property !== 'items';
+}
+
 /** Item filter that returns true if the item is user supplied */
 function userSuppliedOnlyFilter(item) {
     return item.isUserSupplied;
 }
 
-/** Item filter that returns true if the item is an enabled {@link CatalogItem} or an open {@link CatalogGroup}. */
+/** Item filter that returns true if the item is an enabled {@link CatalogItem}. */
 function enabledFilter(item) {
-    return item.isEnabled || item.isOpen;
-}
-
-/** Group filter that returns true if the item is a {@link CatalogGroup} with at least one child item. */
-function populatedGroupsFilter(item) {
-    return !(defined(item.items) && item.items.length === 0);
+    return item.isEnabled;
 }
 
 /**
@@ -301,13 +305,12 @@ function rememberRejections(filterFn) {
  * Takes the hierarchy of serialized catalog members returned by {@link serializeToJson} and flattens it into an Array.
  * @returns {Array}
  */
-function flattenSerializedItems(items) {
+function flattenCatalog(items) {
     return items.reduce(function (soFar, item) {
         soFar.push(item);
 
         if (item.items) {
-            soFar = soFar.concat(flattenSerializedItems(item.items));
-            item.items = undefined;
+            soFar = soFar.concat(flattenCatalog(item.items));
         }
 
         return soFar;

--- a/lib/ViewModels/SharePopupViewModel.js
+++ b/lib/ViewModels/SharePopupViewModel.js
@@ -125,9 +125,10 @@ SharePopupViewModel.prototype._addSharedMembers = function(initSources) {
     if (catalogForSharing.length > 0) {
         initSources.push({
             sharedCatalogMembers: flattenSerializedItems(catalogForSharing)
-                .map(function(item) {
-                    return item.id;
-                })
+                .reduce(function(soFar, item) {
+                    soFar[item.id] = item;
+                    return soFar;
+                }, {})
         });
     }
 };

--- a/lib/ViewModels/SharePopupViewModel.js
+++ b/lib/ViewModels/SharePopupViewModel.js
@@ -53,8 +53,6 @@ var SharePopupViewModel = function(options) {
     });
 
     // Build the share URL.
-    var cameraExtent = this.terria.currentViewer.getCurrentExtent();
-
     var request = {
         version: '0.0.05',
         initSources: this.terria.initSources.slice()
@@ -62,34 +60,84 @@ var SharePopupViewModel = function(options) {
 
     var initSources = request.initSources;
 
-    // Add an init source with user-added catalog members.
-    var userDataSerializeOptions = {
-        userSuppliedOnly: true,
-        skipItemsWithLocalData: true,
-        itemsSkippedBecauseTheyHaveLocalData: []
-    };
+    this._addUserAddedCatalog(initSources);
+    this._addSharedMembers(initSources);
+    this._addViewSettings(initSources);
 
-    var userAddedCatalog = this.terria.catalog.serializeToJson(userDataSerializeOptions);
+    var uri = new URI(window.location);
+
+    // Remove the portion of the URL after the hash.
+    uri.fragment('');
+
+    var requestString = JSON.stringify(request);
+
+    this._baseUrl = uri.toString() + '#start=';
+    this._shortBaseUrl = uri.toString() + '#share=';
+
+    this._longUrl = this._baseUrl + encodeURIComponent(requestString) + this._generateUserPropertiesQuery();
+
+    setShareUrl(this);
+
+    this.terria.currentViewer.captureScreenshot().then(function(dataUrl) {
+        that.imageUrl = dataUrl;
+    });
+};
+
+inherit(PopupViewModel, SharePopupViewModel);
+
+/**
+ * Adds user-added catalog members to the passed initSources.
+ * @private
+ */
+SharePopupViewModel.prototype._addUserAddedCatalog = function(initSources) {
+    var localDataFilterRemembering = rememberRejections(localDataFilter);
+
+    var userAddedCatalog = this.terria.catalog.serializeToJson({
+        itemFilter: combineFilters([
+            localDataFilterRemembering.filter,
+            userSuppliedOnlyFilter
+        ])
+    });
+    this.itemsSkippedBecauseTheyHaveLocalData = localDataFilterRemembering.rejections;
+
+    // Add an init source with user-added catalog members.
     if (userAddedCatalog.length > 0) {
         initSources.push({
-            catalog: userAddedCatalog,
-            catalogIsUserSupplied: true
+            catalog: userAddedCatalog
         });
     }
+};
 
-    // Add an init source with the enabled/opened catalog members.
-    var enabledAndOpenedCatalog = this.terria.catalog.serializeToJson({
-        enabledItemsOnly: true,
-        skipItemsWithLocalData: true,
-        serializeForSharing: true,
+/**
+ * Adds existing catalog members that the user has enabled or opened to the passed initSources object.
+ * @private
+ */
+SharePopupViewModel.prototype._addSharedMembers = function(initSources) {
+    var catalogForSharing = this.terria.catalog.serializeToJson({
+        itemFilter: combineFilters([
+            enabledFilter,
+            localDataFilter,
+            populatedGroupsFilter
+        ]),
+        propertyFilter: sharedPropertyFilter
     });
 
-    if (enabledAndOpenedCatalog.length > 0) {
+    if (catalogForSharing.length > 0) {
         initSources.push({
-            catalog: enabledAndOpenedCatalog,
-            catalogOnlyUpdatesExistingItems: true
+            sharedCatalogMembers: flattenSerializedItems(catalogForSharing)
+                .map(function(item) {
+                    return item.id;
+                })
         });
     }
+};
+
+/**
+ * Adds the details of the current view to the init sources.
+ * @private
+ */
+SharePopupViewModel.prototype._addViewSettings = function(initSources) {
+    var cameraExtent = this.terria.currentViewer.getCurrentExtent();
 
     // Add an init source with the camera position.
     var initialCamera = {
@@ -122,41 +170,25 @@ var SharePopupViewModel = function(options) {
         baseMapName: this.terria.baseMap.name,
         viewerMode: this.terria.leaflet ? '2d': '3d'
     });
-
-    // Add user properties if applicable
-    var userPropertiesQuery = '';
-    this.userPropWhiteList.map(function(key) {
-        var val = this.terria.userProperties[key];
-        if (defined(val)) {
-            userPropertiesQuery += '&' + key + '=' + encodeURIComponent(val);
-        }
-    }, this);
-
-    this.itemsSkippedBecauseTheyHaveLocalData.push.apply(this.itemsSkippedBecauseTheyHaveLocalData, userDataSerializeOptions.itemsSkippedBecauseTheyHaveLocalData);
-
-    var uri = new URI(window.location);
-
-    // Remove the portion of the URL after the hash.
-    uri.fragment('');
-
-    var requestString = JSON.stringify(request);
-
-    this._baseUrl = uri.toString() + '#start=';
-    this._shortBaseUrl = uri.toString() + '#share=';
-
-    this._longUrl = this._baseUrl + encodeURIComponent(requestString) + userPropertiesQuery;
-
-    setShareUrl(that);
-
-    this.terria.currentViewer.captureScreenshot().then(function(dataUrl) {
-        that.imageUrl = dataUrl;
-    });
 };
 
-inherit(PopupViewModel, SharePopupViewModel);
+/**
+ * Generates a query string for custom user properties.
+ *
+ * @returns {String}
+ * @private
+ */
+SharePopupViewModel.prototype._generateUserPropertiesQuery = function() {
+    return this.userPropWhiteList.reduce(function(querySoFar, key) {
+        var val = this.terria.userProperties[key];
+        if (defined(val)) {
+            return querySoFar + '&' + key + '=' + encodeURIComponent(val);
+        }
+        return querySoFar;
+    }.bind(this), '');
+};
 
 function setShareUrl(viewModel) {
-
     var iframeString = '<iframe style="width: 720px; height: 405px; border: none;" src="_TARGET_" allowFullScreen mozAllowFullScreen webkitAllowFullScreen></iframe>';
 
     function setUrlAndEmbed(url) {
@@ -193,5 +225,92 @@ SharePopupViewModel.open = function(options) {
     viewModel.show(options.container);
     return viewModel;
 };
+
+/**
+ * Combines a number of functions that take a single argument and return a boolean into a single function that executes
+ * all of them and returns true only if all them do.
+ *
+ * @param {Array} fns A number of functions to combine into one logical function.
+ * @returns {Function} The resulting function.
+ */
+function combineFilters(fns) {
+    return function() {
+        var outerArgs = arguments;
+
+        return fns.reduce(function(soFar, fn) {
+            return soFar && fn.apply(this, outerArgs);
+        }, true);
+    };
+}
+
+/**
+ * Item filter that true if an item has no local data.
+ */
+function localDataFilter(item) {
+    return !defined(item.data);
+}
+
+/**
+ * Property filter that returns true if the property is in that item's {@link CatalogMember#propertiesForSharing} array.
+ */
+function sharedPropertyFilter(property, item) {
+    return item.propertiesForSharing.indexOf(property) >= 0;
+}
+
+/** Item filter that returns true if the item is user supplied */
+function userSuppliedOnlyFilter(item) {
+    return item.isUserSupplied;
+}
+
+/** Item filter that returns true if the item is an enabled {@link CatalogItem} or an open {@link CatalogGroup}. */
+function enabledFilter(item) {
+    return item.isEnabled || item.isOpen;
+}
+
+/** Group filter that returns true if the item is a {@link CatalogGroup} with at least one child item. */
+function populatedGroupsFilter(item) {
+    return !(defined(item.items) && item.items.length === 0);
+}
+
+/**
+ * Wraps around a filter function and records all items that are excluded by it. Does not modify the function passed in.
+ *
+ * @param filterFn The fn to wrap around
+ * @returns {{filter: filter, rejections: Array}} The resulting filter function that remembers rejections, and an array
+ *          array of the rejected items. As the filter function is used, the rejections array with be populated.
+ */
+function rememberRejections(filterFn) {
+    var rejections = [];
+
+    return {
+        filter: function(item) {
+            var allowed = filterFn(item);
+
+            if (!allowed) {
+                rejections.push(item);
+            }
+
+            return allowed;
+        },
+        rejections: rejections
+    };
+}
+
+/**
+ * Takes the hierarchy of serialized catalog members returned by {@link serializeToJson} and flattens it into an Array.
+ * @returns {Array}
+ */
+function flattenSerializedItems(items) {
+    return items.reduce(function (soFar, item) {
+        soFar.push(item);
+
+        if (item.items) {
+            soFar = soFar.concat(flattenSerializedItems(item.items));
+            item.items = undefined;
+        }
+
+        return soFar;
+    }, []);
+}
 
 module.exports = SharePopupViewModel;

--- a/lib/ViewModels/SharePopupViewModel.js
+++ b/lib/ViewModels/SharePopupViewModel.js
@@ -277,27 +277,4 @@ function flattenCatalog(items) {
     }, []);
 }
 
-/**
- * Traverses a serialized version of the catalog, removing groups that have no items. This is done after serializeToJson
- * is called because it cleans up groups that are left empty by the filters passed to that function. This function will
- * mutate the items property of objects passed to it.
- *
- * @param items {Object[]} An array of serialized catalog members to filter. Will also go into the items property of
- *      objects in this array and filter out empty groups in them too.
- * @returns {Object[]} a trimmed array of serialized objects.
- */
-function trimEmptyGroups(items) {
-    return items
-        .map(function(item) {
-            if (defined(item.items)) {
-                item.items = trimEmptyGroups(item.items);
-            }
-
-            return item;
-        })
-        .filter(function(item) {
-            return !defined(item.items) || item.items.length;
-        });
-}
-
 module.exports = SharePopupViewModel;

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -4,6 +4,7 @@
 var URI = require('urijs');
 
 var CatalogGroup = require('../Models/CatalogGroup');
+var CatalogMember = require('../Models/CatalogMember');
 var corsProxy = require('../Core/corsProxy');
 var loadView = require('../Core/loadView');
 var pollToPromise = require('../Core/pollToPromise');

--- a/lib/ViewModels/ToolsPanelViewModel.js
+++ b/lib/ViewModels/ToolsPanelViewModel.js
@@ -81,7 +81,7 @@ ToolsPanelViewModel.prototype.cacheTiles = function() {
 
 ToolsPanelViewModel.prototype.exportFile = function() {
     //Create the initialization file text
-    var catalog =  this.terria.catalog.serializeToJson({serializeForSharing:false});
+    var catalog =  this.terria.catalog.serializeToJson({itemFilter: CatalogMember.propertyFilters.sharedOnly});
     var camera = getDegreesRect( this.terria.homeView.rectangle);
     var initJsonObject = { corsDomains: corsProxy.corsDomains, camera: camera, services: [], catalog: catalog};
     var initFile = JSON.stringify(initJsonObject, null, 4);
@@ -537,7 +537,7 @@ function requestTiles(toolsPanel, requests, minLevel, maxLevel) {
                 popup.message += '<div>Server=' + uri.toString() + '</div>';
                 popup.message += '<div>Layers=' + params.layers + '</div>';
             }
- 
+
             failedRequests += last.stat.error.number;
 
             if (average > maxAverage || last.stat.success.max > maxMaximum) {
@@ -843,7 +843,7 @@ function requestAbsData(requests) {
         popup.message += '<h2>Caching ' + requests[currentIndex].item.name + '</h2>';
         if (elPopup !== null) {
             elPopup.scrollTop = elPopup.scrollHeight - elPopup.offsetHeight;
-        } 
+        }
 
         when(requests[currentIndex].item._cache()).then(function(){
             if (defined(requests[currentIndex].item._postCache)) {

--- a/lib/ViewModels/updateApplicationOnMessageFromParentWindow.js
+++ b/lib/ViewModels/updateApplicationOnMessageFromParentWindow.js
@@ -4,7 +4,7 @@
 var raiseErrorToUser = require('../Models/raiseErrorToUser');
 
 var updateApplicationOnMessageFromParentWindow = function(terria, window) {
-    if (!window.parent) {
+    if (!window.parent || window.parent === window) {
         return;
     }
 

--- a/test/Core/combineFiltersSpec.js
+++ b/test/Core/combineFiltersSpec.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var combineFilters = require('../../lib/Core/combineFilters');
+
+describe('combineFilters', function() {
+    describe('basic tests:', function() {
+        it('returns true when all filters true', function() {
+            expect(combineFilters([
+                function() { return true; },
+                function() { return true; },
+                function() { return true; }
+            ])()).toBe(true);
+        });
+
+        it('returns false when all functions false', function() {
+            expect(combineFilters([
+                function() { return false; },
+                function() { return false; },
+                function() { return false; }
+            ])()).toBe(false);
+        });
+
+        it('returns false when one functions false', function() {
+            expect(combineFilters([
+                function() { return false; },
+                function() { return true; },
+                function() { return false; }
+            ])()).toBe(false);
+        });
+    });
+
+    it('passes arguments through to all filters', function() {
+        var filters = [
+            jasmine.createSpy('spy1').and.returnValue(true),
+            jasmine.createSpy('spy2').and.returnValue(true),
+            jasmine.createSpy('spy3').and.returnValue(true)
+        ];
+
+        combineFilters(filters)('I', 'am', 'an', 'elephant');
+
+        filters.forEach(function(filterSpy) {
+           expect(filterSpy).toHaveBeenCalledWith('I', 'am', 'an', 'elephant');
+        });
+    });
+
+    it('stops on first false result', function() {
+        var filters = [
+            jasmine.createSpy('spy1').and.returnValue(true),
+            jasmine.createSpy('spy2').and.returnValue(false),
+            jasmine.createSpy('spy3').and.returnValue(true)
+        ];
+
+        combineFilters(filters)();
+
+        expect(filters[0]).toHaveBeenCalled();
+        expect(filters[1]).toHaveBeenCalled();
+        expect(filters[2]).not.toHaveBeenCalled();
+    });
+
+    describe('only calls a function once', function() {
+        it('if it\'s specified multiple times', function() {
+            var spy1 =jasmine.createSpy('spy1').and.returnValue(true);
+
+            var filters = [
+                spy1,
+                jasmine.createSpy('spy2').and.returnValue(true),
+                spy1
+            ];
+
+            combineFilters(filters)();
+
+            expect(spy1.calls.count()).toBe(1);
+        });
+
+        it('if combineFilters() is called on the result of another combineFilters() call', function() {
+            var spy1 = jasmine.createSpy('spy1').and.returnValue(true);
+
+            var combined = combineFilters([
+                spy1,
+                spy1
+            ]);
+
+            combineFilters([combined, spy1])();
+
+            expect(spy1.calls.count()).toBe(1);
+        });
+    });
+});

--- a/test/Models/AbsIttCatalogItemSpec.js
+++ b/test/Models/AbsIttCatalogItemSpec.js
@@ -54,6 +54,7 @@ describe('AbsIttCatalogItem', function() {
     it('can be round-tripped with serializeToJson and updateFromJson', function() {
         item.updateFromJson({
             name: 'Name',
+            id: 'Id',
             description: 'Description',
             rectangle: [-10, 10, -20, 20],
             url: 'http://foo.bar/',

--- a/test/Models/CatalogGroupSpec.js
+++ b/test/Models/CatalogGroupSpec.js
@@ -13,7 +13,8 @@ describe('CatalogGroup', function() {
         terria = new Terria({
             baseUrl: './'
         });
-        group = new CatalogGroup(terria);
+        group = terria.catalog.group;
+        group.preserveOrder = false;
         createCatalogMemberFromType.register('group', CatalogGroup);
         createCatalogMemberFromType.register('item', CatalogItem);
     });

--- a/test/Models/CatalogGroupSpec.js
+++ b/test/Models/CatalogGroupSpec.js
@@ -275,4 +275,39 @@ describe('CatalogGroup', function() {
             });
         });
     });
+
+    it('adds new children to the catalog index', function() {
+        var item1 = new CatalogItem(terria);
+        item1.id = 'blah';
+
+        group.add(item1);
+
+        expect(terria.catalog.shareKeyIndex['blah']).toBe(item1);
+    });
+
+    describe('removes removed children from the catalog index', function() {
+        it('when child has a specific id', function() {
+            var item1 = new CatalogItem(terria);
+            item1.id = 'blah';
+
+            group.add(item1);
+            group.remove(item1);
+
+            expect(terria.catalog.shareKeyIndex['blah']).toBeUndefined();
+        });
+
+        it('when child has no id', function() {
+            var item1 = new CatalogItem(terria);
+            item1.name = 'blah';
+            group.name = 'foo';
+
+            group.add(item1);
+
+            expect(terria.catalog.shareKeyIndex['foo/blah']).toBe(item1);
+
+            group.remove(item1);
+
+            expect(terria.catalog.shareKeyIndex['foo/blah']).toBeUndefined();
+        });
+    });
 });

--- a/test/Models/CatalogItemSpec.js
+++ b/test/Models/CatalogItemSpec.js
@@ -2,19 +2,24 @@
 
 /*global require*/
 var CatalogItem = require('../../lib/Models/CatalogItem');
+var CatalogGroup = require('../../lib/Models/CatalogGroup');
+var Catalog = require('../../lib/Models/Catalog');
 var Terria = require('../../lib/Models/Terria');
+var createCatalogMemberFromType = require('../../lib/Models/createCatalogMemberFromType');
 
-describe('CatalogItem', function() {
+describe('CatalogItem', function () {
     var terria;
     var item;
-    beforeEach(function() {
+    beforeEach(function () {
         terria = new Terria({
             baseUrl: './'
         });
         item = new CatalogItem(terria);
+        createCatalogMemberFromType.register('group', CatalogGroup);
+        createCatalogMemberFromType.register('item', CatalogItem);
     });
 
-    it('uses the url as the direct dataUrl', function() {
+    it('uses the url as the direct dataUrl', function () {
         item.url = 'http://foo.bar';
 
         expect(item.dataUrlType).toBe('direct');
@@ -25,7 +30,7 @@ describe('CatalogItem', function() {
         expect(item.dataUrl).toBe('http://something.else');
     });
 
-    it('explicit dataUrl and dataUrlType overrides using url', function() {
+    it('explicit dataUrl and dataUrlType overrides using url', function () {
         item.url = 'http://foo.bar';
         item.dataUrl = 'http://something.else';
         item.dataUrlType = 'wfs';
@@ -37,5 +42,70 @@ describe('CatalogItem', function() {
         item.url = 'http://hello.there';
         expect(item.dataUrl).toBe('http://something.else');
         expect(item.dataUrlType).toBe('wfs');
+    });
+
+    describe('ids', function () {
+        var catalog;
+
+        beforeEach(function (done) {
+            catalog = new Catalog(terria);
+
+            catalog.updateFromJson([
+                {
+                    name: 'Group',
+                    type: 'group',
+                    items: [
+                        {
+                            name: 'A',
+                            type: 'item'
+                        },
+                        {
+                            name: 'B',
+                            id: 'thisIsAnId',
+                            type: 'item'
+                        },
+                        {
+                            name: 'C',
+                            type: 'item',
+                            shareKeys: ['Another/Path']
+                        },
+                        {
+                            name: 'D',
+                            id: 'thisIsAnotherId',
+                            shareKeys: ['This/Is/A/Path', 'aPreviousId'],
+                            type: 'item'
+                        }
+                    ]
+                }
+            ]).then(done);
+        });
+
+        describe('uniqueId', function () {
+            it('should return path if no id is specified', function () {
+                expect(catalog.group.items[0].items[0].uniqueId).toBe('Root Group/Group/A');
+            });
+
+            it('should return id field if one is specified', function () {
+                expect(catalog.group.items[0].items[1].uniqueId).toBe('thisIsAnId');
+            });
+        });
+
+        describe('allShareKeys', function () {
+            it('should return just the path if no id or shareKeys are specified', function() {
+                expect(catalog.group.items[0].items[0].allShareKeys).toEqual(['Root Group/Group/A']);
+            });
+
+            it('should return just the id if id but no shareKeys are specified', function() {
+                expect(catalog.group.items[0].items[1].allShareKeys).toEqual(['thisIsAnId']);
+            });
+
+            it('should return the path and shareKeys if no id specified', function() {
+                expect(catalog.group.items[0].items[2].allShareKeys).toEqual(['Root Group/Group/C', 'Another/Path']);
+            });
+
+            it('should return the id and shareKeys if id specified', function() {
+                expect(catalog.group.items[0].items[3].allShareKeys).toEqual(['thisIsAnotherId', 'This/Is/A/Path', 'aPreviousId']);
+            });
+        });
     });
 });

--- a/test/Models/CatalogSpec.js
+++ b/test/Models/CatalogSpec.js
@@ -3,7 +3,6 @@
 /*global require,describe,it,expect,beforeEach*/
 var Terria = require('../../lib/Models/Terria');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
-var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var Catalog = require('../../lib/Models/Catalog');
 var CatalogItem = require('../../lib/Models/CatalogItem');

--- a/test/Models/CatalogSpec.js
+++ b/test/Models/CatalogSpec.js
@@ -10,10 +10,12 @@ var createCatalogMemberFromType = require('../../lib/Models/createCatalogMemberF
 var CatalogGroup = require('../../lib/Models/CatalogGroup');
 var GeoJsonCatalogItem = require('../../lib/Models/GeoJsonCatalogItem');
 var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
+var WebMapServiceCatalogItem = require('../../lib/Models/WebMapServiceCatalogItem');
 
 
 describe('Catalog', function() {
-    var terria;
+    var terria
+    var catalog;
 
     beforeEach(function() {
         terria = new Terria({
@@ -22,6 +24,8 @@ describe('Catalog', function() {
         createCatalogMemberFromType.register('group', CatalogGroup);
         createCatalogMemberFromType.register('item', CatalogItem);
         createCatalogMemberFromType.register('imageryLayerCatalogItem', ImageryLayerCatalogItem);
+        createCatalogMemberFromType.register('wms', WebMapServiceCatalogItem);
+        catalog = terria.catalog;
     });
 
     it('can register group and geojson, and update from json', function(done) {
@@ -39,11 +43,6 @@ describe('Catalog', function() {
     });
 
     describe('updateByShareKeys', function () {
-        var catalog;
-
-        beforeEach(function() {
-            catalog = terria.catalog;
-        });
 
         it('works when resolving by id', function (done) {
             catalog.updateFromJson([
@@ -213,6 +212,75 @@ describe('Catalog', function() {
                 expect(catalog.group.items[0].opacity).toBe(0.3);
                 done();
             }).otherwise(fail);
+        });
+    });
+
+    describe('serializeToJson', function () {
+        beforeEach(function(done) {
+            catalog.updateFromJson([
+                {
+                    name: 'A',
+                    type: 'group',
+                    items: [
+                        {
+                            id: 'C',
+                            name: 'C',
+                            type: 'wms'
+                        }
+                    ]
+                },
+                {
+                    name: 'B',
+                    type: 'group',
+                    items: [
+                        {
+                            id: 'D',
+                            name: 'D',
+                            type: 'wms'
+                        }
+                    ]
+                }
+            ]).then(done);
+        });
+
+        it('serializes the catalog recursively', function() {
+            var serialized = catalog.serializeToJson();
+
+            expect(serialized.length).toBe(2);
+            expect(serialized[0].name).toBe('A');
+            expect(serialized[1].items.length).toBe(1);
+            expect(serialized[1].items[0].name).toBe('D');
+        });
+
+        it('can round-trip a basic catalog', function(done) {
+            var serialized = catalog.serializeToJson();
+            var newCatalog = new Catalog(terria);
+            newCatalog.updateFromJson(serialized).then(function() {
+                expect(newCatalog.items).toEqual(catalog.items);
+                done();
+            }).otherwise(fail);
+        });
+
+        it('ignores properties filtered out by propertyFilter', function() {
+            var serialized = catalog.serializeToJson({
+                propertyFilter: function(property, item) {
+                    return property !== 'name';
+                }
+            });
+
+            expect(serialized[0].name).toBeUndefined();
+            expect(serialized[0].id).toBe('Root Group/A');
+        });
+
+        it('ignores items filtered out by itemFilter', function() {
+            var serialized = catalog.serializeToJson({
+                itemFilter: function(item) {
+                    return item.name !== 'C';
+                }
+            });
+
+            expect(serialized[0].items.length).toBe(0);
+            expect(serialized[1].items.length).toBe(1);
         });
     });
 });

--- a/test/Models/CatalogSpec.js
+++ b/test/Models/CatalogSpec.js
@@ -14,7 +14,7 @@ var WebMapServiceCatalogItem = require('../../lib/Models/WebMapServiceCatalogIte
 
 
 describe('Catalog', function() {
-    var terria
+    var terria;
     var catalog;
 
     beforeEach(function() {

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -277,7 +277,7 @@ describe('CsvCatalogItem with lat and lon', function() {
             expect(desc(1)).toContain('boots');
         }).otherwise(fail).then(done);
     });
-    
+
     it('has a blank in the description table for a missing number', function(done) {
         csvItem.url = 'test/missingNumberFormatting.csv';
         return csvItem.load().then(function() {
@@ -303,14 +303,14 @@ describe('CsvCatalogItem with lat and lon', function() {
             csvItem2.url = 'test/csv/lat_lon_val.csv';
             return csvItem2.load().yield(csvItem2);
         }).then(function(csvItem2) {
-            var pixelSizes = csvItem2.dataSource.entities.values.map(function(e) { return e.point._pixelSize._value; });
-            var minPix = Math.min.apply(null, pixelSizes);
-            var maxPix = Math.max.apply(null, pixelSizes);
-            // again, we don't specify the base size, but x10 things should be twice as big as x5 things.
-            expect(maxPix).toEqual(csvItem._maxPix * 2);
-            expect(minPix).toEqual(csvItem._minPix * 2);
-        })
-        .otherwise(fail).then(done);
+                var pixelSizes = csvItem2.dataSource.entities.values.map(function(e) { return e.point._pixelSize._value; });
+                var minPix = Math.min.apply(null, pixelSizes);
+                var maxPix = Math.max.apply(null, pixelSizes);
+                // again, we don't specify the base size, but x10 things should be twice as big as x5 things.
+                expect(maxPix).toEqual(csvItem._maxPix * 2);
+                expect(minPix).toEqual(csvItem._minPix * 2);
+            })
+            .otherwise(fail).then(done);
     });
 
     // Removed: not clear that this is correct behaviour, and it's failing.
@@ -546,7 +546,7 @@ describe('CsvCatalogItem with region mapping', function() {
             // On 2015-08-07, only postcodes 3121 and 3122 have values. On neighboring dates, so do 3123 and 3124.
             var recolorFunction = ImageryProviderHooks.addRecolorFunc.calls.argsFor(0)[1];
             var regionNames = regionDetail.regionProvider.regions.map(getId);
-            
+
             expect(recolorFunction(regionNames.indexOf('3121'))).toBeDefined();
             expect(recolorFunction(regionNames.indexOf('3122'))).toBeDefined();
             expect(recolorFunction(regionNames.indexOf('3123'))).not.toBeDefined();

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -98,6 +98,7 @@ describe('CsvCatalogItem with lat and lon', function() {
         var dataStr = 'col1, col2\ntest, 0';
         csvItem.updateFromJson({
             name: 'Name',
+            id: 'Id',
             description: 'Description',
             rectangle: [-10, 10, -20, 20],
             url: 'http://my.csv.com/test.csv',

--- a/test/Models/WebMapServiceCatalogItemSpec.js
+++ b/test/Models/WebMapServiceCatalogItemSpec.js
@@ -252,6 +252,7 @@ describe('WebMapServiceCatalogItem', function() {
 
     it('can be round-tripped with serializeToJson and updateFromJson', function() {
         wmsItem.name = 'Name';
+        wmsItem.id = 'Id';
         wmsItem.description = 'Description';
         wmsItem.rectangle = Rectangle.fromDegrees(-10, 10, -20, 20);
         wmsItem.legendUrl = new LegendUrl('http://legend.com', 'image/png');

--- a/test/ViewModels/CatalogItemNameSearchProviderViewModelSpec.js
+++ b/test/ViewModels/CatalogItemNameSearchProviderViewModelSpec.js
@@ -221,12 +221,13 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
 
         var item1 = new CatalogItem(terria);
         item1.name = 'Thing to find';
+        item1.id = 'thing1';
         catalogGroup.add(item1);
 
         var item2 = new CatalogItem(terria);
         item2.name = 'Thing to find';
+        item2.id = 'thing2';
         catalogGroup.add(item2);
-
 
         searchProvider.search('to').then(function() {
             expect(searchProvider.searchResults.length).toBe(2);

--- a/wwwroot/test/GetCapabilities/BOM.xml
+++ b/wwwroot/test/GetCapabilities/BOM.xml
@@ -2782,7 +2782,7 @@ For further information please visit the website http://www.bom.gov.au/water/geo
         </Layer>
         <Layer queryable="1">
           <Name>ahgf_shn:AHGFWaterbody</Name>
-          <Title>AHGFWaterbody</Title>
+          <Title>AHGFWaterbody2</Title>
           <Abstract>This is a web service of the Australian Hydrological Geospatial Fabric (Geofabric). &#13;
 For further information please visit the website http://www.bom.gov.au/water/geofabric/index.shtml</Abstract>
           <KeywordList>
@@ -2956,7 +2956,7 @@ For further information please visit the website http://www.bom.gov.au/water/geo
         </Layer>
         <Layer queryable="1">
           <Name>ahgf_gwc:AHGFWaterTableAquifer</Name>
-          <Title>AHGFWaterTableAquifer</Title>
+          <Title>AHGFWaterTableAquifer2</Title>
           <Abstract>This is a web service of the Australian Hydrological Geospatial Fabric (Geofabric). &#13;
 For further information please visit the website http://www.bom.gov.au/water/geofabric/index.shtml</Abstract>
           <KeywordList>


### PR DESCRIPTION
Fixes #986
- Catalog items/groups now look for an "id" field in the JSON, this
  enables share links to work even if the item is renamed or moved.
- If no id is present, share link generation falls back to the path of the
  catalog member
- Catalog members can specify shareKeys when renaming or changing an id to
  preserve compatibility with old share links.
- If no id is present in a share link, the old name-based matching
  functionality is used to preserve compatibility with old share links.
- Matching when performing updates on catalog groups is now done by id
  rather than name where possible.
