### PR TITLE
Remove a lot of private functions from jsdoc docs

### DIFF
--- a/lib/Map/ColorMap.js
+++ b/lib/Map/ColorMap.js
@@ -49,6 +49,7 @@ ColorMap.prototype.toJSON = function() {
 /**
  * Given a simple array of css color strings, eg. ["red", "orange", "black"],
  * return an evenly spaced array suitable to instantiate a color map.
+ * @private
  * @param  {String[]} simpleArray A simple array of css color strings, eg. ["red", "orange", "black"].
  * @return {Object[]} An array of {color, offset} objects.
  */
@@ -62,6 +63,7 @@ function simpleArrayToArray(simpleArray) {
 
 /**
  * Convert 'red-black' to ['red', 'black'].
+ * @private
  * @param  {String} s A hyphen-separated css color string.
  * @return {String[]} An array of css color strings, split by hyphen.
  */

--- a/lib/Map/Legend.js
+++ b/lib/Map/Legend.js
@@ -186,7 +186,7 @@ function svgElement(legend, element, attributes, className, innerText) {
     return ele;
 }
 
-/**
+/*
  * The name of the active data variable, drawn above the ramp or gradient.
  */
 function drawVariableName(legend) {
@@ -197,7 +197,7 @@ function drawVariableName(legend) {
 }
 
 
-/** The older, non-quantised, smooth gradient. */
+/* The older, non-quantised, smooth gradient. */
 function drawGradient(legend, barGroup) {
     var defs = addSvgElement(legend, 'defs', {}); // apparently it's ok to have the defs anywhere in the doc
     var linearGradient = svgElement(legend, 'linearGradient', {
@@ -223,7 +223,7 @@ function drawGradient(legend, barGroup) {
     }, 'gradient-bar');
 }
 
-/**
+/*
  * Draw each of the colored boxes.
  */
 function drawItemBoxes(legend, barGroup) {
@@ -254,7 +254,7 @@ function drawItemBoxes(legend, barGroup) {
     });
 }
 
-/** 
+/*
  * The Y position of the top of a given item number, relative to the top of the bar.
  */
 function itemY(legend, itemNumber) {
@@ -264,6 +264,7 @@ function itemY(legend, itemNumber) {
 
 /**
  * Calculate the length, in characters, of the longest item title, titleAbove or titleBelow.
+ * @private
  * @param  {Object} legend
  * @return {Number} Length in characters
  */
@@ -273,7 +274,7 @@ function longestTitle(legend) {
     }, 0);
 }
 
-/** 
+/*
  * Label the thresholds between bins for numeric columns, or the color boxes themselves in other cases.
  */
 function drawItemLabels(legend, barGroup) {

--- a/lib/Map/LegendUrl.js
+++ b/lib/Map/LegendUrl.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/** A lookup map for displayable mime types */
+/* A lookup map for displayable mime types */
 var DISPLAYABLE_MIME_TYPES = ['image/jpeg', 'image/gif', 'image/png', 'image/svg+xml', 'image/bmp', 'image/x-bmp']
     .reduce(function(acc, mimeType) {
         acc[mimeType] = true;

--- a/lib/Map/RegionProvider.js
+++ b/lib/Map/RegionProvider.js
@@ -287,8 +287,8 @@ RegionProvider.prototype.findDisambigVariable = function(varNames) {
 /**
  * Fetch a list of region IDs in feature ID (FID) order by querying a WFS server.
  * This is a slower fall-back method if we don't have a pre-computed JSON list available.
- *
  * Returns a promise which resolves to an object whose 'values' property can be used as an argument in processRegionIds.
+ * @private
  */
 function loadRegionsFromWfs(regionProvider, propName) {
 
@@ -328,7 +328,7 @@ function loadRegionsFromWfs(regionProvider, propName) {
 /**
  * Given a list of region IDs in feature ID order, apply server replacements if needed, and build the this.regions array.
  * If no propertyName is supplied, also builds this._idIndex (a lookup by attribute for performance).
- *
+ * @private
  * @param {RegionProvider} regionProvider The RegionProvider instance.
  * @param {Array} values An array of string or numeric region IDs, eg. [10050, 10110, 10150, ...] or ['2060', '2061', '2062', ...]
  * @param {String} [propertyName] The property on that.regions elements, on which to save the id. Defaults to 'id'.
@@ -382,7 +382,7 @@ function processRegionIds(regionProvider, values, propertyName, replacementsProp
 
 /**
  * Apply an array of regular expression replacements to a string. Also caches the applied replacements in regionProvider._appliedReplacements.
- *
+ * @private
  * @param {RegionProvider} regionProvider The RegionProvider instance.
  * @param {String} s The string.
  * @param {String} replacementsProp Name of a property containing [ [ regex, replacement], ... ], where replacement is a string which can contain '$1' etc.
@@ -415,7 +415,7 @@ function applyReplacements(regionProvider, s, replacementsProp) {
 
 /**
  * Given a region code, try to find a region that matches it, using replacements, disambiguation, indexes and other wizardry.
- *
+ * @private
  * @param {RegionProvider} regionProvider The RegionProvider instance.
  * @param {String} code Code to search for. Falsy codes return -1.
  * @returns {Number} Zero-based index in list of regions if successful, or -1.
@@ -454,6 +454,7 @@ function findRegionIndex(regionProvider, code, disambigCode) {
 /**
  * Function interface for matching a URL to a {@link CatalogMember} constructor
  * for that URL.
+ * @private
  * @callback RegionProvider~colorFunction
  * @param {Number} value The value for this region.
  * @returns {Number[]} Returns a colorArray in the form [r, g, b, a].

--- a/lib/Map/TableColumn.js
+++ b/lib/Map/TableColumn.js
@@ -424,7 +424,7 @@ function areAllIntegers(array) {
 /**
  * Simple check to try to guess date format, based on max value of first position.
  * If dates are consistent with US format, it will use US format (mm-dd-yyyy).
- *
+ * @private
  * @param  {TableColumn} tableColumn The column.
  * @return {Object} Object with keys:
  *         subtype: The identified subtype, or undefined.
@@ -550,7 +550,7 @@ function calculateFinishDates(julianDates) {
 var endScratch = new JulianDate();
 /**
  * Calculate and return the availability interval for the index'th entry in timeColumn.
- *
+ * @private
  * @param  {TableColumn} timeColumn The time column that applies to this data.
  * @param  {Integer} index The index into the time column.
  * @return {TimeInterval} The time interval over which this entry is visible.
@@ -574,6 +574,7 @@ function calculateAvailability(timeColumn, index) {
 
 /**
  * Calculates and returns the TimeIntervalCollection over which to display each row.
+ * @private
  */
 function calculateAvailabilities(timeColumn) {
     return timeColumn.values.map(function(value, index) {
@@ -583,6 +584,7 @@ function calculateAvailabilities(timeColumn) {
 
 /**
  * Returns a DataSourceClock out of this column. Only call if this is a time column.
+ * @private
  */
 function createClock(timeColumn) {
     var availabilityCollection = new TimeIntervalCollection();
@@ -701,6 +703,7 @@ function sortMostCommonFirst(values, uniqueValues) {
 
 /**
  * Guesses the best variable type based on its name. Returns undefined if no guess.
+ * @private
  * @param {Object[]} hintSet The hint set to use, eg. [{ hint: /^(.*[_ ])?(year)/i, type: VarSubType.YEAR }].
  * @param {String} name The variable name, eg. 'Time (AEST)'.
  * @param {VarType[]|VarSubType[]} unallowedTypes Types not to consider. Pass [] to consider all types or subtypes.

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -405,7 +405,7 @@ TableStructure.prototype.destroy = function() {
 /**
  * Normally a TableStructure is generated from a csvString, using loadFromCsv, or via loadFromJson.
  * However, if its columns are set directly, we should check the columns are all the same length.
- *
+ * @private
  * @param  {Concept[]} columns Array of columns to check.
  * @return {Boolean} True if the columns are all the same length, false otherwise.
  */
@@ -421,7 +421,7 @@ function areColumnsEqualLength(columns) {
  * Normally a TableStructure is generated from a csvString, using loadFromCsv, or via loadFromJson.
  * However, if its columns are set directly, we need to manually build tableStructure._rows,
  * so that several of its methods work correctly.
- *
+ * @private
  * @param  {TableStructure} tableStructure This TableStructure instance.
  * @param  {Concept[]} columns Array of columns.
  * @return {Array[]} Array of rows values, starting with the column names.
@@ -442,6 +442,7 @@ function buildRowsFromColumns(tableStructure, columns) {
  * Given columns, returns columnsByType, which is an object whose keys are elements of VarType,
  * and whose values are arrays of TableColumn objects of that type.
  * All types are present (eg. structure.columnsByType[VarType.ALT] always exists), possibly [].
+ * @private
  */
 function getColumnsByType(columns) {
     var columnsByType = {};

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -396,7 +396,7 @@ sending an email to <a href="mailto:' + item.terria.supportEmail + '">' + item.t
 
 /**
  * Returns a promise which, when resolved, indicates that item._conceptIds and item._conceptNamesMap are loaded.
- *
+ * @private
  * @param  {AbsIttCatalogItem} item This catalog item.
  * @return {Promise} Promise which, when resolved, indicates that item._conceptIds and item._conceptNamesMap are loaded.
  */
@@ -462,7 +462,7 @@ function rebuildData(item) {
  * As they are loaded, each is processed into a tree of AbsCodes under an AbsConcept.
  * Returns a promise which, when resolved, indicates that item._concepts is complete.
  * The promise is cached, since the promise won't ever change for a given datasetId.
- *
+ * @private
  * @param  {AbsIttCatalogItem} item This catalog item.
  * @return {Promise} Promise.
  */
@@ -520,7 +520,7 @@ function loadConcepts(item) {
 
 /**
  * Given a concept object with name and possibly items properties, return its human-readable version.
- *
+ * @private
  * @param  {Object} conceptNameMap An object whose keys are the concept.names, eg. "ANCP".
  *         Values may be Strings (eg. "Ancestry"), or
  *         a 'code map' (eg. "MEASURE" : {"Persons": "Sex", "85 years and over": "Age", "*": "Measure"}.
@@ -600,6 +600,7 @@ function loadTableStructure(item, csvString) {
 
 /**
  * Loads all the datafiles for this catalog item, given the active concepts.
+ * @private
  * @param  {AbsIttCatalogItem} item The AbsIttCatalogItem instance.
  * @return {Promise} A Promise which resolves to an object of TableStructures for each loaded dataset,
  * with the total populations as the final one; and the active combinations.
@@ -692,6 +693,7 @@ function buildValueColumns(item, tableStructures, activeCombinations) {
 
 /**
  * This builds the columns for the table data source.
+ * @private
  * @param  {AbsIttCatalogItem} item This catalog item instance.
  * @param  {Object} tableStructuresAndCombinations The output from loadDataFiles.
  * @return {TableColumn[]} The columns.

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -268,7 +268,7 @@ var NUMBER_AT_END_OF_KEY_REGEX = /\((\d+)\)$/;
 
 /**
  * Adds all passed items to the passed index, and all the children of those items recursively.
- *
+ * @private
  * @param {CatalogMember[]} items
  * @param {Object} index
  */
@@ -301,7 +301,7 @@ function indexWithDescendants(items, index) {
 /**
  * Generates a unique key from a non-unique one by adding a number after it. If the key already has a number added,
  * it will increment that number.
- *
+ * @private
  * @param index An index to check for uniqueness.
  * @param initialKey The key to start from.
  * @returns {String} A new, unique key.

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -333,7 +333,7 @@ defineProperties(CatalogMember.prototype, {
      * Returns a lookup of _sourceInfoItemNames as a map of names to a true value. Memoizes after being called for the
      * first time.
      *
-     * {@private}
+     * @private
      */
     _infoItemsWithSourceInfoLookup: {
         get: function() {
@@ -430,7 +430,7 @@ CatalogMember.prototype.serializeToJson = function(options) {
 /**
  * Gets the ids of all parents of a catalog member, ordered from the closest descendant to the most distant. Ignores
  * the root.
- *
+ * @private
  * @param catalogMember The catalog member to get parent ids for.
  * @param parentIds A starting list of parent ids to add to (allows the function to work recursively).
  * @returns {String[]}

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -555,7 +555,7 @@ function populateGroupFromResults(ckanGroup, json) {
 
 /**
  * Creates a catalog item from the supplied resource and adds it to the supplied parent if necessary..
- *
+ * @private
  * @param resource The Ckan resource
  * @param rootCkanGroup The root group of all items in this Ckan hierarchy
  * @param itemData The data of the item to build the catalog item from

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -143,7 +143,7 @@ var simpleStyleIdentifiers = ['title', 'description', //
 'marker-size', 'marker-symbol', 'marker-color', 'stroke', //
 'stroke-opacity', 'stroke-width', 'fill', 'fill-opacity'];
 
-// this next function modelled on Cesium.geoJsonDataSource's defaultDescribe
+// This next function modelled on Cesium.geoJsonDataSource's defaultDescribe.
 function describeWithoutUnderscores(properties, nameProperty) {
     var html = '';
     for (var key in properties) {
@@ -379,6 +379,7 @@ function nameIsDerivedFromUrl(name, url) {
 
 /**
  * Get a random color for the data based on the passed string (usually dataset name).
+ * @private
  * @param  {String[]} cssColors Array of css colors, eg. ['#AAAAAA', 'red'].
  * @param  {String} name Name to base the random choice on.
  * @return {String} A css color, eg. 'red'.
@@ -397,7 +398,6 @@ function loadGeoJson(geoJsonItem) {
     - if anything is underspecified there, then Cesium's defaults come in.
 
     See https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0
-
     */
 
     function defaultColor(colorString, name) {
@@ -571,7 +571,7 @@ function polygonIsFilled(polygon) {
     }
 
     if (!defined(polygon.material)) {
-        // The default is solid white
+        // The default is solid white.
         return true;
     }
 
@@ -583,7 +583,7 @@ function polygonIsFilled(polygon) {
     return true;
 }
 
-// Set the Cesium Reproject func if not already set - return false if can't set
+// Set the Cesium Reproject func if not already set - return false if can't set.
 function checkProjection(geoJsonItem, code) {
     if (Proj4Definitions.hasOwnProperty(code)) {
         return true;
@@ -647,7 +647,7 @@ function reprojectToGeographic(geoJsonItem, geoJson) {
     });
 }
 
-// Reproject a point list based on the supplied crs code
+// Reproject a point list based on the supplied crs code.
 function reprojectPointList(pts, code) {
     if (!(pts[0] instanceof Array)) {
         return pntReproject(pts, code);  //point
@@ -659,7 +659,7 @@ function reprojectPointList(pts, code) {
     return pts_out;
 }
 
-// find a member by name in the gml
+// Find a member by name in the gml.
 function filterValue(obj, prop, func) {
     for (var p in obj) {
         if (obj.hasOwnProperty(p) === false) {
@@ -676,7 +676,7 @@ function filterValue(obj, prop, func) {
     }
 }
 
-// Filter a geojson coordinates array structure
+// Filter a geojson coordinates array structure.
 function filterArray(pts, func) {
     if (!(pts[0] instanceof Array) || !((pts[0][0]) instanceof Array) ) {
         pts = func(pts);
@@ -690,16 +690,16 @@ function filterArray(pts, func) {
     return result;
 }
 
-// Function to pass to reproject function
+// Function to pass to reproject function.
 function pntReproject(coordinates, id) {
     var source = new proj4.Proj(Proj4Definitions[id]);
     var dest = new proj4.Proj('EPSG:4326');
     var p = proj4.toPoint(coordinates);
-    proj4(source, dest, p);      //do the transformation.  x and y are modified in place
+    proj4(source, dest, p);      // Do the transformation. x and y are modified in place.
     return [p.x, p.y];
 }
 
-// Get Extent of geojson
+// Get Extent of geojson.
 function getExtent(pts, ext) {
     if (!(pts[0] instanceof Array) ) {
         if (pts[0] < ext.west)  { ext.west = pts[0];  }
@@ -714,7 +714,7 @@ function getExtent(pts, ext) {
     }
     else {
         for (var j = 0; j < pts.length; j++) {
-            getExtent(pts[j], ext);  //at array of arrays of points
+            getExtent(pts[j], ext);  // An array of arrays of points.
         }
     }
 }

--- a/lib/Models/LegendHelper.js
+++ b/lib/Models/LegendHelper.js
@@ -95,6 +95,7 @@ function getTableColumnStyle(tableColumn, tableStyle) {
 /**
  * Generates intermediate variables (such as _colorGradient, _binColors) and saves the legend.
  * This could be exposed in an API if needed.
+ * @private
  */
 function generateLegend(legendHelper) {
     var colorMap;
@@ -146,6 +147,7 @@ LegendHelper.prototype.legendUrl = function() {
 /**
  * Convert a value to a fractional value, eg. in a column that ranges from 0 to 100, 20 -> 0.2.
  * TableStyle can override the minimum and maximum of the range.
+ * @private
  * @param  {Number} value The value.
  * @return {Number} The fractional value.
  */
@@ -218,6 +220,7 @@ LegendHelper.prototype.getColorFromValue = function(value) {
 
 /**
  * A helper function to convert an array to a color.
+ * @private
  * @param  {Array} [colorArray] An array of RGBA values from 0 to 255. Even alpha is 0-255. Defaults to [32, 0, 200, 255].
  * @return {Color} The Color object.
  */
@@ -279,7 +282,7 @@ function getColorArrayFromColorGradient(colorGradient, fractionalPosition) {
  * Builds and returns an array describing the legend colors.
  * Each element is an object with keys "color" and "upperBound", eg.
  * [ { color: [r, g, b, a], upperBound: 20 } , { color: [r, g, b, a]: upperBound: 80 } ]
- *
+ * @private
  * @param  {LegendHelper} legendHelper The legend helper.
  * @param {Integer} [colorBins] The number of color bins to use; defaults to legendHelper.tableColumnStyle.colorBins.
  * @return {Array} Array of objects with keys "color" and "upperBound".

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -246,6 +246,7 @@ function reviseLegendHelper(regionMapping) {
  * Generates a LegendHelper.
  * For lat/lon files, updates entities and extent.
  * For region files, rebuilds and redisplays the imageryLayer.
+ * @private
  */
 function changedActiveItems(regionMapping) {
     reviseLegendHelper(regionMapping);
@@ -371,7 +372,7 @@ function loadRegionIds(regionMapping, rawRegionDetails) {
 /**
  * Returns an array the same length as regionProvider.regions, mapping each region into the relevant index into the table data source.
  * Takes the current time into account if there is a time column and _avalabilities is defined.
- *
+ * @private
  * @param {RegionMapping} regionMapping The table data source.
  * @param {JulianDate} [time] The current time, eg. terria.clock.currentTime. NOT the time column's ._clock's time, which is different (and comes from a DataSourceClock).
  * @param {Array} [failedMatches] An optional empty array. If provided, indices of failed matches are appended to the array.
@@ -419,6 +420,7 @@ function getRegionValuesFromIndices(regionIndices, tableStructure) {
  * @param {Array} [regionIndices] An array the same length as regionProvider.regions, mapping each region into the relevant index into the table data source;
  *                                only used if the regions are constant.
  * @param {WebMapServiceImageryProvider} regionImageryProvider The WebMapServiceImageryProvider instance.
+ * @private
  */
 function addDescriptionAndProperties(regionMapping, regionIndices, regionImageryProvider) {
     var tableStructure = regionMapping._tableStructure;
@@ -441,7 +443,7 @@ function addDescriptionAndProperties(regionMapping, regionIndices, regionImagery
     function getRegionRowDescriptionPropertyCallbackForId(uniqueId) {
         /**
          * Returns a function that returns the value of the regionRowDescription at a given time, updating result if available.
-         *
+         * @private
          * @param {JulianDate} [time] The time for which to retrieve the value.
          * @param {Object} [result] The object to store the value into, if omitted, a new instance is created and returned.
          * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
@@ -457,7 +459,7 @@ function addDescriptionAndProperties(regionMapping, regionIndices, regionImagery
     function getRegionRowPropertiesPropertyCallbackForId(uniqueId) {
         /**
          * Returns a function that returns the value of the regionRowProperties at a given time, updating result if available.
-         *
+         * @private
          * @param {JulianDate} [time] The time for which to retrieve the value.
          * @param {Object} [result] The object to store the value into, if omitted, a new instance is created and returned.
          * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied or is unsupported.
@@ -490,7 +492,7 @@ function addDescriptionAndProperties(regionMapping, regionIndices, regionImagery
 
 /**
  * Creates and enables a new ImageryLayer onto terria, showing appropriately colored regions.
- *
+ * @private
  * @param {RegionMapping} regionMapping    The table data source.
  * @param {Number} [layerIndex] The layer index of the new imagery layer.
  * @param {Array} [regionIndices] An array the same length as regionProvider.regions, mapping each region into the relevant index into the table data source.
@@ -547,7 +549,7 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
  * Following previous practice, when the coloring needs to change, the item is hidden, disabled, then re-enabled and re-shown.
  * So, a new imagery layer is created (during 'enable') each time its coloring changes.
  * It would look less flickery to reuse the existing one, but when I tried, I found the recoloring doesn't get used.
- *
+ * @private
  * @param  {RegionMapping} regionMapping The data source.
  * @param  {Array} [regionIndices] Passed into setNewRegionImageryLayer. Saves recalculating it if available.
  */
@@ -640,7 +642,6 @@ function displayFailedAndAmbiguousMatches(regionMapping, failedMatches, ambiguou
 
 /**
 * Destroy the object and release resources
-*
 */
 RegionMapping.prototype.destroy = function() {
     // Do we need to explicitly unsubscribe from the clock?

--- a/lib/Models/TableDataSource.js
+++ b/lib/Models/TableDataSource.js
@@ -204,6 +204,7 @@ function reviseLegendHelper(dataSource) {
  * Generates a LegendHelper.
  * For lat/lon files, updates entities and extent.
  * For region files, rebuilds and redisplays the regionImageryLayer.
+ * @private
  */
 function changedActiveItems(dataSource) {
     reviseLegendHelper(dataSource);
@@ -216,7 +217,7 @@ function changedActiveItems(dataSource) {
  * Calculate the "show" interval collection property, given the availability.
  * The show property has data=true/false over the period it is visible/invisible.
  * If availability is undefined, it has data=false over all possible time.
- *
+ * @private
  * @param  {TimeIntervalCollection} [availability] The availability interval, used to get the start and stop dates. Only the first interval in the collection is used.
  * @return {TimeIntervalCollectionProperty} Has data=false/true over the period this entry is invisible/visible (even if timeColumn is undefined).
  */
@@ -354,7 +355,6 @@ function chooseFallbackNameField(keys) {
 
 /**
 * Destroy the object and release resources
-*
 */
 TableDataSource.prototype.destroy = function() {
     // Do we need to explicitly unsubscribe from the clock?


### PR DESCRIPTION
Add `@private` (or replace `/**` with `/*`) to a lot of private functions which are currently appearing in the documentation, http://localhost:3001/build/TerriaJS/doc/global.html.
This removes them from the documentation.
