### PR TITLE
Escaped commas in exported CSVs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Changed the default for `tableStyle.nullLabel` to '(No value)'.
 * Application name and support email can now be set in config.json's "parameters" section as "appName" and "supportEmail".
 * Fixed showWarnings in config json not being respected by CSV catalog items.
+* Fixed exporting raw data as CSV not escaping commas in the data itself.
 
 ### 2.0.1
 

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -4,6 +4,7 @@
 var Mustache = require('mustache');
 
 var defined = require('terriajs-cesium/Source/Core/defined');
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var destroyObject = require('terriajs-cesium/Source/Core/destroyObject');
 var isArray = require('terriajs-cesium/Source/Core/isArray');
@@ -240,11 +241,17 @@ function generateCsvData(data) {
             continue;
         }
 
-        row1.push(key);
-        row2.push(data[key]);
+        row1.push(makeSafeForCsv(key));
+        row2.push(makeSafeForCsv(data[key]));
     }
 
     return row1.join(',') + '\n' + row2.join(',');
+}
+
+function makeSafeForCsv(value) {
+    value = '' + defaultValue(value, '');
+
+    return '"' + value.replace(/"/g, '""') + '"';
 }
 
 /**

--- a/test/ViewModels/FeatureInfoPanelSectionViewModelSpec.js
+++ b/test/ViewModels/FeatureInfoPanelSectionViewModelSpec.js
@@ -18,7 +18,7 @@ describe('FeatureInfoPanelSectionViewModel', function() {
         });
         var properties = {
             'Foo': 'bar',
-            'herp': 'derp'
+            'herp': 'd"e"r,p'
         };
         feature = new Entity({
             name: 'Bar',
@@ -111,8 +111,9 @@ describe('FeatureInfoPanelSectionViewModel', function() {
     describe('download data', function () {
         describe('on init', function () {
             it('should generate data uris for json and csv for 2-dimensional data', function() {
-                var EXPECTED_CSV_URL = 'data:attachment/csv,Foo%2Cherp%0Abar%2Cderp';
-                var EXPECTED_JSON_URL = 'data:attachment/json,%7B%22Foo%22%3A%22bar%22%2C%22herp%22%3A%22derp%22%7D';
+                // csv should separate with commas and surround data with quotes, and make existing quotes double-quotes ("")
+                var EXPECTED_CSV_URL = 'data:attachment/csv,%22Foo%22%2C%22herp%22%0A%22bar%22%2C%22d%22%22e%22%22r%2Cp%22';
+                var EXPECTED_JSON_URL = 'data:attachment/json,%7B%22Foo%22%3A%22bar%22%2C%22herp%22%3A%22d%5C%22e%5C%22r%2Cp%22%7D';
 
                 var section = new FeatureInfoPanelSectionViewModel(panel, feature);
 
@@ -127,7 +128,7 @@ describe('FeatureInfoPanelSectionViewModel', function() {
                 expect(section.dataDownloads[1].name).toBe('JSON');
             });
 
-            it('should only generate a data uris for json for hierarchical data', function() {
+            it('should only generate data uris for json for hierarchical data', function() {
                 var EXPECTED_JSON_URL = 'data:attachment/json,%7B%22Foo%22%3A%22bar%22%2C%22herp%22%3A%7B%22nestedHerp%22%3A%22nestedDerp%22%7D%7D';
 
                 feature.properties.herp = {


### PR DESCRIPTION
Fixes #1287.

Pretty simple, CSVs were previously naively generated by `.join`ing values together with commas in between, this wraps quotes around the values and escapes quotes by doubling them as per CSV conventions.
