### PR TITLE
Only cache ArcGIS metadata for 24 hours.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Fixed an error when adding a csv with one line of data.
 * Fixed error when adding a csv file with numeric column names.
 * Added `UrlTemplateCatalogItem`, which can be used to access maps via a URL template.
+* `ArcGisMapServerCatalogItem` metadata is now cached by the proxy for only 24 hours.
 
 ### 2.1.1
 

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -195,7 +195,7 @@ function getBaseURI(item) {
 }
 
 function getJson(item, uri) {
-    return loadJson(proxyCatalogItemUrl(item, uri.addQuery('f', 'json').toString()));
+    return loadJson(proxyCatalogItemUrl(item, uri.addQuery('f', 'json').toString(), '1d'));
 }
 
 ArcGisMapServerCatalogItem.prototype._load = function() {


### PR DESCRIPTION
This makes it consistent with other metadata, e.g. WMS GetCapabilities.
