### PR TITLE
Streamline datatype matching

### DIFF
--- a/lib/Models/ArcGisCatalogGroup.js
+++ b/lib/Models/ArcGisCatalogGroup.js
@@ -157,6 +157,9 @@ sending an email to <a href="mailto:'+terria.supportEmail+'">'+terria.supportEma
         if (!defined(dataCustodian) && defined(serviceJson.documentInfo) && defined(serviceJson.documentInfo.Author)) {
             dataCustodian = serviceJson.documentInfo.Author;
         }
+        if (catalogGroup.name === 'Unnamed Item' && defined(serviceJson.mapName) && serviceJson.mapName.length > 0) {
+            catalogGroup.name = serviceJson.mapName;
+        }
 
         addLayersRecursively(catalogGroup, serviceJson, layersJson, legendJson, -1, layersJson.layers, catalogGroup, dataCustodian);
     }).otherwise(function(e) {

--- a/lib/Models/addUserCatalogMember.js
+++ b/lib/Models/addUserCatalogMember.js
@@ -45,6 +45,7 @@ var addUserCatalogMember = function(terria, newCatalogMemberOrPromise, options) 
         terria.catalog.userAddedDataGroup.isOpen = true;
     }).otherwise(function(e) {
         if (!(e instanceof TerriaError)) {
+            console.error(e);
             e = new TerriaError({
                 title: 'Data could not be added',
                 message: 'The specified data could not be added because it is invalid or does not have the expected format.'

--- a/lib/Models/addUserCatalogMember.js
+++ b/lib/Models/addUserCatalogMember.js
@@ -45,7 +45,6 @@ var addUserCatalogMember = function(terria, newCatalogMemberOrPromise, options) 
         terria.catalog.userAddedDataGroup.isOpen = true;
     }).otherwise(function(e) {
         if (!(e instanceof TerriaError)) {
-            console.error(e);
             e = new TerriaError({
                 title: 'Data could not be added',
                 message: 'The specified data could not be added because it is invalid or does not have the expected format.'

--- a/lib/Models/createCatalogItemFromFileOrUrl.js
+++ b/lib/Models/createCatalogItemFromFileOrUrl.js
@@ -8,6 +8,8 @@ var PopupMessageConfirmationViewModel = require('../ViewModels/PopupMessageConfi
 var createCatalogItemFromUrl = require('./createCatalogItemFromUrl');
 var createCatalogMemberFromType = require('./createCatalogMemberFromType');
 var TerriaError = require('../Core/TerriaError');
+var defined = require('terriajs-cesium/Source/Core/defined');
+var OgrCatalogItem = require('../Models/OgrCatalogItem');
 
 /**
  * Asynchronously creates and loads a catalog item for a given file.  The returned promise does not resolve until
@@ -27,39 +29,47 @@ var TerriaError = require('../Core/TerriaError');
  * @return {Promise} A promise that resolves to the created catalog item.
  */
 var createCatalogItemFromFileOrUrl = function(terria, fileOrUrl, dataType, confirmConversion) {
+    function tryConversionService(newItem) {
+       if (name.match(/\.(shp|jpg|jpeg|pdf|xlsx|xls|tif|tiff|png|txt|doc|docx|xml|json)$/)) {
+            terria.error.raiseEvent(new TerriaError({
+                title: 'Unsupported file type',
+                message: 'This file format is not supported by ' + terria.appName + '. Directly supported file formats include: ' + 
+                '<ul><li>.geojson</li><li>.kml, .kmz</li><li>.csv (in <a href="https://github.com/NICTA/nationalmap/wiki/csv-geo-au">csv-geo-au format</a>)</li></ul>' + 
+                'File formats supported through the online conversion service include: ' +
+                '<ul><li>Shapefile (.zip)</li><li>MapInfo TAB (.zip)</li><li>Possibly other <a href="http://www.gdal.org/ogr_formats.html">OGR Vector Formats</a></li></ul>'
+            }));
+            return undefined;
+        } 
+        return getConfirmation(confirmConversion, 'This file is not directly supported by '+terria.appName+'.\n\n' +
+            'Do you want to try uploading it to the '+terria.appName+' conversion service? This may work for ' +
+            'small, zipped Esri Shapefiles or MapInfo TAB files.')
+            .then(function(confirmed) { 
+                return confirmed ? loadItem(new OgrCatalogItem(terria), name, fileOrUrl) : undefined; 
+            });
+    }
+
     var isUrl = typeof fileOrUrl === 'string';
     dataType = defaultValue(dataType, 'auto');
 
     var name = isUrl ? fileOrUrl : fileOrUrl.name;
 
     if (dataType === 'auto') {
-        var newCatalogItem = createCatalogItemFromUrl(name, terria);
-        if (newCatalogItem.type === 'ogr') {
-            if (name.match(/\.(shp|jpg|jpeg|pdf|xlsx|xls|tif|tiff|png|txt|doc|docx|xml|json)$/)) {
-                terria.error.raiseEvent(new TerriaError({
-                    title: 'Unsupported file type',
-                    message: 'This file format is not supported by ' + terria.appName + '. Directly supported file formats include: ' + 
-                    '<ul><li>.geojson</li><li>.kml, .kmz</li><li>.csv (in <a href="https://github.com/NICTA/nationalmap/wiki/csv-geo-au">csv-geo-au format</a>)</li></ul>' + 
-                    'File formats supported through the online conversion service include: ' +
-                    '<ul><li>Shapefile (.zip)</li><li>MapInfo TAB (.zip)</li><li>Possibly other <a href="http://www.gdal.org/ogr_formats.html">OGR Vector Formats</a></li></ul>'
-                }));
-                return undefined;
-            } 
-            return getConfirmation(confirmConversion, 'This file is not directly supported by '+terria.appName+'.\n\n' +
-                'Do you want to try uploading it to the '+terria.appName+' conversion service? This may work for ' +
-                'small, zipped Esri Shapefiles or MapInfo TAB files.')
-                .then(function(confirmed) { 
-                    return confirmed ? loadItem(newCatalogItem, name, fileOrUrl) : undefined; 
-                });
-        } else {
-            return loadItem(newCatalogItem, name, fileOrUrl); // It's a file we support directly
-        }
+        return when(createCatalogItemFromUrl(name, terria, isUrl)).then(function(newItem) { //##Doesn't work for file uploads
+            if (!defined(newItem)) {
+                return tryConversionService();
+            } else {
+                // It's a file or service we support directly
+                // In some cases (web services), the item will already have been loaded by this point.
+                return loadItem(newItem, name, fileOrUrl); 
+            }
+        });
     } else if (dataType === 'other') { // user explicitly chose "Other (use conversion service)"
         return getConfirmation(confirmConversion, 'Ready to upload your file to the ' + terria.appName + ' conversion service?')
             .then(function(confirmed) { 
                 return confirmed ? loadItem(createCatalogMemberFromType('ogr', terria), name, fileOrUrl) : undefined; 
             });
     } else {
+        // User has provided a type, so we go with that.
         return loadItem(createCatalogMemberFromType(dataType, terria), name, fileOrUrl);
     }
 };
@@ -96,7 +106,7 @@ function loadItem(newCatalogItem, name, fileOrUrl) {
         newCatalogItem.dataSourceUrl = fileOrUrl.name;
     }
 
-    return newCatalogItem.load().yield(newCatalogItem);
+    return when(newCatalogItem.load()).yield(newCatalogItem);
 }
 
 module.exports = createCatalogItemFromFileOrUrl;

--- a/lib/Models/createCatalogItemFromUrl.js
+++ b/lib/Models/createCatalogItemFromUrl.js
@@ -25,14 +25,14 @@ var createCatalogItemFromUrl = function(url, terria, allowLoad, index) {
         item.url = url;
         return item.load().yield(item).otherwise(function(e) {
             console.log(e);
-            return createCatalogItemFromUrl(terria, url, allowLoad, index + 1);
+            return createCatalogItemFromUrl(url, terria, allowLoad, index + 1);
         });
     }
 };
 
 /**
  * Registers a constructor for a given type of {@link CatalogMember}.
- * 
+ *
  * @param {createCatalogItemFromUrl~Matcher} matcher A function that is given a URL to match as its only parameter.  If the function returns true, The type name for which to register a constructor.
  * @param {createCatalogItemFromUrl~Constructor} constructor The constructor for data items that match the given matcher.
  * @param {createCatalogItemFromUrl~requiresLoad} requiresLoad A boolean indicating whether the URL must be actually loaded in order to really determine if it matches.

--- a/lib/Models/createCatalogItemFromUrl.js
+++ b/lib/Models/createCatalogItemFromUrl.js
@@ -7,16 +7,27 @@ var mapping = [];
  *
  * @param {String} url The derived type name.
  * @param {Terria} terria The Terria instance.
- * @returns {CatalogMember} The constructed data item, or undefined if the URL is not supported.
+ * @param {Boolean} allowLoad Whether it's ok to attempt to load the URL and detect failures. We generally do this for WMS type services, but not for local files.
+ * @returns {CatalogMember} The constructed data item or promise, or undefined if the URL is not supported.
  */
-var createCatalogItemFromUrl = function(url, terria) {
-    for (var i = 0; i < mapping.length; ++i) {
-        var matcher = mapping[i];
-        if (matcher.matcher(url)) {
-            return new matcher.constructor(terria, url);
-        }
+var createCatalogItemFromUrl = function(url, terria, allowLoad, index) {
+    index = index || 0;
+    if (index >= mapping.length) {
+        return undefined;
     }
-    return undefined;
+    if (mapping[index].matcher && !mapping[index].matcher(url) || (mapping[index].requiresLoad && !allowLoad)) {
+        return createCatalogItemFromUrl(url, terria, allowLoad, index + 1);
+    } else {
+        var item = new mapping[index].constructor(terria);
+        if (!allowLoad) {
+            return item;
+        }
+        item.url = url;
+        return item.load().yield(item).otherwise(function(e) {
+            console.log(e);
+            return createCatalogItemFromUrl(terria, url, allowLoad, index + 1);
+        });
+    }
 };
 
 /**
@@ -24,11 +35,13 @@ var createCatalogItemFromUrl = function(url, terria) {
  * 
  * @param {createCatalogItemFromUrl~Matcher} matcher A function that is given a URL to match as its only parameter.  If the function returns true, The type name for which to register a constructor.
  * @param {createCatalogItemFromUrl~Constructor} constructor The constructor for data items that match the given matcher.
+ * @param {createCatalogItemFromUrl~requiresLoad} requiresLoad A boolean indicating whether the URL must be actually loaded in order to really determine if it matches.
  */
- createCatalogItemFromUrl.register = function(matcher, constructor) {
+ createCatalogItemFromUrl.register = function(matcher, constructor, requiresLoad) {
     mapping.push({
         matcher: matcher,
-        constructor: constructor
+        constructor: constructor,
+        requiresLoad: requiresLoad
     });
 };
 

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -72,7 +72,7 @@ var registerCatalogMembers = function() {
     createCatalogItemFromUrl.register(matchesExtension('topojson'), GeoJsonCatalogItem);
 
     //These items work by trying to match a URL, then loading the data. If it fails, they move on.
-    createCatalogItemFromUrl.register(matchesUrl(/\/WMTS\//i), WebMapTileServiceCatalogGroup, true);
+    createCatalogItemFromUrl.register(matchesUrl(/\/WMTS\b/i), WebMapTileServiceCatalogGroup, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/wfs/i), WebFeatureServiceCatalogGroup, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/wms/i), WebMapServiceCatalogGroup, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/arcgis\/rest\/.*\/\d+\b/i), ArcGisMapServerCatalogItem, true);

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -70,7 +70,19 @@ var registerCatalogMembers = function() {
     createCatalogItemFromUrl.register(matchesExtension('kml'), KmlCatalogItem);
     createCatalogItemFromUrl.register(matchesExtension('kmz'), KmlCatalogItem);
     createCatalogItemFromUrl.register(matchesExtension('topojson'), GeoJsonCatalogItem);
-    createCatalogItemFromUrl.register(matchAll, OgrCatalogItem);
+
+    //These items work by trying to match a URL, then loading the data. If it fails, they move on.
+    createCatalogItemFromUrl.register(matchesUrl(/\/WMTS\//i), WebMapTileServiceCatalogItem, true);
+    createCatalogItemFromUrl.register(matchesUrl(/\/wfs/i), WebFeatureServiceCatalogGroup, true);
+    createCatalogItemFromUrl.register(matchesUrl(/\/wms/i), WebMapServiceCatalogGroup, true);
+    createCatalogItemFromUrl.register(matchesUrl(/\/arcgis\/rest\/.*\/\d+\b/i), ArcGisMapServerCatalogItem, true);
+    createCatalogItemFromUrl.register(matchesUrl(/\/ArcGis\/rest\//i), ArcGisCatalogGroup, true);
+
+    // These don't even try to match a URL, they're just total fallbacks. We really, really want something to work.
+    createCatalogItemFromUrl.register(undefined, WebMapServiceCatalogGroup, true);
+    createCatalogItemFromUrl.register(undefined, WebFeatureServiceCatalogGroup, true);
+    createCatalogItemFromUrl.register(undefined, ArcGisMapServerCatalogItem, true);
+    createCatalogItemFromUrl.register(undefined, ArcGisCatalogGroup, true);
 };
 
 function matchesExtension(extension) {
@@ -80,8 +92,8 @@ function matchesExtension(extension) {
     };
 }
 
-function matchAll() {
-    return true;
+function matchesUrl(regex) {
+    return /./.test.bind(regex);
 }
 
 module.exports = registerCatalogMembers;

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -72,7 +72,7 @@ var registerCatalogMembers = function() {
     createCatalogItemFromUrl.register(matchesExtension('topojson'), GeoJsonCatalogItem);
 
     //These items work by trying to match a URL, then loading the data. If it fails, they move on.
-    createCatalogItemFromUrl.register(matchesUrl(/\/WMTS\//i), WebMapTileServiceCatalogItem, true);
+    createCatalogItemFromUrl.register(matchesUrl(/\/WMTS\//i), WebMapTileServiceCatalogGroup, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/wfs/i), WebFeatureServiceCatalogGroup, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/wms/i), WebMapServiceCatalogGroup, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/arcgis\/rest\/.*\/\d+\b/i), ArcGisMapServerCatalogItem, true);

--- a/lib/ViewModels/AddDataPanelViewModel.js
+++ b/lib/ViewModels/AddDataPanelViewModel.js
@@ -1,18 +1,10 @@
 'use strict';
 
 /*global require*/
-var OpenStreetMapCatalogItem = require('../Models/OpenStreetMapCatalogItem');
-var ArcGisCatalogGroup = require('../Models/ArcGisCatalogGroup');
-var ArcGisMapServerCatalogItem = require('../Models/ArcGisMapServerCatalogItem');
 var addUserCatalogMember = require('../Models/addUserCatalogMember');
 var createCatalogItemFromFileOrUrl = require('../Models/createCatalogItemFromFileOrUrl');
 var loadView = require('../Core/loadView');
 var TerriaError = require('../Core/TerriaError');
-var WebFeatureServiceCatalogGroup = require('../Models/WebFeatureServiceCatalogGroup');
-var WebMapServiceCatalogGroup = require('../Models/WebMapServiceCatalogGroup');
-var WebMapTileServiceCatalogGroup = require('../Models/WebMapTileServiceCatalogGroup');
-
-var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
@@ -56,19 +48,23 @@ AddDataPanelViewModel.prototype.closeIfClickOnBackground = function(viewModel, e
     return true;
 };
 
-AddDataPanelViewModel.prototype.selectFileToUpload = function() {
-    // If the browser doesn't have the FileReader type, this is an old browser (like IE9) that can't ready a user-selected
-    // file from JavaScript without an ugly hack like bouncing it off a server first.  So tell the user this is not supported.
-    if (typeof FileReader === 'undefined') {
-         this.terria.error.raiseEvent(new TerriaError({
+function noFileApiError(terria) {
+    return new TerriaError({
             title: 'File API not supported',
             message: '\
-Sorry, your web browser does not support the File API, which '+this.terria.appName+' requires in order to \
+Sorry, your web browser does not support the File API, which '+terria.appName+' requires in order to \
 add data from a file on your system.  Please upgrade your web browser.  For the best experience, we recommend \
 <a href="http://www.microsoft.com/ie" target="_blank">Internet Explorer 11</a> or the latest version of \
 <a href="http://www.google.com/chrome" target="_blank">Google Chrome</a> or \
 <a href="http://www.mozilla.org/firefox" target="_blank">Mozilla Firefox</a>.'
-        }));
+        });
+}
+
+AddDataPanelViewModel.prototype.selectFileToUpload = function() {
+    // If the browser doesn't have the FileReader type, this is an old browser (like IE9) that can't ready a user-selected
+    // file from JavaScript without an ugly hack like bouncing it off a server first.  So tell the user this is not supported.
+    if (typeof FileReader === 'undefined') {
+        this.terria.error.raiseEvent(noFileApiError(this.terria));
         return;
     }
 
@@ -90,15 +86,7 @@ AddDataPanelViewModel.prototype.addUploadedFile = function() {
     var files = uploadFileElement.files;
 
     if (!defined(files)) {
-         this.terria.error.raiseEvent(new TerriaError({
-            title: 'File API not supported',
-            message: '\
-Sorry, your web browser does not support the File API, which '+this.terria.appName+' requires in order to \
-add data from a file on your system.  Please upgrade your web browser.  For the best experience, we recommend \
-<a href="http://www.microsoft.com/ie" target="_blank">Internet Explorer 11</a> or the latest version of \
-<a href="http://www.google.com/chrome" target="_blank">Google Chrome</a> or \
-<a href="http://www.mozilla.org/firefox" target="_blank">Mozilla Firefox</a>.'
-        }));
+        this.terria.error.raiseEvent(noFileApiError(this.terria));
         return;
     }
 
@@ -124,45 +112,12 @@ add data from a file on your system.  Please upgrade your web browser.  For the 
     }
 };
 
-var wfsUrlRegex = /\bwfs\b/i;
-
 AddDataPanelViewModel.prototype.addUrl = function() {
     this.terria.analytics.logEvent('addDataUrl', this.url);
 
     var that = this;
 
-    var promise;
-    if (this.dataType === 'auto') {
-        var wmsThenWfs = [loadWms, loadWfs];
-        var wfsThenWms = [loadWfs, loadWms];
-        var others = [loadWmts, loadMapServer, loadMapServerLayer, loadFile];
-
-        var loadFunctions;
-
-        // Does this look like a WFS URL?  If so, try that first (before WMS).
-        // This accounts for the fact that a single URL often works as both WMS and WFS.
-        if (wfsUrlRegex.test(this.url)) {
-            loadFunctions = wfsThenWms.concat(others);
-        } else {
-            loadFunctions = wmsThenWfs.concat(others);
-        }
-
-        promise = loadAuto(this, loadFunctions);
-    } else if (this.dataType === 'wms-getCapabilities') {
-        promise = loadWms(this);
-    } else if (this.dataType === 'wfs-getCapabilities') {
-        promise = loadWfs(this);
-    } else if (this.dataType === 'esri-group') {
-        promise = loadMapServer(this).otherwise(function() {
-            return loadMapServerLayer(this);
-        });
-    } else if (this.dataType === 'open-street-map') {
-        promise = loadOpenStreetMapServer(this);
-    } else {
-        promise = loadFile(this);
-    }
-
-    addUserCatalogMember( this.terria, promise).then(function() {
+    addUserCatalogMember(this.terria, createCatalogItemFromFileOrUrl(this.terria, this.url, this.dataType, true)).then(function() {
         that.close();
     });
 };
@@ -172,78 +127,5 @@ AddDataPanelViewModel.open = function(options) {
     viewModel.show(options.container);
     return viewModel;
 };
-
-function loadAuto(viewModel, loadFunctions, index) {
-    index = defaultValue(index, 0);
-    var loadFunction = loadFunctions[index];
-
-    return loadFunction(viewModel).otherwise(function() {
-        return loadAuto(viewModel, loadFunctions, index + 1);
-    });
-}
-
-function loadWms(viewModel) {
-    var wms = new WebMapServiceCatalogGroup(viewModel.terria);
-    wms.name = viewModel.url;
-    wms.url = viewModel.url;
-
-    return wms.load().then(function() {
-        return wms;
-    });
-}
-
-function loadWfs(viewModel) {
-    var wfs = new WebFeatureServiceCatalogGroup(viewModel.terria);
-    wfs.name = viewModel.url;
-    wfs.url = viewModel.url;
-
-    return wfs.load().then(function() {
-        return wfs;
-    });
-}
-
-function loadWmts(viewModel) {
-    var wmts = new WebMapTileServiceCatalogGroup(viewModel.terria);
-    wmts.name = viewModel.url;
-    wmts.url = viewModel.url;
-
-    return wmts.load().then(function() {
-        return wmts;
-    });
-}
-
-function loadMapServer(viewModel) {
-    var mapServer = new ArcGisCatalogGroup(viewModel.terria);
-    mapServer.name = viewModel.url;
-    mapServer.url = viewModel.url;
-
-    return mapServer.load().then(function() {
-        return mapServer;
-    });
-}
-
-function loadMapServerLayer(viewModel) {
-    var mapServer = new ArcGisMapServerCatalogItem(viewModel.terria);
-    mapServer.name = viewModel.url;
-    mapServer.url = viewModel.url;
-    return mapServer.load().then(function() {
-        return mapServer;
-    });
-}
-
-function loadOpenStreetMapServer(viewModel) {
-    var openStreetMapServer = new OpenStreetMapCatalogItem(viewModel.terria);
-    openStreetMapServer.name = viewModel.url;
-    openStreetMapServer.url = viewModel.url;
-
-    return openStreetMapServer.load().then(function() {
-        return openStreetMapServer;
-    });
-}
-
-
-function loadFile(viewModel) {
-    return createCatalogItemFromFileOrUrl(viewModel.terria, viewModel.url, viewModel.dataType, true);
-}
 
 module.exports = AddDataPanelViewModel;


### PR DESCRIPTION
Finally! A PR that actually removes code. It seemed very redundant that we have a whole bunch of decision logic about how to handle user-provided URLs in two different places: AddDataPanelViewModel and createCatalogItemFromFileOrUrl.

I have slightly shifted the semantics of createCatalogItemFromUrl, however, and now it sometimes loads the item as well as just returning an unloaded item. However, every time it was being called, it was always followed with a load anyway.

To fully test this stuff is quite complex. There are three entry points:
- drag/drop a file
- browse to a file
- enter a URL

Then a major branch:
- data type provided; or
- data type "auto"

Then a few possible outcomes:
- data type recognised by URL
- data type recognised by URL and loading
- data type not recognised, let's try OgrCatalogItem

Good luck, dear PR reviewer.
