### PR TITLE
Only add _terria_columnAliases if properties exist

### DIFF
--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -484,7 +484,9 @@ function addDescriptionAndProperties(regionMapping, regionIndices, regionImagery
             if (isConstant) {
                 imageryLayerFeatureInfo.description = regionRowDescriptions[uniqueId];
                 imageryLayerFeatureInfo.properties = regionRowObjects[uniqueId];
-                imageryLayerFeatureInfo.properties._terria_columnAliases = columnAliases;
+                if (defined(imageryLayerFeatureInfo.properties)) {
+                    imageryLayerFeatureInfo.properties._terria_columnAliases = columnAliases;
+                }
             } else {
                 imageryLayerFeatureInfo.description = new CallbackProperty(getRegionRowDescriptionPropertyCallbackForId(uniqueId), isConstant);
                 imageryLayerFeatureInfo.properties = new CallbackProperty(getRegionRowPropertiesPropertyCallbackForId(uniqueId), isConstant);


### PR DESCRIPTION
A minor update to #1483 - no one has found this bug in practice yet, but I hit it while working on #1514.
