### PR TITLE
Use superagent 1.7.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "resolve": "^1.1.6",
     "sanitize-caja": "^0.1.3",
     "simple-statistics": "^1.0.1",
+    "superagent": "~1.7.0",
     "terriajs-cesium": "1.18.0",
     "togeojson": "^0.9.0",
     "urijs": "^1.16.0",


### PR DESCRIPTION
We don't actually need superagent directly, but urthecast uses it, and 1.8.0 (the latest version currently) uses form-data 1.0.0-rc3 which is not compatible with Internet Explorer 9 (it uses FormData, a DOM type not available in IE9, without guarding against undefined references).  So by adding a dependency specifically on 1.7.x here, we force urthecast to get that version and our tests pass in IE9 once again.
