### PR TITLE
Fixes `gulp` command so it runs without errors

### DIFF
--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -25,7 +25,6 @@ var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var AbsDataset = require('./AbsDataset');
 var AbsConcept = require('./AbsConcept');
 var AbsCode = require('./AbsCode');
-var LegendUrl = require('./LegendUrl');
 var naturalSort = require('javascript-natural-sort');
 
 /**


### PR DESCRIPTION
We left a stray `var LegendUrl = require('./LegendUrl')` in `AbsIttCatalogItem.js`.
