### PR TITLE
Use terriajs-cesium 1.15.6

### DIFF
--- a/lib/Core/KnockoutMarkdownBinding.js
+++ b/lib/Core/KnockoutMarkdownBinding.js
@@ -33,7 +33,7 @@ var KnockoutMarkdownBinding = {
                     html = markdownToHtml(rawText, that.allowUnsafeHtml);
                 }
 
-                var nodes = knockout.utils.parseHtmlFragment(html, element);
+                var nodes = knockout.utils.parseHtmlFragment(html);
                 element.className = element.className + ' markdown';
 
                 for (var i = 0; i < nodes.length; ++i) {

--- a/lib/Views/NowViewingTab.html
+++ b/lib/Views/NowViewingTab.html
@@ -42,7 +42,7 @@
                 <div class="now-viewing-item-icon-holder">
                     <button class="now-viewing-item-checkbox clickable" data-bind="click: toggleShown, cesiumSvgPath: { path: isShown ? $root.svgVisible : $root.svgInvisible, width: 32, height: 32 }, css: { 'now-viewing-shown-item': isShown }, attr: {tabindex: $root.isActive ? 0 : -1 }"></button>
                 </div>
-                <button class="now-viewing-item-label clickable" data-bind="text: name, click: toggleLegendVisible, css { 'now-viewing-shown-item': isShown }, attr: {  tabindex: $root.isActive ? 0 : -1 }"></button>
+                <button class="now-viewing-item-label clickable" data-bind="text: name, click: toggleLegendVisible, css: { 'now-viewing-shown-item': isShown }, attr: {  tabindex: $root.isActive ? 0 : -1 }"></button>
 
                 <div class="now-viewing-item-arrow-holder">
                     <button class="now-viewing-arrow" data-bind="click: toggleLegendVisible, cesiumSvgPath: { path: isLegendVisible ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }, attr: {  tabindex: $root.isActive ? 0 : -1 }"></button>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
     "simple-statistics": "^1.0.1",
-    "terriajs-cesium": "1.15.5",
+    "terriajs-cesium": "1.15.6",
     "togeojson": "^0.9.0",
     "urijs": "^1.16.0",
     "urthecast": "^1.0.0"


### PR DESCRIPTION
The only change in this version of terriajs-cesium is an upgrade to knockout 3.4.0:
https://github.com/TerriaJS/cesium/compare/terriajs-1.15.5...terriajs-1.15.6

There are a couple of changes to avoid some dodgy uses of knockout that we got away with in the previous version, but that break in this version.

The new UI needs this new version of Knockout.  Upgrading master to it makes everything a lot simpler.
