### PR TITLE
Re-added ability to share open groups

### DIFF
--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -343,13 +343,16 @@ CatalogMember.prototype.serializeToJson = function(options) {
     result.type = this.type;
     result.id = this.uniqueId;
 
-    result.parents = getParentIds(this).reverse();
+    if (defined(this.parent)) {
+        result.parents = getParentIds(this.parent).reverse();
+    }
 
     return result;
 };
 
 /**
- * Gets the ids of all parents of a catalog member, ordered from the closest descendant to the most distant.
+ * Gets the ids of all parents of a catalog member, ordered from the closest descendant to the most distant. Ignores
+ * the root.
  *
  * @param catalogMember The catalog member to get parent ids for.
  * @param parentIds A starting list of parent ids to add to (allows the function to work recursively).
@@ -358,8 +361,8 @@ CatalogMember.prototype.serializeToJson = function(options) {
 function getParentIds(catalogMember, parentIds) {
     parentIds = defaultValue(parentIds, []);
 
-    if (catalogMember.parent) {
-        return getParentIds(catalogMember.parent, parentIds.concat([catalogMember.parent.uniqueId]));
+    if (defined(catalogMember.parent)) {
+        return getParentIds(catalogMember.parent, parentIds.concat([catalogMember.uniqueId]));
     }
 
     return parentIds;

--- a/lib/ViewModels/SharePopupViewModel.js
+++ b/lib/ViewModels/SharePopupViewModel.js
@@ -133,16 +133,27 @@ SharePopupViewModel.prototype._addSharedMembers = function(initSources) {
             }
         ])
     })).filter(function(item) {
-        // Filter out groups.
-        return item.isEnabled;
-    });
+        return item.isEnabled || item.isOpen;
+    }).reduce(function(soFar, item) {
+        soFar[item.id] = item;
+        return soFar;
+    }, {});
 
-    if (catalogForSharing.length > 0) {
+    // Eliminate open groups without all ancestors open
+    Object.keys(catalogForSharing).forEach(function(key) {
+        var item = catalogForSharing[key];
+        var isGroupWithClosedParent = item.isOpen && item.parents.some(function(parentId) {
+            return !catalogForSharing[parentId];
+        }.bind(this));
+
+        if (isGroupWithClosedParent) {
+            catalogForSharing[key] = undefined;
+        }
+    }.bind(this));
+
+    if (Object.keys(catalogForSharing).length > 0) {
         initSources.push({
-            sharedCatalogMembers: catalogForSharing.reduce(function(soFar, item) {
-                soFar[item.id] = item;
-                return soFar;
-            }, {})
+            sharedCatalogMembers: catalogForSharing
         });
     }
 };
@@ -159,7 +170,7 @@ SharePopupViewModel.prototype._addViewSettings = function(initSources) {
         west: CesiumMath.toDegrees(cameraExtent.west),
         south: CesiumMath.toDegrees(cameraExtent.south),
         east: CesiumMath.toDegrees(cameraExtent.east),
-        north: CesiumMath.toDegrees(cameraExtent.north),
+        north: CesiumMath.toDegrees(cameraExtent.north)
     };
 
     if (defined(this.terria.cesium)) {

--- a/lib/ViewModels/SharePopupViewModel.js
+++ b/lib/ViewModels/SharePopupViewModel.js
@@ -129,13 +129,14 @@ SharePopupViewModel.prototype._addSharedMembers = function(initSources) {
         propertyFilter: combineFilters([
             CatalogMember.propertyFilters.sharedOnly,
             function(property) {
-                return property !== 'name' && property !== 'id';
+                return property !== 'name';
             }
         ])
     })).filter(function(item) {
         return item.isEnabled || item.isOpen;
     }).reduce(function(soFar, item) {
         soFar[item.id] = item;
+        item.id = undefined;
         return soFar;
     }, {});
 

--- a/test/ViewModels/SharePopupViewModelSpec.js
+++ b/test/ViewModels/SharePopupViewModelSpec.js
@@ -4,6 +4,10 @@ var SharePopupViewModel = require('../../lib/ViewModels/SharePopupViewModel');
 var Terria = require('../../lib/Models/Terria');
 var queryToObject = require('terriajs-cesium/Source/Core/queryToObject');
 var URI = require('urijs');
+var WMSCatalogItem = require('../../lib/Models/WebMapServiceCatalogItem');
+var CSVCatalogItem = require('../../lib/Models/CSVCatalogItem');
+var CatalogGroup = require('../../lib/Models/CatalogGroup');
+var createCatalogMemberFromType = require('../../lib/Models/createCatalogMemberFromType');
 
 describe('SharePopupViewModel', function() {
     var terria;
@@ -14,27 +18,28 @@ describe('SharePopupViewModel', function() {
             baseUrl: './'
         });
         terria.baseMap = {};
+        createCatalogMemberFromType.register('group', CatalogGroup);
+        createCatalogMemberFromType.register('item', WMSCatalogItem);
+        createCatalogMemberFromType.register('csv', CSVCatalogItem);
     });
 
-    function init() {
-        sharePopup = new SharePopupViewModel({
-            terria: terria,
-            userPropWhiteList: SharePopupViewModel.defaultUserPropWhiteList.concat(['couldBeAnyString'])
-        });
-    }
-
     describe('share url', function() {
-        testUserProperties(function() {
+        doTests(function() {
             return sharePopup.url;
         });
     });
 
     describe('embed url', function() {
-        testUserProperties(function() {
+        doTests(function() {
             // Get the src of the embed code
             return /src="(.*)"/.exec(sharePopup.embedCode)[1];
         });
     });
+
+    function doTests(urlGetter) {
+        testUserProperties(urlGetter);
+        testSharedCatalogMembers(urlGetter);
+    }
 
     /**
      * Runs tests to ensure that user properties are embedded into the url
@@ -69,6 +74,192 @@ describe('SharePopupViewModel', function() {
             var parsed = parseUrl(url);
 
             expect(parsed.notWhiteListed).toBeUndefined();
+        });
+    }
+
+    function testSharedCatalogMembers(urlGetter) {
+        describe('when sharing catalog members', function() {
+            it('serializes enabled items', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'C',
+                    type: 'item',
+                    isEnabled: true
+                }]).then(function(parsed) {
+                    expect(Object.keys(parsed).length).toBe(1);
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('serializes open groups', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'C',
+                    type: 'group',
+                    isOpen: true
+                }]).then(function(parsed) {
+                    expect(Object.keys(parsed).length).toBe(1);
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('serializes an enabled item inside a closed group', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'Group',
+                    type: 'group',
+                    isOpen: false,
+                    items: [
+                        {
+                            name: 'Item',
+                            type: 'item',
+                            isEnabled: true
+                        }
+                    ]
+                }]).then(function(parsed) {
+                    expect(parsed['Root Group/Group/Item']).not.toBeUndefined();
+                    expect(Object.keys(parsed).length).toBe(1);
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('serializes an open group and an enabled item in a flat map', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'Group',
+                    type: 'group',
+                    isOpen: true,
+                    items: [
+                        {
+                            name: 'Item',
+                            type: 'item',
+                            isEnabled: true
+                        }
+                    ]
+                }]).then(function(parsed) {
+                    expect(parsed['Root Group/Group/Item']).not.toBeUndefined();
+                    expect(parsed['Root Group/Group']).not.toBeUndefined();
+                    expect(Object.keys(parsed).length).toBe(2);
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('filters out items with localData', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'C',
+                    type: 'csv',
+                    data: {
+                        'blah': 'otherBlah'
+                    },
+                    isEnabled: true
+                }]).then(function(parsed) {
+                    expect(Object.keys(parsed).length).toBe(0);
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('indexes against id', function(done) {
+                getParsedShareLinkFor([{
+                    id: 'blahId',
+                    name: 'C',
+                    type: 'csv',
+                    isEnabled: true
+                }]).then(function(parsed) {
+                    expect(Object.keys(parsed)).toEqual(['blahId']);
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('indexes against path when id isn\'t available', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'C',
+                    type: 'csv',
+                    isEnabled: true
+                }]).then(function(parsed) {
+                    expect(Object.keys(parsed)).toEqual(['Root Group/C']);
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('filters out non-shareable properties', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'C',
+                    showWarnings: true,
+                    type: 'csv',
+                    opacity: 0.8,
+                    isEnabled: true
+                }]).then(function(parsed) {
+                    var item = parsed['Root Group/C'];
+                    expect(item.opacity).toBe(0.8);
+                    expect(item.showWarnings).toBeUndefined();
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('filters out name from the object', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'C',
+                    showWarnings: true,
+                    type: 'csv',
+                    opacity: 0.8,
+                    isEnabled: true
+                }]).then(function(parsed) {
+                    var item = parsed['Root Group/C'];
+                    expect(item.name).toBeUndefined();
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('filters out id from the object', function(done) {
+                getParsedShareLinkFor([{
+                    id: 'blah',
+                    name: 'C',
+                    type: 'csv',
+                    isEnabled: true
+                }]).then(function(parsed) {
+                    var item = parsed['blah'];
+                    expect(item.id).toBeUndefined();
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('filters out non-enabled items', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'C',
+                    type: 'csv'
+                }]).then(function(parsed) {
+                    expect(Object.keys(parsed).length).toBe(0);
+                }).then(done).otherwise(done.fail);
+            });
+
+            it('filters out open groups with a closed ancestor', function(done) {
+                getParsedShareLinkFor([{
+                    name: 'Group',
+                    type: 'group',
+                    isOpen: false,
+                    items: [
+                        {
+                            name: 'Group',
+                            type: 'group',
+                            isOpen: true,
+                            items: [
+                                {
+                                    name: 'Group',
+                                    type: 'group',
+                                    isOpen: true,
+                                    items: []
+                                }
+                            ]
+                        }
+                    ]
+                }]).then(function(parsed) {
+                    expect(Object.keys(parsed).length).toBe(0);
+                }).then(done).otherwise(done.fail);
+            });
+
+            function getParsedShareLinkFor(json) {
+                return terria.catalog.updateFromJson(json).then(function() {
+                    init();
+
+                    var url = urlGetter();
+                    var initSources = JSON.parse(parseUrl(url).start).initSources;
+
+                    return initSources.length > 2 ? initSources[1].sharedCatalogMembers : {};
+                });
+            }
+        });
+    }
+
+    function init() {
+        sharePopup = new SharePopupViewModel({
+            terria: terria,
+            userPropWhiteList: SharePopupViewModel.defaultUserPropWhiteList.concat(['couldBeAnyString'])
         });
     }
 

--- a/test/ViewModels/SharePopupViewModelSpec.js
+++ b/test/ViewModels/SharePopupViewModelSpec.js
@@ -5,7 +5,7 @@ var Terria = require('../../lib/Models/Terria');
 var queryToObject = require('terriajs-cesium/Source/Core/queryToObject');
 var URI = require('urijs');
 var WMSCatalogItem = require('../../lib/Models/WebMapServiceCatalogItem');
-var CSVCatalogItem = require('../../lib/Models/CSVCatalogItem');
+var CSVCatalogItem = require('../../lib/Models/CsvCatalogItem');
 var CatalogGroup = require('../../lib/Models/CatalogGroup');
 var createCatalogMemberFromType = require('../../lib/Models/createCatalogMemberFromType');
 


### PR DESCRIPTION
Fixes #1331.
- Share links remembers open groups again.
- It filters out open groups that are inside a closed group, or inside a group that's inside a closed group, etc etc.
- Added tests that probably should have already been in there.
