### PR TITLE
Revert Leaflet from 0.7.7 to 0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "imports-loader": "^0.6.5",
     "javascript-natural-sort": "^0.7.1",
     "json-loader": "^0.5.4",
-    "leaflet": "0.7.7",
+    "leaflet": "0.7.3",
     "less": "^2.6.1",
     "less-plugin-npm-import": "^2.1.0",
     "linkify-it": "^1.2.0",


### PR DESCRIPTION
Fixes #1496.

Here's a comparison between Leaflet 0.7.3:
![leaflet 0 7 3](https://cloud.githubusercontent.com/assets/13863530/15167958/636e8728-1770-11e6-89b6-e057eba4859b.gif)
And Leaflet 0.7.7:
![leaflet 0 7 7](https://cloud.githubusercontent.com/assets/13863530/15167959/642e01c0-1770-11e6-8fd4-642dcf4593d9.gif)
