### PR TITLE
Leaflet fix: allFeaturesAvailablePromise

### DIFF
--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -436,7 +436,13 @@ function pickFeatures(leaflet, latlng, tileCoordinates) {
     // be reasonably sure that all of them will be processed by the time our runLater func is invoked.
     var cleanup = runLater(function() {
         // Set this again just in case a vector pick came through and reset it to the vector's position.
-        leaflet.terria.pickedFeatures.pickPosition = Ellipsoid.WGS84.cartographicToCartesian(pickedLocation);
+        var newPickLocation = Ellipsoid.WGS84.cartographicToCartesian(pickedLocation);
+        var mapInteractionModeStack = leaflet.terria.mapInteractionModeStack;
+        if (defined(mapInteractionModeStack) && mapInteractionModeStack.length > 0) {
+            mapInteractionModeStack[mapInteractionModeStack.length - 1].pickedFeatures.pickPosition = newPickLocation;
+        } else {
+            leaflet.terria.pickedFeatures.pickPosition = newPickLocation;
+        }
 
         // Unset this so that the next click will start building features from scratch.
         leaflet._pickedFeatures = undefined;


### PR DESCRIPTION
AllFeaturesAvailablePromise in Leaflet doesn't resolve if mapInteractionModeStack is in use rather than picked features being stored on leaflet.terria.pickedFeatures. This seems to be because in the cleanup the pickPosition is updated on leaflet.terria.pickedFeatures regardless of whether or not the mapInteractionModeStack is in use.

Tested with the measure tool on rd_newui_measure.
