### PR TITLE
Add WFS support to CKAN catalog items and groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change Log
 
 ### 3.1.1
 
+* The following previously-deprecated functionality was removed in this version:
+  - `CkanCatalogItem.createCatalogItemFromResource`'s `options` `allowGroups` has been replaced with `allowWmsGroups` and `allowWfsGroups`.
 * Added support for WFS in CKAN items.
 * Fixed bug which prevented the terria-server's `"proxyAllDomains": true` option from working.
 * Added support in FeatureInfoTemplate for referencing csv columns by either their name in the csv file, or the name they are given via `TableStyle.columns...name` (if any).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 
 ### 3.1.1
 
-* The following previously-deprecated functionality was removed in this version:
+* Deprecated in this version:
   - `CkanCatalogItem.createCatalogItemFromResource`'s `options` `allowGroups` has been replaced with `allowWmsGroups` and `allowWfsGroups`.
 * Added support for WFS in CKAN items.
 * Fixed bug which prevented the terria-server's `"proxyAllDomains": true` option from working.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 3.1.1
+
+* Added support for WFS in CKAN items.
+
 ### 3.1.0
 
 * Only trigger a search when the user presses enter or stops typing for 3 seconds.  This will greatly reduce the number of times that searches are performed, which is important with a geocoder like Bing Maps that counts each geocode as a transaction.

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -113,12 +113,12 @@ var CkanCatalogGroup = function(terria) {
     this.useResourceName = false;
 
     /**
-     * True to allow entire WMS servers (that is, WMS resources without a clearly-defined layer) to be
-     * added to the catalog; otherwise, false.
+     * True to allow entire WMS AND WFS servers (that is, WMS/WFS resources without a clearly-defined layer) to be
+     * added to the catalog; otherwise, false. (Yes, this is poorly named.)
      * @type {Boolean}
      * @default false
      */
-    this.allowEntireWmsServers = false;
+    this.allowEntireWmsServers = false;  // and WFS servers too.
 
     /**
      * True to allow WMS resources to be added to the catalog; otherwise, false.
@@ -132,6 +132,19 @@ var CkanCatalogGroup = function(terria) {
      * @type {RegExp}
      */
     this.wmsResourceFormat = /^wms$/i;
+
+    /**
+     * True to allow WFS resources to be added to the catalog; otherwise, false.
+     * @type {Boolean}
+     * @default true
+     */
+    this.includeWfs = true;
+
+    /**
+     * Gets or sets a regular expression that, when it matches a resource's format, indicates that the resource is a WMS resource.
+     * @type {RegExp}
+     */
+    this.wfsResourceFormat = /^wfs$/i;
 
     /**
      * True to allow KML resources to be added to the catalog; otherwise, false.
@@ -204,7 +217,24 @@ var CkanCatalogGroup = function(terria) {
      */
     this.itemProperties = undefined;
 
-    knockout.track(this, ['url', 'dataCustodian', 'filterQuery', 'blacklist', 'wmsParameters', 'groupBy', 'useResourceName', 'allowEntireWmsServers', 'includeWms', 'includeKml', 'includeCsv', 'includeEsriMapServer', 'includeGeoJson', 'includeCzml', 'itemProperties']);
+    knockout.track(this, [
+        'url',
+        'dataCustodian',
+        'filterQuery',
+        'blacklist',
+        'wmsParameters',
+        'groupBy',
+        'useResourceName',
+        'allowEntireWmsServers',
+        'includeWms',
+        'includeWfs',
+        'includeKml',
+        'includeCsv',
+        'includeEsriMapServer',
+        'includeGeoJson',
+        'includeCzml',
+        'itemProperties'
+    ]);
 };
 
 inherit(CatalogGroup, CkanCatalogGroup);
