### PR TITLE
Stopped CSWCatalogGroup never proxying.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 
 * Added support in FeatureInfoTemplate for referencing csv columns by either their name in the csv file, or the name they are given via `TableStyle.columns...name` (if any).
 * Improved CSV handling to ignore any blank lines, ie. those containing only commas.
+* Fixed a bug in `CswCatalogGroup` that prevented it from working in Internet Explorer.
 
 ### 3.1.0
 

--- a/lib/Models/CswCatalogGroup.js
+++ b/lib/Models/CswCatalogGroup.js
@@ -373,7 +373,7 @@ CswCatalogGroup.prototype._load = function() {
 
     function loadDomain() {
         var getDomainUrl = cleanUrl(that.url) + '?service=CSW&version=2.0.2&request=GetDomain&propertyname=' + that.domainSpecification.domainPropertyName;
-        return loadXML(proxyCatalogItemUrl(that.terria, getDomainUrl, '1d')).then(function(xml) {
+        return loadXML(proxyCatalogItemUrl(that, getDomainUrl, '1d')).then(function(xml) {
             if (!xml || !xml.documentElement || (xml.documentElement.localName !== 'GetDomainResponse')) {
                 throw new TerriaError({
                     sender: that,
@@ -451,9 +451,13 @@ function findLevel(keys, index, group, separator, queryField) {
         if (index === keys.length - 1) return;
     }
 
-    var groupIndex = group.findIndex(function(element) {
-        return element.group === keys[index];
-    });
+    var groupIndex = -1;
+    for (var i = 0; i < group.length; i++) {
+        if (group[i] === keys[index]) {
+            groupIndex = 0;
+            break;
+        }
+    }
 
     if (groupIndex === -1) { // not found so add it
         addMetadataGroup(keys, index, group, separator, queryField);


### PR DESCRIPTION
Fixes #1490 

`Terria` was being passed into the proxy function instead of the `CatalogItem`. Also fixed usage of `findIndex` which is ES2015 and doesn't work in IE9.
