### PR TITLE
Changed WMS interval creation to use JulianDates instead of JS Dates.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Fixed a bug on IE9 which prevented shortened URLs from loading.
 * Fixed a map started with smooth terrain being unable to switch to 3D terrain.
 * Fixed a bug in `CkanCatalogItem` that prevented it from using the proxy for dataset URLs.
+* Stopped generation of WMS intervals being dependent on JS dates and hence sensitive to DST time gaps.
 
 ### 3.2.0
 

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -648,19 +648,27 @@ function addDurationFromString(start, durationString, wmsItem) {
     // NOTE start is a javascript date, as is the result
     // returns false if the durationString is badly formed
     var matches = durationString.match(/^P(([0-9]+)D)?T?(([0-9]+)H)?(([0-9]+)M)?(([0-9]+)S)?$/);
-    var stop = new Date(start);
+    var stop = JulianDate.clone(start);
     if (matches) {
         // use +matches[i] to force number addition instead of string concatenation
-        if (matches[2]) { stop.setDate(stop.getDate() + (+matches[2])); }
-        if (matches[4]) { stop.setHours(stop.getHours() + (+matches[4])); }
-        if (matches[6]) { stop.setMinutes(stop.getMinutes() + (+matches[6])); }
-        if (matches[8]) { stop.setSeconds(stop.getSeconds() + (+matches[8])); }
+        if (matches[2]) {
+            JulianDate.addDays(start, +matches[2], stop);
+        }
+        if (matches[4]) {
+            JulianDate.addHours(start, +matches[4], stop);
+        }
+        if (matches[6]) {
+            JulianDate.addMinutes(start, +matches[6], stop);
+        }
+        if (matches[8]) {
+            JulianDate.addSeconds(start, +matches[8], stop);
+        }
     } else {
         wmsItem.terria.error.raiseEvent(new TerriaError({
             title: 'Badly formatted periodicity',
             message: '\
 The "' + wmsItem.name + '" dataset has a badly formed periodicity, "' + durationString +
-'".  Click the dataset\'s Info button for more information about the dataset and the data custodian.'
+            '".  Click the dataset\'s Info button for more information about the dataset and the data custodian.'
         }));
         return false;
     }
@@ -681,26 +689,21 @@ function updateIntervalsFromIsoSegments(intervals, isoSegments, time, wmsItem) {
         // and does not use the "R[n]/" prefix for repeated intervals
         // eg. Data refreshed every 30 min: 2000-06-18T14:30Z/2000-06-18T14:30Z/PT30M
         // See 06-042_OpenGIS_Web_Map_Service_WMS_Implementation_Specification.pdf section D.4
-        //
-        // Do date arithmetic using js dates rather than Julian dates
-        // to avoid floating point issues (as Julian dates are fps)
-        // and to avoid potential leap second issues (not sure if these occur with JD)
-        var thisStop = JulianDate.toDate(start),
-            prevStop = JulianDate.toDate(start),
-            stopDate = JulianDate.toDate(stop),
+        var thisStop = start,
+            prevStop = start,
+            stopDate = stop,
             count = 0;
+
         // Add intervals starting at start until:
         //    we detect a bad periodicity (which sets thisStop to false), or
         //    we go past the stop date, or
         //    we go past the max limit
         while (thisStop && prevStop <= stopDate && count < wmsItem.maxRefreshIntervals) {
             thisStop = addDurationFromString(prevStop, isoSegments[2], wmsItem);
-            var prevStopJulianDate = JulianDate.fromDate(prevStop),
-                thisStopJulianDate = JulianDate.fromDate(thisStop);
             intervals.addInterval(new TimeInterval({
-                start: prevStopJulianDate,
-                stop: thisStopJulianDate || prevStopJulianDate, // if there was a bad periodicity, use prevStop
-                data: JulianDate.toIso8601(prevStopJulianDate) // used to form the web request
+                start: prevStop,
+                stop: thisStop || prevStop, // if there was a bad periodicity, use prevStop
+                data: JulianDate.toIso8601(prevStop) // used to form the web request
             }));
             prevStop = thisStop;
             count++;


### PR DESCRIPTION
This resolves a problem in Safari where any WMS item with an interval inside an hour of time that doesn't exist because of DST (e.g. Oct 5 2014 2am - 3am in Sydney) can't show data beyond that time, because a call to the JS date `setHours` (or minutes etc) function in Safari that would put the new value of the date inside one of these non-existent time intervals is simply ignored, so the time never advances beyond it.

This would normally deserve a test but I can't think of a good way to write one, given that it depends on being in a certain timezone and now the code doesn't use timezone-sensitive dates anymore there's no way to reach in and set one.
