### PR TITLE
Use markdown binding on feature info panel.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 2.0.2
+
+* Fixed a bug that caused the content on the feature info panel to be rendered as pure HTML instead of as mixed HTML / Markdown.
+
 ### 2.0.1
 
 * Fixed a bug that caused the last selected ABS concept not to appear in the feature info panel.

--- a/lib/Core/markdownToHtml.js
+++ b/lib/Core/markdownToHtml.js
@@ -1,6 +1,7 @@
 "use strict";
 
 /*global require*/
+var defined = require('terriajs-cesium/Source/Core/defined');
 var MarkdownIt = require('markdown-it');
 var sanitizeCaja = require('sanitize-caja/sanitizer-bundle');
 
@@ -10,6 +11,10 @@ var md = new MarkdownIt({
 });
 
 function markdownToHtml(markdownString, allowUnsafeHtml) {
+    if (!defined(markdownString) || markdownString.length === 0) {
+        return markdownString;
+    }
+
     var unsafeHtml = md.render(markdownString);
     if (allowUnsafeHtml) {
         return unsafeHtml;

--- a/lib/Views/FeatureInfoPanel.html
+++ b/lib/Views/FeatureInfoPanel.html
@@ -10,7 +10,7 @@
                      data-bind="style: { 'max-height': maxHeight + 'px' }">
                     <div class="feature-info-panel-section" data-bind="if: message">
                         <div class="feature-info-panel-section">
-                            <div class="feature-info-panel-section-content" data-bind="html: message"></div>
+                            <div class="feature-info-panel-section-content" data-bind="markdown: message"></div>
                         </div>
                     </div>
                     <div class="feature-info-panel-section" data-bind="foreach: sections">

--- a/lib/Views/FeatureInfoPanelSection.html
+++ b/lib/Views/FeatureInfoPanelSection.html
@@ -10,10 +10,10 @@
         <span class="feature-info-panel-section-label" data-bind="text: name"></span>
     </div>
     <div class="feature-info-panel-section-content-wrapper" data-bind="css:feature == terria.selectedFeature ?'open': 'closed'">
-        <div class="feature-info-panel-section-content" data-bind="html: templatedInfo, visible: templatedInfo"></div>
+        <div class="feature-info-panel-section-content" data-bind="markdown: templatedInfo, visible: templatedInfo"></div>
         <button class="feature-info-panel-text-button" data-bind="visible: templatedInfo && !rawDataVisible, click: showRawData">Show Raw Data</button>
         <button class="feature-info-panel-text-button" data-bind="visible: templatedInfo && rawDataVisible, click: hideRawData">Hide Raw Data</button>
-        <div class="feature-info-panel-section-content" data-bind="html: rawData, visible: rawData && (!templatedInfo || rawDataVisible),
+        <div class="feature-info-panel-section-content" data-bind="markdown: rawData, visible: rawData && (!templatedInfo || rawDataVisible),
           css: { 'feature-info-panel-section-content-white-background': useWhiteBackground }"></div>
 
         <!-- ko if: rawData && (!templatedInfo || rawDataVisible) && dataDownloads.length > 0 -->


### PR DESCRIPTION
Somewhere along the way we started rendering the content of the feature info panel as pure HTML, so we don't get the benefit of markdown formatting and we are potentially more vulnerable to XSS attacks.  This change goes back to using our safe and more featureful `markdown` binding.
