### PR TITLE
Trigger update of React UI on knockout observable property change

### DIFF
--- a/lib/ReactViews/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalogItem.jsx
@@ -1,6 +1,5 @@
 'use strict';
 var React = require('react');
-var when = require('terriajs-cesium/Source/ThirdParty/when');
 var renderAndSubscribe = require('./renderAndSubscribe');
 
 //Individual dataset
@@ -29,9 +28,8 @@ var DataCatalogItem = React.createClass({
 
     addToMap: function(event) {
         event.preventDefault();
-        var that = this;
 
-        that.props.item.toggleEnabled();
+        this.props.item.toggleEnabled();
         this.addToPreview(event);
     },
 

--- a/lib/ReactViews/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalogItem.jsx
@@ -1,6 +1,7 @@
 'use strict';
 var React = require('react');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
+var renderAndSubscribe = require('./renderAndSubscribe');
 
 //Individual dataset
 var DataCatalogItem = React.createClass({
@@ -10,8 +11,7 @@ var DataCatalogItem = React.createClass({
 
     getInitialState: function() {
         return {
-            isPreviewed: false,
-            status: this.getInitialStatus()
+            isPreviewed: false
         };
     },
 
@@ -31,61 +31,34 @@ var DataCatalogItem = React.createClass({
         event.preventDefault();
         var that = this;
 
-        if (that.props.item.isEnabled === false) {
-            that.setState({
-                    status: 'loading'
-                });
-            when(that.props.item.load()).then(function() {
-                that.setState({
-                    status: 'loaded'
-                });
-            that.props.item.isEnabled = true;
-            window.nowViewingUpdate.raiseEvent();
-            });
-        } else {
-           this.props.item.isEnabled = false;
-           window.nowViewingUpdate.raiseEvent();
-           that.setState({
-                    status: 'disabled'
-                });
-        }
-
+        that.props.item.toggleEnabled();
         this.addToPreview(event);
     },
 
-    getInitialStatus: function(){
-        if (this.props.item.isEnabled === true){
-            if (this.props.item.isLoading === true){
-                return 'loading';
+    render: function() {
+        return renderAndSubscribe(this, function() {
+            var item = this.props.item;
+            var iconClass;
+
+            if (item.isEnabled){
+                if (item.isLoading){
+                    iconClass = 'icon icon-loader';
+                } else {
+                    iconClass = 'icon icon-minus';
+                }
             } else {
-                return 'loaded';
+                iconClass = 'icon icon-add';
             }
-        } else {
-            return 'disabled';
-        }
-    },
 
-  render: function(){
-    var item = this.props.item;
-    var iconClass;
-
-    switch (this.state.status) {
-    case 'disabled':
-        iconClass = 'icon icon-add';
-        break;
-    case 'loading':
-        iconClass = 'icon icon-loader';
-        break;
-    case 'loaded':
-        iconClass = 'icon icon-minus';
-        break;
-    default:
-        iconClass = '';
-    }
-
-    return (
-      <li className="clearfix data-catalog-item flex"><button onClick={this.addToMap} title="add to map" className='btn relative btn-add-to-map'><i className={iconClass}> </i></button><button onClick={this.addToPreview} className='btn btn-catalog-item relative'>{item.name}</button></li>
-      );
+            return (
+                <li className="clearfix data-catalog-item flex">
+                    <button onClick={this.addToMap} title="add to map" className='btn relative btn-add-to-map'>
+                        <i className={iconClass}> </i>
+                    </button>
+                    <button onClick={this.addToPreview} className='btn btn-catalog-item relative'>{item.name}</button>
+                </li>
+            );
+        });
     }
 });
 

--- a/lib/ReactViews/Legend.jsx
+++ b/lib/ReactViews/Legend.jsx
@@ -3,6 +3,7 @@ var React = require('react');
 var ModalTriggerButton = require('./ModalTriggerButton.jsx');
 var imageUrlRegex = /[.\/](png|jpg|jpeg|gif)/i;
 var defined = require('terriajs-cesium/Source/Core/defined');
+var renderAndSubscribe = require('./renderAndSubscribe');
 
 // Maybe should be called nowViewingItem?
 var Legend = React.createClass({
@@ -45,37 +46,39 @@ var Legend = React.createClass({
     },
 
     render: function() {
-        var nowViewingItem = this.props.nowViewingItem;
+        return renderAndSubscribe(this, function() {
+            var nowViewingItem = this.props.nowViewingItem;
 
-        var legend = 'No legend to show';
-        var legendUrl;
+            var legend = 'No legend to show';
+            var legendUrl;
 
-        if (nowViewingItem.legendUrl && nowViewingItem.legendUrl.length !== 0) {
-            legendUrl = nowViewingItem.legendUrl.match(imageUrlRegex);
-            if (legendUrl){
-              legend = <a href={legendUrl.input}><img src={legendUrl.input}/></a>;
+            if (nowViewingItem.legendUrl && nowViewingItem.legendUrl.length !== 0) {
+                legendUrl = nowViewingItem.legendUrl.match(imageUrlRegex);
+                if (legendUrl){
+                  legend = (<a href={legendUrl.input}><img src={legendUrl.input}/></a>);
+                }
             }
-        }
-        return (
-            <li className={'now-viewing__item clearfix ' + (this.state.isOpen === true ? 'is-open' : '')}>
-              <button onClick={this.toggleDisplay} className="btn block now-viewing__item-title">{nowViewingItem.name}</button>
-              <div className ="now-viewing__item-inner">
-                <ul className="list-reset flex clearfix now-viewing__item-control">
-                  <li><button onClick={this.zoom} title="Zoom in data" className="btn zoom">Zoom To</button></li>
-                  <li><ModalTriggerButton btnText="info" classNames='info' /></li>
-                  <li><button onClick={this.removeFromMap} title="Remove this data" className="btn remove">Remove</button></li>
-                  <li className='flex-grow right-align'><button onClick={this.toggleVisibility} title="Data show/hide" className="btn visibility"><i className={'icon ' + (this.state.isVisible ? 'icon-visible' : 'icon-invisible')}></i></button></li>
-                </ul>
-                <div className="now-viewing__item-opacity">
-                  <label htmlFor="opacity">Opacity: </label>
-                  <input type='range' name='opacity' min='0' max='1' step='0.01' value={nowViewingItem.opacity} onChange={this.changeOpacity}/>
-                </div>
-                <div className="now-viewing__item-legend">
-                  {legend}
-                </div>
-              </div>
-          </li>
-        );
+            return (
+                <li className={'now-viewing__item clearfix ' + (this.state.isOpen === true ? 'is-open' : '')}>
+                  <button onClick={this.toggleDisplay} className="btn block now-viewing__item-title">{nowViewingItem.name}</button>
+                  <div className ="now-viewing__item-inner">
+                    <ul className="list-reset flex clearfix now-viewing__item-control">
+                      <li><button onClick={this.zoom} title="Zoom in data" className="btn zoom">Zoom To</button></li>
+                      <li><ModalTriggerButton btnText="info" classNames='info' /></li>
+                      <li><button onClick={this.removeFromMap} title="Remove this data" className="btn remove">Remove</button></li>
+                      <li className='flex-grow right-align'><button onClick={this.toggleVisibility} title="Data show/hide" className="btn visibility"><i className={'icon ' + (this.state.isVisible ? 'icon-visible' : 'icon-invisible')}></i></button></li>
+                    </ul>
+                    <div className="now-viewing__item-opacity">
+                      <label htmlFor="opacity">Opacity: </label>
+                      <input type='range' name='opacity' min='0' max='1' step='0.01' value={nowViewingItem.opacity} onChange={this.changeOpacity}/>
+                    </div>
+                    <div className="now-viewing__item-legend">
+                      {legend}
+                    </div>
+                  </div>
+              </li>
+            );
+        });
     }
 });
 module.exports = Legend;

--- a/lib/ReactViews/ModalWindow.jsx
+++ b/lib/ReactViews/ModalWindow.jsx
@@ -1,6 +1,8 @@
 'use strict';
 var React = require('react');
 var Tabs = require('./Tabs.jsx');
+var renderAndSubscribe = require('./renderAndSubscribe');
+
 var ModalWindow = React.createClass({
   propTypes:{
     terria: React.PropTypes.object
@@ -30,13 +32,15 @@ var ModalWindow = React.createClass({
 
 
     render: function() {
-        return (<div className="data-panel-wrapper modal-wrapper fixed flex flex-center" id="data-panel-wrapper" aria-hidden={!this.state.isOpen}>
-                <div onClick={this.closeModal} id="data-panel-overlay" className="modal-overlay absolute" tabIndex="-1"></div>
-                <div id="data-panel" className="data-panel modal-content mx-auto v-middle" aria-labelledby="modalTitle" aria-describedby="modalDescription" role="dialog">
-                <button onClick={this.closeModal} className="btn btn-close-modal" title="Close data panel" data-target="close-modal">Back to Map</button>
-                <Tabs terria={this.props.terria}/>
-                </div>
-                </div>);
+        return renderAndSubscribe(this, function() {
+            return (<div className="data-panel-wrapper modal-wrapper fixed flex flex-center" id="data-panel-wrapper" aria-hidden={!this.state.isOpen}>
+                    <div onClick={this.closeModal} id="data-panel-overlay" className="modal-overlay absolute" tabIndex="-1"></div>
+                    <div id="data-panel" className="data-panel modal-content mx-auto v-middle" aria-labelledby="modalTitle" aria-describedby="modalDescription" role="dialog">
+                    <button onClick={this.closeModal} className="btn btn-close-modal" title="Close data panel" data-target="close-modal">Back to Map</button>
+                    <Tabs terria={this.props.terria}/>
+                    </div>
+                    </div>);
+        });
     }
 });
 module.exports = ModalWindow;

--- a/lib/ReactViews/SidePanel.jsx
+++ b/lib/ReactViews/SidePanel.jsx
@@ -3,6 +3,7 @@ var React = require('react');
 var SearchBox = require('./SearchBox.jsx');
 var ModalTriggerButton = require('./ModalTriggerButton.jsx');
 var Legend = require('./Legend.jsx');
+var renderAndSubscribe = require('./renderAndSubscribe');
 
 var btnAdd = 'Add Data';
 var btnRemove = 'Remove All';
@@ -17,34 +18,35 @@ var SidePanel = React.createClass({
 
     removeAll: function() {
         this.props.terria.nowViewing.removeAll();
-        window.nowViewingUpdate.raiseEvent();
     },
 
     render: function() {
-        var terria = this.props.terria;
-        var nowViewing = this.props.terria.nowViewing.items;
-        var content = null;
-        var remove = null;
+        return renderAndSubscribe(this, function() {
+            var terria = this.props.terria;
+            var nowViewing = this.props.terria.nowViewing.items;
+            var content = null;
+            var remove = null;
 
-        if (nowViewing && nowViewing.length > 0) {
-            remove = (<li><button onClick={this.removeAll} className='btn now-viewing__remove'>{btnRemove}</button></li>);
-            content = nowViewing.map(function(item, i) {
-                return (<Legend nowViewingItem={item} key={i} />);
-            });
-        }
-        return (<div>
-            <SearchBox terria={terria} dataSearch={false}/>
-            <div className="now-viewing hide-if-searching">
-              <ul className="now-viewing__control list-reset clearfix">
-                <li><ModalTriggerButton btnText={btnAdd} classNames = 'now-viewing__add'/></li>
-                {remove}
-              </ul>
-                {(nowViewing && nowViewing.length > 0) ? (<label className='block label-now-viewing-group'> Data Sets </label>) : null}
-                <ul className="now-viewing__content list-reset">
-                    {content}
-                </ul>
-            </div>
-        </div>);
+            if (nowViewing && nowViewing.length > 0) {
+                remove = (<li><button onClick={this.removeAll} className='btn now-viewing__remove'>{btnRemove}</button></li>);
+                content = nowViewing.map(function(item, i) {
+                    return (<Legend nowViewingItem={item} key={i} />);
+                });
+            }
+            return (<div>
+                <SearchBox terria={terria} dataSearch={false}/>
+                <div className="now-viewing hide-if-searching">
+                  <ul className="now-viewing__control list-reset clearfix">
+                    <li><ModalTriggerButton btnText={btnAdd} classNames = 'now-viewing__add'/></li>
+                    {remove}
+                  </ul>
+                    {(nowViewing && nowViewing.length > 0) ? (<label className='block label-now-viewing-group'> Data Sets </label>) : null}
+                    <ul className="now-viewing__content list-reset">
+                        {content}
+                    </ul>
+                </div>
+            </div>);
+        });
     }
 });
 module.exports = SidePanel;

--- a/lib/ReactViews/UiWrapper.jsx
+++ b/lib/ReactViews/UiWrapper.jsx
@@ -73,11 +73,6 @@ UiWrapper.prototype.init = function(main, nav, aside, mapNav, chart, allBaseMaps
         }
     });
 
-    this.nowViewingUpdate.addEventListener(function() {
-        ReactDOM.render(<SidePanel terria={terria} />, nav);
-        ReactDOM.render(<ModalWindow terria={terria}/>, main);
-    });
-
     this.terriaViewerUpdate.addEventListener(function() {
         ReactDOM.render(<MapNavigation terria= {terria} allBaseMaps = {allBaseMaps} terriaViewer={terriaViewer} />, mapNav);
     });

--- a/lib/ReactViews/renderAndSubscribe.js
+++ b/lib/ReactViews/renderAndSubscribe.js
@@ -1,15 +1,66 @@
 'use strict';
 
 /*global require*/
+var defined = require('terriajs-cesium/Source/Core/defined');
+var definedNotNull = require('terriajs-cesium/Source/Core/definedNotNull');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 
 function renderAndSubscribe(that, renderFunction) {
     return knockout.ignoreDependencies(function() {
+        // If there's already a cleanup function, call it now to clean up any previous changes.
+        if (that.__terriaRenderAndSubscribeCleanup) {
+            that.__terriaRenderAndSubscribeCleanup();
+        }
+
+        // Create a cleanup function to undo the changes we're about to make.
+        var changeSubscription;
+        var previousComponentWillUnmount;
+
+        that.__terriaRenderAndSubscribeCleanup = function() {
+            if (defined(changeSubscription)) {
+                changeSubscription.dispose();
+                changeSubscription = undefined;
+            }
+
+            if (defined(previousComponentWillUnmount)) {
+                that.componentWillUnmount = previousComponentWillUnmount;
+                previousComponentWillUnmount = undefined;
+            }
+
+            that.__terriaRenderAndSubscribeCleanup = undefined;
+        };
+
+        // Create a computed observable from the render function.
         var computed = knockout.computed(renderFunction, that);
-        var subscription = computed.subscribe(function() {
-            subscription.dispose();
-            that.forceUpdate();
+
+        // Arrange to unsubscribe from the computed observable if the component unmounts.
+        // This avoids a memory leak.
+        previousComponentWillUnmount = that.componentWillUnmount;
+
+        function componentWillUnmount() {
+            if (defined(that.__terriaRenderAndSubscribeCleanup)) {
+                that.__terriaRenderAndSubscribeCleanup();
+            }
+
+            if (definedNotNull(that.componentWillUnmount)) {
+                that.componentWillUnmount();
+            }
+        }
+
+        that.componentWillUnmount = componentWillUnmount;
+
+        // Subscribe to change notification on the computed observable (the render function).
+        // TODO: this probably ends up calling renderFunction twice: once to recompute the value of the
+        //       computed observable, and again after the forceUpdate for a new computed observable.
+        //       Can we avoid this somehow?
+        changeSubscription = computed.subscribe(function() {
+            if (that.__terriaRenderAndSubscribeCleanup) {
+                that.__terriaRenderAndSubscribeCleanup();
+                that.forceUpdate();
+            }
         });
+
+
         return computed();
     });
 }

--- a/lib/ReactViews/renderAndSubscribe.js
+++ b/lib/ReactViews/renderAndSubscribe.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/*global require*/
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+
+function renderAndSubscribe(that, renderFunction) {
+    return knockout.ignoreDependencies(function() {
+        var computed = knockout.computed(renderFunction, that);
+        var subscription = computed.subscribe(function() {
+            subscription.dispose();
+            that.forceUpdate();
+        });
+        return computed();
+    });
+}
+
+module.exports = renderAndSubscribe;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "proj4": "^2.3.6",
     "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
-    "terriajs-cesium": "git://github.com/TerriaJS/cesium#knockout-3.4.0",
+    "terriajs-cesium": "1.15.6",
     "togeojson": "^0.9.0",
     "urijs": "^1.16.0",
     "urthecast": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "proj4": "^2.3.6",
     "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
-    "terriajs-cesium": "1.15.4",
+    "terriajs-cesium": "git://github.com/TerriaJS/cesium#knockout-3.4.0",
     "togeojson": "^0.9.0",
     "urijs": "^1.16.0",
     "urthecast": "^1.0.0"

--- a/test/ReactViews/renderAndSubscribeSpec.js
+++ b/test/ReactViews/renderAndSubscribeSpec.js
@@ -49,4 +49,19 @@ describe('renderAndSubscribe', function() {
         expect(spy.forceUpdate).not.toHaveBeenCalled();
         expect(secondSpy.forceUpdate).toHaveBeenCalled();
     });
+
+    it('unsubscribes when the component is unmounted', function() {
+        var spy = jasmine.createSpyObj('component', ['forceUpdate', 'componentWillUnmount']);
+
+        var result = renderAndSubscribe(spy, function() {
+            return someObject.foo;
+        });
+
+        spy.componentWillUnmount();
+
+        expect(spy.componentWillUnmount).toHaveBeenCalled();
+
+        someObject.foo = 6;
+        expect(spy.forceUpdate).not.toHaveBeenCalled();
+    });
 });

--- a/test/ReactViews/renderAndSubscribeSpec.js
+++ b/test/ReactViews/renderAndSubscribeSpec.js
@@ -59,6 +59,7 @@ describe('renderAndSubscribe', function() {
 
         spy.componentWillUnmount();
 
+        expect(result).toBe(5);
         expect(spy.componentWillUnmount).toHaveBeenCalled();
 
         someObject.foo = 6;

--- a/test/ReactViews/renderAndSubscribeSpec.js
+++ b/test/ReactViews/renderAndSubscribeSpec.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/*global require*/
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var renderAndSubscribe = require('../../lib/ReactViews/renderAndSubscribe');
+
+describe('renderAndSubscribe', function() {
+    var spy;
+    var someObject;
+
+    beforeEach(function() {
+        spy = jasmine.createSpyObj('component', ['forceUpdate']);
+
+        someObject = {
+            foo: 5,
+            bar: 'hello'
+        };
+
+        knockout.track(someObject, ['foo', 'bar']);
+    });
+
+    it('calls forceUpdate when observables used in the render change', function() {
+        var result = renderAndSubscribe(spy, function() {
+            return someObject.foo;
+        });
+
+        expect(result).toBe(5);
+        expect(spy.forceUpdate).not.toHaveBeenCalled();
+
+        someObject.foo = 6;
+        expect(spy.forceUpdate).toHaveBeenCalled();
+    });
+
+    it('does not call forceUpdate for observables accessed in a nested call to renderAndSubscribe', function() {
+        var secondSpy = jasmine.createSpyObj('nested component', ['forceUpdate']);
+
+        var result = renderAndSubscribe(spy, function() {
+            renderAndSubscribe(secondSpy, function() {
+                return someObject.bar;
+            });
+            return someObject.foo;
+        });
+
+        expect(result).toBe(5);
+        expect(spy.forceUpdate).not.toHaveBeenCalled();
+        expect(secondSpy.forceUpdate).not.toHaveBeenCalled();
+
+        someObject.bar = 'goodbye';
+        expect(spy.forceUpdate).not.toHaveBeenCalled();
+        expect(secondSpy.forceUpdate).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Don't panic, this is a pull request into the `newui` branch.

The basic idea is to structure the render method of each React component (only a few done so far) as a Knockout computed property.  Knockout computed properties know which other observables they depend upon.  When any of those observables change, a change notification is raised on the computed observable, too.  By subscribing to the render computable's change notification, we are notified whenever any of the properties that were used in rendering change, and can re-render.

This isn't the most React-like way we could do this, but it does let us avoid rewriting our Models layer. :)

In the end, we won't need to depend on all of knockout, just the observables part of it.  For example, we can use a library like [ko-observable](https://www.npmjs.com/package/ko-observable) or something similar.  We don't need any of Knockout's DOM manipulation bits.

@chloeleichen  I'm creating this pull request so you can easily see the changes and merge them into your `newui` branch if you're happy.
