### PR TITLE
Added mechanism for hiding the source of catalog items.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 
 ### 2.3.0
 
-* Added a mechanism for hiding the source of a CatalogItem in the view info popup.
+* Added the `hideSource` flag to the init json for hiding the source of a CatalogItem in the View Info popup.
 
 ### 2.2.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 2.3.0
+
+* Added a mechanism for hiding the source of a CatalogItem in the view info popup.
+
 ### 2.2.1
 
 * Improved legend and coloring of ENUM (string) columns of CSV files, to sort first by frequency, then alphabetically.

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -41,16 +41,16 @@ var CatalogMember = function(terria) {
     this.description = '';
 
     /**
-    * Gets or sets the array of section titles and contents for display in the layer info panel.
-    * In future this may replace 'description' above - this list should not contain
-    * sections named 'description' or 'Description' if the 'description' property
-    * is also set as both will be displayed.
-    * The object is of the form {name:string, content:string}.
-    * Content will be rendered as Markdown with HTML.
-    * This property is observable.
-    * @type {Object[]}
-    * @default []
-    */
+     * Gets or sets the array of section titles and contents for display in the layer info panel.
+     * In future this may replace 'description' above - this list should not contain
+     * sections named 'description' or 'Description' if the 'description' property
+     * is also set as both will be displayed.
+     * The object is of the form {name:string, content:string}.
+     * Content will be rendered as Markdown with HTML.
+     * This property is observable.
+     * @type {Object[]}
+     * @default []
+     */
     this.info = [];
 
     /**
@@ -136,6 +136,23 @@ var CatalogMember = function(terria) {
     this.parent = undefined;
 
     knockout.track(this, ['name', 'info', 'infoSectionOrder', 'description', 'isUserSupplied', 'isPromoted', 'initialMessage', 'isHidden', 'cacheDuration', 'customProperties']);
+
+    /**
+     * Indicates that the source of this data should be hidden from the UI (obviously this isn't super-secure as you
+     * can just look at the network requests).
+     *
+     * @type {boolean}
+     */
+    this.hideSource = false;
+
+    /**
+     * The names of items in the {@link CatalogMember#info} array that contain details of the source of this
+     * CatalogMember's data. This should be overridden by children of this class.
+     *
+     * @type {Array}
+     * @private
+     */
+    this._sourceInfoItemNames = [];
 };
 
 var descriptionRegex = /description/i;
