### PR TITLE
Made ArcGis copyrightText property show up in info section

### DIFF
--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -91,20 +91,20 @@ var ArcGisMapServerCatalogItem = function(terria) {
 
     // metadataUrl and legendUrl are derived from url if not explicitly specified.
     overrideProperty(this, 'metadataUrl', {
-        get : function() {
+        get: function() {
             if (defined(this._metadataUrl)) {
                 return this._metadataUrl;
             }
 
             return cleanUrl(this.url);
         },
-        set : function(value) {
+        set: function(value) {
             this._metadataUrl = value;
         }
     });
 
     overrideProperty(this, 'legendUrl', {
-        get : function() {
+        get: function() {
             if (defined(this._legendUrl)) {
                 return this._legendUrl;
             } else if (defined(this._generatedLegendUrl)) {
@@ -113,26 +113,26 @@ var ArcGisMapServerCatalogItem = function(terria) {
                 return new LegendUrl(cleanUrl(this.url) + '/legend');
             }
         },
-        set : function(value) {
+        set: function(value) {
             this._legendUrl = value;
         }
     });
 
     // The dataUrl must be explicitly specified.  Don't try to use `url` as the the dataUrl.
     overrideProperty(this, 'dataUrl', {
-        get : function() {
+        get: function() {
             return this._dataUrl;
         },
-        set : function(value) {
+        set: function(value) {
             this._dataUrl = value;
         }
     });
 
     overrideProperty(this, 'dataUrlType', {
-        get : function() {
+        get: function() {
             return this._dataUrlType;
         },
-        set : function(value) {
+        set: function(value) {
             this._dataUrlType = value;
         }
     });
@@ -146,8 +146,8 @@ defineProperties(ArcGisMapServerCatalogItem.prototype, {
      * @memberOf ArcGisMapServerCatalogItem.prototype
      * @type {String}
      */
-    type : {
-        get : function() {
+    type: {
+        get: function() {
             return 'esri-mapServer';
         }
     },
@@ -157,8 +157,8 @@ defineProperties(ArcGisMapServerCatalogItem.prototype, {
      * @memberOf ArcGisMapServerCatalogItem.prototype
      * @type {String}
      */
-    typeName : {
-        get : function() {
+    typeName: {
+        get: function() {
             return 'Esri ArcGIS MapServer';
         }
     },
@@ -168,8 +168,8 @@ defineProperties(ArcGisMapServerCatalogItem.prototype, {
      * @memberOf ArcGisMapServerCatalogItem.prototype
      * @type {Metadata}
      */
-    metadata : {
-        get : function() {
+    metadata: {
+        get: function() {
             if (!defined(this._metadata)) {
                 this._metadata = requestMetadata(this);
             }
@@ -179,10 +179,10 @@ defineProperties(ArcGisMapServerCatalogItem.prototype, {
 });
 
 /*
-   Goal: To match URLs ending in MapServer/0 where 0 is any number
-   but also allowing for an optional final /, and ? and # terms.
-   For simplicity, match any path that includes /MapServer/0
-*/
+ Goal: To match URLs ending in MapServer/0 where 0 is any number
+ but also allowing for an optional final /, and ? and # terms.
+ For simplicity, match any path that includes /MapServer/0
+ */
 var partsRegex = new RegExp('^(.*\/MapServer\/)([0-9]+)', 'i');
 
 function getBaseURI(item) {
@@ -222,7 +222,7 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
                 that.updateFromMetadata(results[0], results[1], results[2], false);
             } else if (defined(results[1].id)) {
                 // Results of a single layer query. Make it look like a multi layer query result.
-                that.updateFromMetadata(results[0], { "layers": [ results[1] ] }, results[2], false, results[1]);
+                that.updateFromMetadata(results[0], {"layers": [results[1]]}, results[2], false, results[1]);
             } else {
                 console.error("Unusable ArcGIS Mapserver layers metadata: \n" + layersMetadata);
                 throw new RuntimeError('Unusable ArcGIS Mapserver layers metadata from ' + layersUri.toString() + '. See console log for details.');
@@ -257,8 +257,8 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
                     that.terria.error.raiseEvent(new TerriaError({
                         title: 'Dataset will not be shown at this scale',
                         message: 'The "' + that.name + '" dataset will not be shown when zoomed in this close to the map because the data custodian has ' +
-                                 'indicated that the data is not intended or suitable for display at this scale.  Click the dataset\'s Info button on the ' +
-                                 'Now Viewing tab for more information about the dataset and the data custodian.'
+                        'indicated that the data is not intended or suitable for display at this scale.  Click the dataset\'s Info button on the ' +
+                        'Now Viewing tab for more information about the dataset and the data custodian.'
                     }));
                     messageDisplayed = true;
                 }
@@ -354,6 +354,10 @@ ArcGisMapServerCatalogItem.prototype.updateFromMetadata = function(mapServerJson
     updateInfoSection(this, overwrite, 'Data Description', thisLayerJson.description);
     updateInfoSection(this, overwrite, 'Service Description', mapServerJson.serviceDescription);
     updateInfoSection(this, overwrite, 'Service Description', mapServerJson.description);
+
+    var copyrightText = defined(thisLayerJson.copyrightText) && thisLayerJson.copyrightText.length > 0 ?
+        thisLayerJson.copyrightText : mapServerJson.copyrightText;
+    updateInfoSection(this, overwrite, 'Copyright Text', copyrightText);
 };
 
 function maximumScaleToLevel(maximumScale) {
@@ -565,7 +569,7 @@ var labelsRegex = /_Labels$/;
  * @return {Promise}
  */
 ArcGisMapServerCatalogItem.prototype.loadLegendFromJson = function(json) {
-    var options = { title: ''};
+    var options = {title: ''};
     var layers = !defined(this.layers) ? [] : this.layers.toLowerCase().split(',');
     var itemPromises = [];
     var shownLegends = {};

--- a/test/Models/ArcGisMapServerCatalogItemSpec.js
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.js
@@ -88,6 +88,37 @@ describe('ArcGisMapServerCatalogItem', function() {
         expect(item.showTilesAfterMessage).toBe(false);
     });
 
+    describe('after updating metadata', function() {
+        describe('copyright text', function() {
+            it('comes from layer json if valid', function() {
+                update({copyrightText: 'server copyright text'}, {copyrightText: 'layer copyright text'});
+
+                expect(item.info[0].name).toBe('Copyright Text');
+                expect(item.info[0].content).toBe('layer copyright text');
+            });
+
+            it('reverts to server json layer json if undefined', function() {
+                update({copyrightText: 'server copyright text'}, {});
+
+                expect(item.info[0].name).toBe('Copyright Text');
+                expect(item.info[0].content).toBe('server copyright text');
+            });
+
+            it('reverts to server json layer json if empty string', function() {
+                update({copyrightText: 'server copyright text'}, {copyrightText: ''});
+
+                expect(item.info[0].name).toBe('Copyright Text');
+                expect(item.info[0].content).toBe('server copyright text');
+            });
+
+            function update(serverJson, layerJson) {
+                item._legendUrl = '';
+                item.updateFromMetadata(serverJson, {layers: [layerJson]}, undefined, true, layerJson);
+
+            }
+        });
+    });
+
     it('falls back to /legend if no legendUrl provided in json', function() {
         item.updateFromJson({
             metadataUrl: 'http://my.metadata.com',

--- a/test/Models/ArcGisMapServerCatalogItemSpec.js
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.js
@@ -111,6 +111,12 @@ describe('ArcGisMapServerCatalogItem', function() {
                 expect(item.info[0].content).toBe('server copyright text');
             });
 
+            it('adds nothing if neither server or layer json has copyright text', function() {
+                update({}, {});
+
+                expect(item.info.length).toBe(0);
+            });
+
             function update(serverJson, layerJson) {
                 item._legendUrl = '';
                 item.updateFromMetadata(serverJson, {layers: [layerJson]}, undefined, true, layerJson);


### PR DESCRIPTION
Fixes #1188. 

Pretty simple, ArcGis servers have a copyrightText property under both layer and server json, this shows the layer one under "Copyright Text" if it's there, otherwise it shows the server one, otherwise it doesn't add the section at all.
