### PR TITLE
Made CatalogMember return the same load promise

### DIFF
--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -35,7 +35,6 @@ var naturalSort = require('javascript-natural-sort');
 var CatalogGroup = function(terria) {
     CatalogMember.call(this, terria);
 
-    this._loadingPromise = undefined;
     this._lastLoadInfluencingValues = undefined;
 
     /**

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -35,7 +35,6 @@ var CatalogItem = function(terria) {
     this._enabledDate = undefined;
     this._shownDate = undefined;
     this._loadForEnablePromise = undefined;
-    this._loadingPromise = undefined;
     this._lastLoadInfluencingValues = undefined;
 
     // The catalog item to show in the Now Viewing when this item is enabled, instead of this item.

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -168,6 +168,9 @@ var CatalogMember = function(terria) {
      */
     this._sourceInfoItemNames = [];
 
+
+    this._loadingPromise = undefined;
+
     /** Lookup table for _sourceInfoItemNames, access through {@link CatalogMember#_infoItemsWithSourceInfoLookup} */
     this._memoizedInfoItemsSourceLookup = undefined;
 
@@ -510,7 +513,7 @@ CatalogMember.prototype.load = function() {
 
     var that = this;
 
-    return runLater(function() {
+    this._loadingPromise = runLater(function() {
         that._lastLoadInfluencingValues = [];
         if (defined(that._getValuesThatInfluenceLoad)) {
             that._lastLoadInfluencingValues = that._getValuesThatInfluenceLoad();
@@ -527,6 +530,8 @@ CatalogMember.prototype.load = function() {
         that.isLoading = false;
         throw e; // keep throwing this so we can chain more otherwises.
     });
+
+    return this._loadingPromise;
 };
 
 /** A collection of static filters functions used during serialization */

--- a/test/Models/CatalogMemberSpec.js
+++ b/test/Models/CatalogMemberSpec.js
@@ -39,6 +39,13 @@ describe('CatalogMember', function () {
 
             member.load().then(done.fail).otherwise(done);
         });
+
+        it('returns the same promise for subsequent calls', function() {
+            var promise1 = member.load();
+            var promise2 = member.load();
+
+            expect(promise1).toBe(promise2);
+        });
     });
 
     describe('infoWithoutSources', function() {


### PR DESCRIPTION
Fixes #1422 . For some reason when the mutual load code got pulled up into `CatalogGroup` and `CatalogItem` it stopped retaining the load promise, which was causing a new `dataSource` to be created every time `load()` was called on a `CsvCatalogItem`.
