### PR TITLE
Added ability to show raw data of feature

### DIFF
--- a/lib/Styles/FeatureInfoPanel.less
+++ b/lib/Styles/FeatureInfoPanel.less
@@ -71,7 +71,6 @@
 .feature-info-panel-body {
     .opaque-to-input;
 }
-//data-bind="style: { 'max-width': maxWidth + 'px' }
 
 .feature-info-panel-sections {
     overflow-y: auto;
@@ -124,7 +123,20 @@
     top: 6px;
     cursor: pointer;
     font-size: 12pt;
-    color: @info-header-text-color;
+    color: @info-text-color;
+}
+
+.feature-info-panel-toggle-raw-data-button {
+    cursor: pointer;
+    font-size: 10pt;
+    float: right;
+    margin-right: 20px;
+    margin-bottom: 10px;
+    color: @info-text-color;
+
+    &:hover {
+        color: @panel-emphasized-text-color;
+    }
 }
 
 .cesium-infoBox-defaultTable td {

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -29,6 +29,18 @@ var FeatureInfoPanelSectionViewModel = function(terria, feature, catalogItem) {
     this.feature = feature;
     this.name = feature.name ? feature.name : '';
     var template = defined(catalogItem) ? catalogItem.featureInfoTemplate : undefined;
+    var data = propertyValues(feature.properties, terria.clock);
+
+    knockout.track(this, ['name', 'templatedInfo', 'rawData', 'catalogItemName', 'rawDataVisible']);
+    knockout.track(this.terria, ['selectedFeature']);
+
+    // Use a white background when displaying complete HTML documents rather than just snippets.
+    knockout.defineProperty(this, 'useWhiteBackground', {
+        get: function() {
+            return htmlTagRegex.test(this.rawData);
+        }
+    });
+
     if (defined(template)) {
         // template may be a string, eg. '<div>{{{Foo}}} Hello {{name}}</div>'
         if (typeof template === 'string') {
@@ -44,23 +56,16 @@ var FeatureInfoPanelSectionViewModel = function(terria, feature, catalogItem) {
             }
         }
     }
-    this.info = htmlFromFeature(this, terria.clock);
+
+    this.rawDataVisible = false; // raw data should be hidden on init unless there's no template
+
+    this._updateContent(data);
+
     this.catalogItemName = defined(catalogItem) ? catalogItem.name : '';
     configureHtmlUpdater(this);
 
     this.svgArrowDown = svgArrowDown;
     this.svgArrowRight = svgArrowRight;
-
-    knockout.track(this, ['name', 'info', 'catalogItemName']);
-    knockout.track(this.terria, ['selectedFeature']);
-
-    // Use a white background when displaying complete HTML documents rather than just snippets.
-    knockout.defineProperty(this, 'useWhiteBackground', {
-        get: function() {
-            return htmlTagRegex.test(this.info);
-        }
-    });
-
 };
 
 /**
@@ -91,6 +96,27 @@ FeatureInfoPanelSectionViewModel.prototype.toggleOpen = function() {
 
     // ensure the targeting cursor keeps updating (as it is hooked into the Cesium render loop)
     this.terria.currentViewer.notifyRepaintRequired();
+};
+
+FeatureInfoPanelSectionViewModel.prototype._updateContent = function(data) {
+    if (defined(this.template)) {
+        this.templatedInfo = Mustache.render(this.template, data, this.partials);
+    }
+    if (defined(this.feature.description)) {
+        this.rawData = this.feature.description.getValue(this.terria.clock.currentTime);
+    } else if (defined(data)) {
+        // There is no template, and no description - just return the properties as JSON.
+        // TODO: Turn it into a table at source.
+        this.rawData = JSON.stringify(data);
+    }
+};
+
+FeatureInfoPanelSectionViewModel.prototype.showRawData = function() {
+    this.rawDataVisible = true;
+};
+
+FeatureInfoPanelSectionViewModel.prototype.hideRawData = function() {
+    this.rawDataVisible = false;
 };
 
 // Recursively replace '.' and '#' in property keys with _, since Mustache cannot reference keys with these characters.
@@ -128,28 +154,10 @@ function propertyValues(properties, clock) {
     return replaceBadKeyCharacters(result);
 }
 
-function htmlFromFeature(viewModel, clock) {
-    // If a template is defined, render it using feature.properties.
-    // If no template is provided, show feature.description.
-    var feature = viewModel.feature;
-    var data = propertyValues(feature.properties, clock);
-    if (defined(viewModel.template)) {
-        return Mustache.render(viewModel.template, data, viewModel.partials);
-    }
-    if (defined(feature.description)) {
-        return feature.description.getValue(clock.currentTime);
-    }
-    if (defined(data)) {
-        // There is no template, and no description - just return the properties as JSON.
-        // TODO: Turn it into a table at source.
-        return JSON.stringify(data);
-    }
-}
-
 function addInfoUpdater(viewModel) {
     // the return value of addEventListener is a function which removes the event listener
     viewModel._clockSubscription = viewModel.terria.clock.onTick.addEventListener(function(clock) {
-        viewModel.info = htmlFromFeature(viewModel, clock);
+        viewModel._updateContent(propertyValues(viewModel.feature.properties, viewModel.terria.clock));
     });
 }
 

--- a/lib/Views/FeatureInfoPanelSection.html
+++ b/lib/Views/FeatureInfoPanelSection.html
@@ -9,7 +9,11 @@
         <span class="feature-info-panel-section-label" data-bind="text: catalogItemName"></span>
         <span class="feature-info-panel-section-label" data-bind="text: name"></span>
     </div>
-    <div class="feature-info-panel-section-content-wrapper" data-bind ="css:feature == terria.selectedFeature ?'open': 'closed'">
-    <div class="feature-info-panel-section-content" data-bind="markdown: info, css: { 'feature-info-panel-section-content-white-background': useWhiteBackground }"></div>
+    <div class="feature-info-panel-section-content-wrapper" data-bind="css:feature == terria.selectedFeature ?'open': 'closed'">
+        <div class="feature-info-panel-section-content" data-bind="html: templatedInfo, visible: templatedInfo"></div>
+        <button class="feature-info-panel-toggle-raw-data-button" data-bind="visible: templatedInfo && !rawDataVisible, click: showRawData">Show Raw Data</button>
+        <button class="feature-info-panel-toggle-raw-data-button" data-bind="visible: templatedInfo && rawDataVisible, click: hideRawData">Hide Raw Data</button>
+        <div class="feature-info-panel-section-content" data-bind="html: rawData, visible: rawData && (!templatedInfo || rawDataVisible),
+          css: { 'feature-info-panel-section-content-white-background': useWhiteBackground }"></div>
     </div>
 </div>

--- a/test/ViewModels/FeatureInfoPanelSectionViewModelSpec.js
+++ b/test/ViewModels/FeatureInfoPanelSectionViewModelSpec.js
@@ -47,4 +47,59 @@ describe('FeatureInfoPanelSectionViewModel', function() {
         section.destroy();
     });
 
+    describe('when template is provided', function () {
+        var section;
+
+        beforeEach(function () {
+            var catalogItem = {
+                featureInfoTemplate: '<div>{{blah}}</div>'
+            };
+
+            section = new FeatureInfoPanelSectionViewModel(terria, feature, catalogItem);
+        });
+
+        describe('rawDataVisible', function () {
+            it('should be false on init', function () {
+                expect(section.rawDataVisible).toBe(false);
+            });
+
+            it('should be true once showRawData is called', function () {
+                section.showRawData();
+
+                expect(section.rawDataVisible).toBe(true);
+            });
+
+            it('should be false once hideRawData is called', function () {
+                section.showRawData();
+                section.hideRawData();
+
+                expect(section.rawDataVisible).toBe(false);
+            });
+        });
+
+        it('rawData should still be available', function() {
+           expect(section.rawData).toBeDefined();
+        });
+
+        it('templatedInfo should be available', function() {
+            expect(section.templatedInfo).toBeDefined();
+        });
+    });
+
+    describe('when template is not provided', function () {
+        var section;
+
+        beforeEach(function () {
+            section = new FeatureInfoPanelSectionViewModel(terria, feature, {});
+        });
+
+        it('templatedInfo should not be available', function () {
+            expect(section.templatedInfo).not.toBeDefined();
+        });
+
+        it('rawData should be available', function () {
+            expect(section.rawData).toBeDefined();
+        });
+    });
+
 });

--- a/test/ViewModels/FeatureInfoPanelViewModelSpec.js
+++ b/test/ViewModels/FeatureInfoPanelViewModelSpec.js
@@ -151,7 +151,7 @@ describe('FeatureInfoPanelViewModel templating', function() {
             pickedFeatures.allFeaturesAvailablePromise = runLater(function() {});
 
             panel.showFeatures(pickedFeatures).then(function() {
-                expect(regex.test(panel.sections[0].info.replace(/\n/g, ''))).toBe(true);
+                expect(regex.test(panel.sections[0].rawData.replace(/\n/g, ''))).toBe(true);
             }).otherwise(done.fail).then(done);
         }).otherwise(done.fail);
 
@@ -168,7 +168,7 @@ describe('FeatureInfoPanelViewModel templating', function() {
             pickedFeatures.allFeaturesAvailablePromise = runLater(function() {});
 
             panel.showFeatures(pickedFeatures).then(function() {
-                expect(panel.sections[0].info).toBe('A Hoop_Big made of Stainless Steel with Capex funding.');
+                expect(panel.sections[0].templatedInfo).toBe('A Hoop_Big made of Stainless Steel with Capex funding.');
             }).otherwise(done.fail).then(done);
         }).otherwise(done.fail);
     });
@@ -184,7 +184,7 @@ describe('FeatureInfoPanelViewModel templating', function() {
             pickedFeatures.allFeaturesAvailablePromise = runLater(function() {});
 
             panel.showFeatures(pickedFeatures).then(function() {
-                expect(panel.sections[0].info).toBe('historic.# -12; file.number. 10; documents.#1 4');
+                expect(panel.sections[0].templatedInfo).toBe('historic.# -12; file.number. 10; documents.#1 4');
             }).otherwise(done.fail).then(done);
         }).otherwise(done.fail);
     });
@@ -201,7 +201,7 @@ describe('FeatureInfoPanelViewModel templating', function() {
             pickedFeatures.allFeaturesAvailablePromise = runLater(function() {});
 
             panel.showFeatures(pickedFeatures).then(function() {
-                expect(panel.sections[0].info).toBe('<div>Hello Jay&lt;br&gt; - Jay<br></div>');
+                expect(panel.sections[0].templatedInfo).toBe('<div>Hello Jay&lt;br&gt; - Jay<br></div>');
             }).otherwise(done.fail).then(done);
         }).otherwise(done.fail);
 
@@ -218,7 +218,7 @@ describe('FeatureInfoPanelViewModel templating', function() {
             pickedFeatures.allFeaturesAvailablePromise = runLater(function() {});
 
             panel.showFeatures(pickedFeatures).then(function() {
-                expect(panel.sections[0].info).toBe('<div>test <b>Hoop_Big</b></div>');
+                expect(panel.sections[0].templatedInfo).toBe('<div>test <b>Hoop_Big</b></div>');
             }).otherwise(done.fail).then(done);
         }).otherwise(done.fail);
     });
@@ -275,7 +275,7 @@ describe('FeatureInfoPanelViewModel templating', function() {
                     +       '</ul>'
                     +   '</li>'
                     + '</ul>';
-                expect(panel.sections[0].info).toBe(recursedHtml);
+                expect(panel.sections[0].templatedInfo).toBe(recursedHtml);
             }).otherwise(done.fail).then(done);
         }).otherwise(done.fail);
     });
@@ -323,7 +323,7 @@ describe('FeatureInfoPanelViewModel CZML templating', function() {
             pickedFeatures.allFeaturesAvailablePromise = runLater(function() {});
 
             return panel.showFeatures(pickedFeatures).then(function() {
-                expect(panel.sections[0].info).toEqual(target);
+                expect(panel.sections[0].templatedInfo).toEqual(target);
             });
         }).then(done).otherwise(done.fail);
     });
@@ -344,15 +344,15 @@ describe('FeatureInfoPanelViewModel CZML templating', function() {
             terria.clock.currentTime = JulianDate.fromIso8601('2010-02-02');
 
             return panel.showFeatures(pickedFeatures).then(function() {
-                expect(panel.sections[0].info).toEqual(targetBlank);
+                expect(panel.sections[0].templatedInfo).toEqual(targetBlank);
 
                 terria.clock.currentTime = JulianDate.fromIso8601('2012-02-02');
                 terria.clock.tick();
-                expect(panel.sections[0].info).toEqual(targetABC);
+                expect(panel.sections[0].templatedInfo).toEqual(targetABC);
 
                 terria.clock.currentTime = JulianDate.fromIso8601('2014-02-02');
                 terria.clock.tick();
-                expect(panel.sections[0].info).toEqual(targetDEF);
+                expect(panel.sections[0].templatedInfo).toEqual(targetDEF);
             });
         }).then(done).otherwise(done.fail);
 


### PR DESCRIPTION
Fixes #1171 

There's now a button in the feature panel that allows the raw data for a feature to be shown if templated data is normally available, as the templated data is usually only a subset of everything available.

Probably don't merge this yet as there's an ongoing discussion over how the show/hide button should look in #1171.
