### PR TITLE
Handle uppercase WMS parameters with lowercase defaults

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
   *   proj4ServiceBaseUrl: '/proj4/',
   *   corsProxyBaseUrl: '/proxy/'
 * Deprecated terria.regionMappingDefinitionsUrl (set it in config.json or leave it as default).
+* Allow WMS parameters to be specified in json in uppercase (eg. STYLES).
 
 ### 1.0.51
 

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -489,7 +489,7 @@ WebMapServiceCatalogItem.prototype._load = function() {
 };
 
 WebMapServiceCatalogItem.prototype._createImageryProvider = function(time) {
-    var parameters = this.parameters;
+    var parameters = objectToLowercase(this.parameters);
     if (defined(time)) {
         parameters = combine({ time: time }, parameters);
     }
@@ -961,5 +961,17 @@ function getDataCustodian(capabilities) {
         return undefined;
     }
 }
+
+// This is copied directly from Cesium's WebMapServiceImageryProvider.
+function objectToLowercase(obj) {
+    var result = {};
+    for (var key in obj) {
+        if (obj.hasOwnProperty(key)) {
+            result[key.toLowerCase()] = obj[key];
+        }
+    }
+    return result;
+}
+
 
 module.exports = WebMapServiceCatalogItem;

--- a/test/Models/WebMapServiceCatalogItemSpec.js
+++ b/test/Models/WebMapServiceCatalogItemSpec.js
@@ -1,7 +1,8 @@
 'use strict';
 
-/*global require,describe,it,expect,beforeEach*/
+/*global require,describe,it,expect,beforeEach,fail*/
 
+var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
 var Terria = require('../../lib/Models/Terria');
 var LegendUrl = require('../../lib/Models/LegendUrl');
 var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
@@ -207,6 +208,46 @@ describe('WebMapServiceCatalogItem', function() {
         expect(wmsItem.parameters).toEqual({});
         expect(wmsItem.tilingScheme).toBeUndefined();
         expect(wmsItem.getFeatureInfoFormats).toBeUndefined();
+    });
+
+    it('requests styles property', function() {
+        // Spy on the request to create an image, so that we can see what URL is requested.
+        // Unfortunately this is implementation-dependent.
+        spyOn(ImageryProvider, 'loadImage');
+        wmsItem.updateFromJson({
+            dataUrlType: 'wfs',
+            url: 'http://my.wms.com',
+            layers: 'mylayer',
+            tilingScheme: new WebMercatorTilingScheme(),
+            getFeatureInfoFormats: [],
+            parameters: {
+                styles: 'foobar'
+            }
+        });
+        var imageryLayer = wmsItem.createImageryProvider();
+        imageryLayer.requestImage(0, 0, 2);
+        var requestedUrl = ImageryProvider.loadImage.calls.argsFor(0)[0].url;
+        expect(requestedUrl.toLowerCase()).toContain('styles=foobar');
+    });
+
+    it('requests styles property even if uppercase', function() {
+        // Spy on the request to create an image, so that we can see what URL is requested.
+        // Unfortunately this is implementation-dependent.
+        spyOn(ImageryProvider, 'loadImage');
+        wmsItem.updateFromJson({
+            dataUrlType: 'wfs',
+            url: 'http://my.wms.com',
+            layers: 'mylayer',
+            tilingScheme: new WebMercatorTilingScheme(),
+            getFeatureInfoFormats: [],
+            parameters: {
+                STYLES: 'foobar'
+            }
+        });
+        var imageryLayer = wmsItem.createImageryProvider();
+        imageryLayer.requestImage(0, 0, 2);
+        var requestedUrl = ImageryProvider.loadImage.calls.argsFor(0)[0].url;
+        expect(requestedUrl.toLowerCase()).toContain('styles=foobar');
     });
 
     it('can be round-tripped with serializeToJson and updateFromJson', function() {


### PR DESCRIPTION
Converts uppercase WMS properties to lowercase (eg. STYLES -> styles) before combining with defaults.
Includes two new specs to test it.

Fixes #1055.