@@ -264,10 +281,41 @@ defineProperties(CatalogMember.prototype, {
      * All keys that have historically been used to resolve this member - the current uniqueId + past shareKeys.
      */
     allShareKeys : {
-        get : function() {
+        get: function() {
             var allShareKeys = [this.uniqueId];
 
             return this.shareKeys ? allShareKeys.concat(this.shareKeys) : allShareKeys;
+        }
+    },
+
+    /**
+     * A filtered view of {@link CatalogMember#info} that excludes info items that divulge details about the data's
+     * source, as determined by {@link CatalogMember#__sourceInfoItemNames}.
+     */
+    infoWithoutSources: {
+        get: function() {
+            return defaultValue(this.info, []).filter(function(infoItem) {
+                return !defined(this._infoItemsWithSourceInfoLookup[infoItem.name]);
+            }.bind(this));
+        }
+    },
+
+    /**
+     * Returns a lookup of _sourceInfoItemNames as a map of names to a true value. Memoizes after being called for the
+     * first time.
+     *
+     * {@private}
+     */
+    _infoItemsWithSourceInfoLookup: {
+        get: function() {
+            if (!defined(this._memoizedInfoItemsSourceLookup)) {
+                this._memoizedInfoItemsSourceLookup = this._sourceInfoItemNames.reduce(function(lookupSoFar, name) {
+                    lookupSoFar[name] = true;
+                    return lookupSoFar;
+                }, {});
+            }
+
+            return this._memoizedInfoItemsSourceLookup;
         }
     }
 });

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -153,6 +153,9 @@ var CatalogMember = function(terria) {
      * @private
      */
     this._sourceInfoItemNames = [];
+
+    /** Lookup table for _sourceInfoItemNames, access through {@link CatalogMember#_infoItemsWithSourceInfoLookup} */
+    this._memoizedInfoItemsSourceLookup = undefined;
 };
 
 var descriptionRegex = /description/i;

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -110,6 +110,8 @@ var WebMapServiceCatalogItem = function(terria) {
      */
     this.maxRefreshIntervals = 1000;
 
+    this._sourceInfoItemNames = ['GetCapabilities URL'];
+
     knockout.track(this, [
         '_getCapabilitiesUrl', '_legendUrl', '_rectangle', '_rectangleFromMetadata', '_intervalsFromMetadata',
         'layers', 'parameters', 'getFeatureInfoFormats',

--- a/lib/ViewModels/CatalogItemInfoViewModel.js
+++ b/lib/ViewModels/CatalogItemInfoViewModel.js
@@ -26,7 +26,7 @@ var CatalogItemInfoViewModel = function(catalogItem) {
 
     knockout.defineProperty(this, 'sortedInfo', {
         get: function() {
-            var items = this.catalogItem.info.slice();
+            var items = this.catalogItem.hideSource ? this.catalogItem.infoWithoutSources : this.catalogItem.info.slice();
 
             var infoSectionOrder = defaultValue(this.catalogItem.infoSectionOrder, CatalogItemInfoViewModel.infoSectionOrder);
 

--- a/lib/Views/CatalogItemInfo.html
+++ b/lib/Views/CatalogItemInfo.html
@@ -70,106 +70,109 @@
             </div>
             <!-- /ko -->
 
-            <div class="catalog-item-info-section" data-bind="if: catalogItem.url">
-                <h2><span data-bind="text: catalogItem.typeName"></span> URL</h2>
-                <p class="catalog-item-info-description" data-bind="if: catalogItem.type === 'wms'">
-                    This is a <a href="https://en.wikipedia.org/wiki/Web_Map_Service" target="_blank">WMS service</a>, which generates map images on request. It can be used in GIS software with this URL:
-                </p>
-                <p class="catalog-item-info-description" data-bind="if: catalogItem.type === 'wfs'">
-                    This is a <a href="https://en.wikipedia.org/wiki/Web_Feature_Service" target="_blank">WFS service</a>, which transfers raw spatial data on request. It can be used in GIS software with this URL:
-                </p>
+            <!-- ko if: !catalogItem.hideSource -->
+                <div class="catalog-item-info-section" data-bind="if: catalogItem.url">
+                    <h2><span data-bind="text: catalogItem.typeName"></span> URL</h2>
+                    <p class="catalog-item-info-description" data-bind="if: catalogItem.type === 'wms'">
+                        This is a <a href="https://en.wikipedia.org/wiki/Web_Map_Service" target="_blank">WMS service</a>, which generates map images on request. It can be used in GIS software with this URL:
+                    </p>
+                    <p class="catalog-item-info-description" data-bind="if: catalogItem.type === 'wfs'">
+                        This is a <a href="https://en.wikipedia.org/wiki/Web_Feature_Service" target="_blank">WFS service</a>, which transfers raw spatial data on request. It can be used in GIS software with this URL:
+                    </p>
 
-                <input class="catalog-item-info-baseUrl" readonly type="text" data-bind="value: catalogItem.url" size="80" onclick="this.select();" />
-                <p class="catalog-item-info-description" data-bind="if: catalogItem.type === 'wms' || (catalogItem.type === 'esri-mapServer' && typeof catalogItem.layers !== 'undefined')">
-                    Layer name:
-                    <span class="catalog-item-info-tech-attributes" data-bind="text: catalogItem.layers"></span>
-                </p>
-                <p class="catalog-item-info-description" data-bind="if: catalogItem.type === 'wfs'">
-                    Type names:
-                    <span class="catalog-item-info-tech-attributes" data-bind="text: catalogItem.typeNames"></span>
-                </p>
-            </div>
-            <div class="catalog-item-info-section" data-bind="if: catalogItem.metadataUrl">
-                <h2>Metadata URL</h2>
-                <a class="catalog-item-info-description" data-bind="attr: { href: catalogItem.metadataUrl }, text: catalogItem.metadataUrl" target="_blank"></a>
-            </div>
-            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wfs' || catalogItem.dataUrlType === 'wfs-complete'">
-                <h2>Data URL</h2>
-                <div class="catalog-item-info-description">
-                    Use the link below to download the data.  See the
-                    <a href="http://docs.geoserver.org/latest/en/user/services/wfs/reference.html" target="_blank">Web Feature Service (WFS) documentation</a>
-                    for more information on customising URL query parameters.
-                    <div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
+                    <input class="catalog-item-info-baseUrl" readonly type="text" data-bind="value: catalogItem.url" size="80" onclick="this.select();" />
+                    <p class="catalog-item-info-description" data-bind="if: catalogItem.type === 'wms' || (catalogItem.type === 'esri-mapServer' && typeof catalogItem.layers !== 'undefined')">
+                        Layer name:
+                        <span class="catalog-item-info-tech-attributes" data-bind="text: catalogItem.layers"></span>
+                    </p>
+                    <p class="catalog-item-info-description" data-bind="if: catalogItem.type === 'wfs'">
+                        Type names:
+                        <span class="catalog-item-info-tech-attributes" data-bind="text: catalogItem.typeNames"></span>
+                    </p>
                 </div>
-            </div>
-            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wcs' || catalogItem.dataUrlType === 'wcs-complete'">
-                <h2>Data URL</h2>
-                <div class="catalog-item-info-description">
-                    Use the link below to download the data.  See the
-                    <a href="http://docs.geoserver.org/latest/en/user/services/wcs/reference.html" target="_blank">Web Coverage Service (WCS) documentation</a>
-                    for more information on customising URL query parameters.
-                    <div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
+                <div class="catalog-item-info-section" data-bind="if: catalogItem.metadataUrl">
+                    <h2>Metadata URL</h2>
+                    <a class="catalog-item-info-description" data-bind="attr: { href: catalogItem.metadataUrl }, text: catalogItem.metadataUrl" target="_blank"></a>
                 </div>
-            </div>
-            <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'direct'">
-                <h2>Data URL</h2>
-                <div class="catalog-item-info-description">
-                    Use the link below to download data directly.
-                    <div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
-                </div>
-            </div>
-            <div class="catalog-item-info-section">
-                <div class="catalog-item-info-details-heading" data-bind="click: toggleShowDataDetails">
-                    <button class="catalog-item-info-details-label">Data Source Details</button>
-                    <div class="catalog-item-info-details-expand-button-holder">
-                        <button href="#" class="catalog-item-info-details-expand-button" data-bind="cesiumSvgPath: { path: showDataDetails ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }"></button>
+                <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wfs' || catalogItem.dataUrlType === 'wfs-complete'">
+                    <h2>Data URL</h2>
+                    <div class="catalog-item-info-description">
+                        Use the link below to download the data.  See the
+                        <a href="http://docs.geoserver.org/latest/en/user/services/wfs/reference.html" target="_blank">Web Feature Service (WFS) documentation</a>
+                        for more information on customising URL query parameters.
+                        <div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
                     </div>
                 </div>
-                <!-- ko if: showDataDetails -->
-                    <div class="catalog-item-info-table">
-                        <!-- ko if: catalogItem.metadata.dataSourceMetadata.hasChildren -->
-                        <table data-bind="template: { name: 'catalog-item-info-item-template', foreach: catalogItem.metadata.dataSourceMetadata.items }">
-                        </table>
-                        <!-- /ko -->
-                        <!-- ko if: catalogItem.metadata.dataSourceErrorMessage -->
-                        <table>
-                            <tr>
-                                <td class="catalog-item-info-properties-name-cell catalog-item-info-properties-level1">
-                                    <div class="catalog-item-info-properties-arrow"></div>
-                                    <div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.dataSourceErrorMessage"></div>
-                                </td>
-                            </tr>
-                        </table>
-                        <!-- /ko -->
-                    </div>
-                <!-- /ko -->
-            </div>
-            <div class="catalog-item-info-section">
-                <div class="catalog-item-info-details-heading" data-bind="click: toggleShowServiceDetails">
-                    <button class="catalog-item-info-details-label">Data Service Details</button>
-                    <div class="catalog-item-info-details-expand-button-holder">
-                        <button class="catalog-item-info-details-expand-button" data-bind="cesiumSvgPath: { path: showServiceDetails ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }"></button>
+                <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'wcs' || catalogItem.dataUrlType === 'wcs-complete'">
+                    <h2>Data URL</h2>
+                    <div class="catalog-item-info-description">
+                        Use the link below to download the data.  See the
+                        <a href="http://docs.geoserver.org/latest/en/user/services/wcs/reference.html" target="_blank">Web Coverage Service (WCS) documentation</a>
+                        for more information on customising URL query parameters.
+                        <div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
                     </div>
                 </div>
-                <!-- ko if: showServiceDetails -->
-                    <div class="catalog-item-info-table">
-                        <!-- ko if: catalogItem.metadata.serviceMetadata.hasChildren -->
-                        <table data-bind="template: { name: 'catalog-item-info-item-template', foreach: catalogItem.metadata.serviceMetadata.items }">
-                        </table>
-                        <!-- /ko -->
-                        <!-- ko if: catalogItem.metadata.serviceErrorMessage -->
-                        <table>
-                            <tr>
-                                <td class="catalog-item-info-properties-name-cell catalog-item-info-properties-level1">
-                                    <div class="catalog-item-info-properties-arrow"></div>
-                                    <div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.serviceErrorMessage"></div>
-                                </td>
-                            </tr>
-                        </table>
-                        <!-- /ko -->
+                <div class="catalog-item-info-section" data-bind="if: catalogItem.dataUrlType === 'direct'">
+                    <h2>Data URL</h2>
+                    <div class="catalog-item-info-description">
+                        Use the link below to download data directly.
+                        <div><a data-bind="attr: { href: catalogItem.dataUrl }, text: catalogItem.dataUrl" target="_blank"></a></div>
                     </div>
-                <!-- /ko -->
-            </div>
+                </div>
+
+                <div class="catalog-item-info-section">
+                    <div class="catalog-item-info-details-heading" data-bind="click: toggleShowDataDetails">
+                        <button class="catalog-item-info-details-label">Data Source Details</button>
+                        <div class="catalog-item-info-details-expand-button-holder">
+                            <button href="#" class="catalog-item-info-details-expand-button" data-bind="cesiumSvgPath: { path: showDataDetails ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }"></button>
+                        </div>
+                    </div>
+                    <!-- ko if: showDataDetails -->
+                        <div class="catalog-item-info-table">
+                            <!-- ko if: catalogItem.metadata.dataSourceMetadata.hasChildren -->
+                            <table data-bind="template: { name: 'catalog-item-info-item-template', foreach: catalogItem.metadata.dataSourceMetadata.items }">
+                            </table>
+                            <!-- /ko -->
+                            <!-- ko if: catalogItem.metadata.dataSourceErrorMessage -->
+                            <table>
+                                <tr>
+                                    <td class="catalog-item-info-properties-name-cell catalog-item-info-properties-level1">
+                                        <div class="catalog-item-info-properties-arrow"></div>
+                                        <div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.dataSourceErrorMessage"></div>
+                                    </td>
+                                </tr>
+                            </table>
+                            <!-- /ko -->
+                        </div>
+                    <!-- /ko -->
+                </div>
+                <div class="catalog-item-info-section">
+                    <div class="catalog-item-info-details-heading" data-bind="click: toggleShowServiceDetails">
+                        <button class="catalog-item-info-details-label">Data Service Details</button>
+                        <div class="catalog-item-info-details-expand-button-holder">
+                            <button class="catalog-item-info-details-expand-button" data-bind="cesiumSvgPath: { path: showServiceDetails ? $root.svgArrowDown : $root.svgArrowRight, width: 32, height: 32 }"></button>
+                        </div>
+                    </div>
+                    <!-- ko if: showServiceDetails -->
+                        <div class="catalog-item-info-table">
+                            <!-- ko if: catalogItem.metadata.serviceMetadata.hasChildren -->
+                            <table data-bind="template: { name: 'catalog-item-info-item-template', foreach: catalogItem.metadata.serviceMetadata.items }">
+                            </table>
+                            <!-- /ko -->
+                            <!-- ko if: catalogItem.metadata.serviceErrorMessage -->
+                            <table>
+                                <tr>
+                                    <td class="catalog-item-info-properties-name-cell catalog-item-info-properties-level1">
+                                        <div class="catalog-item-info-properties-arrow"></div>
+                                        <div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.serviceErrorMessage"></div>
+                                    </td>
+                                </tr>
+                            </table>
+                            <!-- /ko -->
+                        </div>
+                    <!-- /ko -->
+                </div>
+            <!-- /ko -->
         </div>
     </div>
     <div class="catalog-item-info-loading" data-bind="visible: catalogItem.metadata.isLoading">

--- a/test/Models/CatalogMemberSpec.js
+++ b/test/Models/CatalogMemberSpec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/*global require*/
+var CatalogMember = require('../../lib/Models/CatalogMember');
+var Terria = require('../../lib/Models/Terria');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
+
+describe('CatalogMember', function() {
+    var terria;
+    var member;
+
+    beforeEach(function() {
+        terria = new Terria({
+            baseUrl: './'
+        });
+        member = new CatalogMember(terria);
+    });
+
+    describe('infoWithoutSources', function() {
+        var info;
+
+        beforeEach(function() {
+            info = [{
+                name: 'Info1'
+            }, {
+                name: 'Info2'
+            }];
+
+            member.info = info.slice();
+        });
+
+        it('filters out info items that have been marked as having source info in them', function() {
+            member._sourceInfoItemNames = ['Info1'];
+            expect(member.infoWithoutSources).toEqual([info[1]]);
+        });
+
+        it('returns the same as member.info if no source info items exist', function() {
+            expect(member.infoWithoutSources).toEqual(info);
+        });
+    });
+});

--- a/test/Models/CatalogMemberSpec.js
+++ b/test/Models/CatalogMemberSpec.js
@@ -3,7 +3,6 @@
 /*global require*/
 var CatalogMember = require('../../lib/Models/CatalogMember');
 var Terria = require('../../lib/Models/Terria');
-var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 describe('CatalogMember', function() {
     var terria;


### PR DESCRIPTION
Merging this into jsonTreeview because we need a hotfix for AREMI.

This allows catalog items to specify a `hideSource` property in their JSON, which defaults to `false` but when set to `true` will hide the details of the source of data for a service in the catalog item info panel. This is done by not showing the sections that would normally have this info, and filtering `CatalogMember.info` by excluding info items that have names in a new `_sourceInfoItemNames` property on `CatalogMember`. What info items to exclude varies from item to item, this includes `'GetCapabilities URL'` for `WMSCatalogItem` as that's the use case for this fix.
