### PR TITLE
Added `fogSettings` option to `TerriaViewer`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Warn user when the requested WMS layer doesn't exist, and try to provide a suggestion.
 * Fixed the calculation of a csv file's extent so that missing latitudes and longitudes are ignored, not treated as zero.
 * Upgraded to terriajs-cesium 1.18.0.
+* Added `fogSettings` option to `TerriaViewer` which allows you to alter the Cesium fog settings that were introduced in Cesium 1.16
 
 ### 2.1.1
 

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -72,6 +72,7 @@ var TerriaViewer = function(terria, options) {
     this._uiContainer = defaultValue(options.uiContainer, 'ui');
     this._developerAttribution = options.developerAttribution;
     this.maximumLeafletZoomLevel = options.maximumLeafletZoomLevel;
+    this._fogSettings = options.fogSettings;
 
     var webGLSupport = supportsWebGL();  // true, false, or 'slow'
     this._slowWebGLAvailable = webGLSupport === 'slow';
@@ -615,6 +616,15 @@ TerriaViewer.prototype.selectViewer = function(bCesium) {
         this.terria.cesium = new Cesium(this.terria, viewer);
         this.terria.leaflet = undefined;
         this.terria.currentViewer =  this.terria.cesium;
+
+        // Set fog parameters
+        if (defined(this._fogSettings)) {
+            for (var settingKey in this._fogSettings) {
+                if (this.terria.cesium.scene.fog.hasOwnProperty(settingKey)) {
+                    this.terria.cesium.scene.fog[settingKey] = this._fogSettings[settingKey];
+                }
+            }
+        }
 
         //Simple monitor to start up and switch to 2D if seem to be stuck.
         if (!defined(this.checkedStartupPerformance)) {


### PR DESCRIPTION
Added `fogSettings` option to `TerriaViewer` which allows you to alter the Cesium fog settings that were introduced in Cesium 1.16
