### PR TITLE
Fix csv error with numeric column names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Warn user when the requested WMS layer doesn't exist, and try to provide a suggestion.
 * Fixed the calculation of a csv file's extent so that missing latitudes and longitudes are ignored, not treated as zero.
 * Upgraded to terriajs-cesium 1.18.0.
+* Fixed error when adding a csv file with numeric column names.
 
 ### 2.1.1
 

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -182,26 +182,32 @@ TableStructure.fromCsv = function(csvString, result) {
 
     // Originally from jquery-csv plugin. Modified to avoid stripping leading zeros.
     function castToScalar(value, state) {
-        var hasDot = /\./;
-        var leadingZero = /^0[0-9]/;
-        var numberWithThousands = /^[1-9]\d?\d?(,\d\d\d)+(\.\d+)?$/;
-        if (numberWithThousands.test(value)) {
-            value = value.replace(/,/g, '');
-        }
-        if (isNaN(value)) {
+        if (state.rowNum === 1) {
+            // Don't cast column names
             return value;
         }
-        if (leadingZero.test(value)) {
-            return value;
+        else {
+            var hasDot = /\./;
+            var leadingZero = /^0[0-9]/;
+            var numberWithThousands = /^[1-9]\d?\d?(,\d\d\d)+(\.\d+)?$/;
+            if (numberWithThousands.test(value)) {
+                value = value.replace(/,/g, '');
+            }
+            if (isNaN(value)) {
+                return value;
+            }
+            if (leadingZero.test(value)) {
+                return value;
+            }
+            if (hasDot.test(value)) {
+              return parseFloat(value);
+            }
+            var integer = parseInt(value);
+            if (isNaN(integer)) {
+                return null;
+            }
+            return integer;
         }
-        if (hasDot.test(value)) {
-          return parseFloat(value);
-        }
-        var integer = parseInt(value);
-        if (isNaN(integer)) {
-            return null;
-        }
-        return integer;
     }
 
     //normalize line breaks
@@ -460,4 +466,3 @@ function isInteger(value) {
 }
 
 module.exports = TableStructure;
-

--- a/test/Map/TableStructureSpec.js
+++ b/test/Map/TableStructureSpec.js
@@ -158,6 +158,14 @@ describe('TableStructure', function() {
         expect(tableStructure.columns[1].values.length).toEqual(2);
     });
 
+    it('can read csv string where column names are numbers', function() {
+        var csvString = '1,2\n9,8\n7,6';
+        var tableStructure = new TableStructure();
+        tableStructure.loadFromCsv(csvString);
+        expect(tableStructure.columns[0].name).toEqual('1');
+        expect(tableStructure.columns[1].name).toEqual('2');
+    });
+
     it('can describe rows with dates with and without timezones nicely', function() {
         var csvString = 'date,value\r\n2015-10-15T12:34:56,5\r\n2015-10-02T12:34:56Z,8\r\n2015-11-03\r\n';
         var tableStructure = TableStructure.fromCsv(csvString);
@@ -165,7 +173,7 @@ describe('TableStructure', function() {
         expect(htmls[0]).toContain('Thu Oct 15 2015 12:34:56');  // Thu 15 Oct would be nicer outside USA.
         expect(htmls[0]).not.toContain('2015-10-15T12:34:56');
 
-        var expectedDate1 = JulianDate.toDate(JulianDate.fromIso8601('2015-10-02T12:34:56Z')); 
+        var expectedDate1 = JulianDate.toDate(JulianDate.fromIso8601('2015-10-02T12:34:56Z'));
         expect(htmls[1]).toContain('' + expectedDate1);
         expect(htmls[1]).not.toContain('2015-10-02T12:34:56');
 


### PR DESCRIPTION
Currently, csv files with numeric column names crash and cannot be added as a dataset. This PR fixes that.
