### PR TITLE
Fixed items with duplicate names / ids throwing

### DIFF
--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -274,6 +274,8 @@ CatalogGroup.prototype._setupItemListeners = function() {
     }, null, "arrayChange");
 };
 
+var NUMBER_AT_END_OF_KEY_REGEX = /\((\d+)\)$/;
+
 /**
  * Adds all passed items to the passed index, and all the children of those items recursively.
  *
@@ -283,17 +285,60 @@ CatalogGroup.prototype._setupItemListeners = function() {
 function indexWithDescendants(items, index) {
     items.forEach(function(item) {
         item.allShareKeys.forEach(function (key) {
-            if (index[key]) {
-                throw new RuntimeError('Duplicate shareKey: ' + key);
-            } else {
-                index[key] = item;
+            var insertionKey = key;
+
+            if (index[insertionKey]) {
+                insertionKey = generateUniqueKey(index, key);
+
+                if (item.uniqueId === key) {
+                    // If this duplicate was the item's main key that will be used for sharing it in general, set this
+                    // to the new key. This means that sharing the item will still work most of the time.
+                    item.id = insertionKey;
+                }
+
+                console.warn('Duplicate shareKey: ' + key + '. Inserting new item under ' + insertionKey);
             }
+
+            index[insertionKey] = item;
         }, this);
 
         if (defined(item.items)) {
            indexWithDescendants(item.items, index);
         }
     });
+}
+
+/**
+ * Generates a unique key from a non-unique one by adding a number after it. If the key already has a number added,
+ * it will increment that number.
+ *
+ * @param index An index to check for uniqueness.
+ * @param initialKey The key to start from.
+ * @returns {String} A new, unique key.
+ */
+function generateUniqueKey(index, initialKey) {
+    var currentCandidate = initialKey;
+
+    var counter = 0;
+    while (index[currentCandidate]) {
+        var numberAtEndOfKeyMatches = currentCandidate.match(NUMBER_AT_END_OF_KEY_REGEX);
+        if (numberAtEndOfKeyMatches !== null) {
+            var nextNumber = parseInt(numberAtEndOfKeyMatches[1]) + 1;
+
+            currentCandidate = currentCandidate.replace(NUMBER_AT_END_OF_KEY_REGEX, '(' + nextNumber + ')');
+        } else {
+            currentCandidate += ' (1)';
+        }
+
+        // This loop should always find something eventually, but because it's a bit dangerous looping endlessly...
+        counter++;
+        if (counter >= 100000) {
+            throw new DeveloperError('Was not able to find a unique key for ' + initialKey + ' after 100000 iterations.' +
+                ' This is probably because the regex for matching keys was somehow unable to work for that key.');
+        }
+    }
+
+    return currentCandidate;
 }
 
 /**


### PR DESCRIPTION
Fixes #1284. As per discussion, a duplicate share key will cause the id of the second item to be modified with a (1) or (2) etc.
