### PR TITLE
Make eye icon change when hidden layer is shown via a change in variable selection

### DIFF
--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -623,7 +623,7 @@ ImageryLayerCatalogItem.showLayer = function(catalogItem, layer) {
         return;
     }
 
-    catalogItem.isShown = true;
+    if (catalogItem.isEnabled) catalogItem.isShown = true;
 
     if (defined(catalogItem.terria.cesium)) {
         layer.show = true;
@@ -642,7 +642,7 @@ ImageryLayerCatalogItem.hideLayer = function(catalogItem, layer) {
         return;
     }
 
-    catalogItem.isShown = false;
+    if (catalogItem.isEnabled) catalogItem.isShown = false;
 
     if (defined(catalogItem.terria.cesium)) {
         layer.show = false;

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -623,6 +623,8 @@ ImageryLayerCatalogItem.showLayer = function(catalogItem, layer) {
         return;
     }
 
+    catalogItem.isShown = true;
+
     if (defined(catalogItem.terria.cesium)) {
         layer.show = true;
     }
@@ -639,6 +641,8 @@ ImageryLayerCatalogItem.hideLayer = function(catalogItem, layer) {
     if (!defined(layer)) {
         return;
     }
+
+    catalogItem.isShown = false;
 
     if (defined(catalogItem.terria.cesium)) {
         layer.show = false;


### PR DESCRIPTION
A hidden layer is displayed when you change the concept selection, however the underlying item's `isShown` property is not updated. This change fixes that behaviour so that the layer is displayed and the `isShown` property is set to true (which in turn changes the eye icon in the Now Viewing tab).

Fixes the first point in #1267.
