### PR TITLE
Allow proxying of CkanCatalogItem dataset URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 
 * Fixed a bug on IE9 which prevented shortened URLs from loading.
 * Fixed a map started with smooth terrain being unable to switch to 3D terrain.
+* Fixed a bug in `CkanCatalogItem` that prevented it from using the proxy for dataset URLs.
 
 ### 3.2.0
 

--- a/lib/Models/CkanCatalogItem.js
+++ b/lib/Models/CkanCatalogItem.js
@@ -495,7 +495,7 @@ CkanCatalogItem.prototype._load = function() {
 
     return datasetIdPromise.then(function(datasetId) {
         var datasetUri = baseUri.clone().segment('package_show').addQuery({ id: datasetId });
-        var datasetUrl = proxyCatalogItemUrl(this, datasetUri.toString(), '1d');
+        var datasetUrl = proxyCatalogItemUrl(that, datasetUri.toString(), '1d');
 
         return loadJson(datasetUrl).then(function(json) {
             if (!json.success) {


### PR DESCRIPTION
An accidental use of `this` inside a callback function prevented `proxyCatalogItemUrl` from proxying correctly.
