### PR TITLE
Added ability to set date formats for the timeline in the layer json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 Change Log
 ==========
 
+### 2.3.1
+
+* Added support for configuration of how time is displayed on the timeline - catalog items can now specify a dateFormat hash
+    in their configuration that has formats for `timelineTic` (what is displayed on the timeline itself) and `currentTime`
+    (which is the current time at the top-left).
+
 ### 2.3.0
 
 * Share links now contain details about the picked point, picked features and currently selected feature.
@@ -10,9 +16,6 @@ Change Log
 * Added the `hideSource` flag to the init json for hiding the source of a CatalogItem in the View Info popup.
 * Fixed a bug where `CatalogMember.load` would return a new promise every time it was called, instead of retaining the one in progress.
 * Added support for the `copyrightText` property for ArcGis layers - this now shows up in info under "Copyright Text"
-* Added support for configuration of how time is displayed on the timeline - catalog items can now specify a dateFormat hash
-    in their configuration that has formats for `timelineTic` (what is displayed on the timeline itself) and `currentTime`
-    (which is the current time at the top-left).
 * Showed a message in the catalog item info panel that informs the user that a catalog item is local and can't be shared.
 * TerriaJS now obtains its list of domains that the proxy will proxy for from the `proxyableDomains/` service.  The URL can be overridden by setting `parameters.proxyableDomainsUrl` in `config.json`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ Change Log
 * Added the `hideSource` flag to the init json for hiding the source of a CatalogItem in the View Info popup.
 * Fixed a bug where `CatalogMember.load` would return a new promise every time it was called, instead of retaining the one in progress.
 * Added support for the `copyrightText` property for ArcGis layers - this now shows up in info under "Copyright Text"
