### PR TITLE
Implement per-column table styling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 2.0.2
+
+* Added column-specific styling to CSV files, using a new `tableStyle.columns` json parameter. This is an object whose keys are column names or indices, and whose values are objects of column-specific tableStyle parameters, or two additional column-specific parameters: "name" and "type". See wwwroot/test/init/test-tablestyle.json's CSV column-specific group for an example. [#1097](https://github.com/TerriaJS/terriajs/issues/1097)
+
 ### 2.0.1
 
 * Fixed a bug that caused the last selected ABS concept not to appear in the feature info panel.

--- a/lib/Core/TableColumn.js
+++ b/lib/Core/TableColumn.js
@@ -269,13 +269,14 @@ defineProperties(TableColumn.prototype, {
 
     /**
      * Returns whether this column's indicesOrValues is indices,
-     * ie. whether this column is a non-numeric ENUM type.
+     * ie. whether this column is an ENUM type.
      * @memberOf TableColumn.prototype
      * @type {Boolean}
      */
     usesIndicesIntoUniqueValues: {
         get: function() {
-            return (isNaN(this._minimumValue) && this._type === VarType.ENUM);
+            // In previous versions, also required isNaN(this._minimumValue).
+            return this._type === VarType.ENUM;
         }
     },
 

--- a/lib/Core/TableColumn.js
+++ b/lib/Core/TableColumn.js
@@ -64,6 +64,7 @@ var defaultReplaceWithZeroValues = [null, '-'];
 * @param {String[]} [options.replaceWithZeroValues] If present, and this is a SCALAR type with at least one numerical value, then replace these values with 0.
 *        Defaults to [null, '-']. (Blank values like '' are converted to null before they reach here, so use null instead of '' to catch missing values.)
 * @param {Number} [options.displayDuration]
+* @param {String} [options.id]
 */
 var TableColumn = function(name, values, options) {
     this.options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -72,6 +73,7 @@ var TableColumn = function(name, values, options) {
         parent: this.options.tableStructure,
         active: this.options.active
     });
+    this.id = defaultValue(this.options.id, this.id); // if options.id is provided, use it to override the default (this.id = this.name).
 
     this._unallowedTypes = defaultValue(this.options.unallowedTypes, []);
     this._replaceWithZeroValues = defaultValue(this.options.replaceWithZeroValues, defaultReplaceWithZeroValues);

--- a/lib/Core/TableStructure.js
+++ b/lib/Core/TableStructure.js
@@ -34,7 +34,8 @@ var defaultDisplayVariableTypes = [VarType.ENUM, VarType.SCALAR, VarType.ALT];
  * @param {String[]} [options.replaceWithNullValues] Passed on to TableColumn, unless overridden by options.columnOptions.
  * @param {String[]} [options.replaceWithZeroValues] Passed on to TableColumn, unless overridden by options.columnOptions.
  * @param {Object} [options.columnOptions] An object with keys identifying columns (column names or indices),
- *                 and per-column properties displayDuration, replaceWithNullValues and replaceWithZeroValues. TODO: add title, type.
+ *                 and per-column properties displayDuration, replaceWithNullValues, replaceWithZeroValues, name, and type.
+ *                 Converts strings, which are case-insensitive keys of VarType, to their VarType integer.
  */
 var TableStructure = function(name, options) {
     DisplayVariablesConcept.call(this, name);
@@ -106,6 +107,21 @@ defineProperties(TableStructure.prototype, {
     }
 });
 
+function getVarTypeFromString(typeString) {
+    if (!defined(typeString)) {
+        return;
+    }
+    var typeNumber = parseInt(typeString, 10);
+    if (typeNumber === typeNumber) {  // parseInt returns NaN for non-numeric strings, and NaN !== NaN.
+        return typeNumber;
+    }
+    for (var varTypeName in VarType) {
+        if (typeString.toLowerCase() === varTypeName.toLowerCase()) {
+            return VarType[varTypeName];
+        }
+    }
+}
+
 /**
 * Create a TableStructure from a JSON object, eg. [['x', 'y'], [1, 5], [3, 8], [4, -3]].
 *
@@ -135,7 +151,7 @@ TableStructure.fromJson = function(json, result) {
             columnOptions = defaultValue(result.columnOptions[name], defaultValue(result.columnOptions[columnNumber], defaultValue.EMPTY_OBJECT));
         }
         var niceName = defaultValue(columnOptions.name, name);
-        var type = columnOptions.type;
+        var type = getVarTypeFromString(columnOptions.type);
         var displayDuration = defaultValue(columnOptions.displayDuration, result.displayDuration);
         var replaceWithNullValues = defaultValue(columnOptions.replaceWithNullValues, result.replaceWithNullValues);
         var replaceWithZeroValues = defaultValue(columnOptions.replaceWithZeroValues, result.replaceWithZeroValues);

--- a/lib/Core/TableStructure.js
+++ b/lib/Core/TableStructure.js
@@ -134,16 +134,18 @@ TableStructure.fromJson = function(json, result) {
         if (defined(result.columnOptions)) {
             columnOptions = defaultValue(result.columnOptions[name], defaultValue(result.columnOptions[columnNumber], defaultValue.EMPTY_OBJECT));
         }
+        var niceName = defaultValue(columnOptions.name, name);
         var displayDuration = defaultValue(columnOptions.displayDuration, result.displayDuration);
         var replaceWithNullValues = defaultValue(columnOptions.replaceWithNullValues, result.replaceWithNullValues);
         var replaceWithZeroValues = defaultValue(columnOptions.replaceWithZeroValues, result.replaceWithZeroValues);
-        columns.push(new TableColumn(name, values, {
+        columns.push(new TableColumn(niceName, values, {
             tableStructure: result,
             displayVariableTypes: result.displayVariableTypes,
             unallowedTypes: result.unallowedTypes,
             displayDuration: displayDuration,
             replaceWithNullValues: replaceWithNullValues,
-            replaceWithZeroValues: replaceWithZeroValues
+            replaceWithZeroValues: replaceWithZeroValues,
+            id: name,
         }));
     }
     result.items = columns;

--- a/lib/Core/TableStructure.js
+++ b/lib/Core/TableStructure.js
@@ -135,6 +135,7 @@ TableStructure.fromJson = function(json, result) {
             columnOptions = defaultValue(result.columnOptions[name], defaultValue(result.columnOptions[columnNumber], defaultValue.EMPTY_OBJECT));
         }
         var niceName = defaultValue(columnOptions.name, name);
+        var type = columnOptions.type;
         var displayDuration = defaultValue(columnOptions.displayDuration, result.displayDuration);
         var replaceWithNullValues = defaultValue(columnOptions.replaceWithNullValues, result.replaceWithNullValues);
         var replaceWithZeroValues = defaultValue(columnOptions.replaceWithZeroValues, result.replaceWithZeroValues);
@@ -146,6 +147,7 @@ TableStructure.fromJson = function(json, result) {
             replaceWithNullValues: replaceWithNullValues,
             replaceWithZeroValues: replaceWithZeroValues,
             id: name,
+            type: type
         }));
     }
     result.items = columns;

--- a/lib/Core/TableStructure.js
+++ b/lib/Core/TableStructure.js
@@ -30,9 +30,11 @@ var defaultDisplayVariableTypes = [VarType.ENUM, VarType.SCALAR, VarType.ALT];
  * @param {Object} [options] Options:
  * @param {Array} [options.displayVariableTypes] Which variable types to show in the NowViewing tab. Defaults to ENUM, SCALAR, and ALT (not LAT, LON or TIME).
  * @param {VarType[]} [options.unallowedTypes] An array of types which should not be guessed. If not present, all types are allowed. Cannot include VarType.SCALAR.
- * @param {Number} [options.displayDuration] Passed on to TableColumn.
- * @param {String[]} [options.replaceWithNullValues] Passed on to TableColumn.
- * @param {String[]} [options.replaceWithZeroValues] Passed on to TableColumn.
+ * @param {Number} [options.displayDuration] Passed on to TableColumn, unless overridden by options.columnOptions.
+ * @param {String[]} [options.replaceWithNullValues] Passed on to TableColumn, unless overridden by options.columnOptions.
+ * @param {String[]} [options.replaceWithZeroValues] Passed on to TableColumn, unless overridden by options.columnOptions.
+ * @param {Object} [options.columnOptions] An object with keys identifying columns (column names or indices),
+ *                 and per-column properties displayDuration, replaceWithNullValues and replaceWithZeroValues. TODO: add title, type.
  */
 var TableStructure = function(name, options) {
     DisplayVariablesConcept.call(this, name);
@@ -43,6 +45,7 @@ var TableStructure = function(name, options) {
     this.displayDuration = options.displayDuration;
     this.replaceWithNullValues = options.replaceWithNullValues;
     this.replaceWithZeroValues = options.replaceWithZeroValues;
+    this.columnOptions = options.columnOptions;
 
     /**
      * Gets or sets the active time column for this structure,
@@ -127,13 +130,20 @@ TableStructure.fromJson = function(json, result) {
         for (rowNumber = 1; rowNumber < json.length; rowNumber++) {
             values.push(json[rowNumber][columnNumber]);
         }
+        var columnOptions = defaultValue.EMPTY_OBJECT;
+        if (defined(result.columnOptions)) {
+            columnOptions = defaultValue(result.columnOptions[name], defaultValue(result.columnOptions[columnNumber], defaultValue.EMPTY_OBJECT));
+        }
+        var displayDuration = defaultValue(columnOptions.displayDuration, result.displayDuration);
+        var replaceWithNullValues = defaultValue(columnOptions.replaceWithNullValues, result.replaceWithNullValues);
+        var replaceWithZeroValues = defaultValue(columnOptions.replaceWithZeroValues, result.replaceWithZeroValues);
         columns.push(new TableColumn(name, values, {
             tableStructure: result,
             displayVariableTypes: result.displayVariableTypes,
             unallowedTypes: result.unallowedTypes,
-            displayDuration: result.displayDuration,
-            replaceWithNullValues: result.replaceWithNullValues,
-            replaceWithZeroValues: result.replaceWithZeroValues
+            displayDuration: displayDuration,
+            replaceWithNullValues: replaceWithNullValues,
+            replaceWithZeroValues: replaceWithZeroValues
         }));
     }
     result.items = columns;

--- a/lib/Map/Legend.js
+++ b/lib/Map/Legend.js
@@ -298,14 +298,14 @@ function drawItemLabels(legend, barGroup) {
 
     legend.items.forEach(function(item, i) {
         var y = itemY(legend, i);
-        if (item.titleAbove) {
+        if (defined(item.titleAbove)) {
             drawLabel(y, item.titleAbove);
             drawTick(y);
         }
-        if (item.title) {
+        if (defined(item.title)) {
             drawLabel(y + legend.itemHeight / 2, item.title);
         }
-        if (item.titleBelow) {
+        if (defined(item.titleBelow)) {
             drawLabel(y + legend.itemHeight, item.titleBelow);
             drawTick(y + legend.itemHeight);
         }

--- a/lib/Map/LegendHelper.js
+++ b/lib/Map/LegendHelper.js
@@ -382,7 +382,7 @@ function buildLegendProps(legendHelper, colorMap) {
             items: gradientLabelPoints(tableColumnStyle.legendTicks)
         };
     } else if (tableColumn.usesIndicesIntoUniqueValues) {
-        // Non-numeric ENUM legend labels are centered on each box, and slightly separated.
+        // ENUM legend labels are centered on each box, and slightly separated.
         // Reverse the color bins so that the first one appears at the top, not the bottom.
         var reversedBinColors = binColors.slice(0, tableColumn.uniqueValues.length);
         reversedBinColors.reverse();

--- a/lib/Map/LegendHelper.js
+++ b/lib/Map/LegendHelper.js
@@ -57,8 +57,8 @@ var LegendHelper = function(tableColumn, tableStyle, regionProvider) {
 function getTableColumnStyle(tableColumn, tableStyle) {
     var tableColumnStyle = {};
     if (defined(tableStyle.columns)) {
-        if (defined(tableStyle.columns[tableColumn.name])) {
-            tableColumnStyle = tableStyle.columns[tableColumn.name];
+        if (defined(tableStyle.columns[tableColumn.id])) {
+            tableColumnStyle = tableStyle.columns[tableColumn.id];
         } else {
             // Also support column indices as keys into tableStyle.columns
             var tableStructure = tableColumn.parent;

--- a/lib/Map/LegendHelper.js
+++ b/lib/Map/LegendHelper.js
@@ -40,15 +40,7 @@ var defaultColorArray = [32, 32, 32, 255];  // Used if no selected variable.
 var LegendHelper = function(tableColumn, tableStyle, regionProvider) {
     this.tableColumn = tableColumn;
     this.tableStyle = defined(tableStyle) ? tableStyle : new TableStyle();  // instead of defaultValue, so new object only created if needed.
-    // Find the right table column style for this column.
-    // By default, take styling directly from the tableStyle, unless there is a suitable 'columns' entry.
-    this.tableColumnStyle = this.tableStyle;
-    if (defined(this.tableStyle.columns)) {
-        if (defined(this.tableStyle.columns[this.tableColumn.name])) {
-            // TODO: need to copy defaults from tableStyle too.
-            this.tableColumnStyle = this.tableStyle.columns[this.tableColumn.name];
-        }
-    }
+    this.tableColumnStyle = getTableColumnStyle(tableColumn, this.tableStyle);
     this._legend = undefined;  // we could make a getter for this if it is ever needed.
     this._colorGradient = undefined;
     this._binColors = undefined;
@@ -59,6 +51,33 @@ var LegendHelper = function(tableColumn, tableStyle, regionProvider) {
     this.tableColumnStyle.legendTicks = defaultValue(this.tableColumnStyle.legendTicks, 0);
     this.tableColumnStyle.scale = defaultValue(this.tableColumnStyle.scale, 1);
 };
+
+// Find the right table column style for this column.
+// By default, take styling directly from the tableStyle, unless there is a suitable 'columns' entry.
+function getTableColumnStyle(tableColumn, tableStyle) {
+    var tableColumnStyle = {};
+    if (defined(tableStyle.columns)) {
+        if (defined(tableStyle.columns[tableColumn.name])) {
+            tableColumnStyle = tableStyle.columns[tableColumn.name];
+        } else {
+            // Also support column indices as keys into tableStyle.columns
+            var tableStructure = tableColumn.parent;
+            var columnIndex = tableStructure.columns.indexOf(tableColumn);
+            if (defined(tableStyle.columns[columnIndex])) {
+                tableColumnStyle = tableStyle.columns[columnIndex];
+            }
+        }
+    }
+    // Copy defaults from tableStyle too.
+    for (var propertyName in tableStyle) {
+        if (tableStyle.hasOwnProperty(propertyName)) {
+            if (!defined(tableColumnStyle[propertyName])) {
+                tableColumnStyle[propertyName] = tableStyle[propertyName];
+            }
+        }
+    }
+    return tableColumnStyle;
+}
 
 /**
  * Generates intermediate variables (such as _colorGradient, _binColors) and saves the legend.

--- a/lib/Map/LegendHelper.js
+++ b/lib/Map/LegendHelper.js
@@ -56,7 +56,7 @@ var LegendHelper = function(tableColumn, tableStyle, regionProvider) {
 // By default, take styling directly from the tableStyle, unless there is a suitable 'columns' entry.
 function getTableColumnStyle(tableColumn, tableStyle) {
     var tableColumnStyle = {};
-    if (defined(tableStyle.columns)) {
+    if (defined(tableColumn) && defined(tableStyle.columns)) {
         if (defined(tableStyle.columns[tableColumn.id])) {
             tableColumnStyle = tableStyle.columns[tableColumn.id];
         } else {

--- a/lib/Map/LegendHelper.js
+++ b/lib/Map/LegendHelper.js
@@ -330,10 +330,10 @@ function buildBinColors(legendHelper, colorBins) {
 
 function convertToStringWithAtMostTwoDecimalPlaces(f, tableColumnStyle) {
     f = Math.round(f * 100) / 100;
-    if (defined(tableColumnStyle.format) && tableColumnStyle.format.thousandSeparator) {
+    // if (defined(tableColumnStyle.format) && tableColumnStyle.format.thousandSeparator) {
         // TODO: replace formatNumberWithCommas with generic thousand separator.
         f = formatNumberWithCommas(f, 5);   // Use commas once there are over 5 digits before the decimal point.
-    }
+    // }
     return f;
 }
 

--- a/lib/Map/LegendHelper.js
+++ b/lib/Map/LegendHelper.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /*global require*/
+var clone = require('terriajs-cesium/Source/Core/clone');
 var Color = require('terriajs-cesium/Source/Core/Color');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
@@ -55,22 +56,25 @@ var LegendHelper = function(tableColumn, tableStyle, regionProvider) {
 // Find the right table column style for this column.
 // By default, take styling directly from the tableStyle, unless there is a suitable 'columns' entry.
 function getTableColumnStyle(tableColumn, tableStyle) {
-    var tableColumnStyle = {};
+    var tableColumnStyle;
     if (defined(tableColumn) && defined(tableStyle.columns)) {
         if (defined(tableStyle.columns[tableColumn.id])) {
-            tableColumnStyle = tableStyle.columns[tableColumn.id];
+            tableColumnStyle = clone(tableStyle.columns[tableColumn.id]);
         } else {
             // Also support column indices as keys into tableStyle.columns
             var tableStructure = tableColumn.parent;
             var columnIndex = tableStructure.columns.indexOf(tableColumn);
             if (defined(tableStyle.columns[columnIndex])) {
-                tableColumnStyle = tableStyle.columns[columnIndex];
+                tableColumnStyle = clone(tableStyle.columns[columnIndex]);
             }
         }
     }
+    if (!defined(tableColumnStyle)) {
+        return tableStyle;
+    }
     // Copy defaults from tableStyle too.
     for (var propertyName in tableStyle) {
-        if (tableStyle.hasOwnProperty(propertyName)) {
+        if (tableStyle.hasOwnProperty(propertyName) && tableColumnStyle.hasOwnProperty(propertyName)) {
             if (!defined(tableColumnStyle[propertyName])) {
                 tableColumnStyle[propertyName] = tableStyle[propertyName];
             }

--- a/lib/Map/LegendHelper.js
+++ b/lib/Map/LegendHelper.js
@@ -40,15 +40,24 @@ var defaultColorArray = [32, 32, 32, 255];  // Used if no selected variable.
 var LegendHelper = function(tableColumn, tableStyle, regionProvider) {
     this.tableColumn = tableColumn;
     this.tableStyle = defined(tableStyle) ? tableStyle : new TableStyle();  // instead of defaultValue, so new object only created if needed.
+    // Find the right table column style for this column.
+    // By default, take styling directly from the tableStyle, unless there is a suitable 'columns' entry.
+    this.tableColumnStyle = this.tableStyle;
+    if (defined(this.tableStyle.columns)) {
+        if (defined(this.tableStyle.columns[this.tableColumn.name])) {
+            // TODO: need to copy defaults from tableStyle too.
+            this.tableColumnStyle = this.tableStyle.columns[this.tableColumn.name];
+        }
+    }
     this._legend = undefined;  // we could make a getter for this if it is ever needed.
     this._colorGradient = undefined;
     this._binColors = undefined;
     this._regionProvider = regionProvider;
-    this._nullColorArray = defined(this.tableStyle.nullColor) ? getColorArrayFromCssColorString(this.tableStyle.nullColor) : defaultColorArray;
+    this._nullColorArray = defined(this.tableColumnStyle.nullColor) ? getColorArrayFromCssColorString(this.tableColumnStyle.nullColor) : defaultColorArray;
 
-    this.tableStyle.colorBins = defaultValue(this.tableStyle.colorBins, 7);
-    this.tableStyle.legendTicks = defaultValue(this.tableStyle.legendTicks, 0);
-    this.tableStyle.scale = defaultValue(this.tableStyle.scale, 1);
+    this.tableColumnStyle.colorBins = defaultValue(this.tableColumnStyle.colorBins, 7);
+    this.tableColumnStyle.legendTicks = defaultValue(this.tableColumnStyle.legendTicks, 0);
+    this.tableColumnStyle.scale = defaultValue(this.tableColumnStyle.scale, 1);
 };
 
 /**
@@ -59,11 +68,11 @@ function generateLegend(legendHelper) {
     var colorMap;
     var colorBins;
     var tableColumn = legendHelper.tableColumn;
-    if (!defined(legendHelper.tableStyle.colorMap)) {
+    if (!defined(legendHelper.tableColumnStyle.colorMap)) {
         // There is no colorMap defined, so set a good default.
         if (!defined(tableColumn) || (tableColumn.type === VarType.ENUM)) {
             // If no table column is active, color it as if it were an ENUM with the maximum available colors.
-            // Recall tableStyle.colorBins is the number of bins.
+            // Recall tableColumnStyle.colorBins is the number of bins.
             if (defined(tableColumn)) {
                 colorBins = Math.min(tableColumn.values.length, defaultEnumColorCodes.length);
             } else {
@@ -75,7 +84,7 @@ function generateLegend(legendHelper) {
             colorMap = defaultScalarColorMap;
         }
     } else {
-        colorMap = legendHelper.tableStyle.colorMap;
+        colorMap = legendHelper.tableColumnStyle.colorMap;
     }
 
     legendHelper._colorGradient = buildColorGradient(colorMap);
@@ -109,23 +118,23 @@ LegendHelper.prototype.legendUrl = function() {
  * @return {Number} The fractional value.
  */
 function getFractionalValue(legendHelper, value) {
-    var minValue = legendHelper.tableStyle.minDisplayValue || legendHelper.tableColumn.minimumValue;
-    var maxValue = legendHelper.tableStyle.maxDisplayValue || legendHelper.tableColumn.maximumValue;
+    var minValue = legendHelper.tableColumnStyle.minDisplayValue || legendHelper.tableColumn.minimumValue;
+    var maxValue = legendHelper.tableColumnStyle.maxDisplayValue || legendHelper.tableColumn.maximumValue;
     var f = (maxValue === minValue) ? 0 : (value - minValue) / (maxValue - minValue);
-    if (legendHelper.tableStyle.clampDisplayValue) {
+    if (legendHelper.tableColumnStyle.clampDisplayValue) {
         f = Math.max(0.0, Math.min(1.0, f));
     }
     return f;
 }
 
 /**
- * Maps an absolute value to a scale, based on tableStyle.
+ * Maps an absolute value to a scale, based on tableColumnStyle.
  * @param  {Number} [value] The absolute value.
  * @return {Number} The scale.
  */
 LegendHelper.prototype.getScaleFromValue = function(value) {
-    var scale = this.tableStyle.scale;
-    if (this.tableStyle.scaleByValue && defined(value)) {
+    var scale = this.tableColumnStyle.scale;
+    if (this.tableColumnStyle.scaleByValue && defined(value)) {
         var fractionalValue = getFractionalValue(this, value);
         if (defined(fractionalValue) && fractionalValue === fractionalValue) { // testing for NaN
             scale = scale * (fractionalValue + 0.5);
@@ -228,19 +237,19 @@ function getColorArrayFromColorGradient(colorGradient, fractionalPosition) {
  * [ { color: [r, g, b, a], upperBound: 20 } , { color: [r, g, b, a]: upperBound: 80 } ]
  * 
  * @param  {LegendHelper} legendHelper The legend helper.
- * @param {Integer} [colorBins] The number of color bins to use; defaults to legendHelper.tableStyle.colorBins.
+ * @param {Integer} [colorBins] The number of color bins to use; defaults to legendHelper.tableColumnStyle.colorBins.
  * @return {Array} Array of objects with keys "color" and "upperBound".
  */
 function buildBinColors(legendHelper, colorBins) {
     var tableColumn = legendHelper.tableColumn;
-    var tableStyle = legendHelper.tableStyle;
+    var tableColumnStyle = legendHelper.tableColumnStyle;
     var colorGradient = legendHelper._colorGradient;
     var regionProvider = legendHelper._regionProvider;
     if (!defined(colorBins)) {
-        colorBins = tableStyle.colorBins;
+        colorBins = tableColumnStyle.colorBins;
     }
 
-    if (colorBins <= 0 || tableStyle.colorBinMethod.match(/none/i)) {
+    if (colorBins <= 0 || tableColumnStyle.colorBinMethod.match(/none/i)) {
         return undefined;
     }
     var binColors = [];
@@ -261,8 +270,8 @@ function buildBinColors(legendHelper, colorBins) {
     var binCount = Math.min(colorBins, numericalValues.length);
 
     // Convert the output formats of two binning methods into our format.
-    if (tableStyle.colorBinMethod === 'quantile' ||
-        tableStyle.colorBinMethod === 'auto' && numericalValues.length > 1000 && (defined(tableColumn) && !tableColumn.usesIndicesIntoUniqueValues)) {
+    if (tableColumnStyle.colorBinMethod === 'quantile' ||
+        tableColumnStyle.colorBinMethod === 'auto' && numericalValues.length > 1000 && (defined(tableColumn) && !tableColumn.usesIndicesIntoUniqueValues)) {
         // the quantile method is simpler, less accurate, but faster for large datasets. One issue is we don't check to see if any
         // values actually lie within a given quantile, so it's bad for small datasets.
         for (i = 0; i < binCount; i++) {
@@ -296,8 +305,13 @@ function buildBinColors(legendHelper, colorBins) {
 }
 
 
-function convertToStringWithAtMostTwoDecimalPlaces(f) {
-    return formatNumberWithCommas(Math.round(f * 100) / 100, 5);  // Use commas once there are over 5 digits before the decimal point.
+function convertToStringWithAtMostTwoDecimalPlaces(f, tableColumnStyle) {
+    f = Math.round(f * 100) / 100;
+    if (defined(tableColumnStyle.format) && tableColumnStyle.format.thousandSeparator) {
+        // TODO: replace formatNumberWithCommas with generic thousand separator.
+        f = formatNumberWithCommas(f, 5);   // Use commas once there are over 5 digits before the decimal point.
+    }
+    return f;
 }
 
 function convertColorArrayToCssString(colorArray) {
@@ -306,7 +320,7 @@ function convertColorArrayToCssString(colorArray) {
 
 function buildLegendProps(legendHelper, colorMap) {
     var tableColumn = legendHelper.tableColumn;
-    var tableStyle = legendHelper.tableStyle;
+    var tableColumnStyle = legendHelper.tableColumnStyle;
     var binColors = legendHelper._binColors;
 
     // No legend if fixed color for all points, or if no active tableColumn
@@ -317,11 +331,11 @@ function buildLegendProps(legendHelper, colorMap) {
     var minimumValue = tableColumn.minimumValue;
     var maximumValue = tableColumn.maximumValue;
     if (minimumValue !== maximumValue) {
-        if (defined(tableStyle.maxDisplayValue)) {
-            maximumValue = tableStyle.maxDisplayValue;
+        if (defined(tableColumnStyle.maxDisplayValue)) {
+            maximumValue = tableColumnStyle.maxDisplayValue;
         }
-        if (defined(tableStyle.minDisplayValue)) {
-            minimumValue = tableStyle.minDisplayValue;
+        if (defined(tableColumnStyle.minDisplayValue)) {
+            minimumValue = tableColumnStyle.minDisplayValue;
         }
     }
 
@@ -330,15 +344,15 @@ function buildLegendProps(legendHelper, colorMap) {
         var segments = 2 + ticks;
         for (var i = 1; i <= segments; i++) {
             items.push({
-                titleAbove: convertToStringWithAtMostTwoDecimalPlaces(minimumValue + (maximumValue - minimumValue) * (i / segments)),
-                titleBelow: (i === 1) ? convertToStringWithAtMostTwoDecimalPlaces(minimumValue) : undefined
+                titleAbove: convertToStringWithAtMostTwoDecimalPlaces(minimumValue + (maximumValue - minimumValue) * (i / segments), tableColumnStyle),
+                titleBelow: (i === 1) ? convertToStringWithAtMostTwoDecimalPlaces(minimumValue, tableColumnStyle) : undefined
             });
         }
         return items;
     }
 
     var result;
-    var nullLabel = defaultValue(tableStyle.nullLabel, '');
+    var nullLabel = defaultValue(tableColumnStyle.nullLabel, '');
     if (!binColors) {
         // Display a smooth gradient with number of ticks requested.
         return {
@@ -346,7 +360,7 @@ function buildLegendProps(legendHelper, colorMap) {
             barHeightMin: 130,
             gradientColorMap: colorMap,
             labelTickColor: 'darkgray',
-            items: gradientLabelPoints(tableStyle.legendTicks)
+            items: gradientLabelPoints(tableColumnStyle.legendTicks)
         };
     } else if (tableColumn.usesIndicesIntoUniqueValues) {
         // Non-numeric ENUM legend labels are centered on each box, and slightly separated.
@@ -375,8 +389,8 @@ function buildLegendProps(legendHelper, colorMap) {
             items: binColors.map(function(b, i) {
                 return {
                     // these long checks are to avoid showing max and min values when they're identical to the second highest and second lowest numbers
-                    titleAbove: (i === 0 || i < binColors.length - 1 || b.upperBound > binColors[i - 1].upperBound) ? convertToStringWithAtMostTwoDecimalPlaces(b.upperBound) : undefined,
-                    titleBelow: (i === 0 && b.upperBound !== minimumValue) ? convertToStringWithAtMostTwoDecimalPlaces(minimumValue) : undefined,
+                    titleAbove: (i === 0 || i < binColors.length - 1 || b.upperBound > binColors[i - 1].upperBound) ? convertToStringWithAtMostTwoDecimalPlaces(b.upperBound, tableColumnStyle) : undefined,
+                    titleBelow: (i === 0 && b.upperBound !== minimumValue) ? convertToStringWithAtMostTwoDecimalPlaces(minimumValue, tableColumnStyle) : undefined,
                     color: 'rgb(' + b.colorArray[0] + ',' + b.colorArray[1] + ',' + b.colorArray[2] + ')'
                 };
             })

--- a/lib/Models/Concept.js
+++ b/lib/Models/Concept.js
@@ -13,6 +13,13 @@ var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
  */
 var Concept = function(name) {
     /**
+     * Gets or sets the id of the concept item. By default this is the same as the name.
+     * It is allowed to be different eg. for csv files with tersely-named columns.
+     * @type {String}
+     */
+    this.id = name;
+
+    /**
      * Gets or sets the name of the concept item.  This property is observable.
      * @type {String}
      */

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -382,7 +382,8 @@ function loadTableFromCsv(item, csvString) {
     var options = {
         displayDuration: tableStyle.displayDuration,
         replaceWithNullValues: tableStyle.replaceWithNullValues,
-        replaceWithZeroValues: tableStyle.replaceWithZeroValues
+        replaceWithZeroValues: tableStyle.replaceWithZeroValues,
+        columnOptions: tableStyle.columns  // may contain per-column replacements for these
     };
     var tableStructure = new TableStructure(item.name, options);
     tableStructure.loadFromCsv(csvString);

--- a/lib/Models/TableColumnStyle.js
+++ b/lib/Models/TableColumnStyle.js
@@ -8,6 +8,7 @@ var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var ColorMap = require('../Map/ColorMap');
 var serializeToJson = require('../Core/serializeToJson');
 var updateFromJson = require('../Core/updateFromJson');
+var VarType = require('../Map/VarType');
 
 /**
  * A set of properties that define how a table column should be displayed.
@@ -143,10 +144,28 @@ var TableColumnStyle = function(options) {
     this.legendTicks = defaultValue(options.legendTicks, 3);
 
     /**
-     * A nice name for this column.
+     * Display name for this column.
      * @type {String}
      */
     this.name = options.name;
+
+    /**
+     * The variable type of this column. Convert strings, which are case-insensitive keys of VarType, to numbers. See VarType for further information.
+     * @type {String|Number}
+     */
+    this.type = undefined;
+    if (defined(options.type)) {
+        var typeNumber = parseInt(options.type, 10);
+        if (typeNumber === typeNumber) {
+            this.type = typeNumber;
+        } else {
+            for (var varTypeName in VarType) {
+                if (options.type.toLowerCase() === varTypeName.toLowerCase()) {
+                    this.type = VarType[varTypeName];
+                }
+            }
+        }
+    }
 };
 
 // When colorMap is updated, we need to convert it to a colorMap.

--- a/lib/Models/TableColumnStyle.js
+++ b/lib/Models/TableColumnStyle.js
@@ -18,6 +18,29 @@ var updateFromJson = require('../Core/updateFromJson');
  * @constructor
  *
  * @param {Object} [options] The values of the properties of the new instance.
+ * @param {Float} [options.minDisplayValue] All data values less than or equal to this are considered equal for the purpose of display.
+ * @param {Float} [options.maxDisplayValue] All data values reater than or equal to this are considered equal for the purpose of display.
+ * @param {Float} [options.displayDuration] Display duration.
+ * @param {Array} [options.replaceWithZeroValues] Values to replace with zero, eg. ['-', null] will replace '-' and empty values with 0.
+ * @param {Array} [options.replaceWithNullValues] Values to replace with null, eg. ['na', 'NA'] will replace these values with null.
+ * @param {String} [options.nullColor] The css string for the color with which to display null values.
+ * @param {String} [options.nullLabel] The legend label for null values.
+ * @param {Float} [options.scale] The size of each point or billboard.
+ * @param {Boolean} [options.scaleByValue] Should points and billboards representing each feature be scaled by the size of their data variable?
+ * @param {Boolean} [options.clampDisplayValue] Display values that fall outside the display range as min and max colors.
+ * @param {String} [options.imageUrl] A string representing an image to display at each point, for lat-long datasets.
+ * @param {Object} [options.featureInfoFields] An object of { "myCol": "My column" } properties, defining which columns get displayed in feature info boxes
+ *                 and what label is used instead of the column's actual name.
+ * @param {Number} [options.colorBins] The number of discrete colours that a color gradient should be quantised into.
+ * @param {String} [options.colorBinMethod] The method for quantising colors: "auto" (default), "ckmeans", "quantile" or "none" (equivalent to colorBins: 0).
+ * @param {String|Array} [options.colorMap] Gets or sets a string or {@link ColorMap} array, specifying how to map values to colors.  Setting this property sets
+ *                 colorPalette to undefined.  If this property is a string, it specifies a list of CSS colors separated by hyphens (-),
+ *                 and the colors are evenly spaced over the range of values.  For example, "red-white-hsl(240,50%,50%)".
+ * @param {String} [options.colorPalette] Gets or sets the [ColorBrewer](http://colorbrewer2.org/) palette to use when mapping values to colors.  Setting this
+ *                 property sets colorMap to undefined.  This property is ignored if colorMap is defined.
+ * @param {Integer} [options.legendTicks] How many horizontal ticks to draw on the generated color ramp legend, not counting the top or bottom.
+ * @param {String} [options.name] Display name for this column.
+ * @param {String|Number} [options.type] The variable type of this column. Should be one of the keys of VarType (case-insensitive), eg. 'ENUM', 'SCALAR', 'TIME'.
  */
 var TableColumnStyle = function(options) {
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -41,7 +64,7 @@ var TableColumnStyle = function(options) {
     this.displayDuration = options.displayDuration;
 
     /**
-     * Values to replace with null, eg. ['-', ''].
+     * Values to replace with zero, eg. ['-', null].
      * @type {Array}
      */
     this.replaceWithZeroValues = options.replaceWithZeroValues;
@@ -53,19 +76,19 @@ var TableColumnStyle = function(options) {
     this.replaceWithNullValues = options.replaceWithNullValues;
 
     /**
-     * The default color for null values.
+     * The css string for the color with which to display null values.
      * @type {String}
      */
     this.nullColor = options.nullColor;
 
     /**
-     * The default legend label for null values.
+     * The legend label for null values.
      * @type {String}
      */
     this.nullLabel = options.nullLabel;
 
     /**
-     * The size of each point or billboard
+     * The size of each point or billboard.
      * @type {Float}
      */
     this.scale = options.scale;
@@ -96,7 +119,7 @@ var TableColumnStyle = function(options) {
     this.featureInfoFields = options.featureInfoFields;
 
     /**
-     * The number of discrete colours that a colour gradient should be quantised into.
+     * The number of discrete colours that a color gradient should be quantised into.
      * @type {Number}
      */
     this.colorBins = options.colorBins;
@@ -109,11 +132,11 @@ var TableColumnStyle = function(options) {
 
     /**
      * Gets or sets a string or {@link ColorMap} array, specifying how to map values to colors.  Setting this property sets
-     * {@link TableStyle#colorPalette} to undefined.  If this property is a string, it specifies a list of CSS colors separated by hyphens (-),
+     * {@link TableColumnStyle#colorPalette} to undefined.  If this property is a string, it specifies a list of CSS colors separated by hyphens (-),
      * and the colors are evenly spaced over the range of values.  For example, "red-white-hsl(240,50%,50%)".
-     * @memberOf TableStyle.prototype
-     * @type {String}
-     * @see TableStyle#colorPalette
+     * @memberOf TableColumnStyle.prototype
+     * @type {String|Array}
+     * @see TableColumnStyle#colorPalette
      */
     if (defined(options.colorMap)) {
         this.colorMap = new ColorMap(options.colorMap);
@@ -123,10 +146,10 @@ var TableColumnStyle = function(options) {
 
     /**
      * Gets or sets the [ColorBrewer](http://colorbrewer2.org/) palette to use when mapping values to colors.  Setting this
-     * property sets {@link TableStyle#colorMap} to undefined.  This property is ignored if {@link TableStyle#colorMap} is defined.
-     * @memberOf TableStyle.prototype
+     * property sets {@link TableColumnStyle#colorMap} to undefined.  This property is ignored if {@link TableColumnStyle#colorMap} is defined.
+     * @memberOf TableColumnStyle.prototype
      * @type {String}
-     * @see  TableStyle#colorMap
+     * @see  TableColumnStyle#colorMap
      */
     this.colorPalette = options.colorPalette;  // Only need this here so that updateFromJson sees colorPalette as a property.
     if (defined(options.colorPalette)) {

--- a/lib/Models/TableColumnStyle.js
+++ b/lib/Models/TableColumnStyle.js
@@ -8,7 +8,6 @@ var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var ColorMap = require('../Map/ColorMap');
 var serializeToJson = require('../Core/serializeToJson');
 var updateFromJson = require('../Core/updateFromJson');
-var VarType = require('../Map/VarType');
 
 /**
  * A set of properties that define how a table column should be displayed.

--- a/lib/Models/TableColumnStyle.js
+++ b/lib/Models/TableColumnStyle.js
@@ -141,6 +141,12 @@ var TableColumnStyle = function(options) {
      * @type {Integer}
      */
     this.legendTicks = defaultValue(options.legendTicks, 3);
+
+    /**
+     * A nice name for this column.
+     * @type {String}
+     */
+    this.name = options.name;
 };
 
 // When colorMap is updated, we need to convert it to a colorMap.

--- a/lib/Models/TableColumnStyle.js
+++ b/lib/Models/TableColumnStyle.js
@@ -130,9 +130,10 @@ var TableColumnStyle = function(options) {
      * @see  TableStyle#colorMap
      */
     this.colorPalette = options.colorPalette;  // Only need this here so that updateFromJson sees colorPalette as a property.
-    if (defined(this.colorPalette)) {
+    if (defined(options.colorPalette)) {
+        // Note the promise created here is lost.
         var that = this;
-        return ColorMap.loadFromPalette(this.colorPalette).then(function(colorMap) {
+        ColorMap.loadFromPalette(this.colorPalette).then(function(colorMap) {
             that.colorMap = colorMap;
         });
     }
@@ -150,22 +151,11 @@ var TableColumnStyle = function(options) {
     this.name = options.name;
 
     /**
-     * The variable type of this column. Convert strings, which are case-insensitive keys of VarType, to numbers. See VarType for further information.
+     * The variable type of this column.
+     * Converts strings, which are case-insensitive keys of VarType, to numbers. See TableStructure for further information.
      * @type {String|Number}
      */
-    this.type = undefined;
-    if (defined(options.type)) {
-        var typeNumber = parseInt(options.type, 10);
-        if (typeNumber === typeNumber) {
-            this.type = typeNumber;
-        } else {
-            for (var varTypeName in VarType) {
-                if (options.type.toLowerCase() === varTypeName.toLowerCase()) {
-                    this.type = VarType[varTypeName];
-                }
-            }
-        }
-    }
+    this.type = options.type;
 };
 
 // When colorMap is updated, we need to convert it to a colorMap.

--- a/lib/Models/TableColumnStyle.js
+++ b/lib/Models/TableColumnStyle.js
@@ -1,0 +1,179 @@
+'use strict';
+
+/*global require*/
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
+var defined = require('terriajs-cesium/Source/Core/defined');
+var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
+
+var ColorMap = require('../Map/ColorMap');
+var serializeToJson = require('../Core/serializeToJson');
+var updateFromJson = require('../Core/updateFromJson');
+
+/**
+ * A set of properties that define how a table column should be displayed.
+ * If not set explicitly, many of these properties will be given default or guessed values elsewhere,
+ * such as in CsvCatalogItem.
+ *
+ * @alias TableColumnStyle
+ * @constructor
+ *
+ * @param {Object} [options] The values of the properties of the new instance.
+ */
+var TableColumnStyle = function(options) {
+    options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+    /**
+     * All data values less than or equal to this are considered equal for the purpose of display.
+     * @type {Float}
+     */
+    this.minDisplayValue = options.minDisplayValue;
+
+    /**
+     * All data values greater than or equal to this are considered equal for the purpose of display.
+     * @type {Float}
+     */
+    this.maxDisplayValue = options.maxDisplayValue;
+
+    /**
+     * Display duration.
+     * @type {Float}
+     */
+    this.displayDuration = options.displayDuration;
+
+    /**
+     * Values to replace with null, eg. ['-', ''].
+     * @type {Array}
+     */
+    this.replaceWithZeroValues = options.replaceWithZeroValues;
+
+    /**
+     * Values to replace with null, eg. ['na', 'NA'].
+     * @type {Array}
+     */
+    this.replaceWithNullValues = options.replaceWithNullValues;
+
+    /**
+     * The default color for null values.
+     * @type {String}
+     */
+    this.nullColor = options.nullColor;
+
+    /**
+     * The default legend label for null values.
+     * @type {String}
+     */
+    this.nullLabel = options.nullLabel;
+
+    /**
+     * The size of each point or billboard
+     * @type {Float}
+     */
+    this.scale = options.scale;
+
+    /**
+     * Should points and billboards representing each feature be scaled by the size of their data variable?
+     * @type {Boolean}
+     */
+    this.scaleByValue = options.scaleByValue;
+
+    /**
+     * Display values that fall outside the display range as min and max colors.
+     * @type {Boolean}
+     */
+    this.clampDisplayValue = options.clampDisplayValue;
+
+    /**
+     * A string representing an image to display at each point, for lat-long datasets.
+     * @type {String}
+     */
+    this.imageUrl = options.imageUrl;
+
+    /**
+     * An object of { "myCol": "My column" } properties, defining which columns get displayed in feature info boxes
+     * (when clicked on), and what label is used instead of the column's actual name.
+     * @type {Object}
+     */
+    this.featureInfoFields = options.featureInfoFields;
+
+    /**
+     * The number of discrete colours that a colour gradient should be quantised into.
+     * @type {Number}
+     */
+    this.colorBins = options.colorBins;
+
+    /**
+     * The method for quantising colors: "auto" (default), "ckmeans", "quantile" or "none" (equivalent to colorBins: 0).
+     * @type {String}
+     */
+    this.colorBinMethod = defaultValue(options.colorBinMethod, 'auto');
+
+    /**
+     * Gets or sets a string or {@link ColorMap} array, specifying how to map values to colors.  Setting this property sets
+     * {@link TableStyle#colorPalette} to undefined.  If this property is a string, it specifies a list of CSS colors separated by hyphens (-),
+     * and the colors are evenly spaced over the range of values.  For example, "red-white-hsl(240,50%,50%)".
+     * @memberOf TableStyle.prototype
+     * @type {String}
+     * @see TableStyle#colorPalette
+     */
+    if (defined(options.colorMap)) {
+        this.colorMap = new ColorMap(options.colorMap);
+    } else {
+        this.colorMap = undefined;
+    }
+
+    /**
+     * Gets or sets the [ColorBrewer](http://colorbrewer2.org/) palette to use when mapping values to colors.  Setting this
+     * property sets {@link TableStyle#colorMap} to undefined.  This property is ignored if {@link TableStyle#colorMap} is defined.
+     * @memberOf TableStyle.prototype
+     * @type {String}
+     * @see  TableStyle#colorMap
+     */
+    this.colorPalette = options.colorPalette;  // Only need this here so that updateFromJson sees colorPalette as a property.
+    if (defined(this.colorPalette)) {
+        var that = this;
+        return ColorMap.loadFromPalette(this.colorPalette).then(function(colorMap) {
+            that.colorMap = colorMap;
+        });
+    }
+
+    /**
+     * How many horizontal ticks to draw on the generated color ramp legend, not counting the top or bottom.
+     * @type {Integer}
+     */
+    this.legendTicks = defaultValue(options.legendTicks, 3);
+};
+
+// When colorMap is updated, we need to convert it to a colorMap.
+// When colorPalette is updated, we need to update colorMap.
+TableColumnStyle.prototype.updaters = {
+    colorMap: function(tableColumnStyle, json, propertyName) {
+        tableColumnStyle.colorMap = new ColorMap(json[propertyName]);
+    },
+    colorPalette: function(tableColumnStyle, json, propertyName) {
+        return ColorMap.loadFromPalette(json[propertyName]).then(function(colorMap) {
+            tableColumnStyle.colorMap = colorMap;
+        });
+    }
+};
+freezeObject(TableColumnStyle.prototype.updaters);
+
+TableColumnStyle.prototype.serializers = {
+    colorMap: function(tableColumnStyle, json, propertyName) {
+        // Only serialize colorMap if there is no colorPalette.
+        if (!defined(tableColumnStyle.colorPalette)) {
+            json[propertyName] = tableColumnStyle[propertyName];
+        }
+    }
+};
+freezeObject(TableColumnStyle.prototype.serializers);
+
+TableColumnStyle.prototype.updateFromJson = function(json, options) {
+    return updateFromJson(this, json, options);
+};
+
+TableColumnStyle.prototype.serializeToJson = function(options) {
+    return serializeToJson(this, undefined, options);
+};
+
+
+module.exports = TableColumnStyle;

--- a/lib/Models/TableDataSource.js
+++ b/lib/Models/TableDataSource.js
@@ -73,8 +73,6 @@ var TableDataSource = function(tableStructure, tableStyle) {
     knockout.getObservable(this._tableStructure, 'activeItems').subscribe(changedActiveItems.bind(null, this), this);
 };
 
-// TODO: do we need to stop this.tableStyle from being serialized/updated?
-
 defineProperties(TableDataSource.prototype, {
     /**
      * Gets a human-readable name for this instance.
@@ -236,10 +234,10 @@ function calculateShow(availability) {
 }
 
 // Adds a point of the given scale, color and show (availability) to the entity.
-// If there is an image defined in the tableStyle, use a billboard instead.
-function addPointToEntity(entity, tableStyle, scale, color, show) {
+// If there is an image defined in the tableColumnStyle, use a billboard instead.
+function addPointToEntity(entity, tableColumnStyle, scale, color, show) {
     //no image so use point
-    if (!defined(tableStyle) || !defined(tableStyle.imageUrl) || tableStyle.imageUrl === '') {
+    if (!defined(tableColumnStyle) || !defined(tableColumnStyle.imageUrl) || tableColumnStyle.imageUrl === '') {
         entity.point = {
             outlineColor: new Color(0, 0, 0, 1),
             outlineWidth: 1,
@@ -251,7 +249,7 @@ function addPointToEntity(entity, tableStyle, scale, color, show) {
         entity.billboard = {
             horizontalOrigin : HorizontalOrigin.CENTER,
             verticalOrigin : VerticalOrigin.BOTTOM,
-            image : tableStyle.imageUrl,
+            image : tableColumnStyle.imageUrl,
             scale : scale,
             color : color,
             show : show
@@ -268,13 +266,14 @@ function setEntityProperties(entity, properties) {
     entity.properties = properties;
 }
 
-// Set the features (entities) on this data source, using tableColumn to provide values and tableStyle for styling.
+// Set the features (entities) on this data source, using tableColumn to provide values and tableStyle + legendHelper.tableColumnStyle for styling.
 // Set the extent based on those entities.
 function updateEntitiesAndExtent(dataSource) {
     var tableStructure = dataSource._tableStructure;
     var legendHelper = dataSource._legendHelper;
     var tableColumn = legendHelper.tableColumn;
     var tableStyle = legendHelper.tableStyle;
+    var tableColumnStyle = legendHelper.tableColumnStyle;
     var longitudeColumn = tableStructure.columnsByType[VarType.LON][0];
     var latitudeColumn = tableStructure.columnsByType[VarType.LAT][0];
     if (defined(longitudeColumn) && defined(latitudeColumn)) {
@@ -312,7 +311,7 @@ function updateEntitiesAndExtent(dataSource) {
             var scale = legendHelper.getScaleFromValue(value);
             entity.availability = timeColumn && timeColumn.availabilities && timeColumn.availabilities[i];
             var show = calculateShow(entity.availability);
-            addPointToEntity(entity, tableStyle, scale, color, show);
+            addPointToEntity(entity, tableColumnStyle, scale, color, show);
             dataSource._entityCollection.add(entity);
         }
 

--- a/lib/Models/TableDataSource.js
+++ b/lib/Models/TableDataSource.js
@@ -285,7 +285,7 @@ function updateEntitiesAndExtent(dataSource) {
 
         var rowObjects = tableStructure.toRowObjects();
         var fallbackNameField = chooseFallbackNameField(tableStructure.getColumnNames());
-        var rowDescriptions = tableStructure.toRowDescriptions(dataSource.tableStyle && dataSource.tableStyle.featureInfoFields);
+        var rowDescriptions = tableStructure.toRowDescriptions(tableStyle && tableStyle.featureInfoFields);
 
         for (var i = 0; i < rowObjects.length; i++) {
             if (!definedNotNull(latitudeColumn.values[i]) || !definedNotNull(longitudeColumn.values[i])) {

--- a/lib/Models/TableStyle.js
+++ b/lib/Models/TableStyle.js
@@ -6,17 +6,26 @@ var defined = require('terriajs-cesium/Source/Core/defined');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 
 var ColorMap = require('../Map/ColorMap');
+var inherit = require('../Core/inherit');
 var serializeToJson = require('../Core/serializeToJson');
+var TableColumnStyle = require('./TableColumnStyle');
 var updateFromJson = require('../Core/updateFromJson');
 
 /**
-  * A set of properties that define how a table, such as a CSV file, should be displayed.
-  * If not set explicitly, many of these properties will be given default or guessed values elsewhere,
-  * such as in CsvCatalogItem.
-  * @param {Object} [options] The values of the properties of the new instance.
-  */
+ * A set of properties that define how a table, such as a CSV file, should be displayed.
+ * If not set explicitly, many of these properties will be given default or guessed values elsewhere,
+ * such as in CsvCatalogItem.
+ *
+ * @alias TableStyle
+ * @constructor
+ * @extends TableColumnStyle
+ *
+ * @param {Object} [options] The values of the properties of the new instance.
+ */
 var TableStyle = function(options) {
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+    TableColumnStyle.call(this, options);
 
     /**
      * The name of the variable (column) to be used for region mapping.
@@ -37,163 +46,19 @@ var TableStyle = function(options) {
     this.dataVariable = options.dataVariable;
 
     /**
-     * All data values less than or equal to this are considered equal for the purpose of display.
-     * @type {Float}
-     */
-    this.minDisplayValue = options.minDisplayValue;
-
-    /**
-     * All data values greater than or equal to this are considered equal for the purpose of display.
-     * @type {Float}
-     */
-    this.maxDisplayValue = options.maxDisplayValue;
-
-    /**
-     * Display duration.
-     * @type {Float}
-     */
-    this.displayDuration = options.displayDuration;
-
-    /**
-     * Values to replace with null, eg. ['-', ''].
-     * @type {Array}
-     */
-    this.replaceWithZeroValues = options.replaceWithZeroValues;
-
-    /**
-     * Values to replace with null, eg. ['na', 'NA'].
-     * @type {Array}
-     */
-    this.replaceWithNullValues = options.replaceWithNullValues;
-
-    /**
-     * The default color for null values.
-     * @type {String}
-     */
-    this.nullColor = options.nullColor;
-
-    /**
-     * The default legend label for null values.
-     * @type {String}
-     */
-    this.nullLabel = options.nullLabel;
-
-    /**
-     * The size of each point or billboard
-     * @type {Float}
-     */
-    this.scale = options.scale;
-
-    /**
-     * Should points and billboards representing each feature be scaled by the size of their data variable?
-     * @type {Boolean}
-     */
-    this.scaleByValue = options.scaleByValue;
-
-    /**
-     * Display values that fall outside the display range as min and max colors.
-     * @type {Boolean}
-     */
-    this.clampDisplayValue = options.clampDisplayValue;
-
-    /**
-     * A string representing an image to display at each point, for lat-long datasets.
-     * @type {String}
-     */
-    this.imageUrl = options.imageUrl;
-
-    /**
-     * An object of { "myCol": "My column" } properties, defining which columns get displayed in feature info boxes
-     * (when clicked on), and what label is used instead of the column's actual name.
-     * @type {Object}
-     */
-    this.featureInfoFields = options.featureInfoFields;
-
-    /**
      * The column name or index to use as the time column. Defaults to the first one found. Pass null for none.
      * @type {String|Integer|null}
      */
     this.timeColumn = options.timeColumn;
 
     /**
-     * The number of discrete colours that a colour gradient should be quantised into.
-     * @type {Number}
+     * Column-specific styling. TODO: turn each element into a TableColumnStyle.
+     * @type {Object}
      */
-    this.colorBins = options.colorBins;
+    this.columns = options.columns;
 
-    /**
-     * The method for quantising colors: "auto" (default), "ckmeans", "quantile" or "none" (equivalent to colorBins: 0).
-     * @type {String}
-     */
-    this.colorBinMethod = defaultValue(options.colorBinMethod, 'auto');
-
-    /**
-     * Gets or sets a string or {@link ColorMap} array, specifying how to map values to colors.  Setting this property sets
-     * {@link TableStyle#colorPalette} to undefined.  If this property is a string, it specifies a list of CSS colors separated by hyphens (-),
-     * and the colors are evenly spaced over the range of values.  For example, "red-white-hsl(240,50%,50%)".
-     * @memberOf TableStyle.prototype
-     * @type {String}
-     * @see TableStyle#colorPalette
-     */
-    if (defined(options.colorMap)) {
-        this.colorMap = new ColorMap(options.colorMap);
-    } else {
-        this.colorMap = undefined;
-    }
-
-    /**
-     * Gets or sets the [ColorBrewer](http://colorbrewer2.org/) palette to use when mapping values to colors.  Setting this
-     * property sets {@link TableStyle#colorMap} to undefined.  This property is ignored if {@link TableStyle#colorMap} is defined.
-     * @memberOf TableStyle.prototype
-     * @type {String}
-     * @see  TableStyle#colorMap
-     */
-    this.colorPalette = options.colorPalette;  // Only need this here so that updateFromJson sees colorPalette as a property.
-    if (defined(this.colorPalette)) {
-        var that = this;
-        return ColorMap.loadFromPalette(this.colorPalette).then(function(colorMap) {
-            that.colorMap = colorMap;
-        });
-    }
-
-    /**
-     * How many horizontal ticks to draw on the generated color ramp legend, not counting the top or bottom.
-     * @type {Integer}
-     */
-    this.legendTicks = defaultValue(options.legendTicks, 3);
 };
 
-// When colorMap is updated, we need to convert it to a colorMap.
-// When colorPalette is updated, we need to update colorMap.
-TableStyle.prototype.updaters = {
-    colorMap: function(tableStyle, json, propertyName) {
-        tableStyle.colorMap = new ColorMap(json[propertyName]);
-    },
-    colorPalette: function(tableStyle, json, propertyName) {
-        return ColorMap.loadFromPalette(json[propertyName]).then(function(colorMap) {
-            tableStyle.colorMap = colorMap;
-        });
-    }
-};
-freezeObject(TableStyle.prototype.updaters);
-
-TableStyle.prototype.serializers = {
-    colorMap: function(tableStyle, json, propertyName) {
-        // Only serialize colorMap if there is no colorPalette.
-        if (!defined(tableStyle.colorPalette)) {
-            json[propertyName] = tableStyle[propertyName];
-        }
-    }
-};
-freezeObject(TableStyle.prototype.serializers);
-
-TableStyle.prototype.updateFromJson = function(json, options) {
-    return updateFromJson(this, json, options);
-};
-
-TableStyle.prototype.serializeToJson = function(options) {
-    return serializeToJson(this, undefined, options);
-};
-
+inherit(TableColumnStyle, TableStyle);
 
 module.exports = TableStyle;

--- a/lib/Models/TableStyle.js
+++ b/lib/Models/TableStyle.js
@@ -7,9 +7,7 @@ var defined = require('terriajs-cesium/Source/Core/defined');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 
-var ColorMap = require('../Map/ColorMap');
 var inherit = require('../Core/inherit');
-var serializeToJson = require('../Core/serializeToJson');
 var TableColumnStyle = require('./TableColumnStyle');
 var updateFromJson = require('../Core/updateFromJson');
 
@@ -69,7 +67,7 @@ inherit(TableColumnStyle, TableStyle);
 // This also has the advantage of not using the TableColumnStyle constructor to set the properties, which causes problems with colorPalette too.
 TableStyle.prototype.updateFromJson = function(json, options) {
     var promises = [updateFromJson(this, json, options)];
-    this.columns = objectToTableColumnStyle(json, promises, options)
+    this.columns = objectToTableColumnStyle(json, promises, options);
     return when.all(promises);
 };
 

--- a/lib/Models/TableStyle.js
+++ b/lib/Models/TableStyle.js
@@ -1,9 +1,11 @@
 'use strict';
 
 /*global require*/
+var clone = require('terriajs-cesium/Source/Core/clone');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var ColorMap = require('../Map/ColorMap');
 var inherit = require('../Core/inherit');
@@ -56,18 +58,43 @@ var TableStyle = function(options) {
      * where columnIdentifier is either the name or the column index (zero-based).
      * @type {Object}
      */
-    this.columns = undefined;
-    if (defined(options.columns)) {
-        this.columns = {};
-        for (var propertyName in options.columns) {
-            if (options.columns.hasOwnProperty(propertyName)) {
-                this.columns[propertyName] = new TableColumnStyle(options.columns[propertyName]);
-            }
-        }
-    }
+    this.columns = objectToTableColumnStyle(options, []);  // If any promises are created (thanks to colorPalette), they are lost here.
 
 };
 
 inherit(TableColumnStyle, TableStyle);
+
+// When columns is updated via json, turn it into TableColumnStyle objects.
+// Do this in updateFromJson so we can keep track of the promises required by the colorPalette option.
+// This also has the advantage of not using the TableColumnStyle constructor to set the properties, which causes problems with colorPalette too.
+TableStyle.prototype.updateFromJson = function(json, options) {
+    var promises = [updateFromJson(this, json, options)];
+    this.columns = objectToTableColumnStyle(json, promises, options)
+    return when.all(promises);
+};
+
+TableStyle.prototype.updaters = clone(TableStyle.prototype.updaters);
+TableStyle.prototype.updaters['columns'] = function(tableStyle, json, propertyName) {
+    // Do not update columns here; do it directly in the updateFromJson function.
+    // tableStyle.columns = objectToTableColumnStyle(json[propertyName]);
+};
+freezeObject(TableStyle.prototype.updaters);
+
+function objectToTableColumnStyle(json, promises, options) {
+    if (defined(json.columns)) {
+        var columns = {};
+        for (var propertyName in json.columns) {
+            if (json.columns.hasOwnProperty(propertyName)) {
+                columns[propertyName] = new TableColumnStyle();
+                var thisPromise = columns[propertyName].updateFromJson(json.columns[propertyName], options);
+                if (defined(thisPromise)) {
+                    promises.push(thisPromise);
+                }
+            }
+        }
+        return columns;
+    }
+
+}
 
 module.exports = TableStyle;

--- a/lib/Models/TableStyle.js
+++ b/lib/Models/TableStyle.js
@@ -52,7 +52,8 @@ var TableStyle = function(options) {
     this.timeColumn = options.timeColumn;
 
     /**
-     * Column-specific styling, with the format { columnName1: tableColumnStyle1, columnName2: tableColumnStyle2, ... }.
+     * Column-specific styling, with the format { columnIdentifier1: tableColumnStyle1, columnIdentifier2: tableColumnStyle2, ... },
+     * where columnIdentifier is either the name or the column index (zero-based).
      * @type {Object}
      */
     this.columns = undefined;

--- a/lib/Models/TableStyle.js
+++ b/lib/Models/TableStyle.js
@@ -72,10 +72,12 @@ TableStyle.prototype.updateFromJson = function(json, options) {
 };
 
 TableStyle.prototype.updaters = clone(TableStyle.prototype.updaters);
+
+// Disable the 'columns' updaters, so we do not update columns here; do it directly in the updateFromJson function.
+// Why? TableColumnStyle's colorPalette actually returns a promise. The updaters can't handle a promise, but updateFromJson can.
 TableStyle.prototype.updaters['columns'] = function(tableStyle, json, propertyName) {
-    // Do not update columns here; do it directly in the updateFromJson function.
-    // tableStyle.columns = objectToTableColumnStyle(json[propertyName]);
 };
+
 freezeObject(TableStyle.prototype.updaters);
 
 function objectToTableColumnStyle(json, promises, options) {

--- a/lib/Models/TableStyle.js
+++ b/lib/Models/TableStyle.js
@@ -52,10 +52,18 @@ var TableStyle = function(options) {
     this.timeColumn = options.timeColumn;
 
     /**
-     * Column-specific styling. TODO: turn each element into a TableColumnStyle.
+     * Column-specific styling, with the format { columnName1: tableColumnStyle1, columnName2: tableColumnStyle2, ... }.
      * @type {Object}
      */
-    this.columns = options.columns;
+    this.columns = undefined;
+    if (defined(options.columns)) {
+        this.columns = {};
+        for (var propertyName in options.columns) {
+            if (options.columns.hasOwnProperty(propertyName)) {
+                this.columns[propertyName] = new TableColumnStyle(options.columns[propertyName]);
+            }
+        }
+    }
 
 };
 

--- a/lib/Models/TableStyle.js
+++ b/lib/Models/TableStyle.js
@@ -20,7 +20,13 @@ var updateFromJson = require('../Core/updateFromJson');
  * @constructor
  * @extends TableColumnStyle
  *
- * @param {Object} [options] The values of the properties of the new instance.
+ * @param {Object} [options] The values of the properties of the new instance. Options may include all those options found in TableColumnStyle, plus:
+ * @param {String} [options.regionVariable] The name of the variable (column) to be used for region mapping.
+ * @param {String} [options.regionType] The identifier of a region type, as used by RegionProviderList.
+ * @param {String} [options.dataVariable] The name of the default variable (column) containing data to be used for scaling and coloring.
+ * @param {String|Integer|null} [options.timeColumn] The column name or index to use as the time column. Defaults to the first one found. Pass null for none.
+ * @param {Object} [options.columns] Column-specific styling, with the format { columnIdentifier1: tableColumnStyle1, columnIdentifier2: tableColumnStyle2, ... },
+ *                 where columnIdentifier is either the name or the column index (zero-based).
  */
 var TableStyle = function(options) {
     options = defaultValue(options, defaultValue.EMPTY_OBJECT);
@@ -34,13 +40,13 @@ var TableStyle = function(options) {
     this.regionVariable = options.regionVariable;
 
     /**
-     * The identifier of a region type, as used by RegionProviderList
+     * The identifier of a region type, as used by RegionProviderList.
      * @type {String}
      */
     this.regionType = options.regionType;
 
     /**
-     * The name of the variable (column) containing data to be used for scaling and coloring.
+     * The name of the default variable (column) containing data to be used for scaling and coloring.
      * @type {String}
      */
     this.dataVariable = options.dataVariable;

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -489,7 +489,7 @@ describe('CsvCatalogItem with lat and lon', function() {
             }).otherwise(fail).then(done);
         });
 
-        it('supports title and nullColor with column ref by name', function(done) {
+        it('supports name and nullColor with column ref by name', function(done) {
             csvItem.url = 'test/csv/lat_lon_badvalue.csv';
             csvItem._tableStyle = new TableStyle({
                 nullColor: '#123456',
@@ -497,7 +497,7 @@ describe('CsvCatalogItem with lat and lon', function() {
                     value: {
                         replaceWithNullValues: ['bad'],
                         nullColor: '#A0B0C0',
-                        title: 'Temperature'
+                        name: 'Temperature'
                     }
                 }
             });

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -526,6 +526,21 @@ describe('CsvCatalogItem with lat and lon', function() {
             }).otherwise(fail).then(done);
         });
 
+        it('supports type', function(done) {
+            csvItem.url = 'test/csv/lat_lon_badvalue.csv';
+            csvItem._tableStyle = new TableStyle({
+                columns: {
+                    value: {
+                        replaceWithNullValues: ['bad'],
+                        type: 'enum'
+                    }
+                }
+            });
+            csvItem.load().then(function() {
+                expect(csvItem.tableStructure.columns[2].type).toEqual(VarType.ENUM);
+            }).otherwise(fail).then(done);
+        });
+
     });
 
 });

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -471,11 +471,49 @@ describe('CsvCatalogItem with lat and lon', function() {
             }).otherwise(fail).then(done);
         });
 
-        it('supports nullColor', function(done) {
+        it('uses correct defaults', function(done) {
+            // nullColor is passed through to the columns as well, if not overridden explicitly.
+            csvItem.url = 'test/csv/lat_lon_badvalue.csv';
+            csvItem._tableStyle = new TableStyle({
+                nullColor: '#A0B0C0',
+                columns: {
+                    value: {
+                        replaceWithNullValues: ['bad']
+                    }
+                }
+            });
+            var nullColor = new Color(160/255, 176/255, 192/255, 1);
+            csvItem.load().then(function() {
+                function cval(i) { return csvItem.dataSource.entities.values[i]._point._color._value; }
+                expect(cval(1)).toEqual(nullColor);
+            }).otherwise(fail).then(done);
+        });
+
+        it('supports title and nullColor with column ref by name', function(done) {
+            csvItem.url = 'test/csv/lat_lon_badvalue.csv';
+            csvItem._tableStyle = new TableStyle({
+                nullColor: '#123456',
+                columns: {
+                    value: {
+                        replaceWithNullValues: ['bad'],
+                        nullColor: '#A0B0C0',
+                        title: 'Temperature'
+                    }
+                }
+            });
+            var nullColor = new Color(160/255, 176/255, 192/255, 1);
+            csvItem.load().then(function() {
+                expect(csvItem.tableStructure.columns[2].name).toEqual('Temperature');
+                function cval(i) { return csvItem.dataSource.entities.values[i]._point._color._value; }
+                expect(cval(1)).toEqual(nullColor);
+            }).otherwise(fail).then(done);
+        });
+
+        it('supports nullColor with column ref by number', function(done) {
             csvItem.url = 'test/csv/lat_lon_badvalue.csv';
             csvItem._tableStyle = new TableStyle({
                 columns: {
-                    value: {
+                    2: {
                         replaceWithNullValues: ['bad'],
                         nullColor: '#A0B0C0'
                     }
@@ -485,7 +523,6 @@ describe('CsvCatalogItem with lat and lon', function() {
             csvItem.load().then(function() {
                 function cval(i) { return csvItem.dataSource.entities.values[i]._point._color._value; }
                 expect(cval(1)).toEqual(nullColor);
-                expect(cval(2)).not.toEqual(nullColor);
             }).otherwise(fail).then(done);
         });
 

--- a/wwwroot/test/init/test-tablestyle.json
+++ b/wwwroot/test/init/test-tablestyle.json
@@ -1,15 +1,15 @@
 {
-"homeCamera": {
+  "homeCamera": {
     "north": -36,
     "east": 146,
     "south": -38,
     "west": 143
   },
-    "catalog": [
+  "catalog": [
     {
-      "name": "CSV testing",
+      "name": "CSV color maps and palettes",
       "type": "group",
-      "isOpen": true,
+      "isOpen": false,
       "items": [
         {
           "name": "Green-orange postcodes",
@@ -143,6 +143,30 @@
           "tableStyle": {
             "colorMap": "green-hsl(120,100%,70%)-white-hsl(0,100%,70%)-red",
             "featureInfoFields": { "Value": true, "Mod10": true }
+          }
+        }
+      ]
+    },
+    {
+      "name": "CSV column-specific",
+      "type": "group",
+      "isOpen": false,
+      "items": [
+        {
+          "name": "Mod10 as enum, Mod100 Spectral",
+          "type": "csv",
+          "url": "/build/TerriaJS/test/csv/3000s.csv",
+          "opacity": 1,
+          "tableStyle": {
+            "colorMap": "green-orange",
+            "columns": {
+              "Mod10": {
+                "type": "enum"
+              },
+              "Mod100": {
+                "colorPalette": "Spectral"
+              }
+            }
           }
         }
       ]

--- a/wwwroot/test/init/test-tablestyle.json
+++ b/wwwroot/test/init/test-tablestyle.json
@@ -161,7 +161,8 @@
             "colorMap": "green-orange",
             "columns": {
               "Mod10": {
-                "type": "enum"
+                "type": "enum",
+                "colorBins": 10
               },
               "Mod100": {
                 "colorPalette": "Spectral"

--- a/wwwroot/test/init/test-tablestyle.json
+++ b/wwwroot/test/init/test-tablestyle.json
@@ -158,14 +158,19 @@
           "url": "/build/TerriaJS/test/csv/3000s.csv",
           "opacity": 1,
           "tableStyle": {
-            "colorMap": "green-orange",
+            "colorMap": "black-orange",
             "columns": {
+              "Value": {
+                "name": "Postal code"
+              },
               "Mod10": {
                 "type": "enum",
-                "colorBins": 10
+                "colorBins": 10,
+                "name": "Last digit of postcode"
               },
               "Mod100": {
-                "colorPalette": "Spectral"
+                "colorPalette": "Spectral",
+                "name": "Last 2 digits of postcode"
               }
             }
           }


### PR DESCRIPTION
Fixes #1097. 

Columns can be specified by either their name in the csv file, or their position (0 for the first column, etc).  I've added `name` and `type` to the list of tableStyle parameters that apply in `tableStyle.columns`.

An example is the final catalog item at http://localhost:3001/#build/terriajs/test/init/test-tablestyle.json .

One implementation decision I've made, which we can discuss, is: if you supply a new `name` for a column, but not a `type`, its type is guessed based on the _new_ name, not its old name.  

Unsupported in this PR:
- Setting `columns.x.type` to `region`
- `columns.x.regionType`
- Columns cannot be specified by regex.