@@ -269,6 +299,7 @@ defineProperties(CkanCatalogGroup.prototype, {
 CkanCatalogGroup.defaultUpdaters = clone(CatalogGroup.defaultUpdaters);
 
 CkanCatalogGroup.defaultUpdaters.wmsResourceFormat = createRegexDeserializer('wmsResourceFormat');
+CkanCatalogGroup.defaultUpdaters.wfsResourceFormat = createRegexDeserializer('wfsResourceFormat');
 CkanCatalogGroup.defaultUpdaters.kmlResourceFormat = createRegexDeserializer('kmlResourceFormat');
 CkanCatalogGroup.defaultUpdaters.csvResourceFormat = createRegexDeserializer('csvResourceFormat');
 CkanCatalogGroup.defaultUpdaters.esriMapServerResourceFormat = createRegexDeserializer('esriMapServerResourceFormat');
@@ -287,6 +318,7 @@ CkanCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 CkanCatalogGroup.defaultSerializers.items = CatalogGroup.enabledShareableItemsSerializer;
 
 CkanCatalogGroup.defaultSerializers.wmsResourceFormat = createRegexSerializer('wmsResourceFormat');
+CkanCatalogGroup.defaultSerializers.wfsResourceFormat = createRegexSerializer('wfsResourceFormat');
 CkanCatalogGroup.defaultSerializers.kmlResourceFormat = createRegexSerializer('kmlResourceFormat');
 CkanCatalogGroup.defaultSerializers.csvResourceFormat = createRegexSerializer('csvResourceFormat');
 CkanCatalogGroup.defaultSerializers.esriMapServerResourceFormat = createRegexSerializer('esriMapServerResourceFormat');
@@ -296,7 +328,21 @@ CkanCatalogGroup.defaultSerializers.czmlResourceFormat = createRegexSerializer('
 freezeObject(CkanCatalogGroup.defaultSerializers);
 
 CkanCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
-    return [this.url, this.filterQuery, this.blacklist, this.filterByWmsGetCapabilities, this.minimumMaxScaleDenominator, this.allowEntireWmsServers, this.includeKml, this.includeWms, this.includeCsv, this.includeEsriMapServer, this.includeGeoJson, this.includeCzml];
+    return [
+        this.url,
+        this.filterQuery,
+        this.blacklist,
+        this.filterByWmsGetCapabilities,
+        this.minimumMaxScaleDenominator,
+        this.allowEntireWmsServers,
+        this.includeWms,
+        this.includeWfs,
+        this.includeKml,
+        this.includeCsv,
+        this.includeEsriMapServer,
+        this.includeGeoJson,
+        this.includeCzml
+    ];
 };
 
 CkanCatalogGroup.prototype._load = function() {
@@ -461,10 +507,11 @@ function createItemFromResource(resource, ckanGroup, itemData, extras, parent) {
         parent: parent,
         ckanBaseUrl: ckanGroup.url,
         wmsResourceFormat: ckanGroup.includeWms ? ckanGroup.wmsResourceFormat : undefined,
-        esriMapServerResourceFormat: ckanGroup.includeEsriMapServer ? ckanGroup.esriMapServerResourceFormat : undefined,
+        wfsResourceFormat: ckanGroup.includeWfs ? ckanGroup.wfsResourceFormat : undefined,
         kmlResourceFormat: ckanGroup.includeKml ? ckanGroup.kmlResourceFormat : undefined,
-        geoJsonResourceFormat: ckanGroup.includeGeoJson ? ckanGroup.geoJsonResourceFormat : undefined,
         csvResourceFormat: ckanGroup.includeCsv ? ckanGroup.csvResourceFormat : undefined,
+        esriMapServerResourceFormat: ckanGroup.includeEsriMapServer ? ckanGroup.esriMapServerResourceFormat : undefined,
+        geoJsonResourceFormat: ckanGroup.includeGeoJson ? ckanGroup.geoJsonResourceFormat : undefined,
         czmlResourceFormat: ckanGroup.includeCzml ? ckanGroup.czmlResourceFormat : undefined,
         allowGroups: ckanGroup.allowEntireWmsServers,
         dataCustodian: ckanGroup.dataCustodian,

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -113,12 +113,20 @@ var CkanCatalogGroup = function(terria) {
     this.useResourceName = false;
 
     /**
-     * True to allow entire WMS AND WFS servers (that is, WMS/WFS resources without a clearly-defined layer) to be
-     * added to the catalog; otherwise, false. (Yes, this is poorly named.)
+     * True to allow entire WMS servers (that is, WMS resources without a clearly-defined layer) to be
+     * added to the catalog; otherwise, false.
      * @type {Boolean}
      * @default false
      */
-    this.allowEntireWmsServers = false;  // and WFS servers too.
+    this.allowEntireWmsServers = false;
+
+    /**
+     * True to allow entire WFS servers (that is, WFS resources without a clearly-defined layer) to be
+     * added to the catalog; otherwise, false.
+     * @type {Boolean}
+     * @default false
+     */
+    this.allowEntireWfsServers = false;
 
     /**
      * True to allow WMS resources to be added to the catalog; otherwise, false.
@@ -226,6 +234,7 @@ var CkanCatalogGroup = function(terria) {
         'groupBy',
         'useResourceName',
         'allowEntireWmsServers',
+        'allowEntireWfsServers',
         'includeWms',
         'includeWfs',
         'includeKml',
@@ -335,6 +344,7 @@ CkanCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
         this.filterByWmsGetCapabilities,
         this.minimumMaxScaleDenominator,
         this.allowEntireWmsServers,
+        this.allowEntireWfsServers,
         this.includeWms,
         this.includeWfs,
         this.includeKml,
@@ -513,7 +523,8 @@ function createItemFromResource(resource, ckanGroup, itemData, extras, parent) {
         esriMapServerResourceFormat: ckanGroup.includeEsriMapServer ? ckanGroup.esriMapServerResourceFormat : undefined,
         geoJsonResourceFormat: ckanGroup.includeGeoJson ? ckanGroup.geoJsonResourceFormat : undefined,
         czmlResourceFormat: ckanGroup.includeCzml ? ckanGroup.czmlResourceFormat : undefined,
-        allowGroups: ckanGroup.allowEntireWmsServers,
+        allowWmsGroups: ckanGroup.allowEntireWmsServers,
+        allowWfsGroups: ckanGroup.allowEntireWfsServers,
         dataCustodian: ckanGroup.dataCustodian,
         itemProperties: ckanGroup.itemProperties,
         useResourceName: ckanGroup.useResourceName

--- a/lib/Models/CkanCatalogItem.js
+++ b/lib/Models/CkanCatalogItem.js
@@ -22,6 +22,8 @@ var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var URI = require('urijs');
 var WebMapServiceCatalogGroup = require('./WebMapServiceCatalogGroup');
 var WebMapServiceCatalogItem = require('./WebMapServiceCatalogItem');
+var WebFeatureServiceCatalogGroup = require('./WebFeatureServiceCatalogGroup');
+var WebFeatureServiceCatalogItem = require('./WebFeatureServiceCatalogItem');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 /**
@@ -74,6 +76,19 @@ function CkanCatalogItem(terria) {
      * @type {RegExp}
      */
     this.wmsResourceFormat = /^wms$/i;
+
+    /**
+     * Gets or sets a value indicating whether this may be a WFS resource.
+     * @type {Boolean}
+     * @default true
+     */
+    this.allowWfs = true;
+
+    /**
+     * Gets or sets a regular expression that, when it matches a resource's format, indicates that the resource is a WFS resource.
+     * @type {RegExp}
+     */
+    this.wfsResourceFormat = /^wfs$/i;
 
     /**
      * Gets or sets a value indicating whether this may be a KML resource.
@@ -225,6 +240,7 @@ defineProperties(CkanCatalogItem.prototype, {
 CkanCatalogItem.defaultUpdaters = clone(CatalogItem.defaultUpdaters);
 
 CkanCatalogItem.defaultUpdaters.wmsResourceFormat = createRegexDeserializer('wmsResourceFormat');
+CkanCatalogItem.defaultUpdaters.wfsResourceFormat = createRegexDeserializer('wfsResourceFormat');
 CkanCatalogItem.defaultUpdaters.kmlResourceFormat = createRegexDeserializer('kmlResourceFormat');
 CkanCatalogItem.defaultUpdaters.csvResourceFormat = createRegexDeserializer('csvResourceFormat');
 CkanCatalogItem.defaultUpdaters.esriMapServerResourceFormat = createRegexDeserializer('esriMapServerResourceFormat');
@@ -241,6 +257,7 @@ freezeObject(CkanCatalogItem.defaultUpdaters);
 CkanCatalogItem.defaultSerializers = clone(CatalogItem.defaultSerializers);
 
 CkanCatalogItem.defaultSerializers.wmsResourceFormat = createRegexSerializer('wmsResourceFormat');
+CkanCatalogItem.defaultSerializers.wfsResourceFormat = createRegexSerializer('wfsResourceFormat');
 CkanCatalogItem.defaultSerializers.kmlResourceFormat = createRegexSerializer('kmlResourceFormat');
 CkanCatalogItem.defaultSerializers.csvResourceFormat = createRegexSerializer('csvResourceFormat');
 CkanCatalogItem.defaultSerializers.esriMapServerResourceFormat = createRegexSerializer('esriMapServerResourceFormat');
@@ -260,6 +277,8 @@ freezeObject(CkanCatalogItem.defaultSerializers);
  * @param {String} [options.parent] The parent of this catalog item.
  * @param {RegExp} [options.wmsResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
  *                                             is a WMS resource.  If undefined, WMS resources will not be returned.
+ * @param {RegExp} [options.wfsResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
+ *                                             is a WFS resource.  If undefined, WFS resources will not be returned.
  * @param {RegExp} [options.esriMapServerResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
  *                                                       is an Esri MapServer resource.  If undefined, Esri MapServer resources will not be returned.
  * @param {RegExp} [options.kmlResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
@@ -270,7 +289,7 @@ freezeObject(CkanCatalogItem.defaultSerializers);
  *                                             is a CSV resource.  If undefined, CSV resources will not be returned.
  * @param {RegExp} [options.czmlResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
  *                                              is a CZML resource.  If undefined, CZML resources will not be returned.
- * @param {Boolean} [options.allowGroups=false] True to allow this function to return groups in addition to items.  For example if the resource
+ * @param {Boolean} [options.allowGroups=false] True to allow this function to return WMS and WFS groups in addition to items.  For example if the resource
  *                                              refers to a WMS server but no layer is available, a {@see WebMapServiceCatalogGroup} for the
  *                                              server will be returned.
  * @param {Boolean} [options.useResourceName=false] True to use the name of the resource for the name of the catalog item; false to use the
@@ -300,6 +319,7 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
 
     var formats = [
         [options.wmsResourceFormat, WebMapServiceCatalogItem],
+        [options.wfsResourceFormat, WebFeatureServiceCatalogItem],
         [options.esriMapServerResourceFormat, ArcGisMapServerCatalogItem],
         [options.kmlResourceFormat, KmlCatalogItem],
         [options.geoJsonResourceFormat, GeoJsonCatalogItem],
@@ -315,6 +335,7 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
     }
 
     var isWms = matchingFormats[0][1] === WebMapServiceCatalogItem;
+    var isWfs = matchingFormats[0][1] === WebFeatureServiceCatalogItem;
 
     var baseUrl = resource.wms_url;
     if (!defined(baseUrl)) {
@@ -332,16 +353,16 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
     var url = baseUrl;
 
     var newItem;
-    if (isWms) {
+    if (isWms || isWfs) {
         var layerName = resource.wms_layer || params.LAYERS || params.layers || params.typeName;
         if (defined(layerName)) {
-            newItem = new WebMapServiceCatalogItem(options.terria);
+            newItem = isWms ? new WebMapServiceCatalogItem(options.terria) : new WebFeatureServiceCatalogItem(options.terria);
             newItem.layers = layerName;
         } else {
             if (!options.allowGroups) {
                 return undefined;
             }
-            newItem = new WebMapServiceCatalogGroup(options.terria);
+            newItem = isWms ? new WebMapServiceCatalogGroup(options.terria) : new WebFeatureServiceCatalogGroup(options.terria);
         }
         uri.search('');
         url = uri.toString();

--- a/lib/Models/CkanCatalogItem.js
+++ b/lib/Models/CkanCatalogItem.js
@@ -10,6 +10,7 @@ var CsvCatalogItem = require('./CsvCatalogItem');
 var CzmlCatalogItem = require('./CzmlCatalogItem');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var deprecationWarning = require('terriajs-cesium/Source/Core/deprecationWarning');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var GeoJsonCatalogItem = require('./GeoJsonCatalogItem');
 var inherit = require('../Core/inherit');
@@ -289,8 +290,11 @@ freezeObject(CkanCatalogItem.defaultSerializers);
  *                                             is a CSV resource.  If undefined, CSV resources will not be returned.
  * @param {RegExp} [options.czmlResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
  *                                              is a CZML resource.  If undefined, CZML resources will not be returned.
- * @param {Boolean} [options.allowGroups=false] True to allow this function to return WMS and WFS groups in addition to items.  For example if the resource
+ * @param {Boolean} [options.allowWmsGroups=false] True to allow this function to return WMS groups in addition to items.  For example if the resource
  *                                              refers to a WMS server but no layer is available, a {@see WebMapServiceCatalogGroup} for the
+ *                                              server will be returned.
+ * @param {Boolean} [options.allowWfsGroups=false] True to allow this function to return WFS groups in addition to items.  For example if the resource
+ *                                              refers to a WFS server but no layer is available, a {@see WebFeatureServiceCatalogGroup} for the
  *                                              server will be returned.
  * @param {Boolean} [options.useResourceName=false] True to use the name of the resource for the name of the catalog item; false to use the
  *                                                  name of the dataset.
@@ -299,6 +303,9 @@ freezeObject(CkanCatalogItem.defaultSerializers);
  * @return {CatalogMember} The created catalog member, or undefined if no catalog member could be created from the resource.
  */
 CkanCatalogItem.createCatalogItemFromResource = function(options) {
+    if (defined(options.allowGroups)) {
+        deprecationWarning('allowGroups', 'allowGroups is deprecated. Please use allowWmsGroups and/or allowWfsGroups instead.');
+    }
     var resource = options.resource;
     var itemData = options.itemData;
     var extras = options.extras;
@@ -359,10 +366,13 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
             newItem = isWms ? new WebMapServiceCatalogItem(options.terria) : new WebFeatureServiceCatalogItem(options.terria);
             newItem.layers = layerName;
         } else {
-            if (!options.allowGroups) {
+            if (isWms && (options.allowWmsGroups || options.allowGroups)) {  // allowGroups is deprecated.
+                newItem = new WebMapServiceCatalogGroup(options.terria);
+            } else if (isWfs && options.allowWfsGroups) {
+                newItem = new WebFeatureServiceCatalogGroup(options.terria);
+            } else {
                 return undefined;
             }
-            newItem = isWms ? new WebMapServiceCatalogGroup(options.terria) : new WebFeatureServiceCatalogGroup(options.terria);
         }
         uri.search('');
         url = uri.toString();

--- a/lib/Models/WebFeatureServiceCatalogGroup.js
+++ b/lib/Models/WebFeatureServiceCatalogGroup.js
@@ -207,6 +207,9 @@ function cleanAndProxyUrl(catalogGroup, url) {
 }
 
 function addFeatureTypes(wfsGroup, featureTypes, items, parent, supportsJsonGetFeature, dataCustodian) {
+    if (!defined(featureTypes)) {
+        return;
+    }
     if (!(featureTypes instanceof Array)) {
         featureTypes = [featureTypes];
     }


### PR DESCRIPTION
Adds WFS support to CKAN. Fixes #1553.

In fact, in most cases, you don't really want to use this. You really want to pretend that WFS servers are WMS servers, because most of them double up as WMS, and WMS is better.

You can do that by using init json like so - note the `filterQuery` and `wmsResourceFormat` lines:

```
{
    "catalog": [
        {
            "blacklist": {...},
            "filterByWmsGetCapabilities": false,
            "filterQuery": [  // Only gets resources with format = WFS, wfs, WMS, wms and csv-geo-au
                "fq=+(res_format%3aWFS%20OR%20res_format%3awfs%20OR%20res_format%3awms%20OR%20res_format%3aWMS%20OR%20res_format%3acsv-geo-au)"
            ],
            "url": "example.com",
            "type": "ckan",
            "name": "Name",
            "includeCsv": true,
            "allowEntireWmsServers": true,  // optionally
            "useResourceName": true,  // optionally
            "wmsResourceFormat": "(wms|wfs)$"
        }
    ]
}
```

Still, if you ever do want to use WFS, you'd need this PR.
