### PR TITLE
Tweaked the location bar

### DIFF
--- a/lib/ViewModels/LocationBarViewModel.js
+++ b/lib/ViewModels/LocationBarViewModel.js
@@ -5,7 +5,6 @@ var proj4 = require('proj4');
 var Cartesian2 = require('terriajs-cesium/Source/Core/Cartesian2');
 var Cartographic = require('terriajs-cesium/Source/Core/Cartographic');
 var CesiumMath = require('terriajs-cesium/Source/Core/Math');
-var CesiumTerrainProvider = require('terriajs-cesium/Source/Core/CesiumTerrainProvider');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
@@ -150,7 +149,9 @@ function cartographicToFields(viewModel, coordinates, errorBar) {
 
         viewModel.north = projPoint[1].toFixed(2) + viewModel.projectionUnits;
         viewModel.east = projPoint[0].toFixed(2) + viewModel.projectionUnits;
-        viewModel.utmZone = zone + ' ' + (latitude < 0.0 ? 'S' : 'N');
+
+        viewModel.utmZone = zone + (latitude < 0.0 ? 'S' : 'N');
+
     }
 
     viewModel.latitude = Math.abs(latitude).toFixed(3) +
@@ -176,7 +177,7 @@ function debounceSampleAccurateHeight(viewModel, globe, position) {
     Cartographic.clone(position, lastHeightSamplePosition);
 
     var terrainProvider = globe.terrainProvider;
-    if (terrainProvider instanceof CesiumTerrainProvider) {
+    if (!(terrainProvider instanceof EllipsoidTerrainProvider)) {
         clearTimeout(accurateHeightTimer);
         accurateHeightTimer = setTimeout(function() {
             sampleAccurateHeight(viewModel, terrainProvider, position);


### PR DESCRIPTION
- Removed spacing in UTM zone to be in line with the standard.
- Call `sampleAccurateHeight` when not using `EllipsoidTerrainProvider` so as to allow accurate sampling with providers other than `CesiumTerrainProvider`
