### PR TITLE
Wfs parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 3.3.0
+
+* Support `parameters` property in WebFeatureServiceCatalogItem to allow accessing URLs which need additional parameters.
+
 ### 3.2.1
 
 * Fixed a bug on IE9 which prevented shortened URLs from loading.

--- a/lib/Models/WebFeatureServiceCatalogItem.js
+++ b/lib/Models/WebFeatureServiceCatalogItem.js
@@ -2,6 +2,7 @@
 
 /*global require*/
 var URI = require('urijs');
+var combine = require('terriajs-cesium/Source/Core/combine');
 
 var clone = require('terriajs-cesium/Source/Core/clone');
 var defined = require('terriajs-cesium/Source/Core/defined');
@@ -10,7 +11,6 @@ var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
 var loadXML = require('terriajs-cesium/Source/Core/loadXML');
-var objectToQuery = require('terriajs-cesium/Source/Core/objectToQuery');
 
 var GeoJsonCatalogItem = require('./GeoJsonCatalogItem');
 var CatalogItem = require('./CatalogItem');
@@ -60,6 +60,12 @@ var WebFeatureServiceCatalogItem = function(terria) {
      */
     this.requestGml = true;
 
+    /**
+     * Gets or sets the additional parameters to pass to the WFS server when requesting geometry.
+     * @type {Object}
+     */
+    this.parameters = {};
+
     knockout.track(this, ['_dataUrl', '_dataUrlType', '_metadataUrl', 'typeNames', 'requestGeoJson', 'requestGml']);
 
     // dataUrl, metadataUrl, and legendUrl are derived from url if not explicitly specified.
@@ -71,7 +77,16 @@ var WebFeatureServiceCatalogItem = function(terria) {
             }
 
             if (this.dataUrlType === 'wfs') {
-                url = cleanUrl(url) + '?service=WFS&version=1.1.0&request=GetFeature&typeName=' + this.typeNames + '&srsName=EPSG%3A4326&maxFeatures=1000';
+                url = new URI(cleanUrl(url))
+                    .setQuery(combine({
+                        'service': 'WFS',
+                        'version': '1.1.0',
+                        'request': 'GetFeature',
+                        'typeName': this.typeNames,
+                        'srsName': 'EPSG:4326',
+                        'maxFeatures': '1000'
+                    }, this.parameters))
+                    .toString();
             }
 
             return url;
@@ -100,7 +115,13 @@ var WebFeatureServiceCatalogItem = function(terria) {
                 return this._metadataUrl;
             }
 
-            return cleanUrl(this.url) + '?service=WFS&version=1.1.0&request=GetCapabilities';
+            return new URI(cleanUrl(this.url))
+                .setQuery(combine({
+                    service: 'WFS',
+                    version: '1.1.0',
+                    request: 'GetCapabilities'
+                    }, this.parameters))
+                .toString();
         },
         set : function(value) {
             this._metadataUrl = value;
@@ -180,7 +201,7 @@ WebFeatureServiceCatalogItem.defaultSerializers.metadataUrl = function(wfsItem, 
 freezeObject(WebFeatureServiceCatalogItem.defaultSerializers);
 
 WebFeatureServiceCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
-    return [this.url, this.typeNames, this.requestGeoJson, this.requestGml];
+    return [this.url, this.typeNames, this.requestGeoJson, this.requestGml, this.parameters];
 };
 
 WebFeatureServiceCatalogItem.prototype._load = function() {
@@ -250,25 +271,29 @@ function loadGml(wfsItem) {
 
 function buildGeoJsonUrl(wfsItem) {
     var url = cleanAndProxyUrl(wfsItem, wfsItem.url);
-    return url + '?' + objectToQuery({
-        service: 'WFS',
-        request: 'GetFeature',
-        typeName: wfsItem.typeNames,
-        version: '1.1.0',
-        outputFormat: 'JSON',
-        srsName: 'EPSG:4326'
-    });
+    return new URI(url)
+        .setQuery(combine({
+            service: 'WFS',
+            request: 'GetFeature',
+            typeName: wfsItem.typeNames,
+            version: '1.1.0',
+            outputFormat: 'JSON',
+            srsName: 'EPSG:4326'
+            }, wfsItem.parameters))
+        .toString();
 }
 
 function buildGmlUrl(wfsItem) {
     var url = cleanAndProxyUrl(wfsItem, wfsItem.url);
-    return url + '?' + objectToQuery({
+    return new URI(url)
+        .setQuery(combine({
         service: 'WFS',
         request: 'GetFeature',
         typeName: wfsItem.typeNames,
         version: '1.1.0',
         srsName: 'EPSG:4326'
-    });
+        }, wfsItem.parameters))
+        .toString();
 }
 
 function cleanAndProxyUrl(catalogItem, url) {


### PR DESCRIPTION
- Support `parameters` property in WebFeatureServiceCatalogItem to allow accessing URLs which need additional parameters.
