### PR TITLE
Added an undefined check in region mapping for no properties.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Fixed a bug on IE9 which prevented shortened URLs from loading.
 * Fixed a map started with smooth terrain being unable to switch to 3D terrain.
 * Fixed a bug in `CkanCatalogItem` that prevented it from using the proxy for dataset URLs.
+* Fixed feature picking when displaying a point-based vector and a region mapped layer at the same time.
 
 ### 3.2.0
 

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -484,7 +484,10 @@ function addDescriptionAndProperties(regionMapping, regionIndices, regionImagery
             if (isConstant) {
                 imageryLayerFeatureInfo.description = regionRowDescriptions[uniqueId];
                 imageryLayerFeatureInfo.properties = regionRowObjects[uniqueId];
-                imageryLayerFeatureInfo.properties._terria_columnAliases = columnAliases;
+
+                if (imageryLayerFeatureInfo.properties) {
+                    imageryLayerFeatureInfo.properties._terria_columnAliases = columnAliases;
+                }
             } else {
                 imageryLayerFeatureInfo.description = new CallbackProperty(getRegionRowDescriptionPropertyCallbackForId(uniqueId), isConstant);
                 imageryLayerFeatureInfo.properties = new CallbackProperty(getRegionRowPropertiesPropertyCallbackForId(uniqueId), isConstant);


### PR DESCRIPTION
I've got no idea what this really does or how it works or how feature properties can be undefined and yet still display - maybe @RacingTadpole could explain this to me when he's back? But this fixes up feature picking when you've got both a region mapped dataset and a vector point dataset at the same time.
