### PR TITLE
Improve previewing in new UI

### DIFF
--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -13,6 +13,7 @@ var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
 var Entity = require('terriajs-cesium/Source/DataSources/Entity');
 var formatError = require('terriajs-cesium/Source/Core/formatError');
 var getTimestamp = require('terriajs-cesium/Source/Core/getTimestamp');
+var ImageryLayer = require('terriajs-cesium/Source/Scene/ImageryLayer');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var loadWithXhr = require('terriajs-cesium/Source/Core/loadWithXhr');
@@ -761,6 +762,75 @@ Cesium.prototype._buildPickedFeatures = function(providerCoords, pickPosition, e
     });
 
     return result;
+};
+
+Cesium.prototype.addImageryProvider = function(options) {
+    var scene = this.scene;
+
+    var errorEvent = options.imageryProvider.errorEvent;
+
+    if (defined(errorEvent)) {
+        errorEvent.addEventListener(function(tileProviderError) {
+            // We're only concerned about failures for tiles that actually overlap this item's extent.
+            if (defined(options.rectangle)) {
+                var tilingScheme = options.imageryProvider.tilingScheme;
+                var tileExtent = tilingScheme.tileXYToRectangle(tileProviderError.x, tileProviderError.y, tileProviderError.level);
+                var intersection = Rectangle.intersection(tileExtent, options.rectangle);
+                if (!defined(intersection)) {
+                    return;
+                }
+            }
+
+            if (defined(tileProviderError.error) && tileProviderError.error.statusCode === 404) {
+                if(!options.treat404AsError) {
+                    return;
+                }
+            } else if (defined(tileProviderError.error) && tileProviderError.error.statusCode === 403) {
+                if(!options.treat403AsError) {
+                    return;
+                }
+                // ignoreUnknownTileErrors is only for genuinely unknown (no status code) issues
+            } else if (options.ignoreUnknownTileErrors && (!defined(tileProviderError.error) || !defined(tileProviderError.error.statusCode))) {
+                return;
+            }
+
+
+            // Retry 3 times.
+            if (tileProviderError.timesRetried < 3) {
+                tileProviderError.retry = true;
+                return;
+            }
+
+            // After three failures, advise the user that something is wrong and hide the catalog item.
+            // (if the item isn't already hidden, that is)
+            if (defined(options.onLoadError)) {
+                options.onLoadError(tileProviderError);
+            }
+        });
+    }
+
+    var result = new ImageryLayer(options.imageryProvider, {
+        show : false,
+        alpha : options.opacity,
+        rectangle : options.clipToRectangle ? options.rectangle : undefined,
+        isRequired : options.isRequiredForRendering
+    });
+
+    // layerIndex is an optional parameter used when the imageryLayer corresponds to a CsvCatalogItem whose selected item has just changed
+    // to ensure that the layer is re-added in the correct position
+    scene.imageryLayers.add(result, options.layerIndex);
+
+    this.updateLayerOrderToKeepOnTop();
+
+    return result;
+};
+
+Cesium.prototype.showImageryLayer = function(options) {
+    options.layer.show = true;
+};
+
+Cesium.prototype.hideImageryLayer = function(options) {
+    options.layer.show = false;
 };
 
 function postRender(cesium, date) {

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -825,6 +825,11 @@ Cesium.prototype.addImageryProvider = function(options) {
     return result;
 };
 
+Cesium.prototype.removeImageryLayer = function(options) {
+    var scene = this.scene;
+    scene.imageryLayers.remove(options.layer);
+};
+
 Cesium.prototype.showImageryLayer = function(options) {
     options.layer.show = true;
 };

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -614,4 +614,30 @@ CsvCatalogItem.prototype.getNextColor = function() {
     return colors[0];
 };
 
+CsvCatalogItem.prototype.showOnSeparateMap = function(globeOrMap) {
+    var dataSource = this._dataSource;
+    var removeRegionMapping;
+
+    if (defined(this._regionMapping)) {
+        removeRegionMapping = this._regionMapping.showOnSeparateMap(globeOrMap);
+    }
+
+    if (defined(dataSource)) {
+        globeOrMap.addDataSource({
+            dataSource: dataSource
+        });
+    }
+
+    return function() {
+        if (defined(removeRegionMapping)) {
+            removeRegionMapping();
+        }
+        if (defined(dataSource)) {
+            globeOrMap.removeDataSource({
+                dataSource: dataSource
+            });
+        }
+    };
+};
+
 module.exports = CsvCatalogItem;

--- a/lib/Models/CzmlCatalogItem.js
+++ b/lib/Models/CzmlCatalogItem.js
@@ -5,13 +5,12 @@
 var CzmlDataSource = require('terriajs-cesium/Source/DataSources/CzmlDataSource');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
-var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 
+var DataSourceCatalogItem = require('./DataSourceCatalogItem');
 var Metadata = require('./Metadata');
 var TerriaError = require('../Core/TerriaError');
-var CatalogItem = require('./CatalogItem');
 var inherit = require('../Core/inherit');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var readJson = require('../Core/readJson');
@@ -27,7 +26,7 @@ var readJson = require('../Core/readJson');
  * @param {String} [url] The URL from which to retrieve the CZML data.
  */
 var CzmlCatalogItem =  function(terria, url) {
-    CatalogItem.call(this, terria);
+    DataSourceCatalogItem.call(this, terria);
 
     this._dataSource = undefined;
 
@@ -52,7 +51,7 @@ var CzmlCatalogItem =  function(terria, url) {
 
 };
 
-inherit(CatalogItem, CzmlCatalogItem);
+inherit(DataSourceCatalogItem, CzmlCatalogItem);
 
 defineProperties(CzmlCatalogItem.prototype, {
     /**
@@ -142,38 +141,6 @@ CzmlCatalogItem.prototype._load = function() {
             errorLoading(that);
         });
     }
-};
-
-CzmlCatalogItem.prototype._enable = function() {
-};
-
-CzmlCatalogItem.prototype._disable = function() {
-};
-
-CzmlCatalogItem.prototype._show = function() {
-    if (!defined(this._dataSource)) {
-        throw new DeveloperError('This data source is not enabled.');
-    }
-
-    var dataSources =  this.terria.dataSources;
-    if (dataSources.contains(this._dataSource)) {
-        throw new DeveloperError('This data source is already shown.');
-    }
-
-    dataSources.add(this._dataSource);
-};
-
-CzmlCatalogItem.prototype._hide = function() {
-    if (!defined(this._dataSource)) {
-        throw new DeveloperError('This data source is not enabled.');
-    }
-
-    var dataSources =  this.terria.dataSources;
-    if (!dataSources.contains(this._dataSource)) {
-        throw new DeveloperError('This data source is not shown.');
-    }
-
-    dataSources.remove(this.dataSource, false);
 };
 
 function doneLoading(czmlItem) {

--- a/lib/Models/DataSourceCatalogItem.js
+++ b/lib/Models/DataSourceCatalogItem.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/*global require*/
+var defined = require('terriajs-cesium/Source/Core/defined');
+var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
+
+var CatalogItem = require('./CatalogItem');
+var inherit = require('../Core/inherit');
+
+/**
+ * A {@link CatalogItem} that is added to the map as a Cesium {@link DataSource}
+ *
+ * @alias DataSourceCatalogItem
+ * @constructor
+ * @extends CatalogItem
+ * @abstract
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+var DataSourceCatalogItem = function(terria) {
+    CatalogItem.call(this, terria);
+};
+
+inherit(CatalogItem, DataSourceCatalogItem);
+
+defineProperties(DataSourceCatalogItem.prototype, {
+    /**
+     * Gets the data source associated with this catalog item.
+     * @memberOf DataSourceCatalogItem.prototype
+     * @type {DataSource}
+     */
+    dataSource : {
+        get : function() {
+            throw new DeveloperError('Types derived from DataSourceCatalogItem must implement a "dataSource" property.');
+        }
+    }
+});
+
+DataSourceCatalogItem.prototype._enable = function() {
+};
+
+DataSourceCatalogItem.prototype._disable = function() {
+};
+
+DataSourceCatalogItem.prototype._show = function() {
+    if (!defined(this.dataSource)) {
+        throw new DeveloperError('This data source is not loaded.');
+    }
+
+    var dataSources =  this.terria.dataSources;
+    if (dataSources.contains(this.dataSource)) {
+        return;
+    }
+
+    dataSources.add(this.dataSource);
+};
+
+DataSourceCatalogItem.prototype._hide = function() {
+    if (!defined(this.dataSource)) {
+        throw new DeveloperError('This data source is not loaded.');
+    }
+
+    var dataSources =  this.terria.dataSources;
+    if (!dataSources.contains(this.dataSource)) {
+        return;
+    }
+
+    dataSources.remove(this.dataSource, false);
+};
+
+DataSourceCatalogItem.prototype.showOnSeparateMap = function(globeOrMap) {
+    var dataSource = this.dataSource;
+
+    globeOrMap.addDataSource({
+        dataSource: dataSource
+    });
+
+    return function() {
+        globeOrMap.removeDataSource({
+            dataSource: dataSource
+        });
+    };
+};
+
+module.exports = DataSourceCatalogItem;

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -24,7 +24,7 @@ var topojson = require('terriajs-cesium/Source/ThirdParty/topojson');
 
 var PointGraphics = require('terriajs-cesium/Source/DataSources/PointGraphics');
 
-var CatalogItem = require('./CatalogItem');
+var DataSourceCatalogItem = require('./DataSourceCatalogItem');
 var standardCssColors = require('../Core/standardCssColors');
 var formatPropertyValue = require('../Core/formatPropertyValue');
 var hashFromString = require('../Core/hashFromString');
@@ -47,7 +47,7 @@ var urijs = require('urijs');
  * @param {String} [url] The URL from which to retrieve the GeoJSON data.
  */
 var GeoJsonCatalogItem =  function(terria, url) {
-    CatalogItem.call(this, terria);
+    DataSourceCatalogItem.call(this, terria);
 
     this._dataSource = undefined;
     this._readyData = undefined;
@@ -80,7 +80,7 @@ var GeoJsonCatalogItem =  function(terria, url) {
     knockout.track(this, ['data', 'dataSourceUrl', 'style']);
 };
 
-inherit(CatalogItem, GeoJsonCatalogItem);
+inherit(DataSourceCatalogItem, GeoJsonCatalogItem);
 
 defineProperties(GeoJsonCatalogItem.prototype, {
     /**
@@ -285,38 +285,6 @@ function getJson(entry, deferred) {
         deferred.resolve(loadJson(uri));
     });
 }
-
-GeoJsonCatalogItem.prototype._enable = function() {
-};
-
-GeoJsonCatalogItem.prototype._disable = function() {
-};
-
-GeoJsonCatalogItem.prototype._show = function() {
-    if (!defined(this._dataSource)) {
-        throw new DeveloperError('This data source is not loaded.');
-    }
-
-    var dataSources =  this.terria.dataSources;
-    if (dataSources.contains(this._dataSource)) {
-        return;
-    }
-
-    dataSources.add(this._dataSource);
-};
-
-GeoJsonCatalogItem.prototype._hide = function() {
-    if (!defined(this._dataSource)) {
-        throw new DeveloperError('This data source is not loaded.');
-    }
-
-    var dataSources =  this.terria.dataSources;
-    if (!dataSources.contains(this._dataSource)) {
-        return;
-    }
-
-    dataSources.remove(this._dataSource, false);
-};
 
 function updateModelFromData(geoJsonItem, geoJson) {
     // If this GeoJSON data is an object literal with a single property, treat that

--- a/lib/Models/GlobeOrMap.js
+++ b/lib/Models/GlobeOrMap.js
@@ -295,6 +295,30 @@ GlobeOrMap.prototype._shiftDisclaimers = function(px) {
     }
 };
 
+GlobeOrMap.prototype.addImageryProvider = function(options) {
+    throw new DeveloperError('addImageryProvider must be implemented in the derived class.');
+};
+
+GlobeOrMap.prototype.removeImageryLayer = function(options) {
+    throw new DeveloperError('removeImageryLayer must be implemented in the derived class.');
+};
+
+GlobeOrMap.prototype.showImageryLayer = function(options) {
+    throw new DeveloperError('showImageryLayer must be implemented in the derived class.');
+};
+
+GlobeOrMap.prototype.hideImageryLayer = function(options) {
+    throw new DeveloperError('hideImageryLayer must be implemented in the derived class.');
+};
+
+GlobeOrMap.prototype.addDataSource = function(options) {
+    this.terria.dataSources.add(options.dataSource);
+};
+
+GlobeOrMap.prototype.removeDataSource = function(options) {
+    this.terria.dataSources.remove(options.dataSource, false);
+};
+
 GlobeOrMap.disposeCommonListeners = function(globeOrMap) {
     globeOrMap._disclaimerShiftSubscription.dispose();
     globeOrMap._disclaimerShiftSubscription = undefined;

--- a/lib/Models/GpxCatalogItem.js
+++ b/lib/Models/GpxCatalogItem.js
@@ -151,6 +151,11 @@ GpxCatalogItem.prototype._hide = function() {
     }
 };
 
+GpxCatalogItem.prototype.showOnSeparateMap = function(globeOrMap) {
+    if (defined(this._geoJsonItem)) {
+        return this._geoJsonItem.showOnSeparateMap(globeOrMap);
+    }
+};
 
 function loadGpxText(gpxItem, text) {
 

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -8,19 +8,15 @@ var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
-var ImageryLayer = require('terriajs-cesium/Source/Scene/ImageryLayer');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
-var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
 var TimeIntervalCollection = require('terriajs-cesium/Source/Core/TimeIntervalCollection');
 
 var CatalogItem = require('./CatalogItem');
-var CesiumTileLayer = require('../Map/CesiumTileLayer');
 var inherit = require('../Core/inherit');
 var TerriaError = require('../Core/TerriaError');
 var overrideProperty = require('../Core/overrideProperty');
-var rectangleToLatLngBounds = require('../Map/rectangleToLatLngBounds');
 
 /**
  * A {@link CatalogItem} that is added to the map as a rasterized imagery layer.
@@ -401,6 +397,12 @@ ImageryLayerCatalogItem.prototype._hide = function() {
     ImageryLayerCatalogItem.hideLayer(this, this._nextLayer);
 };
 
+ImageryLayerCatalogItem.prototype.showOnSeparateMap = function(globeOrMap) {
+    var imageryProvider = this._createImageryProvider();
+    var layer = ImageryLayerCatalogItem.enableLayer(this, imageryProvider, this.opacity, undefined, globeOrMap);
+    ImageryLayerCatalogItem.showLayer(this, layer, globeOrMap);
+};
+
 function updateOpacity(imageryLayerItem) {
     if (defined(imageryLayerItem._imageryLayer) && imageryLayerItem.isEnabled && imageryLayerItem.isShown) {
         if (defined(imageryLayerItem._imageryLayer.alpha)) {
@@ -415,108 +417,48 @@ function updateOpacity(imageryLayerItem) {
     }
 }
 
-ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opacity, layerIndex, terria) {
-    var result;
+ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opacity, layerIndex, globeOrMap) {
+    globeOrMap = defaultValue(globeOrMap, catalogItem.terria.currentViewer);
 
-    terria = defaultValue(terria, catalogItem.terria);
-
-    if (defined(terria.cesium)) {
-        var scene = terria.cesium.scene;
-
-        var errorEvent = imageryProvider.errorEvent;
-
-        if (defined(errorEvent)) {
-            errorEvent.addEventListener(function(tileProviderError) {
-                // We're only concerned about failures for tiles that actually overlap this item's extent.
-                if (defined(catalogItem.rectangle)) {
-                    var tilingScheme = imageryProvider.tilingScheme;
-                    var tileExtent = tilingScheme.tileXYToRectangle(tileProviderError.x, tileProviderError.y, tileProviderError.level);
-                    var intersection = Rectangle.intersection(tileExtent, catalogItem.rectangle);
-                    if (!defined(intersection)) {
-                        return;
-                    }
-                }
-
-                if (defined(tileProviderError.error) && tileProviderError.error.statusCode === 404) {
-                    if(!catalogItem.treat404AsError) {
-                        return;
-                    }
-                } else if (defined(tileProviderError.error) && tileProviderError.error.statusCode === 403) {
-                    if(!catalogItem.treat403AsError) {
-                        return;
-                    }
-                    // ignoreUnknownTileErrors is only for genuinely unknown (no status code) issues
-                } else if (catalogItem.ignoreUnknownTileErrors && (!defined(tileProviderError.error) || !defined(tileProviderError.error.statusCode))) {
-                    return;
-                }
-
-
-                // Retry 3 times.
-                if (tileProviderError.timesRetried < 3) {
-                    tileProviderError.retry = true;
-                    return;
-                }
-
-                // After three failures, advise the user that something is wrong and hide the catalog item.
-                // (if the item isn't already hidden, that is)
-                if (catalogItem.isShown) {
-                    terria.error.raiseEvent(new TerriaError({
-                        sender: catalogItem,
-                        title: 'Error accessing catalogue item',
-                        message: '\
+    const layer = globeOrMap.addImageryProvider({
+        imageryProvider: imageryProvider,
+        rectangle: catalogItem.rectangle,
+        clipToRectangle: catalogItem.clipToRectangle,
+        opacity: opacity,
+        layerIndex: layerIndex,
+        treat403AsError: catalogItem.treat403AsError,
+        treat404AsError: catalogItem.treat404AsError,
+        ignoreUnknownTileErrors: catalogItem.ignoreUnknownTileErrors,
+        isRequiredForRendering: catalogItem.isRequiredForRendering,
+        onLoadError: function() {
+            if (defined(layer) && layer.show) {
+                catalogItem.terria.error.raiseEvent(new TerriaError({
+                    sender: catalogItem,
+                    title: 'Error accessing catalogue item',
+                    message: '\
 An error occurred while attempting to download tiles for catalogue item ' + catalogItem.name + '.  This may indicate that there is a \
 problem with your internet connection, that the catalogue item is temporarily unavailable, or that the catalogue item \
 is invalid.  The catalogue item has been hidden from the map.  You may re-show it in the Now Viewing panel to try again.'
-                    }));
+                }));
 
-                    catalogItem.isShown = false;
-                }
-            });
-        }
-
-        result = new ImageryLayer(imageryProvider, {
-            show : false,
-            alpha : opacity,
-            rectangle : catalogItem.clipToRectangle ? catalogItem.rectangle : undefined,
-            isRequired : catalogItem.isRequiredForRendering
-        });
-
-        // layerIndex is an optional parameter used when the imageryLayer corresponds to a CsvCatalogItem whose selected item has just changed
-        // to ensure that the layer is re-added in the correct position
-        scene.imageryLayers.add(result, layerIndex);
-
-        terria.cesium.updateLayerOrderToKeepOnTop();
-
-    } else if (defined(terria.leaflet)) {
-        var options = {
-            opacity: opacity,
-            bounds : catalogItem.clipToRectangle && catalogItem.rectangle ? rectangleToLatLngBounds(catalogItem.rectangle) : undefined
-        };
-
-        if (defined(terria.leaflet.map.options.maxZoom)) {
-            options.maxZoom = terria.leaflet.map.options.maxZoom;
-        }
-
-        result = new CesiumTileLayer(imageryProvider, options);
-
-        result.errorEvent.addEventListener(function(sender, message) {
+                globeOrMap.hideImageryProvider(layer);
+            }
+        },
+        onProjectionError: function() {
             // If the TileLayer experiences an error, hide the catalog item and inform the user.
-            catalogItem.isShown = false;
-
-            terria.error.raiseEvent({
+            catalogItem.terria.error.raiseEvent({
                 sender: catalogItem,
                 title: 'Unable to display dataset',
                 message: '\
-"' + catalogItem.name + '" cannot be shown in 2D because it does not support the standard Web Mercator (EPSG:3857) projection.  \
-Please switch to 3D if it is supported on your system, update the dataset to support the projection, or use a different dataset.'
+    "' + catalogItem.name + '" cannot be shown in 2D because it does not support the standard Web Mercator (EPSG:3857) projection.  \
+    Please switch to 3D if it is supported on your system, update the dataset to support the projection, or use a different dataset.'
             });
 
-            // If the user re-shows the dataset, show the error again.
-            result.initialized = false;
-        });
-    }
+            globeOrMap.hideImageryProvider(layer);
+        }
+    });
 
-    return result;
+    return layer;
 };
 
 ImageryLayerCatalogItem.disableLayer = function(catalogItem, layer, terria) {
@@ -623,23 +565,15 @@ function setOpacity(catalogItem, layer, opacity) {
     }
 }
 
-ImageryLayerCatalogItem.showLayer = function(catalogItem, layer, terria) {
+ImageryLayerCatalogItem.showLayer = function(catalogItem, layer, globeOrMap) {
     if (!defined(layer)) {
         return;
     }
 
-    terria = defaultValue(terria, catalogItem.terria);
-
-    if (defined(terria.cesium)) {
-        layer.show = true;
-    }
-
-    if (defined(terria.leaflet)) {
-        if (!terria.leaflet.map.hasLayer(layer)) {
-            layer.addTo(terria.leaflet.map);
-        }
-        terria.leaflet.updateLayerOrder();
-    }
+    globeOrMap = defaultValue(globeOrMap, catalogItem.terria.currentViewer);
+    globeOrMap.showImageryLayer({
+        layer: layer
+    });
 };
 
 ImageryLayerCatalogItem.hideLayer = function(catalogItem, layer, terria) {
@@ -647,15 +581,10 @@ ImageryLayerCatalogItem.hideLayer = function(catalogItem, layer, terria) {
         return;
     }
 
-    terria = defaultValue(terria, catalogItem.terria);
-
-    if (defined(terria.cesium)) {
-        layer.show = false;
-    }
-
-    if (defined(terria.leaflet)) {
-        terria.leaflet.map.removeLayer(layer);
-    }
+    globeOrMap = defaultValue(globeOrMap, catalogItem.terria.currentViewer);
+    globeOrMap.hideImageryLayer({
+        layer: layer
+    });
 };
 
 function fixNextLayerOrder(catalogItem) {

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -3,6 +3,7 @@
 /*global require*/
 var clone = require('terriajs-cesium/Source/Core/clone');
 var DataSourceClock = require('terriajs-cesium/Source/DataSources/DataSourceClock');
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
@@ -414,11 +415,13 @@ function updateOpacity(imageryLayerItem) {
     }
 }
 
-ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opacity, layerIndex) {
+ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opacity, layerIndex, terria) {
     var result;
 
-    if (defined(catalogItem.terria.cesium)) {
-        var scene = catalogItem.terria.cesium.scene;
+    terria = defaultValue(terria, catalogItem.terria);
+
+    if (defined(terria.cesium)) {
+        var scene = terria.cesium.scene;
 
         var errorEvent = imageryProvider.errorEvent;
 
@@ -457,7 +460,7 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
                 // After three failures, advise the user that something is wrong and hide the catalog item.
                 // (if the item isn't already hidden, that is)
                 if (catalogItem.isShown) {
-                    catalogItem.terria.error.raiseEvent(new TerriaError({
+                    terria.error.raiseEvent(new TerriaError({
                         sender: catalogItem,
                         title: 'Error accessing catalogue item',
                         message: '\
@@ -482,16 +485,16 @@ is invalid.  The catalogue item has been hidden from the map.  You may re-show i
         // to ensure that the layer is re-added in the correct position
         scene.imageryLayers.add(result, layerIndex);
 
-        catalogItem.terria.cesium.updateLayerOrderToKeepOnTop();
+        terria.cesium.updateLayerOrderToKeepOnTop();
 
-    } else if (defined(catalogItem.terria.leaflet)) {
+    } else if (defined(terria.leaflet)) {
         var options = {
             opacity: opacity,
             bounds : catalogItem.clipToRectangle && catalogItem.rectangle ? rectangleToLatLngBounds(catalogItem.rectangle) : undefined
         };
 
-        if (defined(catalogItem.terria.leaflet.map.options.maxZoom)) {
-            options.maxZoom = catalogItem.terria.leaflet.map.options.maxZoom;
+        if (defined(terria.leaflet.map.options.maxZoom)) {
+            options.maxZoom = terria.leaflet.map.options.maxZoom;
         }
 
         result = new CesiumTileLayer(imageryProvider, options);
@@ -500,7 +503,7 @@ is invalid.  The catalogue item has been hidden from the map.  You may re-show i
             // If the TileLayer experiences an error, hide the catalog item and inform the user.
             catalogItem.isShown = false;
 
-            catalogItem.terria.error.raiseEvent({
+            terria.error.raiseEvent({
                 sender: catalogItem,
                 title: 'Unable to display dataset',
                 message: '\
@@ -516,16 +519,18 @@ Please switch to 3D if it is supported on your system, update the dataset to sup
     return result;
 };
 
-ImageryLayerCatalogItem.disableLayer = function(catalogItem, layer) {
+ImageryLayerCatalogItem.disableLayer = function(catalogItem, layer, terria) {
     if (!defined(layer)) {
         return;
     }
 
-    if (defined(catalogItem.terria.cesium)) {
-        var scene = catalogItem.terria.cesium.scene;
+    terria = defaultValue(terria, catalogItem.terria);
+
+    if (defined(terria.cesium)) {
+        var scene = terria.cesium.scene;
         scene.imageryLayers.remove(layer);
-    } else if (defined(catalogItem.terria.leaflet)) {
-        var map = catalogItem.terria.leaflet.map;
+    } else if (defined(terria.leaflet)) {
+        var map = terria.leaflet.map;
         map.removeLayer(layer);
     }
 };
@@ -618,34 +623,38 @@ function setOpacity(catalogItem, layer, opacity) {
     }
 }
 
-ImageryLayerCatalogItem.showLayer = function(catalogItem, layer) {
+ImageryLayerCatalogItem.showLayer = function(catalogItem, layer, terria) {
     if (!defined(layer)) {
         return;
     }
 
-    if (defined(catalogItem.terria.cesium)) {
+    terria = defaultValue(terria, catalogItem.terria);
+
+    if (defined(terria.cesium)) {
         layer.show = true;
     }
 
-    if (defined(catalogItem.terria.leaflet)) {
-        if (!catalogItem.terria.leaflet.map.hasLayer(layer)) {
-            layer.addTo(catalogItem.terria.leaflet.map);
+    if (defined(terria.leaflet)) {
+        if (!terria.leaflet.map.hasLayer(layer)) {
+            layer.addTo(terria.leaflet.map);
         }
-        catalogItem.terria.leaflet.updateLayerOrder();
+        terria.leaflet.updateLayerOrder();
     }
 };
 
-ImageryLayerCatalogItem.hideLayer = function(catalogItem, layer) {
+ImageryLayerCatalogItem.hideLayer = function(catalogItem, layer, terria) {
     if (!defined(layer)) {
         return;
     }
 
-    if (defined(catalogItem.terria.cesium)) {
+    terria = defaultValue(terria, catalogItem.terria);
+
+    if (defined(terria.cesium)) {
         layer.show = false;
     }
 
-    if (defined(catalogItem.terria.leaflet)) {
-        catalogItem.terria.leaflet.map.removeLayer(layer);
+    if (defined(terria.leaflet)) {
+        terria.leaflet.map.removeLayer(layer);
     }
 };
 

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -401,6 +401,12 @@ ImageryLayerCatalogItem.prototype.showOnSeparateMap = function(globeOrMap) {
     var imageryProvider = this._createImageryProvider();
     var layer = ImageryLayerCatalogItem.enableLayer(this, imageryProvider, this.opacity, undefined, globeOrMap);
     ImageryLayerCatalogItem.showLayer(this, layer, globeOrMap);
+
+    var that = this;
+    return function() {
+        ImageryLayerCatalogItem.hideLayer(that, layer, globeOrMap);
+        ImageryLayerCatalogItem.disableLayer(that, layer, globeOrMap);
+    };
 };
 
 function updateOpacity(imageryLayerItem) {
@@ -461,20 +467,15 @@ is invalid.  The catalogue item has been hidden from the map.  You may re-show i
     return layer;
 };
 
-ImageryLayerCatalogItem.disableLayer = function(catalogItem, layer, terria) {
+ImageryLayerCatalogItem.disableLayer = function(catalogItem, layer, globeOrMap) {
     if (!defined(layer)) {
         return;
     }
 
-    terria = defaultValue(terria, catalogItem.terria);
-
-    if (defined(terria.cesium)) {
-        var scene = terria.cesium.scene;
-        scene.imageryLayers.remove(layer);
-    } else if (defined(terria.leaflet)) {
-        var map = terria.leaflet.map;
-        map.removeLayer(layer);
-    }
+    globeOrMap = defaultValue(globeOrMap, catalogItem.terria.currentViewer);
+    globeOrMap.removeImageryLayer({
+        layer: layer
+    });
 };
 
 function updateClockSubscription(catalogItem) {
@@ -576,7 +577,7 @@ ImageryLayerCatalogItem.showLayer = function(catalogItem, layer, globeOrMap) {
     });
 };
 
-ImageryLayerCatalogItem.hideLayer = function(catalogItem, layer, terria) {
+ImageryLayerCatalogItem.hideLayer = function(catalogItem, layer, globeOrMap) {
     if (!defined(layer)) {
         return;
     }

--- a/lib/Models/KmlCatalogItem.js
+++ b/lib/Models/KmlCatalogItem.js
@@ -4,7 +4,6 @@
 
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
-var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
 var KmlDataSource = require('terriajs-cesium/Source/DataSources/KmlDataSource');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
@@ -12,9 +11,9 @@ var PolygonHierarchy = require('terriajs-cesium/Source/Core/PolygonHierarchy');
 var sampleTerrain = require('terriajs-cesium/Source/Core/sampleTerrain');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 
+var DataSourceCatalogItem = require('./DataSourceCatalogItem');
 var Metadata = require('./Metadata');
 var TerriaError = require('../Core/TerriaError');
-var CatalogItem = require('./CatalogItem');
 var inherit = require('../Core/inherit');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var readXml = require('../Core/readXml');
@@ -30,7 +29,7 @@ var readXml = require('../Core/readXml');
  * @param {String} [url] The URL from which to retrieve the KML or KMZ data.
  */
 var KmlCatalogItem =  function(terria, url) {
-     CatalogItem.call(this, terria);
+    DataSourceCatalogItem.call(this, terria);
 
     this._dataSource = undefined;
 
@@ -54,7 +53,7 @@ var KmlCatalogItem =  function(terria, url) {
     knockout.track(this, ['data', 'dataSourceUrl']);
 };
 
-inherit(CatalogItem, KmlCatalogItem);
+inherit(DataSourceCatalogItem, KmlCatalogItem);
 
 defineProperties(KmlCatalogItem.prototype, {
     /**
@@ -176,38 +175,6 @@ If you believe it is a bug in '+that.terria.appName+', please report it by email
             errorLoading(that);
         });
     }
-};
-
-KmlCatalogItem.prototype._enable = function() {
-};
-
-KmlCatalogItem.prototype._disable = function() {
-};
-
-KmlCatalogItem.prototype._show = function() {
-    if (!defined(this._dataSource)) {
-        throw new DeveloperError('This data source is not enabled.');
-    }
-
-    var dataSources =  this.terria.dataSources;
-    if (dataSources.contains(this._dataSource)) {
-        throw new DeveloperError('This data source is already shown.');
-    }
-
-    dataSources.add(this._dataSource);
-};
-
-KmlCatalogItem.prototype._hide = function() {
-    if (!defined(this._dataSource)) {
-        throw new DeveloperError('This data source is not enabled.');
-    }
-
-    var dataSources =  this.terria.dataSources;
-    if (!dataSources.contains(this._dataSource)) {
-        throw new DeveloperError('This data source is not shown.');
-    }
-
-    dataSources.remove(this._dataSource, false);
 };
 
 function doneLoading(kmlItem) {

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -354,6 +354,11 @@ Leaflet.prototype.addImageryProvider = function(options) {
     return result;
 };
 
+Leaflet.prototype.removeImageryLayer = function(options) {
+    var map = this.map;
+    map.removeLayer(options.layer);
+};
+
 Leaflet.prototype.showImageryLayer = function(options) {
     if (!this.map.hasLayer(options.layer)) {
         options.layer.addTo(this.map);

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -7,6 +7,7 @@ var html2canvas = require('html2canvas');
 var Cartesian2 = require('terriajs-cesium/Source/Core/Cartesian2');
 var Cartographic = require('terriajs-cesium/Source/Core/Cartographic');
 var CesiumMath = require('terriajs-cesium/Source/Core/Math');
+var CesiumTileLayer = require('../Map/CesiumTileLayer');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var destroyObject = require('terriajs-cesium/Source/Core/destroyObject');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
@@ -327,6 +328,41 @@ Leaflet.prototype.pickFromLocation = function(latlng, imageryLayerCoords, existi
     }
 
     pickFeatures(this, latlng, imageryLayerCoords);
+};
+
+Leaflet.prototype.addImageryProvider = function(options) {
+    var layerOptions = {
+        opacity: options.opacity,
+        bounds : options.clipToRectangle && options.rectangle ? rectangleToLatLngBounds(options.rectangle) : undefined
+    };
+
+    if (defined(this.map.options.maxZoom)) {
+        options.maxZoom = this.map.options.maxZoom;
+    }
+
+    var result = new CesiumTileLayer(options.imageryProvider, layerOptions);
+
+    result.errorEvent.addEventListener(function(sender, message) {
+        if (defined(options.onProjectionError)) {
+            options.onProjectionError();
+        }
+
+        // If the user re-shows the dataset, show the error again.
+        result.initialized = false;
+    });
+
+    return result;
+};
+
+Leaflet.prototype.showImageryLayer = function(options) {
+    if (!this.map.hasLayer(options.layer)) {
+        options.layer.addTo(this.map);
+    }
+    this.updateLayerOrder();
+};
+
+Leaflet.prototype.hideImageryLayer = function(options) {
+    this.map.removeLayer(options.layer);
 };
 
 /**

--- a/lib/Models/NoViewer.js
+++ b/lib/Models/NoViewer.js
@@ -123,4 +123,16 @@ NoViewer.prototype.lower = function(index) {
 NoViewer.prototype.lowerToBottom = function(item) {
 };
 
+NoViewer.prototype.addImageryProvider = function(options) {
+};
+
+NoViewer.prototype.removeImageryLayer = function(options) {
+};
+
+NoViewer.prototype.showImageryLayer = function(options) {
+};
+
+NoViewer.prototype.hideImageryLayer = function(options) {
+};
+
 module.exports = NoViewer;

--- a/lib/Models/OgrCatalogItem.js
+++ b/lib/Models/OgrCatalogItem.js
@@ -154,6 +154,12 @@ OgrCatalogItem.prototype._hide = function() {
     }
 };
 
+OgrCatalogItem.prototype.showOnSeparateMap = function(globeOrMap) {
+    if (defined(this._geoJsonItem)) {
+        return this._geoJsonItem.showOnSeparateMap(globeOrMap);
+    }
+};
+
 function loadOgrData(ogrItem, file, url) {
     var terria = ogrItem.terria;
     // generate form to submit file for conversion

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -1,37 +1,32 @@
 /*global require*/
 "use strict";
 
-var L = require('leaflet');
-
-// var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
+var arraysAreEqual = require('../Core/arraysAreEqual');
 var CallbackProperty = require('terriajs-cesium/Source/DataSources/CallbackProperty');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var destroyObject = require('terriajs-cesium/Source/Core/destroyObject');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
-// var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
-var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
-var when = require('terriajs-cesium/Source/ThirdParty/when');
-
-var arraysAreEqual = require('../Core/arraysAreEqual');
 var getUniqueValues = require('../Core/getUniqueValues');
+var ImageryLayerCatalogItem = require('../Models/ImageryLayerCatalogItem');
 var ImageryProviderHooks = require('../Map/ImageryProviderHooks');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var L = require('leaflet');
+var Leaflet = require('../Models/Leaflet');
 var LegendHelper = require('../Models/LegendHelper');
+var proxyCatalogItemUrl = require('../Models/proxyCatalogItemUrl');
 var RegionProviderList = require('../Map/RegionProviderList');
 var TableStructure = require('../Map/TableStructure');
 var TableStyle = require('../Models/TableStyle');
 var TerriaError = require('../Core/TerriaError');
+var TileLayerFilter = require('../ThirdParty/TileLayer.Filter');
 var VarType = require('../Map/VarType');
-
-// Used for region mapping
+var WebMapServiceCatalogItem = require('../Models/WebMapServiceCatalogItem');
 var WebMapServiceImageryProvider = require('terriajs-cesium/Source/Scene/WebMapServiceImageryProvider');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
-var ImageryLayerCatalogItem = require('../Models/ImageryLayerCatalogItem');
-var ImageryProviderHooks = require('../Map/ImageryProviderHooks');
-var proxyCatalogItemUrl = require('../Models/proxyCatalogItemUrl');
-var TileLayerFilter = require('../ThirdParty/TileLayer.Filter');
-var WebMapServiceCatalogItem = require('../Models/WebMapServiceCatalogItem');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 // TileLayerFilter.initialize adds the 'setFilter' method to CesiumTileLayer
 // which is returned by ImageryLayerCatalogItem.enableLayer and used as _imageryLayer with leaflet.
@@ -267,37 +262,46 @@ function changedActiveItems(regionMapping) {
     }
 }
 
+RegionMapping.prototype.showOnSeparateMap = function(globeOrMap) {
+    if (defined(this._regionDetails)) {
+        var layer = createNewRegionImageryLayer(this, 0, undefined, globeOrMap);
+        ImageryLayerCatalogItem.showLayer(this._catalogItem, layer, globeOrMap);
+
+        var that = this;
+        return function() {
+            ImageryLayerCatalogItem.hideLayer(that._catalogItem, layer, globeOrMap);
+            ImageryLayerCatalogItem.disableLayer(that._catalogItem, layer, globeOrMap);
+        };
+    }
+};
+
 // The functions enable, disable, show and hide are required for region mapping.
 RegionMapping.prototype.enable = function(layerIndex) {
-    var that = this;
     if (defined(this._regionDetails)) {
-        updateClockSubscription(that);
-        setNewRegionImageryLayer(that, layerIndex);
+        updateClockSubscription(this);
+        setNewRegionImageryLayer(this, layerIndex);
     }
 };
 
 RegionMapping.prototype.disable = function() {
-    var that = this;
     if (defined(this._regionDetails)) {
-        updateClockSubscription(that);
-        ImageryLayerCatalogItem.disableLayer(that._catalogItem, that._imageryLayer);
-        that._imageryLayer = undefined;
+        updateClockSubscription(this);
+        ImageryLayerCatalogItem.disableLayer(this._catalogItem, this._imageryLayer);
+        this._imageryLayer = undefined;
     }
 };
 
 RegionMapping.prototype.show = function() {
-    var that = this;
     if (defined(this._regionDetails)) {
-        updateClockSubscription(that);
-        ImageryLayerCatalogItem.showLayer(that._catalogItem, that._imageryLayer);
+        updateClockSubscription(this);
+        ImageryLayerCatalogItem.showLayer(this._catalogItem, this._imageryLayer);
     }
 };
 
 RegionMapping.prototype.hide = function() {
-    var that = this;
     if (defined(this._regionDetails)) {
-        updateClockSubscription(that);
-        ImageryLayerCatalogItem.hideLayer(that._catalogItem, that._imageryLayer);
+        updateClockSubscription(this);
+        ImageryLayerCatalogItem.hideLayer(this._catalogItem, this._imageryLayer);
     }
 };
 
@@ -504,7 +508,14 @@ function addDescriptionAndProperties(regionMapping, regionIndices, regionImagery
  *                  If not provided, it is calculated, and failed/ambiguous warnings are displayed to the user.
  */
 function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
+    regionMapping._imageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices);
+}
+
+function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, globeOrMap) {
     var catalogItem = regionMapping._catalogItem;
+
+    globeOrMap = defaultValue(globeOrMap, catalogItem.terria.currentViewer);
+
     var regionDetail = regionMapping._regionDetails[0];
     var legendHelper = regionMapping._legendHelper;
     var tableStructure = regionMapping._tableStructure;
@@ -512,7 +523,7 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
     if (!defined(regionIndices)) {
         failedMatches = [];
         ambiguousMatches = [];
-        regionIndices = calculateRegionIndices(regionMapping, regionMapping._catalogItem.terria.clock.currentTime, failedMatches, ambiguousMatches);
+        regionIndices = calculateRegionIndices(regionMapping, catalogItem.terria.clock.currentTime, failedMatches, ambiguousMatches);
         if (!regionMapping._hasDisplayedFeedback && catalogItem.showWarnings) {
             regionMapping._hasDisplayedFeedback = true;
             displayFailedAndAmbiguousMatches(regionMapping, failedMatches, ambiguousMatches);
@@ -521,7 +532,7 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
     var regionValues = getRegionValuesFromIndices(regionIndices, tableStructure);
 
     var regionImageryProvider = new WebMapServiceImageryProvider({
-        url: proxyCatalogItemUrl(regionMapping._catalogItem, regionDetail.regionProvider.server),
+        url: proxyCatalogItemUrl(catalogItem, regionDetail.regionProvider.server),
         layers: regionDetail.regionProvider.layerName,
         parameters: WebMapServiceCatalogItem.defaultParameters,
         getFeatureInfoParameters: WebMapServiceCatalogItem.defaultParameters,
@@ -537,9 +548,9 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
     );
     ImageryProviderHooks.addRecolorFunc(regionImageryProvider, colorFunction);
 
-    regionMapping._imageryLayer = ImageryLayerCatalogItem.enableLayer(catalogItem, regionImageryProvider, catalogItem.opacity, layerIndex);
-    if (defined(catalogItem.terria.leaflet) && colorFunction) {
-        regionMapping._imageryLayer.setFilter(function () {
+    var layer = ImageryLayerCatalogItem.enableLayer(catalogItem, regionImageryProvider, catalogItem.opacity, layerIndex, globeOrMap);
+    if (defined(globeOrMap instanceof Leaflet) && colorFunction) {
+        layer.setFilter(function () {
             new L.CanvasFilter(this, {
                 channelFilter: function (image) {
                     return ImageryProviderHooks.recolorImage(image, colorFunction);
@@ -547,6 +558,8 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
             }).render();
         });
     }
+
+    return layer;
 }
 
 /**

--- a/lib/Models/WebFeatureServiceCatalogItem.js
+++ b/lib/Models/WebFeatureServiceCatalogItem.js
@@ -228,6 +228,12 @@ WebFeatureServiceCatalogItem.prototype._hide = function() {
     }
 };
 
+WebFeatureServiceCatalogItem.prototype.showOnSeparateMap = function(globeOrMap) {
+    if (defined(this._geoJsonItem)) {
+        return this._geoJsonItem.showOnSeparateMap(globeOrMap);
+    }
+};
+
 function loadGeoJson(wfsItem) {
     var promise = loadJson(buildGeoJsonUrl(wfsItem)).then(function(json) {
         return json;

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
@@ -86,7 +86,7 @@ const DataCatalogGroup = React.createClass({
         if (group.isLoading) {
             children.push(<li key="loader"><Loader /></li>);
         } else if (group.items.length === 0) {
-            children.push(<li className="label no-results" key="empty"> No data </li>);
+            children.push(<li className="label no-results" key="empty"> This group is empty </li>);
         }
 
         return children;

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -1,11 +1,9 @@
 'use strict';
 
 const CesiumMath = require('terriajs-cesium/Source/Core/Math');
-const createCatalogMemberFromType = require('../../Models/createCatalogMemberFromType');
 const defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 const defined = require('terriajs-cesium/Source/Core/defined');
 const GeoJsonCatalogItem = require('../../Models/GeoJsonCatalogItem');
-const ImageryLayerCatalogItem = require('../../Models/ImageryLayerCatalogItem');
 const ObserveModelMixin = require('../ObserveModelMixin');
 const OpenStreetMapCatalogItem = require('../../Models/OpenStreetMapCatalogItem');
 const React = require('react');
@@ -76,7 +74,7 @@ const DataPreviewMap = React.createClass({
             this.rectangleCatalogItem.isEnabled = false;
         }
 
-        let previewed = this.props.previewedCatalogItem;
+        const previewed = this.props.previewedCatalogItem;
         if (previewed && defined(previewed.type) && previewed.isMappable) {
             const that = this;
             return when(previewed.load()).then(function() {
@@ -98,24 +96,27 @@ const DataPreviewMap = React.createClass({
                         return;
                     }
 
-                    if (defined(nowViewingItem._createImageryProvider)) {
-                        const imageryProvider = nowViewingItem._createImageryProvider();
-                        const layer = ImageryLayerCatalogItem.enableLayer(nowViewingItem, imageryProvider, nowViewingItem.opacity, undefined, that.terriaPreview);
-                        ImageryLayerCatalogItem.showLayer(nowViewingItem, layer, that.terriaPreview);
-                        that.updateBoundingRectangle(nowViewingItem);
-
-                        that.removePreviewFromMap = function() {
-                            ImageryLayerCatalogItem.hideLayer(nowViewingItem, layer, that.terriaPreview);
-                            ImageryLayerCatalogItem.disableLayer(nowViewingItem, layer, that.terriaPreview);
-                        };
-                    } else if (defined(nowViewingItem.dataSource)) {
-                        const dataSource = nowViewingItem.dataSource;
-                        that.terriaPreview.dataSources.add(dataSource);
-
-                        that.removePreviewFromMap = function() {
-                            that.terriaPreview.dataSources.remove(dataSource);
-                        };
+                    if (defined(nowViewingItem.showOnSeparateMap)) {
+                        that.removePreviewFromMap = nowViewingItem.showOnSeparateMap(that.terriaPreview.currentViewer);
                     }
+        //             if (defined(nowViewingItem._createImageryProvider)) {
+        //                 const imageryProvider = nowViewingItem._createImageryProvider();
+        //                 const layer = ImageryLayerCatalogItem.enableLayer(nowViewingItem, imageryProvider, nowViewingItem.opacity, undefined, that.terriaPreview);
+        //                 ImageryLayerCatalogItem.showLayer(nowViewingItem, layer, that.terriaPreview);
+        //                 that.updateBoundingRectangle(nowViewingItem);
+
+        //                 that.removePreviewFromMap = function() {
+        //                     ImageryLayerCatalogItem.hideLayer(nowViewingItem, layer, that.terriaPreview);
+        //                     ImageryLayerCatalogItem.disableLayer(nowViewingItem, layer, that.terriaPreview);
+        //                 };
+        //             } else if (defined(nowViewingItem.dataSource)) {
+        //                 const dataSource = nowViewingItem.dataSource;
+        //                 that.terriaPreview.dataSources.add(dataSource);
+
+        //                 that.removePreviewFromMap = function() {
+        //                     that.terriaPreview.dataSources.remove(dataSource);
+        //                 };
+        //             }
                 });
             });
         }

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -101,11 +101,19 @@ const DataPreviewMap = React.createClass({
 
                     if (defined(nowViewingItem.showOnSeparateMap)) {
                         that.removePreviewFromMap = nowViewingItem.showOnSeparateMap(that.terriaPreview.currentViewer);
-                        that.previewBadgeElement.textContent = 'PREVIEW';
+                        if (that.removePreviewFromMap) {
+                            that.previewBadgeElement.textContent = 'PREVIEW';
+                        } else {
+                            that.previewBadgeElement.textContent = 'NO PREVIEW AVAILABLE';
+                        }
                     } else {
                         that.previewBadgeElement.textContent = 'NO PREVIEW AVAILABLE';
                     }
+
+                    that.updateBoundingRectangle();
                 });
+            }).otherwise(function() {
+                that.previewBadgeElement.textContent = 'NO PREVIEW AVAILABLE';
             });
         }
     },
@@ -129,13 +137,13 @@ const DataPreviewMap = React.createClass({
         this.updateBoundingRectangle();
     },
 
-    updateBoundingRectangle(previewed) {
+    updateBoundingRectangle() {
         if (defined(this.rectangleCatalogItem)) {
             this.rectangleCatalogItem.isEnabled = false;
             this.rectangleCatalogItem = undefined;
         }
 
-        let catalogItem = defaultValue(previewed, this.props.previewedCatalogItem);
+        let catalogItem = this.props.previewedCatalogItem;
         catalogItem = defaultValue(catalogItem.nowViewingCatalogItem, catalogItem);
 
         if (!defined(catalogItem) || !defined(catalogItem.rectangle)) {

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -71,10 +71,10 @@ const DataPreviewMap = React.createClass({
                 //     return;
                 // }
 
-                // Preview the nowViewingCatalogItem if there is one.
-                previewed = defaultValue(previewed.nowViewingCatalogItem, previewed);
-
                 if (defined(previewed._createImageryProvider)) {
+                    // Preview the nowViewingCatalogItem if there is one.
+                    previewed = defaultValue(previewed.nowViewingCatalogItem, previewed);
+
                     const imageryProvider = previewed._createImageryProvider();
                     const layer = ImageryLayerCatalogItem.enableLayer(previewed, imageryProvider, previewed.opacity, undefined, that.terriaPreview);
                     ImageryLayerCatalogItem.showLayer(previewed, layer, that.terriaPreview);

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -98,11 +98,6 @@ const DataPreviewMap = React.createClass({
                         return;
                     }
 
-                    // if (defined(that.removePreviewFromMap)) {
-                    //     that.removePreviewFromMap();
-                    //     that.removePreviewFromMap = undefined;
-                    // }
-
                     if (defined(nowViewingItem._createImageryProvider)) {
                         const imageryProvider = nowViewingItem._createImageryProvider();
                         const layer = ImageryLayerCatalogItem.enableLayer(nowViewingItem, imageryProvider, nowViewingItem.opacity, undefined, that.terriaPreview);
@@ -113,19 +108,13 @@ const DataPreviewMap = React.createClass({
                             ImageryLayerCatalogItem.hideLayer(nowViewingItem, layer, that.terriaPreview);
                             ImageryLayerCatalogItem.disableLayer(nowViewingItem, layer, that.terriaPreview);
                         };
-                    } else {
-                        // const type = previewed.type;
-                        // const serializedCatalogItem = previewed.serializeToJson();
-                        // const catalogItem = createCatalogMemberFromType(type, that.terriaPreview);
+                    } else if (defined(nowViewingItem.dataSource)) {
+                        const dataSource = nowViewingItem.dataSource;
+                        that.terriaPreview.dataSources.add(dataSource);
 
-                        // catalogItem.updateFromJson(serializedCatalogItem);
-                        // catalogItem.isEnabled = true;
-
-                        // that.updateBoundingRectangle(catalogItem);
-
-                        // that.removePreviewFromMap = function() {
-                        //     catalogItem.isEnabled = false;
-                        // };
+                        that.removePreviewFromMap = function() {
+                            that.terriaPreview.dataSources.remove(dataSource);
+                        };
                     }
                 });
             });

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -47,6 +47,7 @@ const DataPreviewMap = React.createClass({
         this.isZoomedToExtent = false;
         this.lastPreviewedCatalogItem = undefined;
         this.removePreviewFromMap = undefined;
+        this.previewBadgeElement = undefined;
     },
 
     componentDidMount() {
@@ -61,6 +62,8 @@ const DataPreviewMap = React.createClass({
         if (this.lastPreviewedCatalogItem === this.props.previewedCatalogItem) {
             return;
         }
+
+        this.previewBadgeElement.textContent = 'PREVIEW LOADING...';
 
         this.isZoomedToExtent = false;
         this.terriaPreview.currentViewer.zoomTo(this.terriaPreview.homeView);
@@ -98,25 +101,10 @@ const DataPreviewMap = React.createClass({
 
                     if (defined(nowViewingItem.showOnSeparateMap)) {
                         that.removePreviewFromMap = nowViewingItem.showOnSeparateMap(that.terriaPreview.currentViewer);
+                        that.previewBadgeElement.textContent = 'PREVIEW';
+                    } else {
+                        that.previewBadgeElement.textContent = 'NO PREVIEW AVAILABLE';
                     }
-        //             if (defined(nowViewingItem._createImageryProvider)) {
-        //                 const imageryProvider = nowViewingItem._createImageryProvider();
-        //                 const layer = ImageryLayerCatalogItem.enableLayer(nowViewingItem, imageryProvider, nowViewingItem.opacity, undefined, that.terriaPreview);
-        //                 ImageryLayerCatalogItem.showLayer(nowViewingItem, layer, that.terriaPreview);
-        //                 that.updateBoundingRectangle(nowViewingItem);
-
-        //                 that.removePreviewFromMap = function() {
-        //                     ImageryLayerCatalogItem.hideLayer(nowViewingItem, layer, that.terriaPreview);
-        //                     ImageryLayerCatalogItem.disableLayer(nowViewingItem, layer, that.terriaPreview);
-        //                 };
-        //             } else if (defined(nowViewingItem.dataSource)) {
-        //                 const dataSource = nowViewingItem.dataSource;
-        //                 that.terriaPreview.dataSources.add(dataSource);
-
-        //                 that.removePreviewFromMap = function() {
-        //                     that.terriaPreview.dataSources.remove(dataSource);
-        //                 };
-        //             }
                 });
             });
         }
@@ -232,11 +220,15 @@ const DataPreviewMap = React.createClass({
         }
     },
 
+    refPreviewBadge(element) {
+        this.previewBadgeElement = element;
+    },
+
     render() {
         return (<div className='data-preview-map' onClick={this.clickMap}>
                     <div className='terria-preview' ref={this.mapIsReady}>
                     </div>
-                    <label className='label--preview-badge'></label>
+                    <label className='label--preview-badge' ref={this.refPreviewBadge}>PREVIEW LOADING...</label>
                 </div>
                 );
     }

--- a/lib/Sass/partial/_labels.scss
+++ b/lib/Sass/partial/_labels.scss
@@ -49,11 +49,12 @@ label {
   position: absolute;
   top: 0;
   left: $padding;
-  width: 78px;
-  height: 32px;
-  background-image: url('./TerriaJS/images/preview.svg');
+  height: 22px;
+  //background-image: url('./TerriaJS/images/preview.svg');
   background-size: contain;
-  background-color: transparent;
+  background-color: white;
+  text-color: #353B43;
+  padding: 5px;
 }
 
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "resolve": "^1.1.7",
     "simple-statistics": "^1.0.1",
     "superagent": "~1.7.0",
-    "terriajs-cesium": "1.19.2",
+    "terriajs-cesium": "1.19.3",
     "togeojson": "^0.13.0",
     "urijs": "^1.17.1",
     "urthecast": "^1.0.0",


### PR DESCRIPTION
This PR eliminates the copy-for-Terria thing we had going on before and instead teaches catalog items how to add themselves to a separate map and then uses that for the preview.  The main benefit of this approach is that catalog items no longer need to be loaded a bunch of times.  A single load is done no matter how many main/preview maps are in use.

Fixes #1436 

I'm going to insta-merge this into newui, but I'm opening it as a PR in case anyone is curious.
