### PR TITLE
URI correction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ A pull request MUST:
 - pass lint
 - follow code style (4-space indents, maximum semicolons, single-quoted strings etc)
 - update CHANGES.md (add a new version at the top if needed)
-- be submitted by someone who has signed the [Contributor Licence Agreement](cla-assistant.io/TerriaJS/terria).
+- be submitted by someone who has signed the [Contributor Licence Agreement](https://cla-assistant.io/TerriaJS/terriajs).
 - be a named branch (not master) which merges cleanly with master
 
 It SHOULD:


### PR DESCRIPTION
Corrected URI for the external CLA agreement from ( cla-assistant.io/TerriaJS/terria ) to the FQDN of ( https://cla-assistant.io/TerriaJS/terriajs ) to prevent the auto-resolving of the address to https://github.com/TerriaJS/terriajs/blob/master/cla-assistant.io/TerriaJS/terria which doesn't exist (and also had a typo in the repo reference anyway).
