### PR TITLE
Stopped trying to update for top layer before we have a timeline to update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Fixed a bug on IE9 which prevented shortened URLs from loading.
 * Fixed a map started with smooth terrain being unable to switch to 3D terrain.
 * Fixed a bug in `CkanCatalogItem` that prevented it from using the proxy for dataset URLs.
+* Fixed a bug where sharing a time-series layer would completely crash Terria on reload.
 
 ### 3.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,13 +5,13 @@ Change Log
 ### 3.3.0
 
 * Support `parameters` property in WebFeatureServiceCatalogItem to allow accessing URLs which need additional parameters.
+* Fixed a bug where sharing a time-series layer would completely crash Terria on reload.
 
 ### 3.2.1
 
 * Fixed a bug on IE9 which prevented shortened URLs from loading.
 * Fixed a map started with smooth terrain being unable to switch to 3D terrain.
 * Fixed a bug in `CkanCatalogItem` that prevented it from using the proxy for dataset URLs.
-* Fixed a bug where sharing a time-series layer would completely crash Terria on reload.
 * Stopped generation of WMS intervals being dependent on JS dates and hence sensitive to DST time gaps.
 * Fixed a bug which led to zero property values being considered time-varying in the Feature Info panel.
 * Fixed a bug which prevented lat/lon injection into templates with time-varying properties.

--- a/lib/ViewModels/AnimationViewModel.js
+++ b/lib/ViewModels/AnimationViewModel.js
@@ -51,8 +51,6 @@ var AnimationViewModel = function(options) {
     this.layerName = undefined;
     this.timeline = undefined;
 
-    updateForNewTopLayer(this);
-
     knockout.track(this, ['showAnimation', 'isPlaying', 'isLooping', 'currentTimeString', 'fasterActive', 'slowerActive', 'gotoStartActive', 'layerName']);
 
     var that = this;
@@ -65,10 +63,6 @@ var AnimationViewModel = function(options) {
             that.currentTimeString = formatDateTime(time, that.locale);
         }
     });
-
-    knockout.getObservable(this.terria.timeSeriesStack, 'topLayer').subscribe(function() {
-        updateForNewTopLayer(this);
-    }, this);
 
     window.addEventListener('resize', function() {
         if (defined(that.timeline)) {
@@ -155,6 +149,17 @@ AnimationViewModel.prototype.setupTimeline = function() {
     // keep a reference to the bound scrubFunction so we can deregister it by reference later.
     timeline.scrubFunction = scrub.bind(undefined, this);
     timeline.addEventListener('settime', timeline.scrubFunction, false);
+};
+
+/**
+ * Update for the current top layer and continue to listen for changes - only call this after this.timeline has been
+ * set either by #setupTimeline or externally mocked by tests.
+ */
+AnimationViewModel.prototype.listenForTopLayerChanges = function() {
+    updateForNewTopLayer(this);
+    knockout.getObservable(this.terria.timeSeriesStack, 'topLayer').subscribe(function() {
+        updateForNewTopLayer(this);
+    }, this);
 };
 
 function scrub(viewModel, e) {
@@ -304,6 +309,7 @@ AnimationViewModel.create = function(options) {
     var result = new AnimationViewModel(options);
     result.show(options.container);
     result.setupTimeline();
+    result.listenForTopLayerChanges();
     return result;
 };
 

--- a/test/ViewModels/AnimationViewModelSpec.js
+++ b/test/ViewModels/AnimationViewModelSpec.js
@@ -21,6 +21,7 @@ describe('AnimationViewModel', function() {
             terria: terria
         });
         animationVm.timeline = jasmine.createSpyObj('timeline', ['zoomTo', 'resize', '_makeTics']);
+        animationVm.listenForTopLayerChanges();
 
         catalogItem = new ImageryLayerCatalogItem(terria);
         catalogItem.clock = jasmine.createSpyObj('clock', ['getValue']);


### PR DESCRIPTION
Was happening because the AnimationViewModel would get initialised and show the top layer on the timeline before we actually made the timeline. I've moved that functionality from the constructor to the setup method that actually binds the ViewModel to the view and creates the timeline itself so it always happens in the right order.
