### PR TITLE
Search improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+### 3.0.1
+
+* Only trigger a search when the user presses enter or stops typing for 3 seconds.  This will greatly reduce the number of times that searches are performed, which is important with a geocoder like Bing Maps that counts each geocode as a transaction.
+* Reduced the tendency for search to lock up the web browser while it is in progress.
+
 ### 3.0.0
 
 * TerriaJS-based application are now best built using Webpack instead of Browserify.

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -19,8 +19,6 @@ var CatalogMember = require('./CatalogMember');
 var inherit = require('../Core/inherit');
 var raiseErrorOnRejectedPromise = require('./raiseErrorOnRejectedPromise');
 
-var naturalSort = require('javascript-natural-sort');
-
 /**
  * A group of data items and other groups in the {@link Catalog}.  A group can contain
  * {@link CatalogMember|CatalogMembers} or other
@@ -68,7 +66,22 @@ var CatalogGroup = function(terria) {
         } else if (!itemA.isPromoted && itemB.isPromoted) {
             return 1;
         } else {
-            return naturalSort(itemA.name, itemB.name);
+            var aNameSortKey = itemA.nameSortKey;
+            var bNameSortKey = itemB.nameSortKey;
+
+            for (var i = 0; i < aNameSortKey.length && i < bNameSortKey.length; ++i) {
+                if (aNameSortKey[i] < bNameSortKey[i]) {
+                    return -1;
+                } else if (aNameSortKey[i] > bNameSortKey[i]) {
+                    return 1;
+                }
+            }
+
+            if (aNameSortKey.length === bNameSortKey.length) {
+                return 0;
+            } else {
+                return aNameSortKey.length > bNameSortKey.length ? 1 : -1;
+            }
         }
     };
 
@@ -452,7 +465,6 @@ CatalogGroup.prototype.findFirstItemByName = function(name) {
  * @param {Boolean} [sortRecursively=false] true to sort the items in sub-groups as well; false to sort only the items in this group.
  */
 CatalogGroup.prototype.sortItems = function(sortRecursively) {
-    naturalSort.insensitive = true;
     // Allow a group to be non-sorted, while still containing sorted groups.
     if (this.preserveOrder) {
         // Bubble promoted items to the top without changing their relative order.

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -176,6 +176,20 @@ var CatalogMember = function(terria) {
 
     knockout.track(this, ['name', 'info', 'infoSectionOrder', 'description', 'isUserSupplied', 'isPromoted',
         'initialMessage', 'isHidden', 'cacheDuration', 'customProperties', 'isLoading', 'isWaitingForDisclaimer']);
+
+    knockout.defineProperty(this, 'nameSortKey', {
+        get: function() {
+            var parts = this.name.split(/(\d+)/);
+            return parts.map(function(part) {
+                var parsed = parseInt(part, 10);
+                if (parsed === parsed) {
+                    return parsed;
+                } else {
+                    return part.trim().toLowerCase();
+                }
+            });
+        }
+    });
 };
 
 var descriptionRegex = /description/i;
@@ -355,6 +369,7 @@ defineProperties(CatalogMember.prototype, {
  * @type {Object}
  */
 CatalogMember.defaultUpdaters = {
+    nameSortKey: function() {}
 };
 
 freezeObject(CatalogMember.defaultUpdaters);
@@ -365,6 +380,7 @@ freezeObject(CatalogMember.defaultUpdaters);
  * @type {Object}
  */
 CatalogMember.defaultSerializers = {
+    nameSortKey: function() {}
 };
 
 freezeObject(CatalogMember.defaultSerializers);

--- a/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
+++ b/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
@@ -2,6 +2,7 @@
 
 /*global require*/
 var inherit = require('../Core/inherit');
+var runLater = require('../Core/runLater');
 var SearchProviderViewModel = require('./SearchProviderViewModel');
 var SearchResultViewModel = require('./SearchResultViewModel');
 
@@ -165,20 +166,31 @@ function findMatchingItemsRecursively(viewModel, searchInProgress, searchExpress
         }
 
         if (defined(item.items)) {
-            var loadPromise = item.load();
-            if (defined(loadPromise) && item.isLoading) {
-                var searchPromise = loadPromise.then(
-                    findItemsInLoadedGroup.bind(undefined, viewModel, searchInProgress, searchExpression, item, path.slice(), searchFilters)
-                    );
-                searchPromise = searchPromise.otherwise(ignoreLoadErrors);
-                promises.push(searchPromise);
-            } else {
-                findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, item, path, promises, searchFilters);
-            }
+            promises.push(loadAndSearchGroup(viewModel, item, searchInProgress, searchExpression, path, promises[0], searchFilters));
         }
     }
 
     path.pop();
+}
+
+function loadAndSearchGroup(viewModel, group, searchInProgress, searchExpression, path, beforePromise, searchFilters) {
+    beforePromise = beforePromise || when();
+
+    path = path.slice();
+
+    // Let a previous load finish first.
+    return beforePromise.then(function() {
+        return runLater(function() {
+            var loadPromise = group.load();
+            if (defined(loadPromise) && group.isLoading) {
+                return loadPromise.then(function() {
+                    return findItemsInLoadedGroup(viewModel, searchInProgress, searchExpression, group, path, searchFilters);
+                });
+            } else {
+                return findItemsInLoadedGroup(viewModel, searchInProgress, searchExpression, group, path, searchFilters);
+            }
+        });
+    }).otherwise(ignoreLoadErrors);
 }
 
 function findItemsInLoadedGroup(viewModel, searchInProgress, searchExpression, item, path, searchFilters) {

--- a/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
+++ b/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
@@ -88,11 +88,10 @@ CatalogItemNameSearchProviderViewModel.prototype.search = function(searchText) {
 
     var path = [];
     var topLevelGroup =  this.terria.catalog.group;
-    var promises = [];
-    findMatchingItemsRecursively(this, searchInProgress, new RegExp(searchText, 'i'), topLevelGroup, path, promises, searchFilters);
+    var promise = findMatchingItemsRecursively(this, searchInProgress, new RegExp(searchText, 'i'), topLevelGroup, path, undefined, searchFilters);
 
     var that = this;
-    return when.all(promises, function() {
+    return when(promise).then(function() {
         if (searchInProgress.cancel) {
             return;
         }
@@ -146,7 +145,7 @@ function itemMatchesFilters(item, searchFilters) {
  }
 
 
-function findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, group, path, promises, searchFilters) {
+function findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, group, path, promise, searchFilters) {
     path.push(group);
     if (!defined (searchFilters)) {
         searchFilters = {};
@@ -166,37 +165,37 @@ function findMatchingItemsRecursively(viewModel, searchInProgress, searchExpress
         }
 
         if (defined(item.items)) {
-            promises.push(loadAndSearchGroup(viewModel, item, searchInProgress, searchExpression, path, promises[0], searchFilters));
+            promise = loadAndSearchGroup(viewModel, item, searchInProgress, searchExpression, path, promise, searchFilters);
         }
     }
 
     path.pop();
+
+    return promise;
 }
 
-function loadAndSearchGroup(viewModel, group, searchInProgress, searchExpression, path, beforePromise, searchFilters) {
-    beforePromise = beforePromise || when();
-
+function loadAndSearchGroup(viewModel, group, searchInProgress, searchExpression, path, promise, searchFilters) {
     path = path.slice();
 
-    // Let a previous load finish first.
-    return beforePromise.then(function() {
+    // Let a previous load (represented by 'promise') finish first.
+    return when(promise).then(function() {
+        if (searchInProgress.cancel) {
+            return;
+        }
         return runLater(function() {
+            if (searchInProgress.cancel) {
+                return;
+            }
             var loadPromise = group.load();
             if (defined(loadPromise) && group.isLoading) {
                 return loadPromise.then(function() {
-                    return findItemsInLoadedGroup(viewModel, searchInProgress, searchExpression, group, path, searchFilters);
-                });
+                    return findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, group, path, undefined, searchFilters);
+                }).otherwise(ignoreLoadErrors);
             } else {
-                return findItemsInLoadedGroup(viewModel, searchInProgress, searchExpression, group, path, searchFilters);
+                return findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, group, path, undefined, searchFilters);
             }
         });
-    }).otherwise(ignoreLoadErrors);
-}
-
-function findItemsInLoadedGroup(viewModel, searchInProgress, searchExpression, item, path, searchFilters) {
-    var childPromises = [];
-    findMatchingItemsRecursively(viewModel, searchInProgress, searchExpression, item, path, childPromises, searchFilters);
-    return when.all(childPromises);
+    });
 }
 
 function ignoreLoadErrors() {

--- a/lib/ViewModels/SearchTabViewModel.js
+++ b/lib/ViewModels/SearchTabViewModel.js
@@ -26,8 +26,9 @@ var SearchTabViewModel = function(options) {
     this.svgPathHeight = 32;
     this.searchText = '';
     this.searchProviders = defaultValue(options.searchProviders, []).slice();
+    this.isSearchActive = false;
 
-    knockout.track(this, ['name', 'searchText', 'searchProviders']);
+    knockout.track(this, ['name', 'searchText', 'searchProviders', 'isSearchActive']);
 
     // Knockout's hasFocus binding doesn't work with a knockout-es5 property (as of v3.2.0).
     // So, just use a regular observable.
@@ -41,10 +42,10 @@ var SearchTabViewModel = function(options) {
 
     var searchTextObservable = knockout.getObservable(this, 'searchText');
 
-    searchTextObservable.extend({ rateLimit: 250 });
+    this._debounceSearchTimeoutID = undefined;
 
     searchTextObservable.subscribe(function() {
-        this.search();
+        this.debounceSearch();
     }, this);
 
     // Focus the search box when the tab is activated.
@@ -64,9 +65,35 @@ SearchTabViewModel.prototype.show = function(container) {
     loadView(require('../Views/SearchTab.html'), container, this);
 };
 
+SearchTabViewModel.prototype.debounceSearch = function() {
+    this.clearSearchTimeout();
+
+    var that = this;
+    this._debounceSearchTimeoutID = setTimeout(function() {
+        that.search();
+    }, 3000);
+};
+
 SearchTabViewModel.prototype.search = function() {
+    this.clearSearchTimeout();
+    this.isSearchActive = true;
     for (var i = 0; i < this.searchProviders.length; ++i) {
         this.searchProviders[i].search(this.searchText);
+    }
+};
+
+SearchTabViewModel.prototype.keyPressInSearch = function(viewModel, e) {
+    if (e.keyCode === 13) {
+        this.search();
+    }
+    return true;
+};
+
+SearchTabViewModel.prototype.clearSearchTimeout = function() {
+    this.isSearchActive = false;
+    if (defined(this._debounceSearchTimeoutID)) {
+        clearTimeout(this._debounceSearchTimeoutID);
+        this._debounceSearchTimeoutID = undefined;
     }
 };
 
@@ -90,6 +117,7 @@ SearchTabViewModel.prototype.showInfo = function(item) {
 };
 
 SearchTabViewModel.prototype.clearSearchText = function() {
+    this.clearSearchTimeout();
     this.searchText = '';
     this.searchBoxHasFocus(true);
 };

--- a/lib/ViewModels/SearchTabViewModel.js
+++ b/lib/ViewModels/SearchTabViewModel.js
@@ -76,7 +76,7 @@ SearchTabViewModel.prototype.debounceSearch = function() {
 
 SearchTabViewModel.prototype.search = function() {
     this.clearSearchTimeout();
-    this.isSearchActive = true;
+    this.isSearchActive = this.searchText && this.searchText.length > 0;
     for (var i = 0; i < this.searchProviders.length; ++i) {
         this.searchProviders[i].search(this.searchText);
     }
@@ -120,6 +120,7 @@ SearchTabViewModel.prototype.clearSearchText = function() {
     this.clearSearchTimeout();
     this.searchText = '';
     this.searchBoxHasFocus(true);
+    this.search();
 };
 
 module.exports = SearchTabViewModel;

--- a/lib/Views/SearchTab.html
+++ b/lib/Views/SearchTab.html
@@ -48,10 +48,10 @@
 
 <div class="search-tab">
     <form class="search-tab-form" data-bind="submit: activateFirstResult">
-        <input class="search-tab-input" type="text" placeholder="Search address, landmark, or data set" data-bind="value: searchText, valueUpdate: 'input', hasFocus: searchBoxHasFocus, attr: {  tabindex: isActive ? 0 : -1 }" />
+        <input class="search-tab-input" type="text" placeholder="Search address, landmark, or data set" data-bind="value: searchText, valueUpdate: 'input', hasFocus: searchBoxHasFocus, attr: {  tabindex: isActive ? 0 : -1 }, event: { keypress: keyPressInSearch }" />
         <div class="search-tab-input-clear" data-bind="visible: searchText.length > 0, click: clearSearchText">&times;</div>
     </form>
-    <div class="search-tab-results-area" tabindex="-1" data-bind="visible: searchText, foreach: searchProviders">
+    <div class="search-tab-results-area" tabindex="-1" data-bind="visible: isSearchActive, foreach: searchProviders">
         <div class="search-tab-provider">
             <div class="search-tab-provider-header" data-bind="click: toggleOpen">
                 <a href="#" class="search-tab-provider-label" data-bind="text: name, attr: {tabindex: $root.isActive ? 0 : -1 }"></a>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "hammerjs": "^2.0.6",
     "html2canvas": "0.5.0-alpha2",
     "imports-loader": "^0.6.5",
+    "javascript-natural-sort": "^0.7.1",
     "json-loader": "^0.5.4",
     "leaflet": "0.7.7",
     "less": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "hammerjs": "^2.0.6",
     "html2canvas": "0.5.0-alpha2",
     "imports-loader": "^0.6.5",
-    "javascript-natural-sort": "^0.7.1",
     "json-loader": "^0.5.4",
     "leaflet": "0.7.7",
     "less": "^2.6.1",

--- a/test/Models/CatalogGroupSpec.js
+++ b/test/Models/CatalogGroupSpec.js
@@ -42,6 +42,146 @@ describe('CatalogGroup', function() {
         });
     });
 
+    it('sorts correctly when there is a number at the beginning', function(done) {
+        group.updateFromJson({
+            type: 'group',
+            items: [
+                {
+                    name: '10 Thing',
+                    type: 'group',
+                    url: 'http://not.valid'
+                },
+                {
+                    name: '2 Thing',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                },
+                {
+                    name: '1 Thing',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                }
+            ]
+        }).then(function() {
+            expect(group.items.length).toBe(3);
+            expect(group.items[0].name).toBe('1 Thing');
+            expect(group.items[1].name).toBe('2 Thing');
+            expect(group.items[2].name).toBe('10 Thing');
+        }).then(done).otherwise(done.fail);
+    });
+
+    it('sorts correctly when there is a number at the end', function(done) {
+        group.updateFromJson({
+            type: 'group',
+            items: [
+                {
+                    name: 'Thing 10',
+                    type: 'group',
+                    url: 'http://not.valid'
+                },
+                {
+                    name: 'Thing 2',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                },
+                {
+                    name: 'Thing 1',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                }
+            ]
+        }).then(function() {
+            expect(group.items.length).toBe(3);
+            expect(group.items[0].name).toBe('Thing 1');
+            expect(group.items[1].name).toBe('Thing 2');
+            expect(group.items[2].name).toBe('Thing 10');
+        }).then(done).otherwise(done.fail);
+    });
+
+    it('sorts items correctly when there is a number in the middle', function(done) {
+        group.updateFromJson({
+            type: 'group',
+            items: [
+                {
+                    name: 'Thing 10 Yay',
+                    type: 'group',
+                    url: 'http://not.valid'
+                },
+                {
+                    name: 'Thing 2 Yay',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                },
+                {
+                    name: 'Thing 1 Yay',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                }
+            ]
+        }).then(function() {
+            expect(group.items.length).toBe(3);
+            expect(group.items[0].name).toBe('Thing 1 Yay');
+            expect(group.items[1].name).toBe('Thing 2 Yay');
+            expect(group.items[2].name).toBe('Thing 10 Yay');
+        }).then(done).otherwise(done.fail);
+    });
+
+    it('sorts numbered items after unnumbered items', function(done) {
+        group.updateFromJson({
+            type: 'group',
+            items: [
+                {
+                    name: 'Thing 1',
+                    type: 'group',
+                    url: 'http://not.valid'
+                },
+                {
+                    name: 'Thing',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                }
+            ]
+        }).then(function() {
+            expect(group.items.length).toBe(2);
+            expect(group.items[0].name).toBe('Thing');
+            expect(group.items[1].name).toBe('Thing 1');
+        }).then(done).otherwise(done.fail);
+    });
+
+    it('sorts numbers before letters', function(done) {
+        group.updateFromJson({
+            type: 'group',
+            items: [
+                {
+                    name: 'A',
+                    type: 'group',
+                    url: 'http://not.valid'
+                },
+                {
+                    name: '10',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                },
+                {
+                    name: '2',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                },
+                {
+                    name: '1',
+                    type: 'group',
+                    url: 'http://not.valid.either'
+                }
+            ]
+        }).then(function() {
+            expect(group.items.length).toBe(4);
+            expect(group.items[0].name).toBe('1');
+            expect(group.items[1].name).toBe('2');
+            expect(group.items[2].name).toBe('10');
+            expect(group.items[3].name).toBe('A');
+        }).then(done).otherwise(done.fail);
+    });
+
     it('does not sort on load if preserveOrder is true', function(done) {
         group.updateFromJson({
             type: 'group',

--- a/test/Models/ClockSpec.js
+++ b/test/Models/ClockSpec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Clock = require('../../lib/Models/Clock');
+var ClockStep = require('terriajs-cesium/Source/Core/ClockStep');
 var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
 var Terria = require('../../lib/Models/Terria');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
@@ -53,6 +54,7 @@ describe('Clock', function() {
         });
 
         it('should advance across a gap on tick if the tick would put currentTime into a gap', function() {
+            clock.clockStep = ClockStep.TICK_DEPENDENT;
             clock.currentTime = JulianDate.fromIso8601('2016-01-07');
 
             expect(clock.currentTime).not.toEqual(JulianDate.fromIso8601('2016-01-12'));

--- a/test/Models/LegendHelperSpec.js
+++ b/test/Models/LegendHelperSpec.js
@@ -61,14 +61,23 @@ describe('LegendHelper', function() {
         expect(legendHelper.legendUrl()).toBeDefined();  // Side-effects. Hmmm.
         expect(legendHelper.getColorArrayFromValue(9)).toEqual([0, 0, 255, 255]);
         expect(legendHelper.getColorArrayFromValue(5)[2]).toEqualEpsilon(127, 2);
-        expect(legendHelper.getColorArrayFromValue(1)).toEqual([0, 0, 0, 255]);
+
+        expect(compareColors(legendHelper.getColorArrayFromValue(1), [0, 0, 0, 255])).toBe(true);
+
         var legend = legendHelper._legend;
         var numItems = legend.items.length;
         expect(+legend.items[0].titleBelow).toEqual(1);
         expect(+legend.items[numItems - 1].titleAbove).toEqual(9);
-        expect(getColorArrayFromCssColorString(legend.gradientColorMap[0].color)).toEqual(legendHelper.getColorArrayFromValue(1));
-        expect(getColorArrayFromCssColorString(legend.gradientColorMap[1].color)).toEqual(legendHelper.getColorArrayFromValue(9));
+        expect(compareColors(getColorArrayFromCssColorString(legend.gradientColorMap[0].color), legendHelper.getColorArrayFromValue(1))).toBe(true);
+        expect(compareColors(getColorArrayFromCssColorString(legend.gradientColorMap[1].color), legendHelper.getColorArrayFromValue(9))).toBe(true);
     });
+
+    function compareColors(a, b) {
+        return Math.abs(a[0] - b[0]) <= 1 &&
+               Math.abs(a[1] - b[1]) <= 1 &&
+               Math.abs(a[2] - b[2]) <= 1 &&
+               Math.abs(a[3] - b[3]) <= 1;
+    }
 
 });
 

--- a/test/ViewModels/CatalogItemNameSearchProviderViewModelSpec.js
+++ b/test/ViewModels/CatalogItemNameSearchProviderViewModelSpec.js
@@ -171,7 +171,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
         }
 
         // Add an 11th item that will flip out if asked to load.
-        var FlipOutGroup = function() {
+        var FlipOutGroup = function(terria) {
             CatalogGroup.call(this, terria);
 
             this.name = 'Flip Out Group';
@@ -180,6 +180,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
             };
         };
         inherit(CatalogGroup, FlipOutGroup);
+        catalogGroup.add(new FlipOutGroup(terria));
 
         searchProvider.maxResults = maxResults;
         searchProvider.search('thing').then(function() {

--- a/test/ViewModels/CatalogItemNameSearchProviderViewModelSpec.js
+++ b/test/ViewModels/CatalogItemNameSearchProviderViewModelSpec.js
@@ -34,8 +34,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
         searchProvider.search('thing').then(function() {
             expect(searchProvider.searchResults.length).toBe(1);
             expect(searchProvider.searchResults[0].name).toBe('Thing to find');
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
 
@@ -49,8 +48,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
         searchProvider.search('to').then(function() {
             expect(searchProvider.searchResults.length).toBe(1);
             expect(searchProvider.searchResults[0].name).toBe('Group to find');
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('does not find catalog items if they do not match', function(done) {
@@ -62,8 +60,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
 
         searchProvider.search('foo').then(function() {
             expect(searchProvider.searchResults.length).toBe(0);
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('finds items in asynchronously-loaded groups', function(done) {
@@ -86,8 +83,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
         searchProvider.search('thing').then(function() {
             expect(searchProvider.searchResults.length).toBe(1);
             expect(searchProvider.searchResults[0].name).toBe('Thing to find');
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('finds results of a certain type in a case-insensitive manner', function(done) {
@@ -104,8 +100,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
         searchProvider.search('to is:wMs').then(function() {
             expect(searchProvider.searchResults.length).toBe(1);
             expect(searchProvider.searchResults[0].name).toBe('WMS item to find');
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('finds results not of a certain type in a case-insensitive manner', function(done) {
@@ -122,8 +117,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
         searchProvider.search('to -is:wMs').then(function() {
             expect(searchProvider.searchResults.length).toBe(1);
             expect(searchProvider.searchResults[0].name).toBe('GeoJson item to find');
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('finds results having a certain url', function(done) {
@@ -142,8 +136,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
         searchProvider.search('to url:server1.gov').then(function() {
             expect(searchProvider.searchResults.length).toBe(1);
             expect(searchProvider.searchResults[0].name).toBe('Server 1 item to find');
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('finds results that do not have a certain url', function(done) {
@@ -162,8 +155,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
         searchProvider.search('to -url:server1.gov').then(function() {
             expect(searchProvider.searchResults.length).toBe(1);
             expect(searchProvider.searchResults[0].name).toBe('Server 2 item to find');
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('stops searching after the specified number of items', function(done) {
@@ -192,8 +184,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
         searchProvider.maxResults = maxResults;
         searchProvider.search('thing').then(function() {
             expect(searchProvider.searchResults.length).toBe(maxResults);
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('combines duplicate search entries of the same item in different groups', function(done) {
@@ -212,8 +203,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
             expect(searchProvider.searchResults.length).toBe(1);
             expect(searchProvider.searchResults[0].name).toBe('Thing to find');
             expect(searchProvider.searchResults[0].tooltip).toMatch(/^In multiple locations including: /);
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
     it('does not combine different items with the same item name', function(done) {
@@ -233,8 +223,7 @@ describe('CatalogItemNameSearchProviderViewModel', function() {
             expect(searchProvider.searchResults.length).toBe(2);
             expect(searchProvider.searchResults[0].name).toBe('Thing to find');
             expect(searchProvider.searchResults[1].name).toBe('Thing to find');
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
 });


### PR DESCRIPTION
Two improvements to search:
- Instead of rapid-firing searches at the geocoder every 250ms or so, we now wait until either the user presses enter or three seconds pass.  This should greatly reduce or Bing Maps transaction usage.
- Made search less likely to lock up the browser by:
  - Only loading one catalog group at a time.
  - Using a much faster method to sort catalog items after load.  Previously we were using [javascript-natural-sort](https://www.npmjs.com/package/javascript-natural-sort) but it's extraordinarily slow.  Now, catalog members have a `nameSortKey` that is computed once (and recalculated if the name is changed) formed by splitting the name into string parts and number parts and comparing each separately.

Fixes #1325 
Fixes #1155 
