### PR TITLE
Add lat/lon to feature data when it updates with time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ Change Log
 * Fixed a map started with smooth terrain being unable to switch to 3D terrain.
 * Fixed a bug in `CkanCatalogItem` that prevented it from using the proxy for dataset URLs.
 * Stopped generation of WMS intervals being dependent on JS dates and hence sensitive to DST time gaps.
+* Fixed a bug which led to zero property values being considered time-varying in the Feature Info panel.
+* Fixed a bug which prevented lat/lon injection into templates with time-varying properties.
 
 ### 3.2.0
 

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -60,21 +60,7 @@ var FeatureInfoPanelSectionViewModel = function(featureInfoPanelViewModel, featu
         }
     }
 
-    var data = propertyValues(feature.properties, this.formats, this.terria.clock);
-
-    if (defined(data)) {
-        var position = this.terria.pickedFeatures && this.terria.pickedFeatures.pickPosition;
-
-        if (defined(position)) {
-            var latLngInRadians = Ellipsoid.WGS84.cartesianToCartographic(position);
-            data.terria = {
-                coords: {
-                    latitude: CesiumMath.toDegrees(latLngInRadians.latitude),
-                    longitude: CesiumMath.toDegrees(latLngInRadians.longitude)
-                }
-            };
-        }
-    }
+    var data = propertyValues(feature.properties, this.formats, this.terria.clock, this.terria.pickedFeatures);
 
     if (nameTemplate) {
         this.name = Mustache.render(nameTemplate, data);
@@ -325,11 +311,12 @@ function applyFormatsInPlace(properties, formats) {
     }
 }
 
-function propertyValues(properties, formats, clock) {
+function propertyValues(properties, formats, clock, pickedFeatures) {
     // Manipulate the properties before templating them.
     // If they require .getValue, apply that.
     // If they have bad keys, fix them.
     // If they have formatting, apply it.
+    // Add in the picked lat & lon.
     var result = propertyGetTimeValues(properties, clock);
     // If property names were changed, let the template access the original property names too.
     if (defined(result) && defined(result._terria_columnAliases)) {
@@ -342,13 +329,25 @@ function propertyValues(properties, formats, clock) {
     if (defined(formats)) {
         applyFormatsInPlace(result, formats);
     }
+    var position = pickedFeatures && pickedFeatures.pickPosition;
+
+    if (defined(position)) {
+        var latLngInRadians = Ellipsoid.WGS84.cartesianToCartographic(position);
+        result.terria = {
+            coords: {
+                latitude: CesiumMath.toDegrees(latLngInRadians.latitude),
+                longitude: CesiumMath.toDegrees(latLngInRadians.longitude)
+            }
+        };
+    }
+
     return result;
 }
 
 function addInfoUpdater(viewModel) {
     // the return value of addEventListener is a function which removes the event listener
     viewModel._clockSubscription = viewModel.terria.clock.onTick.addEventListener(function(clock) {
-        viewModel._updateContent(propertyValues(viewModel.feature.properties, viewModel.formats, viewModel.terria.clock));
+        viewModel._updateContent(propertyValues(viewModel.feature.properties, viewModel.formats, viewModel.terria.clock, viewModel.terria.pickedFeatures));
     });
 }
 

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -333,6 +333,9 @@ function propertyValues(properties, formats, clock, pickedFeatures) {
 
     if (defined(position)) {
         var latLngInRadians = Ellipsoid.WGS84.cartesianToCartographic(position);
+        if (!defined(result)) {
+            result = {};
+        }
         result.terria = {
             coords: {
                 latitude: CesiumMath.toDegrees(latLngInRadians.latitude),

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -360,7 +360,7 @@ function areAllPropertiesConstant(properties) {
     var result = true;
     for (var key in properties) {
         if (properties.hasOwnProperty(key)) {
-            result = result && properties[key] && (properties[key].isConstant !== false);
+            result = result && defined(properties[key]) && (properties[key].isConstant !== false);
         }
     }
     return result;

--- a/test/ViewModels/FeatureInfoPanelSectionViewModelSpec.js
+++ b/test/ViewModels/FeatureInfoPanelSectionViewModelSpec.js
@@ -122,6 +122,47 @@ describe('FeatureInfoPanelSectionViewModel', function() {
         });
     });
 
+    it('lat and long of the clicked point are available with time-varying properties', function() {
+        // Added because it used to only work for constant properties - see https://github.com/TerriaJS/terriajs/pull/1595 .
+        var catalogItem = {
+            featureInfoTemplate: '<div>{{terria.coords.latitude}} {{terria.coords.longitude}}</div>'
+        };
+        terria.pickedFeatures = new PickedFeatures();
+        terria.pickedFeatures.pickPosition = Ellipsoid.WGS84.cartographicToCartesian(Cartographic.fromDegrees(2, 4, 6));
+        var varyingProperties = {
+            'foo': {a: 'bar', isConstant: false},
+            'abc': 'def'
+        };
+        var varyingFeature = new Entity({
+            name: 'Bar',
+            properties: varyingProperties,
+            imageryLayer: {}
+        });
+        var section = new FeatureInfoPanelSectionViewModel(panel, varyingFeature, catalogItem);
+
+        expect(section.templatedInfo).toBe('<div>3.999999999999998 2</div>');
+    });
+
+    it('does not think a falsy property value is time-varying', function() {
+        // Added because it used to think this - see https://github.com/TerriaJS/terriajs/pull/1595 .
+        var catalogItem = {
+            featureInfoTemplate: '<div>{{terria.coords.latitude}} {{terria.coords.longitude}}</div>'
+        };
+        terria.pickedFeatures = new PickedFeatures();
+        terria.pickedFeatures.pickPosition = Ellipsoid.WGS84.cartographicToCartesian(Cartographic.fromDegrees(2, 4, 6));
+        var falsyProperties = {
+            'foo': 0,
+            'abc': 'def'
+        };
+        var falsyFeature = new Entity({
+            name: 'Bar',
+            properties: falsyProperties,
+            imageryLayer: {}
+        });
+        var section = new FeatureInfoPanelSectionViewModel(panel, falsyFeature, catalogItem);
+        expect(section.terria.clock.onTick.numberOfListeners).toEqual(0);
+    });
+
     describe('when template is not provided', function () {
         var section;
 


### PR DESCRIPTION
This fixes the first part of #1578.

There were two compounding problems 
- a zero property value erroneously led to the property being considered time-varying,
- and lat-lon was not added to time-varying data.
