### PR TITLE
Fixed setting terrain mode to smooth at startup

### DIFF
--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -117,16 +117,20 @@ If you\'re on a desktop or laptop, consider increasing the size of your window.'
 
     this._terrainProvider = undefined;
     if (this._useWebGL) {
-        if (typeof options.terrain === 'string' || options.terrain instanceof String) {
-            this._terrainProvider = new CesiumTerrainProvider({
-                url : options.terrain
-            });
-        } else if (defined(options.terrain)) {
-            this._terrainProvider = options.terrain;
-        } else {
-            this._terrainProvider = new CesiumTerrainProvider({
-                url : '//assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-            });
+        if (terria.viewerMode === ViewerMode.CesiumTerrain) {
+            if (typeof options.terrain === 'string' || options.terrain instanceof String) {
+                this._terrainProvider = new CesiumTerrainProvider({
+                    url: options.terrain
+                });
+            } else if (defined(options.terrain)) {
+                this._terrainProvider = options.terrain;
+            } else {
+                this._terrainProvider = new CesiumTerrainProvider({
+                    url: '//assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
+                });
+            }
+        } else if (terria.viewerMode === ViewerMode.CesiumEllipsoid) {
+            this._terrainProvider = new EllipsoidTerrainProvider();
         }
     }
 


### PR DESCRIPTION
Previously if `terria.viewerMode` was set to `CesiumEllipsoid` on terria init, it would still have terrain because it only switched to `EllipsoidTerrainProvider` on `viewerMode` change and not on startup.
