### PR TITLE
Make feature info respect current time, for region-mapped csvs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Improved ABS display (to hide the regions) when a concept is deselected.
 * Improved readability of ArcGis catalog items and legends by replacing underscores with spaces.
 * `ArcGisMapServerCatalogItem` metadata is now cached by the proxy for only 24 hours.
+* Improved the feature info panel to update the display of time-varying region-mapped csv files for the current time.
 
 ### 2.1.1
 

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -4,6 +4,7 @@
 var L = require('leaflet');
 
 // var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
+var CallbackProperty = require('terriajs-cesium/Source/Core/CallbackProperty');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
@@ -183,7 +184,6 @@ defineProperties(RegionMapping.prototype, {
 
     /**
      * Gets the Cesium or Leaflet imagery layer object associated with this data source.
-     * Used in region mapping only.
      * This property is undefined if the data source is not enabled.
      * @memberOf RegionMapping.prototype
      * @type {Object}
@@ -191,6 +191,18 @@ defineProperties(RegionMapping.prototype, {
     imageryLayer: {
         get: function() {
             return this._imageryLayer;
+        }
+    },
+
+    /**
+     * Gets a Boolean value saying whether the region mapping is constant (true) or time-varying (false).
+     * @memberOf RegionMapping.prototype
+     * @type {Boolean}
+     */
+    isConstant: {
+        get: function() {
+            var timeColumn = regionMapping._tableStructure.activeTimeColumn;
+            return (!defined(timeColumn) || !defined(timeColumn._clock));
         }
     }
 
@@ -398,15 +410,17 @@ function getRegionValuesFromIndices(regionIndices, tableStructure) {
     return regionValues;
 }
 
-/**
- * A function that returns the value of the regionRowDescription at a given time.
- *
- * @param {JulianDate} [time] The time for which to retrieve the value.
- * @param {Object} [result] The object to store the value into, if omitted, a new instance is created and returned.
- * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
- */
-function regionRowDescriptionPropertyCallback(time, result) {
+function getRegionRowDescriptionPropertyCallbackForId(uniqueId) {
+    /**
+     * Returns a function that returns the value of the regionRowDescription at a given time, updating result if available.
+     *
+     * @param {JulianDate} [time] The time for which to retrieve the value.
+     * @param {Object} [result] The object to store the value into, if omitted, a new instance is created and returned.
+     * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
+     */
+    return function regionRowDescriptionPropertyCallback(time, result) {
 
+    }
 }
 
 /**
@@ -458,7 +472,8 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
         }
         for (var i = 0; i < imageryLayerFeatureInfos.length; ++i) {
             var imageryLayerFeatureInfo = imageryLayerFeatureInfos[i];
-            var uniqueId = imageryLayerFeatureInfos[i].data.properties[regionDetail.regionProvider.uniqueIdProp];
+            var uniqueId = imageryLayerFeatureInfo.data.properties[regionDetail.regionProvider.uniqueIdProp];
+            // imageryLayerFeatureInfo.description = new CallbackProperty(getRegionRowDescriptionPropertyCallbackForId(uniqueId), regionMapping.isConstant);
             var rowObject = regionRowObjects[uniqueId];
             if (defined(rowObject)) {
                 imageryLayerFeatureInfo.properties = rowObject;
@@ -522,9 +537,8 @@ function onClockTick(regionMapping, clock) {
 }
 
 function updateClockSubscription(regionMapping) {
-    // Only if there is a clock.  Assume the first time column is the one.
-    var timeColumn = regionMapping._tableStructure.activeTimeColumn;
-    if (!defined(timeColumn) || !defined(timeColumn._clock)) {
+    // Only if there is a clock.
+    if (regionMapping.isConstant) {
         return;
     }
     var catalogItem = regionMapping._catalogItem;

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -410,17 +410,49 @@ function getRegionValuesFromIndices(regionIndices, tableStructure) {
     return regionValues;
 }
 
-function getRegionRowDescriptionPropertyCallbackForId(uniqueId) {
-    /**
-     * Returns a function that returns the value of the regionRowDescription at a given time, updating result if available.
-     *
-     * @param {JulianDate} [time] The time for which to retrieve the value.
-     * @param {Object} [result] The object to store the value into, if omitted, a new instance is created and returned.
-     * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
-     */
-    return function regionRowDescriptionPropertyCallback(time, result) {
+function addDescriptionAndProperties(regionMapping) {
+    var rowObjects = tableStructure.toRowObjects();
 
+    function getRegionRowDescriptionPropertyCallbackForId(uniqueId) {
+        /**
+         * Returns a function that returns the value of the regionRowDescription at a given time, updating result if available.
+         *
+         * @param {JulianDate} [time] The time for which to retrieve the value.
+         * @param {Object} [result] The object to store the value into, if omitted, a new instance is created and returned.
+         * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
+         */
+        return function regionRowDescriptionPropertyCallback(time, result) {
+            var regionIndices = calculateRegionIndices(regionMapping, time);
+            var regionRowObjects = regionIndices.map(function(i) { return rowObjects[i]; });
+            if (defined(rowObject)) {
+                // result parameter is unsupported (should it be supported?)
+                return regionRowDescriptions[uniqueId];
+            }
+        }
     }
+
+    // Put the properties and the description of this row onto the image of the region.
+    var rowDescriptions = tableStructure.toRowDescriptions(regionMapping._tableStyle.featureInfoFields);
+    var regionRowDescriptions = regionIndices.map(function(i) { return rowDescriptions[i]; });
+    ImageryProviderHooks.addPickFeaturesHook(regionImageryProvider, function(imageryLayerFeatureInfos) {
+        if (!defined(imageryLayerFeatureInfos) || imageryLayerFeatureInfos.length === 0) {
+            return;
+        }
+        for (var i = 0; i < imageryLayerFeatureInfos.length; ++i) {
+            var imageryLayerFeatureInfo = imageryLayerFeatureInfos[i];
+            var uniqueId = imageryLayerFeatureInfo.data.properties[regionDetail.regionProvider.uniqueIdProp];
+            imageryLayerFeatureInfo.description = new CallbackProperty(getRegionRowDescriptionPropertyCallbackForId(uniqueId), regionMapping.isConstant);
+            // var rowObject = regionRowObjects[uniqueId];
+            // if (defined(rowObject)) {
+            //     imageryLayerFeatureInfo.properties = rowObject;
+            //     imageryLayerFeatureInfo.description = regionRowDescriptions[uniqueId];
+            // } else {
+            //     imageryLayerFeatureInfo.properties = undefined;
+            //     imageryLayerFeatureInfo.description = undefined;
+            // }
+        }
+        return imageryLayerFeatureInfos;
+    });
 }
 
 /**
@@ -461,30 +493,6 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
         legendHelper.getColorArrayFromValue.bind(legendHelper)
     );
     ImageryProviderHooks.addRecolorFunc(regionImageryProvider, colorFunction);
-    // Put the description of this row onto the image of the region.
-    var rowObjects = tableStructure.toRowObjects();
-    var regionRowObjects = regionIndices.map(function(i) { return rowObjects[i]; });
-    var rowDescriptions = tableStructure.toRowDescriptions(regionMapping._tableStyle.featureInfoFields);
-    var regionRowDescriptions = regionIndices.map(function(i) { return rowDescriptions[i]; });
-    ImageryProviderHooks.addPickFeaturesHook(regionImageryProvider, function(imageryLayerFeatureInfos) {
-        if (!defined(imageryLayerFeatureInfos) || imageryLayerFeatureInfos.length === 0) {
-            return;
-        }
-        for (var i = 0; i < imageryLayerFeatureInfos.length; ++i) {
-            var imageryLayerFeatureInfo = imageryLayerFeatureInfos[i];
-            var uniqueId = imageryLayerFeatureInfo.data.properties[regionDetail.regionProvider.uniqueIdProp];
-            // imageryLayerFeatureInfo.description = new CallbackProperty(getRegionRowDescriptionPropertyCallbackForId(uniqueId), regionMapping.isConstant);
-            var rowObject = regionRowObjects[uniqueId];
-            if (defined(rowObject)) {
-                imageryLayerFeatureInfo.properties = rowObject;
-                imageryLayerFeatureInfo.description = regionRowDescriptions[uniqueId];
-            } else {
-                imageryLayerFeatureInfo.properties = undefined;
-                imageryLayerFeatureInfo.description = undefined;
-            }
-        }
-        return imageryLayerFeatureInfos;
-    });
 
     regionMapping._imageryLayer = ImageryLayerCatalogItem.enableLayer(catalogItem, regionImageryProvider, catalogItem.opacity, layerIndex);
     if (defined(catalogItem.terria.leaflet) && colorFunction) {

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -471,14 +471,6 @@ function addDescriptionAndProperties(regionMapping, regionImageryProvider) {
             var uniqueId = imageryLayerFeatureInfo.data.properties[uniqueIdProp];
             imageryLayerFeatureInfo.description = new CallbackProperty(getRegionRowDescriptionPropertyCallbackForId(uniqueId), regionMapping.isConstant);
             imageryLayerFeatureInfo.properties = new CallbackProperty(getRegionRowPropertiesPropertyCallbackForId(uniqueId), regionMapping.isConstant);
-            // var rowObject = regionRowObjects[uniqueId];
-            // if (defined(rowObject)) {
-            //     imageryLayerFeatureInfo.properties = rowObject;
-            //     imageryLayerFeatureInfo.description = regionRowDescriptions[uniqueId];
-            // } else {
-            //     imageryLayerFeatureInfo.properties = undefined;
-            //     imageryLayerFeatureInfo.description = undefined;
-            // }
         }
         return imageryLayerFeatureInfos;
     });

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -4,14 +4,14 @@
 var L = require('leaflet');
 
 // var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
-var CallbackProperty = require('terriajs-cesium/Source/Core/CallbackProperty');
+var CallbackProperty = require('terriajs-cesium/Source/DataSources/CallbackProperty');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var destroyObject = require('terriajs-cesium/Source/Core/destroyObject');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
-var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 // var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var arraysAreEqual = require('../Core/arraysAreEqual');
@@ -69,7 +69,6 @@ var RegionMapping = function(catalogItem, tableStructure, tableStyle) {
     this._regionDetails = undefined; // For caching the region details.
     this._imageryLayer = undefined;
     this._hadImageryAtLayerIndex = undefined;
-    this._regionImageryProvider = undefined;
     this._clockTickSubscription = undefined; // For time-varying region-mapped csvs only.
     this._previousRegionIndices = undefined; // For time-varying region-mapped csvs only. Only redraws regions if they've changed.
     this._hasDisplayedFeedback = false; // So that we only show the feedback once.
@@ -201,7 +200,7 @@ defineProperties(RegionMapping.prototype, {
      */
     isConstant: {
         get: function() {
-            var timeColumn = regionMapping._tableStructure.activeTimeColumn;
+            var timeColumn = this._tableStructure.activeTimeColumn;
             return (!defined(timeColumn) || !defined(timeColumn._clock));
         }
     }
@@ -356,6 +355,7 @@ RegionMapping.prototype.loadRegionDetails = function() {
     });
 };
 
+// Loads region ids from the region providers, and returns the region details.
 function loadRegionIds(regionMapping, rawRegionDetails) {
     var promises = rawRegionDetails.map(function(rawRegionDetail) { return rawRegionDetail.regionProvider.loadRegionIDs(); });
     return when.all(promises).then(function() {
@@ -420,11 +420,16 @@ function getRegionValuesFromIndices(regionIndices, tableStructure) {
     return regionValues;
 }
 
-function addDescriptionAndProperties(regionMapping) {
+// Put the properties and the description of this row onto the image of the region.
+function addDescriptionAndProperties(regionMapping, regionImageryProvider) {
+    var tableStructure = regionMapping._tableStructure;
     var rowObjects = tableStructure.toRowObjects();
     if (rowObjects.length === 0) {
         return;
     }
+    var rowDescriptions = tableStructure.toRowDescriptions(regionMapping._tableStyle.featureInfoFields);
+    var regionDetail = regionMapping._regionDetails[0];
+    var uniqueIdProp = regionDetail.regionProvider.uniqueIdProp;
 
     function getRegionRowDescriptionPropertyCallbackForId(uniqueId) {
         /**
@@ -436,25 +441,36 @@ function addDescriptionAndProperties(regionMapping) {
          */
         return function regionRowDescriptionPropertyCallback(time, result) {
             var regionIndices = calculateRegionIndices(regionMapping, time);
-            var regionRowObjects = regionIndices.map(function(i) { return rowObjects[i]; });
-            if (defined(rowObject)) {
-                // result parameter is unsupported (should it be supported?)
-                return regionRowDescriptions[uniqueId];
-            }
-        }
+            var regionRowDescriptions = regionIndices.map(function(i) { return rowDescriptions[i]; });
+            // result parameter is unsupported (should it be supported?)
+            return regionRowDescriptions[uniqueId] || 'No data for the selected date.';
+        };
     }
 
-    // Put the properties and the description of this row onto the image of the region.
-    var rowDescriptions = tableStructure.toRowDescriptions(regionMapping._tableStyle.featureInfoFields);
-    var regionRowDescriptions = regionIndices.map(function(i) { return rowDescriptions[i]; });
+    function getRegionRowPropertiesPropertyCallbackForId(uniqueId) {
+        /**
+         * Returns a function that returns the value of the regionRowProperties at a given time, updating result if available.
+         *
+         * @param {JulianDate} [time] The time for which to retrieve the value.
+         * @param {Object} [result] The object to store the value into, if omitted, a new instance is created and returned.
+         * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
+         */
+        return function regionRowPropertiesPropertyCallback(time, result) {
+            var regionIndices = calculateRegionIndices(regionMapping, time);
+            var regionRowObjects = regionIndices.map(function(i) { return rowObjects[i]; });
+            return regionRowObjects[uniqueId] || {};
+        };
+    }
+
     ImageryProviderHooks.addPickFeaturesHook(regionImageryProvider, function(imageryLayerFeatureInfos) {
         if (!defined(imageryLayerFeatureInfos) || imageryLayerFeatureInfos.length === 0) {
             return;
         }
         for (var i = 0; i < imageryLayerFeatureInfos.length; ++i) {
             var imageryLayerFeatureInfo = imageryLayerFeatureInfos[i];
-            var uniqueId = imageryLayerFeatureInfo.data.properties[regionDetail.regionProvider.uniqueIdProp];
+            var uniqueId = imageryLayerFeatureInfo.data.properties[uniqueIdProp];
             imageryLayerFeatureInfo.description = new CallbackProperty(getRegionRowDescriptionPropertyCallbackForId(uniqueId), regionMapping.isConstant);
+            imageryLayerFeatureInfo.properties = new CallbackProperty(getRegionRowPropertiesPropertyCallbackForId(uniqueId), regionMapping.isConstant);
             // var rowObject = regionRowObjects[uniqueId];
             // if (defined(rowObject)) {
             //     imageryLayerFeatureInfo.properties = rowObject;
@@ -469,7 +485,7 @@ function addDescriptionAndProperties(regionMapping) {
 }
 
 /**
- * Creates and enables a new ImageryLayer onto terria, showing appropriately colored regions with feature descriptions.
+ * Creates and enables a new ImageryLayer onto terria, showing appropriately colored regions.
  *
  * @param {RegionMapping} regionMapping    The table data source.
  * @param {Number} [layerIndex] The layer index of the new imagery layer.
@@ -493,14 +509,17 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
     }
     var regionValues = getRegionValuesFromIndices(regionIndices, tableStructure);
 
-    // Recolor the regions, and add feature descriptions.
     var regionImageryProvider = new WebMapServiceImageryProvider({
-        url: proxyCatalogItemUrl(catalogItem, regionDetail.regionProvider.server),
+        url: proxyCatalogItemUrl(regionMapping._catalogItem, regionDetail.regionProvider.server),
         layers: regionDetail.regionProvider.layerName,
         parameters: WebMapServiceCatalogItem.defaultParameters,
         getFeatureInfoParameters: WebMapServiceCatalogItem.defaultParameters,
         tilingScheme: new WebMercatorTilingScheme()
     });
+
+    addDescriptionAndProperties(regionMapping, regionImageryProvider);
+
+    // Recolor the regions.
     var colorFunction = regionDetail.regionProvider.getColorLookupFunc(
         regionValues,
         legendHelper.getColorArrayFromValue.bind(legendHelper)

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -358,12 +358,12 @@ function loadRegionIds(regionMapping, rawRegionDetails) {
  * Takes the current time into account if there is a time column and _avalabilities is defined.
  *
  * @param {RegionMapping} regionMapping The table data source.
- * @param {Clock} [clock] The terria clock. (NOT the time column's ._clock, which does not show the same time (and is a DataSourceClock).
+ * @param {JulianDate} [time] The current time, eg. terria.clock.currentTime. NOT the time column's ._clock's time, which is different (and comes from a DataSourceClock).
  * @param {Array} [failedMatches] An optional empty array. If provided, indices of failed matches are appended to the array.
  * @param {Array} [ambiguousMatches] An optional empty array. If provided, indices of matches which duplicate prior matches are appended to the array.
  * @return {Array} An array the same length as regionProvider.regions, mapping each region into the relevant index into the table data source.
  */
-function calculateRegionIndices(regionMapping, clock, failedMatches, ambiguousMatches) {
+function calculateRegionIndices(regionMapping, time, failedMatches, ambiguousMatches) {
     // As described in load, currently we only use the first possible region column.
     var regionDetail = regionMapping._regionDetails[0];
     var tableStructure = regionMapping._tableStructure;
@@ -372,7 +372,7 @@ function calculateRegionIndices(regionMapping, clock, failedMatches, ambiguousMa
     var timeColumn = tableStructure.activeTimeColumn;
     if (defined(timeColumn) && timeColumn.availabilities) {
         regionColumnValues = regionColumnValues.map(function(value, index) {
-            return (timeColumn.availabilities[index].contains(clock.currentTime) ? value : undefined);
+            return (timeColumn.availabilities[index].contains(time) ? value : undefined);
         });
     }
     // regionIndices will be an array the same length as regionProvider.regions, giving the index of each region into the table.
@@ -399,6 +399,17 @@ function getRegionValuesFromIndices(regionIndices, tableStructure) {
 }
 
 /**
+ * A function that returns the value of the regionRowDescription at a given time.
+ *
+ * @param {JulianDate} [time] The time for which to retrieve the value.
+ * @param {Object} [result] The object to store the value into, if omitted, a new instance is created and returned.
+ * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
+ */
+function regionRowDescriptionPropertyCallback(time, result) {
+
+}
+
+/**
  * Creates and enables a new ImageryLayer onto terria, showing appropriately colored regions with feature descriptions.
  *
  * @param {RegionMapping} regionMapping    The table data source.
@@ -415,7 +426,7 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
     if (!defined(regionIndices)) {
         failedMatches = [];
         ambiguousMatches = [];
-        regionIndices = calculateRegionIndices(regionMapping, regionMapping._catalogItem.terria.clock, failedMatches, ambiguousMatches);
+        regionIndices = calculateRegionIndices(regionMapping, regionMapping._catalogItem.terria.clock.currentTime, failedMatches, ambiguousMatches);
         if (!regionMapping._hasDisplayedFeedback && catalogItem.showWarnings) {
             regionMapping._hasDisplayedFeedback = true;
             displayFailedAndAmbiguousMatches(regionMapping, failedMatches, ambiguousMatches);
@@ -501,7 +512,7 @@ function redisplayRegions(regionMapping, regionIndices) {
 
 function onClockTick(regionMapping, clock) {
     // Check if record data has changed.
-    var regionIndices = calculateRegionIndices(regionMapping, clock);
+    var regionIndices = calculateRegionIndices(regionMapping, clock.currentTime);
     if (arraysAreEqual(regionMapping._previousRegionIndices, regionIndices)) {
         return;
     }

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -420,8 +420,14 @@ function getRegionValuesFromIndices(regionIndices, tableStructure) {
     return regionValues;
 }
 
-// Put the properties and the description of this row onto the image of the region.
-function addDescriptionAndProperties(regionMapping, regionImageryProvider) {
+/**
+ * Put the properties and the description of this row onto the image of the region. Handles time-varying and constant regions.
+ * @param {RegionMapping} regionMapping The region mapping instance.
+ * @param {Array} [regionIndices] An array the same length as regionProvider.regions, mapping each region into the relevant index into the table data source;
+ *                                only used if the regions are constant.
+ * @param {WebMapServiceImageryProvider} regionImageryProvider The WebMapServiceImageryProvider instance.
+ */
+function addDescriptionAndProperties(regionMapping, regionIndices, regionImageryProvider) {
     var tableStructure = regionMapping._tableStructure;
     var rowObjects = tableStructure.toRowObjects();
     if (rowObjects.length === 0) {
@@ -430,6 +436,14 @@ function addDescriptionAndProperties(regionMapping, regionImageryProvider) {
     var rowDescriptions = tableStructure.toRowDescriptions(regionMapping._tableStyle.featureInfoFields);
     var regionDetail = regionMapping._regionDetails[0];
     var uniqueIdProp = regionDetail.regionProvider.uniqueIdProp;
+    var isConstant = regionMapping.isConstant;
+
+    var regionRowDescriptions;
+    var regionRowObjects;
+    if (isConstant) {
+        regionRowObjects = regionIndices.map(function(i) { return rowObjects[i]; });
+        regionRowDescriptions = regionIndices.map(function(i) { return rowDescriptions[i]; });
+    }
 
     function getRegionRowDescriptionPropertyCallbackForId(uniqueId) {
         /**
@@ -440,8 +454,8 @@ function addDescriptionAndProperties(regionMapping, regionImageryProvider) {
          * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
          */
         return function regionRowDescriptionPropertyCallback(time, result) {
-            var regionIndices = calculateRegionIndices(regionMapping, time);
-            var regionRowDescriptions = regionIndices.map(function(i) { return rowDescriptions[i]; });
+            var timeSpecificRegionIndices = calculateRegionIndices(regionMapping, time);
+            var regionRowDescriptions = timeSpecificRegionIndices.map(function(i) { return rowDescriptions[i]; });
             // result parameter is unsupported (should it be supported?)
             return regionRowDescriptions[uniqueId] || 'No data for the selected date.';
         };
@@ -456,8 +470,8 @@ function addDescriptionAndProperties(regionMapping, regionImageryProvider) {
          * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
          */
         return function regionRowPropertiesPropertyCallback(time, result) {
-            var regionIndices = calculateRegionIndices(regionMapping, time);
-            var regionRowObjects = regionIndices.map(function(i) { return rowObjects[i]; });
+            var timeSpecificRegionIndices = calculateRegionIndices(regionMapping, time);
+            var regionRowObjects = timeSpecificRegionIndices.map(function(i) { return rowObjects[i]; });
             return regionRowObjects[uniqueId] || {};
         };
     }
@@ -469,8 +483,13 @@ function addDescriptionAndProperties(regionMapping, regionImageryProvider) {
         for (var i = 0; i < imageryLayerFeatureInfos.length; ++i) {
             var imageryLayerFeatureInfo = imageryLayerFeatureInfos[i];
             var uniqueId = imageryLayerFeatureInfo.data.properties[uniqueIdProp];
-            imageryLayerFeatureInfo.description = new CallbackProperty(getRegionRowDescriptionPropertyCallbackForId(uniqueId), regionMapping.isConstant);
-            imageryLayerFeatureInfo.properties = new CallbackProperty(getRegionRowPropertiesPropertyCallbackForId(uniqueId), regionMapping.isConstant);
+            if (isConstant) {
+                imageryLayerFeatureInfo.description = regionRowDescriptions[uniqueId];
+                imageryLayerFeatureInfo.properties = regionRowObjects[uniqueId];
+            } else {
+                imageryLayerFeatureInfo.description = new CallbackProperty(getRegionRowDescriptionPropertyCallbackForId(uniqueId), isConstant);
+                imageryLayerFeatureInfo.properties = new CallbackProperty(getRegionRowPropertiesPropertyCallbackForId(uniqueId), isConstant);
+            }
         }
         return imageryLayerFeatureInfos;
     });
@@ -509,7 +528,7 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
         tilingScheme: new WebMercatorTilingScheme()
     });
 
-    addDescriptionAndProperties(regionMapping, regionImageryProvider);
+    addDescriptionAndProperties(regionMapping, regionIndices, regionImageryProvider);
 
     // Recolor the regions.
     var colorFunction = regionDetail.regionProvider.getColorLookupFunc(

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -288,9 +288,13 @@ function replaceBadKeyCharacters(properties) {
 }
 
 function propertyGetTimeValues(properties, clock) {
-    // Check each property for a getValue function; if it exists, use it to get the current value.
+    // properties itself may be a time-varying "property" with a getValue function.
+    // If not, check each of its properties for a getValue function; if it exists, use it to get the current value.
     var result = {};
     var currentTime = clock.currentTime;
+    if (typeof properties.getValue === 'function') {
+        return properties.getValue(currentTime);
+    }
     for (var key in properties) {
         if (properties.hasOwnProperty(key)) {
             if (properties[key] && typeof properties[key].getValue === 'function') {

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -231,6 +231,9 @@ FeatureInfoPanelSectionViewModel.prototype._resetDownloadDropdownPosition = func
  * row being the data. If the object is too hierarchical to be made into a CSV, returns undefined.
  */
 function generateCsvData(data) {
+    if (!defined(data)) {
+        return;
+    }
     var row1 = [];
     var row2 = [];
 
@@ -290,6 +293,9 @@ function replaceBadKeyCharacters(properties) {
 function propertyGetTimeValues(properties, clock) {
     // properties itself may be a time-varying "property" with a getValue function.
     // If not, check each of its properties for a getValue function; if it exists, use it to get the current value.
+    if (!defined(properties)) {
+        return;
+    }
     var result = {};
     var currentTime = clock.currentTime;
     if (typeof properties.getValue === 'function') {

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -933,7 +933,7 @@ describe('CsvCatalogItem with region mapping', function() {
                     return regionImageryProvider.pickFeatures(3698, 2513, 12, 2.5323739090365693, -0.6604719122857645);
                 }).then(function(r) {
                     expect(r[0].name).toEqual("3124");
-                    var description = r[0].description.getValue(terria.clock.currentTime);
+                    var description = r[0].description; //.getValue(terria.clock.currentTime);
                     expect(description).toContain("42.42");
                     expect(description).toContain("the universe");
                 }).otherwise(fail).then(done);
@@ -990,7 +990,7 @@ describe('CsvCatalogItem with region mapping', function() {
                     return regionImageryProvider.pickFeatures(3698, 2513, 12, 2.5323739090365693, -0.6604719122857645);
                 }).then(function(r) {
                     expect(r[0].name).toEqual("Boroondara (C)");
-                    var description = r[0].description.getValue(terria.clock.currentTime);
+                    var description = r[0].description; //.getValue(terria.clock.currentTime);
                     expect(description).toContain("42.42");
                     expect(description).toContain("the universe");
                 }).otherwise(fail).then(done);
@@ -1073,7 +1073,7 @@ describe('CsvCatalogItem with region mapping', function() {
                     return regionImageryProvider.pickFeatures(464, 314, 9, 2.558613543017636, -0.6605448031188106);
                 }).then(function(r) {
                     expect(r[0].name).toEqual("Wellington (S)");
-                    var description = r[0].description.getValue(terria.clock.currentTime);
+                    var description = r[0].description; //.getValue(terria.clock.currentTime);
                     expect(description).toContain("Wellington"); // leaving it open whether it should show server-side ID or provided value
                     expect(description).toContain("Melbourne");
                 }).then(function() {
@@ -1081,7 +1081,7 @@ describe('CsvCatalogItem with region mapping', function() {
                     return regionImageryProvider.pickFeatures(233, 152, 8, 2.600997237149669, -0.5686381345023742);
                 }).then(function(r) {
                     expect(r[0].name).toEqual("Wellington (A)");
-                    var description = r[0].description.getValue(terria.clock.currentTime);
+                    var description = r[0].description; //.getValue(terria.clock.currentTime);
                     expect(description).toContain("Wellington");
                     expect(description).toContain("Sydney");
                 }).otherwise(fail).then(done);

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -933,8 +933,9 @@ describe('CsvCatalogItem with region mapping', function() {
                     return regionImageryProvider.pickFeatures(3698, 2513, 12, 2.5323739090365693, -0.6604719122857645);
                 }).then(function(r) {
                     expect(r[0].name).toEqual("3124");
-                    expect(r[0].description).toContain("42.42");
-                    expect(r[0].description).toContain("the universe");
+                    var description = r[0].description.getValue(terria.clock.currentTime);
+                    expect(description).toContain("42.42");
+                    expect(description).toContain("the universe");
                 }).otherwise(fail).then(done);
             });
         });
@@ -989,8 +990,9 @@ describe('CsvCatalogItem with region mapping', function() {
                     return regionImageryProvider.pickFeatures(3698, 2513, 12, 2.5323739090365693, -0.6604719122857645);
                 }).then(function(r) {
                     expect(r[0].name).toEqual("Boroondara (C)");
-                    expect(r[0].description).toContain("42.42");
-                    expect(r[0].description).toContain("the universe");
+                    var description = r[0].description.getValue(terria.clock.currentTime);
+                    expect(description).toContain("42.42");
+                    expect(description).toContain("the universe");
                 }).otherwise(fail).then(done);
             });
         });
@@ -1071,15 +1073,17 @@ describe('CsvCatalogItem with region mapping', function() {
                     return regionImageryProvider.pickFeatures(464, 314, 9, 2.558613543017636, -0.6605448031188106);
                 }).then(function(r) {
                     expect(r[0].name).toEqual("Wellington (S)");
-                    expect(r[0].description).toContain("Wellington"); // leaving it open whether it should show server-side ID or provided value
-                    expect(r[0].description).toContain("Melbourne");
+                    var description = r[0].description.getValue(terria.clock.currentTime);
+                    expect(description).toContain("Wellington"); // leaving it open whether it should show server-side ID or provided value
+                    expect(description).toContain("Melbourne");
                 }).then(function() {
                     var regionImageryProvider = ImageryLayerCatalogItem.enableLayer.calls.argsFor(0)[1];
                     return regionImageryProvider.pickFeatures(233, 152, 8, 2.600997237149669, -0.5686381345023742);
                 }).then(function(r) {
                     expect(r[0].name).toEqual("Wellington (A)");
-                    expect(r[0].description).toContain("Wellington");
-                    expect(r[0].description).toContain("Sydney");
+                    var description = r[0].description.getValue(terria.clock.currentTime);
+                    expect(description).toContain("Wellington");
+                    expect(description).toContain("Sydney");
                 }).otherwise(fail).then(done);
             });
         });


### PR DESCRIPTION
Fixes #1248 .
You can try this out with the #test droughts.csv and/or [SA3-Region-Innovation-Data-2009-14 csv-geo-au](https://data.gov.au/dataset/sa3-region-innovation-data-2009-14).