+* Added support for configuration of how time is displayed on the timeline - catalog items can now specify a dateFormat hash
+    in their configuration that has formats for `timelineTic` (what is displayed on the timeline itself) and `currentTime`
+    (which is the current time at the top-left).
 
 ### 2.2.1
 

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -167,6 +167,8 @@ var CatalogItem = function(terria) {
      */
     this.maximumShownFeatureInfos = terria.configParameters.defaultMaximumShownFeatureInfos;
 
+    this.dateFormat = {};
+
     this._legendUrl = undefined;
     this._legendUrls = [];
     this._dataUrl = undefined;

--- a/lib/ViewModels/AnimationViewModel.js
+++ b/lib/ViewModels/AnimationViewModel.js
@@ -11,6 +11,7 @@ var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var Timeline = require('terriajs-cesium/Source/Widgets/Timeline/Timeline');
+var dateFormat = require('dateformat');
 
 var loadView = require('../Core/loadView');
 
@@ -56,8 +57,13 @@ var AnimationViewModel = function(options) {
 
     var that = this;
     this.terria.clock.onTick.addEventListener(function(clock) {
-        var time = clock.currentTime;
-        that.currentTimeString = formatDateTime(JulianDate.toDate(time), that.locale);
+        var time = JulianDate.toDate(clock.currentTime);
+
+        if (defined(that.terria.timeSeriesStack.topLayer) && defined(that.terria.timeSeriesStack.topLayer.dateFormat.currentTime)) {
+            that.currentTimeString = dateFormat(time, that.terria.timeSeriesStack.topLayer.dateFormat.currentTime);
+        } else {
+            that.currentTimeString = formatDateTime(time, that.locale);
+        }
     });
 
     knockout.getObservable(this.terria.timeSeriesStack, 'topLayer').subscribe(function() {
@@ -107,24 +113,24 @@ function updateForNewTopLayer(animationViewModel) {
             }
         }
     }
+
     if (animationViewModel.showAnimation) {
-        animationViewModel.layerName = terria.timeSeriesStack.topLayer.name;
-        if (defined(animationViewModel.timeline)) {
-            animationViewModel.timeline.zoomTo(terria.clock.startTime, terria.clock.stopTime);
-        }
+        animationViewModel.refreshTimeline(terria.timeSeriesStack.topLayer);
     }
 }
 
 function formatDate(d, locale) {
     function pad(s) { return (s < 10) ? '0' + s : s; }
+
     if (defined(locale)) {
         return d.toLocaleDateString(locale);
     }
-    return [pad(d.getDate()), pad(d.getMonth()+1), d.getFullYear()].join('/');
+    return [pad(d.getDate()), pad(d.getMonth() + 1), d.getFullYear()].join('/');
 }
 
 function formatTime(d, locale) {
     function pad(s) { return (s < 10) ? '0' + s : s; }
+
     if (defined(locale)) {
         return d.toLocaleTimeString(locale);
     }
@@ -136,38 +142,27 @@ function formatDateTime(d, locale) {
 }
 
 
-function setupTimeline(viewModel) {
+AnimationViewModel.prototype.setupTimeline = function() {
     var timelineContainer = document.getElementsByClassName('animation-timeline')[0];
     var controlsContainer = document.getElementsByClassName('animation-controls')[0];
 
     L.DomEvent.disableClickPropagation(timelineContainer);
     L.DomEvent.disableClickPropagation(controlsContainer);
 
-    var timeline = new Timeline(timelineContainer, viewModel.terria.clock);
-    viewModel.timeline = timeline;
-
-    timeline.makeLabel = function(time) {
-        var totalDays = JulianDate.daysDifference(viewModel.terria.clock.stopTime, viewModel.terria.clock.startTime);
-        if (totalDays > 14) {
-            return formatDate(JulianDate.toDate(time), viewModel.locale);
-        }
-        else if (totalDays < 1) {
-            return formatTime(JulianDate.toDate(time), viewModel.locale);
-        }
-        return formatDateTime(JulianDate.toDate(time), viewModel.locale);
-    };
+    var timeline = new Timeline(timelineContainer, this.terria.clock);
+    this.timeline = timeline;
 
     timeline.scrubFunction = function(e) {
         var clock = e.clock;
         clock.currentTime = e.timeJulian;
         clock.shouldAnimate = false;
-        viewModel.isPlaying = false;
-        viewModel.terria.currentViewer.notifyRepaintRequired();
-    };
+        this.isPlaying = false;
+        this.terria.currentViewer.notifyRepaintRequired();
+    }.bind(this);
 
     timeline.addEventListener('settime', timeline.scrubFunction, false);
-    viewModel.timeline.zoomTo(viewModel.terria.clock.startTime, viewModel.terria.clock.stopTime);
-}
+    timeline.zoomTo(this.terria.clock.startTime, this.terria.clock.stopTime);
+};
 
 AnimationViewModel.prototype.show = function(container) {
     loadView(require('fs').readFileSync(__dirname + '/../Views/Animation.html', 'utf8'), container, this);
@@ -232,11 +227,63 @@ AnimationViewModel.prototype.toggleLoop = function() {
     }
 };
 
+/**
+ * Refreshes Cesium's timeline control based on the passed layer
+ *
+ * @param {CatalogItem} layer
+ */
+AnimationViewModel.prototype.refreshTimeline = function(layer) {
+    // There's no way to refresh this without abusing a private func for some reason.
+    this.timeline._highlightRanges = [];
+
+    this.layerName = layer.name;
+    this.timeline.zoomTo(this.terria.clock.startTime, this.terria.clock.stopTime);
+
+    if (defined(layer.intervals)) {
+        for (var i = 1; i < layer.intervals._intervals.length; i++) {
+            var gapStart = layer.intervals._intervals[i - 1].stop;
+            var gapEnd = layer.intervals._intervals[i].start;
+
+            // This shades the intervals themselves - commented because is this actually better?
+            // var intervalRange = this.timeline.addHighlightRange('rgba(0, 0, 255, 0.9)', 27, 0);
+            // intervalRange.setRange(layer.intervals._intervals[i - 1].start, layer.intervals._intervals[i - 1].stop);
+
+            // This shades the gaps
+            if (JulianDate.compare(gapEnd, gapStart) > 0) {
+                var range = this.timeline.addHighlightRange('rgba(0, 0, 0, 0.5)', 27, 0);
+                range.setRange(gapStart, gapEnd);
+            }
+        }
+    }
+
+    if (defined(layer.dateFormat.timelineTic)) {
+        this.timeline.makeLabel = function(time) {
+            return dateFormat(JulianDate.toDate(time), layer.dateFormat.timelineTic);
+        };
+    } else {
+        this.timeline.makeLabel = function(time) {
+            var totalDays = JulianDate.daysDifference(this.terria.clock.stopTime, this.terria.clock.startTime);
+
+            if (totalDays > 14) {
+                return formatDate(JulianDate.toDate(time), this.locale);
+            }
+            else if (totalDays < 1) {
+                return formatTime(JulianDate.toDate(time), this.locale);
+            }
+
+            return formatDateTime(JulianDate.toDate(time), this.locale);
+        }.bind(this);
+    }
+
+    // Force timeline rendering to refresh.
+    this.timeline._makeTics();
+};
+
 AnimationViewModel.create = function(options) {
     // Creates the viewmodel, sets up the timeline and shows the view.
     var result = new AnimationViewModel(options);
     result.show(options.container);
-    setupTimeline(result);
+    result.setupTimeline();
     return result;
 };
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "brfs": "^1.4.0",
+    "dateformat": "^1.0.12",
     "hammerjs": "^2.0.4",
     "html2canvas": "0.5.0-alpha2",
     "javascript-natural-sort": "^0.7.1",

--- a/test/ViewModels/AnimationViewModelSpec.js
+++ b/test/ViewModels/AnimationViewModelSpec.js
@@ -5,9 +5,6 @@ var AnimationViewModel = require('../../lib/ViewModels/AnimationViewModel');
 var Terria = require('../../lib/Models/Terria');
 var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
-var L = require('leaflet');
-var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
-var TimeIntervalCollection = require('terriajs-cesium/Source/Core/TimeIntervalCollection');
 
 describe('AnimationViewModel', function() {
     var terria, catalogItem;

--- a/test/ViewModels/AnimationViewModelSpec.js
+++ b/test/ViewModels/AnimationViewModelSpec.js
@@ -3,10 +3,14 @@
 /*global require*/
 var AnimationViewModel = require('../../lib/ViewModels/AnimationViewModel');
 var Terria = require('../../lib/Models/Terria');
-var CatalogItem = require('../../lib/Models/CatalogItem');
+var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
+var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
+var L = require('leaflet');
+var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
+var TimeIntervalCollection = require('terriajs-cesium/Source/Core/TimeIntervalCollection');
 
 describe('AnimationViewModel', function() {
-    var terria;
+    var terria, catalogItem;
     var animationVm;
 
     beforeEach(function() {
@@ -16,21 +20,20 @@ describe('AnimationViewModel', function() {
         animationVm = new AnimationViewModel({
             terria: terria
         });
-        animationVm.timeline = {
-            zoomTo: jasmine.createSpy('zoomTo'),
-            resize: jasmine.createSpy('resize') // this gets triggered in saucelabs for some reason.
-        };
+        animationVm.timeline = jasmine.createSpyObj('timeline', ['zoomTo', 'resize', '_makeTics']);
+
+        catalogItem = new ImageryLayerCatalogItem(terria);
+        catalogItem.clock = jasmine.createSpyObj('clock', ['getValue']);
     });
 
     it('on init, showAnimation should be false', function() {
-       expect(animationVm.showAnimation).toBe(false);
+        expect(animationVm.showAnimation).toBe(false);
     });
 
     describe('when a layer is added to the time series stack', function() {
         var LAYER_NAME = 'blahface';
 
         beforeEach(function() {
-            var catalogItem = buildCatalogItem();
             catalogItem.name = LAYER_NAME;
 
             terria.timeSeriesStack.addLayerToTop(catalogItem);
@@ -47,8 +50,6 @@ describe('AnimationViewModel', function() {
 
     describe('when the last layer is removed from the time series stack', function() {
         beforeEach(function() {
-            var catalogItem = buildCatalogItem();
-
             terria.timeSeriesStack.addLayerToTop(catalogItem);
             terria.timeSeriesStack.removeLayer(catalogItem);
         });
@@ -58,11 +59,33 @@ describe('AnimationViewModel', function() {
         });
     });
 
-    function buildCatalogItem() {
-        var catalogItem = new CatalogItem(terria);
-        catalogItem.clock = {
-            getValue: jasmine.createSpy('getValue')
-        };
-        return catalogItem;
-    }
+    describe('timelineTic format', function() {
+        it('should be used if provided', function() {
+            catalogItem.dateFormat.timelineTic = 'mmm';
+            terria.timeSeriesStack.addLayerToTop(catalogItem);
+            expect(animationVm.timeline.makeLabel(JulianDate.fromIso8601('2016-01-01'))).toBe('Jan');
+        });
+
+        it('should not be used if not provided', function() {
+            terria.timeSeriesStack.addLayerToTop(catalogItem);
+            expect(animationVm.timeline.makeLabel(JulianDate.fromIso8601('2016-01-01'))).toBe('01/01/2016, 00:00:00');
+        });
+    });
+
+    describe('currentTime format', function() {
+        it('should be used if provided', function() {
+            catalogItem.dateFormat.currentTime = 'mmm';
+            terria.timeSeriesStack.addLayerToTop(catalogItem);
+            terria.clock.currentTime = JulianDate.fromIso8601('2016-01-01');
+            terria.clock.onTick.raiseEvent(terria.clock);
+            expect(animationVm.currentTimeString).toBe('Jan');
+        });
+
+        it('should not be used if not provided', function() {
+            terria.timeSeriesStack.addLayerToTop(catalogItem);
+            terria.clock.currentTime = JulianDate.fromIso8601('2016-01-01');
+            terria.clock.onTick.raiseEvent(terria.clock);
+            expect(animationVm.currentTimeString).toBe('01/01/2016, 00:00:00');
+        });
+    });
 });

--- a/wwwroot/test/init/timeseries.json
+++ b/wwwroot/test/init/timeseries.json
@@ -1,0 +1,40 @@
+{
+    "catalog": [{
+        "name": "Time series tests",
+        "type": "group",
+        "isOpen": true,
+        "items": [
+            {
+                "name": "WMS time series (solar hourly direct, BOM)",
+                "layers": "Mean direct normal exposure",
+                "info": [
+                    {
+                        "name": "Licensing, Terms & Conditions",
+                        "content": "[Licence](http://creativecommons.org/licenses/by/3.0/au/)"
+                    }
+                ],
+                "dataCustodian": "[Australian Bureau of Meteorology](http://www.bom.gov.au/water/geofabric/)",
+                "url": "http://neii.bom.gov.au/services/solarclim/wms/data/monClim_dirNorExp1Hou.nc?service=WMS&version=1.3.0&request=GetCapabilities&LAYER=mean_exposure",
+                "type": "wms",
+                "opacity": "1.0",
+                "displayDuration": 360,
+                "dateFormat": {
+                    "timelineTic": "mmmm",
+                    "currentTime": "mmmm HH:MM:ss"
+                }
+            },
+            {
+                "name": "Lat lon CSV with duration of 1 hour",
+                "type": "csv",
+                "url": "build/terriajs/test/csv/lat_lon_date_value.csv",
+                "tableStyle": {
+                    "displayDuration": 60
+                },
+                "dateFormat": {
+                    "timelineTic": "HH:MM",
+                    "currentTime": "mmmm HH:MM:ss"
+                }
+            }
+        ]
+    }]
+}


### PR DESCRIPTION
Pulled out from the becalmed #1328 for AREMI and GEOGLAM.

`timelineTic` and `currentTime` can be specified in the config JSON, and these override the default format for times in the timeline.
