### PR TITLE
ABS works with multiple concepts having multiple options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 2.0.1
+
+* Fixed a bug that caused the last selected ABS concept not to appear in the feature info panel.
+
 ### 2.0.0
 
 * The following previously-deprecated functionality was removed in this version:

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -573,7 +573,7 @@ AbsIttCatalogItem._generateAllCombinations = function(pools) {
                 return partialResult.concat(poolMember);
             });
         }));
-    })
+    });
     return result;
 };
 

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -541,29 +541,41 @@ function getHumanReadableConceptName(conceptNameMap, concept) {
     }
 }
 
-// Eg. [[a,b,c], [d], [e,f]] => [[a,d,e], [a,d,f], [b,d,e], [b,d,f], [c,d,e], [c,d,f]].
-function generateAllCombinations(listOfLists) {
-    // Take each possible subelement from the first element, and call again.
-    // If we're down to an empty list, return.
-    // In python, it would be a one-liner: list(itertools.product(*listOfLists)).
-    if (listOfLists.length < 2) {
-        // So that [[1, 2]] returns [[1, 2]]. (Otherwise would return [1, 2].)
-        return listOfLists;
-    }
-    var result = [];
-    listOfLists[0].forEach(function(subElement) {
-        var tailCombinations = generateAllCombinations(listOfLists.slice(1));
-        if (defined(tailCombinations)) {
-            var headAndTails = tailCombinations.map(function(tailCombination) {
-                return [subElement].concat(tailCombination);
-            });
-            result = result.concat(headAndTails);
-        } else {
-            result = result.concat([subElement]);
-        }
-    });
-    return result;
+function flatten(arrayOfArrays) {
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce
+    return arrayOfArrays.reduce(function(a, b) {
+        return a.concat(b);
+    }, []);
 }
+
+// Eg. [[a,b,c], [d], [e,f]] => [[a,d,e], [a,d,f], [b,d,e], [b,d,f], [c,d,e], [c,d,f]].
+AbsIttCatalogItem._generateAllCombinations = function(pools) {
+    // In python, it would be a one-liner: list(itertools.product(*pools)).
+    // This code is based on the python equivalent at https://docs.python.org/2/library/itertools.html#itertools.product
+    // def product(*args):
+    //     # product('ABCD', 'xy') --> Ax Ay Bx By Cx Cy Dx Dy
+    //     pools = map(tuple, args)
+    //     result = [[]]
+    //     for pool in pools:
+    //         result = [x+[y] for x in result for y in pool]
+    //     for prod in result:
+    //         yield tuple(prod)
+    // Note for A = [1, 2, 3], B = [10, 20] in python, [a + b for a in A for b in B] = [11, 21, 12, 22, 13, 23].
+    // In js, A.map(function(a) { return B.map(function(b) { return a + b}) }) = [ [ 11, 21 ], [ 12, 22 ], [ 13, 23 ] ].
+    // For A = [[]], B = [1], in python [a+[b] for a in A for b in B] = [[1]].
+    // In js, A.map(function(a) { return B.map(function(b) { return a.concat(b); }) }) = [ [ [ 1 ] ] ].
+    // So we need to flatten the js result to make it match itertool's.
+    var result = [[]];
+    pools.forEach(function(pool) {
+        result = flatten(result.map(function(partialResult) {
+            return pool.map(function(poolMember) {
+                console.log(pool.join(', '), ':', partialResult.join(', '), '&', poolMember);
+                return partialResult.concat(poolMember);
+            });
+        }));
+    })
+    return result;
+};
 
 // Returns the active regiontype code, eg. SA4, or undefined if none _or more than one_ active.
 function getActiveRegionTypeCode(item) {
@@ -607,7 +619,7 @@ function loadDataFiles(item) {
     }
 
     // Find every possible combination, taking a single code from each concept.
-    var activeCombinations = generateAllCombinations(activeCodesPerConcept);
+    var activeCombinations = AbsIttCatalogItem._generateAllCombinations(activeCodesPerConcept);
 
     // Construct the 'and' part of the requests by combining concept.id and the AbsCode.name,
     // eg. and=REGIONTYPE.SA4,AGE.A04,MEASURE.3

--- a/test/Models/AbsIttCatalogItemSpec.js
+++ b/test/Models/AbsIttCatalogItemSpec.js
@@ -9,6 +9,61 @@ var AbsIttCatalogItem = require('../../lib/Models/AbsIttCatalogItem');
 var sinon = require('sinon');
 // var URI = require('urijs');
 
+describe('AbsIttCatalogItem._generateAllCombinations', function() {
+
+    it('works with one code and one concept', function() {
+        var test = [[1]];
+        var target = [[1]];
+        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
+    });
+
+    it('works with one code per concept', function() {
+        var test = [[1], [2], [3], [4]];
+        var target = [[1, 2, 3, 4]];
+        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
+    });
+
+    it('works with two codes in a single concept', function() {
+        var test = [[1, 10]];
+        var target = [[1], [10]];
+        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
+    });
+
+    it('works with two codes in first concept', function() {
+        var test = [[1, 10], [2], [3], [4]];
+        var target = [[1, 2, 3, 4], [10, 2, 3, 4]];
+        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
+    });
+
+    it('works with two codes in first two concepts', function() {
+        var test = [[1, 10], [2, 20], [3], [4]];
+        // Actually the order of the subarrays is not important.
+        var target = [[1, 2, 3, 4], [1, 20, 3, 4], [10, 2, 3, 4], [10, 20, 3, 4]];
+        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
+    });
+
+    it('works with two codes in first three concepts', function() {
+        var test = [[1, 10], [2, 20], [3, 30], [4]];
+        // Actually the order of the subarrays is not important.
+        var target =  [[ 1, 2, 3, 4], [1, 2, 30, 4], [1, 20, 3, 4], [1, 20, 30, 4], [10, 2, 3, 4], [10, 2, 30, 4], [10, 20, 3, 4], [10, 20, 30, 4]];
+        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
+    });
+
+    it('works with two codes in last concept', function() {
+        var test = [[1], [2], [3], [4, 40]];
+        var target = [[1, 2, 3, 4], [1, 2, 3, 40]];
+        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
+    });
+
+    it('works with two codes in last two concepts', function() {
+        var test = [[1], [2], [3, 30], [4, 40]];
+        var target = [[1, 2, 3, 4], [1, 2, 3, 40], [1, 2, 30, 4], [1, 2, 30, 40]];
+        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
+    });
+
+});
+
+
 describe('AbsIttCatalogItem', function() {
     var terria;
     var item;


### PR DESCRIPTION
This fixes a bug that can crop up in the ABS displays.

To see the bug, eg. enable ABS -> Personal Income (weekly), then choose two income ranges from the Now Viewing tab. Click on a region in the map and you'll see it has only one.
