### PR TITLE
Use the same name, allowMultiple, for ABS and CSV concepts

### DIFF
--- a/lib/Models/AbsCode.js
+++ b/lib/Models/AbsCode.js
@@ -44,6 +44,14 @@ var AbsCode = function(code, name, concept) {
     this.concept = concept;
 
     /**
+     * Flag to say if this if this concept only allows more than one active child.
+     * Defaults to the same as concept.
+     * Only meaningful if this concept has an items array.
+     * @type {Boolean}
+     */
+    this.allowMultiple = this.concept.allowMultiple;
+
+    /**
      * Gets or sets a value indicating whether this abs code is currently open.  When an
      * item is open, its child items (if any) are visible.  This property is observable.
      * @type {Boolean}
@@ -107,7 +115,7 @@ AbsCode.prototype.toggleActive = function(test) {
         });
     }
     function clearSiblings(code) {
-        if (!code.concept.allowMultiple) {
+        if (!code.parent.allowMultiple) {
             code.parent.items.forEach( function(item) {
                 if (item !== code) {
                     item.isActive = false;

--- a/lib/Models/AbsCode.js
+++ b/lib/Models/AbsCode.js
@@ -107,7 +107,7 @@ AbsCode.prototype.toggleActive = function(test) {
         });
     }
     function clearSiblings(code) {
-        if (defined(code.parent.isUnique) && code.parent.isUnique) {
+        if (!code.concept.allowMultiple) {
             code.parent.items.forEach( function(item) {
                 if (item !== code) {
                     item.isActive = false;

--- a/lib/Models/AbsConcept.js
+++ b/lib/Models/AbsConcept.js
@@ -25,7 +25,7 @@ var Concept = require('./Concept');
  * @param {Object[]} [options.codes] ABS code objects describing a tree of codes under this concept,
  *        eg. [{code: '01_02', description: 'Negative/Nil Income', parentCode: 'TOT', parentDescription: 'Total'}, ...].
  * @param {String[]} [options.filter] The initial concepts and codes to activate.
- * @param {Boolean} [options.isUnique] Does this concept only allow one active child (eg. Region type)?
+ * @param {Boolean} [options.allowMultiple] Does this concept only allow multiple active children (eg. all except Region type)?
  * @param {Function} [options.activeItemsChangedCallback] A function called when activeItems changes.
  */
 var AbsConcept = function(options) {
@@ -59,11 +59,11 @@ var AbsConcept = function(options) {
     this.isSelectable = false;
 
     /**
-     * Flag to say if this if this concept only allows one active child.
+     * Flag to say if this if this concept only allows more than one active child. (Defaults to false.)
      * This property is observable.
      * @type {Boolean}
      */
-    this.isUnique = options.isUnique;
+    this.allowMultiple = defaultValue(options.allowMultiple, false);
 
     if (defined(options.codes)) {
         var anyActive = buildConceptTree(this, options.filter, this, options.codes);

--- a/lib/Models/AbsConcept.js
+++ b/lib/Models/AbsConcept.js
@@ -60,7 +60,6 @@ var AbsConcept = function(options) {
 
     /**
      * Flag to say if this if this concept only allows more than one active child. (Defaults to false.)
-     * This property is observable.
      * @type {Boolean}
      */
     this.allowMultiple = defaultValue(options.allowMultiple, false);

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -696,7 +696,7 @@ function buildTableColumns(item, tableStructuresAndCombinations) {
     var firstTableStructure = tableStructures[0];
     var timeColumn = firstTableStructure.columns[0];
     var regionColumn = firstTableStructure.columns[2];
-    var isTimeVarying = (timeColumn.minimumValue !== timeColumn.maximumValue);
+    var isTimeVarying = defined(timeColumn) && (timeColumn.minimumValue !== timeColumn.maximumValue);
     // If there is time variation, for now, let's turn off the displayPercent option.
     // (since we don't have time-varying population data yet)
     if (isTimeVarying) {

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -487,7 +487,7 @@ function loadConcepts(item) {
                     id: conceptId,
                     codes: codes,
                     filter: item.filter,
-                    isUnique: (conceptId === item.regionTypeConcept || item.uniqueValuedConcepts.indexOf(conceptId) >= 0),
+                    allowMultiple: !(conceptId === item.regionTypeConcept || item.uniqueValuedConcepts.indexOf(conceptId) >= 0),
                     activeItemsChangedCallback: function() {
                         // Close any picked features, as the description of any associated with this catalog item may change.
                         item.terria.pickedFeatures = undefined;


### PR DESCRIPTION
Rationalise the "isUnique" and "allowMultiple" properties across ABS and CSV concepts.
