### PR TITLE
Use node-sass instead of the Ruby one

### DIFF
--- a/lib/ReactViews/Search/SearchHeader.jsx
+++ b/lib/ReactViews/Search/SearchHeader.jsx
@@ -2,18 +2,17 @@
 
 import React from 'react';
 import Loader from '../Loader.jsx';
-/**
- *  Renders either a loader or a message based off search state.
- *
- *  @param {Object} props props
- *  @returns {ReactComponent} The component
- */
-export default props => {
-    if (this.props.isSearching) {
-        return <div><Loader key="loader"/></div>;
-    } else if (this.props.searchMessage) {
-        return <div key="message" className='label no-results'>{this.props.searchMessage}</div>;
-    }
+import defined from 'terriajs-cesium/Source/Core/defined';
 
-    return null;
-};
+/** Renders either a loader or a message based off search state. */
+export default React.createClass({
+    render() {
+        if (this.props.isSearching) {
+            return <div><Loader key="loader"/></div>;
+        } else if (this.props.searchMessage) {
+            return <div key="message" className='label no-results'>{this.props.searchMessage}</div>;
+        } else {
+            return null;
+        }
+    }
+});

--- a/lib/ReactViews/Tabs.jsx
+++ b/lib/ReactViews/Tabs.jsx
@@ -13,7 +13,7 @@ const Tabs = React.createClass({
     propTypes: {
         terria: React.PropTypes.object.isRequired,
         viewState: React.PropTypes.object.isRequired,
-        tabs: React.PropTypes.array.isRequired
+        tabs: React.PropTypes.array
     },
 
     getInitialState() {

--- a/lib/Sass/component/_bottom_dock.scss
+++ b/lib/Sass/component/_bottom_dock.scss
@@ -8,7 +8,7 @@
     bottom: 0;
     z-index: 10;
     background: $dark;
-    @media(screen and min-width: $sm){
+    @media screen and (min-width: $sm){
         left: $work-bench-width;
         .is-full-screen &{
             left: 0;

--- a/lib/Sass/component/_chart.scss
+++ b/lib/Sass/component/_chart.scss
@@ -68,7 +68,7 @@ $chart-darker: darken($dark, 8%);
   z-index: 10;
   background: $dark;
   padding-bottom: 13px;
-  @media(screen and min-width: $sm) {
+  @media screen and (min-width: $sm) {
     left: $work-bench-width;
     .is-full-screen & {
       left: 0;

--- a/lib/Sass/component/_location_bar.scss
+++ b/lib/Sass/component/_location_bar.scss
@@ -3,7 +3,7 @@ $distance-bg: rgba($dark, 0.9);
 .location-distance{
   @extend .clearfix;
   display: none;
-  @media(screen and min-width: $sm){
+  @media screen and (min-width: $sm){
     display: block;
   }
   position: absolute;

--- a/lib/Sass/component/_now_viewing.scss
+++ b/lib/Sass/component/_now_viewing.scss
@@ -3,7 +3,7 @@ $now-viewing-margin: $padding-small - 1px;
 
 .now-viewing{
   .workbench__inner.is-now-viewing &{
-    @media(screen and max-width: $sm){
+    @media screen and (max-width: $sm){
       position: fixed;
       left: 0;
       width: 100%;
@@ -122,7 +122,7 @@ $now-viewing-margin: $padding-small - 1px;
       text-align: center;
   }
   .btn--toggle.is-open{
-    @media(screen and min-width: $sm){
+    @media screen and (min-width: $sm){
       padding-left: 8px;
     }
   }

--- a/lib/Sass/partial/_branding.scss
+++ b/lib/Sass/partial/_branding.scss
@@ -11,7 +11,7 @@
     max-height: 100%;
     width: auto;
   }
-  @media(screen and min-width: $sm){
+  @media screen and (min-width: $sm){
       width: 100%;
       padding: $padding;
       height: $logo-height;

--- a/lib/Sass/partial/_layout.scss
+++ b/lib/Sass/partial/_layout.scss
@@ -55,7 +55,7 @@
     bottom: $chart-height;
   }
 
-  @media(screen and min-width: $sm){
+  @media screen and (min-width: $sm) {
     //temp
     // width: calc(100% - $work-bench-width);
     left: $work-bench-width;

--- a/lib/Sass/partial/_map_navigation.scss
+++ b/lib/Sass/partial/_map_navigation.scss
@@ -22,7 +22,7 @@
       position: fixed;
       bottom: $input-height + $padding;
       right: 2vw;
-      @media(screen and min-width: $sm){
+      @media screen and (min-width: $sm){
         //temp
         position: absolute;
         right: 28px;

--- a/lib/Sass/partial/_modal_window.scss
+++ b/lib/Sass/partial/_modal_window.scss
@@ -12,7 +12,7 @@
   -moz-backface-visibility: hidden;
   backface-visibility: hidden;
   @include transition(all 0.3s);
-  @media(screen and min-width: $sm){
+  @media screen and (min-width: $sm){
     @include transform(translateY(20%));
     width: 100%;
     overflow: hidden;
@@ -20,7 +20,7 @@
     margin: 0 auto;
   }
   .is-open & {
-    @media(screen and min-width: $sm){
+    @media screen and (min-width: $sm){
       @include transform(none);
       opacity: 1;
       visibility: visible;

--- a/lib/Sass/partial/_tabs.scss
+++ b/lib/Sass/partial/_tabs.scss
@@ -40,7 +40,7 @@
 
 .data-explorer,
 .my-data{
-    @media(screen and min-width: $sm){
+    @media screen and (min-width: $sm){
       width: 40%;
       float: left;
       height: 100%;


### PR DESCRIPTION
This is a PR into the `newui-webpack` branch.

`node-sass` reported a bunch of errors in the SASS that the other tool didn't, so I had to fix those.
This PR also undoes one of Alex's eslint changes that seemed to be breaking NationalMap, and I wasn't entirely sure how to fix it.
