### PR TITLE
When sharing enabled layers, share link no longer serializes name or id

### DIFF
--- a/lib/ViewModels/SharePopupViewModel.js
+++ b/lib/ViewModels/SharePopupViewModel.js
@@ -126,7 +126,12 @@ SharePopupViewModel.prototype._addSharedMembers = function(initSources) {
         itemFilter: combineFilters([
             CatalogMember.itemFilters.noLocalData
         ]),
-        propertyFilter: CatalogMember.propertyFilters.sharedOnly
+        propertyFilter: combineFilters([
+            CatalogMember.propertyFilters.sharedOnly,
+            function(property) {
+                return property !== 'name' && property !== 'id';
+            }
+        ])
     })).filter(function(item) {
         // Filter out groups.
         return item.isEnabled;


### PR DESCRIPTION
Fixes #1264.

Removed name because we don't want to keep the name (we want underground fortresses!).
Removed id because we don't need it at all (we already have the id as a key for that object).
