### PR TITLE
Filter out csv rows containing only nulls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 3.1.1
+
+* Improved CSV handling to ignore any blank lines, ie. those containing only commas.
+
 ### 3.1.0
 
 * Only trigger a search when the user presses enter or stops typing for 3 seconds.  This will greatly reduce the number of times that searches are performed, which is important with a geocoder like Bing Maps that counts each geocode as a transaction.

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -219,8 +219,9 @@ TableStructure.fromCsv = function(csvString, result) {
     var json = csv.toArrays(csvString, {
         onParseValue: castToScalar
     });
-    // Remove any blank lines. Blank lines come back as [null].
-    json = json.filter(function(jsonLine) { return (jsonLine.length > 1 || jsonLine[0] !== null); });
+    // Remove any blank lines. Completely blank lines come back as [null]; lines with no entries as [null, null, ..., null].
+    // So remove all lines that consist only of nulls.
+    json = json.filter(function(jsonLine) { return jsonLine.every(function(c) { return (c === null); }); });
     return TableStructure.fromJson(json, result);
 };
 

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -221,7 +221,7 @@ TableStructure.fromCsv = function(csvString, result) {
     });
     // Remove any blank lines. Completely blank lines come back as [null]; lines with no entries as [null, null, ..., null].
     // So remove all lines that consist only of nulls.
-    json = json.filter(function(jsonLine) { return jsonLine.every(function(c) { return (c === null); }); });
+    json = json.filter(function(jsonLine) { return !jsonLine.every(function(c) { return (c === null); }); });
     return TableStructure.fromJson(json, result);
 };
 

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -195,7 +195,8 @@ describe('CsvCatalogItem with lat and lon', function() {
             var tableStructure = csvItem.dataSource.tableStructure;
             var latColumn = tableStructure.columnsByType[VarType.LAT][0];
             var lonColumn = tableStructure.columnsByType[VarType.LON][0];
-            expect(tableStructure.columns[0].values.length).toBe(7);
+            // There are 7 lines after the header, but only 4 are non-blank.
+            expect(tableStructure.columns[0].values.length).toBe(4);
             expect(latColumn.minimumValue).toBeLessThan(-30);
             expect(lonColumn.minimumValue).toBeGreaterThan(150);
         }).otherwise(fail).then(done);


### PR DESCRIPTION
Fixes #1504.

Note if there are lines which are simply missing a lat, a lon, or a region identifier, then they will not appear on the map, but will still appear in the legend. A good example is to drag https://github.com/TerriaJS/terriajs/blob/master/wwwroot/test/csv/blank_line.csv onto the map.
