### PR TITLE
Provide a general number formatting function to feature info templates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 
 * Support `parameters` property in WebFeatureServiceCatalogItem to allow accessing URLs which need additional parameters.
 * Fixed a bug where sharing a time-series layer would completely crash Terria on reload.
+* Added a direct way to format numbers in feature info templates, eg. `{{#terria.formatNumber}}{"useGrouping": true, "maximumFractionDigits": 3}{{value}}{{/terria.formatNumber}}`. The quotes around the keys are optional.
 
 ### 3.2.1
 

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -332,11 +332,9 @@ function propertyValues(properties, formats, clock, pickedFeatures) {
     var position = pickedFeatures && pickedFeatures.pickPosition;
 
     result.terria = {
-        formatNumber: function() {
-            return function(text, render) {
-                return formatNumberForLocale(render(text), {useGrouping: true});
-            };
-        }
+        // Implements number formatting using this syntax:
+        // {{#terria.formatNumber}}{useGrouping: true}{{value}}{{/terria.formatNumber}}
+        formatNumber: mustacheFormatNumberFunction
     };
     if (defined(position)) {
         var latLngInRadians = Ellipsoid.WGS84.cartesianToCartographic(position);
@@ -350,6 +348,26 @@ function propertyValues(properties, formats, clock, pickedFeatures) {
     }
 
     return result;
+}
+
+function mustacheFormatNumberFunction() {
+    return function(text, render) {
+        // Eg. "{foo:1}hi there".match(optionReg) = ["{foo:1}hi there", "{foo:1}", "hi there"].
+        // Note this won't work with nested objects in the options (but these aren't used yet).
+        var optionReg = /^(\{[^}]+\})(.*)/;
+        var components = text.match(optionReg);
+        // This regex unfortunately matches double-braced text like {{number}}, so detect that separately and do not treat it as option json.
+        var startsWithdoubleBraces = (text.length > 4) && (text[0] === '{') && (text[1] === '{');
+        if (!components || startsWithdoubleBraces) {
+            // If no options were provided, just use the defaults.
+            return formatNumberForLocale(render(text));
+        }
+        // Allow {foo: 1} by converting it to {"foo": 1} for JSON.parse.
+        var quoteReg = /([{,])(\s*)([A-Za-z0-9_\-]+?)\s*:/;
+        var jsonOptions = components[1].replace(quoteReg, '$1"$3":');
+        var options = JSON.parse(jsonOptions);
+        return formatNumberForLocale(render(components[2]), options);
+    };
 }
 
 function addInfoUpdater(viewModel) {

--- a/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
+++ b/lib/ViewModels/FeatureInfoPanelSectionViewModel.js
@@ -331,16 +331,21 @@ function propertyValues(properties, formats, clock, pickedFeatures) {
     }
     var position = pickedFeatures && pickedFeatures.pickPosition;
 
+    result.terria = {
+        formatNumber: function() {
+            return function(text, render) {
+                return formatNumberForLocale(render(text), {useGrouping: true});
+            };
+        }
+    };
     if (defined(position)) {
         var latLngInRadians = Ellipsoid.WGS84.cartesianToCartographic(position);
         if (!defined(result)) {
             result = {};
         }
-        result.terria = {
-            coords: {
-                latitude: CesiumMath.toDegrees(latLngInRadians.latitude),
-                longitude: CesiumMath.toDegrees(latLngInRadians.longitude)
-            }
+        result.terria.coords = {
+            latitude: CesiumMath.toDegrees(latLngInRadians.latitude),
+            longitude: CesiumMath.toDegrees(latLngInRadians.longitude)
         };
     }
 

--- a/test/ViewModels/FeatureInfoPanelViewModelSpec.js
+++ b/test/ViewModels/FeatureInfoPanelViewModelSpec.js
@@ -222,10 +222,35 @@ describe('FeatureInfoPanelViewModel templating', function() {
         }).then(done).otherwise(done.fail);
     });
 
-    it('can format numbers in template using terria.formatNumber', function(done) {
-        item.featureInfoTemplate = 'Raw: {{big}}  Formatted: {{#terria.formatNumber}}{{big}}{{/terria.formatNumber}}';
+    it('can format numbers using terria.formatNumber', function(done) {
+        item.featureInfoTemplate = 'Base: {{#terria.formatNumber}}{{big}}{{/terria.formatNumber}}';
+        item.featureInfoTemplate += '  Sep: {{#terria.formatNumber}}{"useGrouping":true}{{big}}{{/terria.formatNumber}}';
+        item.featureInfoTemplate += '  DP: {{#terria.formatNumber}}{"maximumFractionDigits":3}{{decimal}}{{/terria.formatNumber}}';
         return loadAndPick().then(function() {
-            expect(panel.sections[0].templatedInfo).toBe('Raw: 1234567  Formatted: ' + '1' + separator + '234' + separator + '567');
+            expect(panel.sections[0].templatedInfo).toBe('Base: 1234567  Sep: ' + '1' + separator + '234' + separator + '567' + '  DP: 3.142');
+        }).then(done).otherwise(done.fail);
+    });
+
+    it('can format numbers using terria.formatNumber without quotes', function(done) {
+        item.featureInfoTemplate = 'Sep: {{#terria.formatNumber}}{useGrouping:true}{{big}}{{/terria.formatNumber}}';
+        item.featureInfoTemplate += '  DP: {{#terria.formatNumber}}{maximumFractionDigits:3}{{decimal}}{{/terria.formatNumber}}';
+        return loadAndPick().then(function() {
+            expect(panel.sections[0].templatedInfo).toBe('Sep: ' + '1' + separator + '234' + separator + '567' + '  DP: 3.142');
+        }).then(done).otherwise(done.fail);
+    });
+
+    // Do we want it to handle badly specified options gracefully?
+    // it('handles bad terria.formatNumber options gracefully', function(done) {
+    //     item.featureInfoTemplate = 'Test: {{#terria.formatNumber}}{badjson}{{big}}{{/terria.formatNumber}}';
+    //     return loadAndPick().then(function() {
+    //         expect(panel.sections[0].templatedInfo).toBe('Test: 1234567');
+    //     }).then(done).otherwise(done.fail);
+    // });
+
+    it('handles non-numbers terria.formatNumber', function(done) {
+        item.featureInfoTemplate = 'Test: {{#terria.formatNumber}}text{{/terria.formatNumber}}';
+        return loadAndPick().then(function() {
+            expect(panel.sections[0].templatedInfo).toBe('Test: text');
         }).then(done).otherwise(done.fail);
     });
 

--- a/test/ViewModels/FeatureInfoPanelViewModelSpec.js
+++ b/test/ViewModels/FeatureInfoPanelViewModelSpec.js
@@ -222,6 +222,13 @@ describe('FeatureInfoPanelViewModel templating', function() {
         }).then(done).otherwise(done.fail);
     });
 
+    it('can format numbers in template using terria.formatNumber', function(done) {
+        item.featureInfoTemplate = 'Raw: {{big}}  Formatted: {{#terria.formatNumber}}{{big}}{{/terria.formatNumber}}';
+        return loadAndPick().then(function() {
+            expect(panel.sections[0].templatedInfo).toBe('Raw: 1234567  Formatted: ' + '1' + separator + '234' + separator + '567');
+        }).then(done).otherwise(done.fail);
+    });
+
     it('can render a recursive featureInfoTemplate', function(done) {
 
         item.featureInfoTemplate = {

--- a/tutorials/FeatureInfoTemplate/FeatureInfoTemplate.md
+++ b/tutorials/FeatureInfoTemplate/FeatureInfoTemplate.md
@@ -57,3 +57,33 @@ You can make use of partial templates (and even recursive templates) by specifyi
 After Mustache has rendered the template, the result is displayed using [Markdown](https://help.github.com/articles/markdown-basics/), so you could also write:
 
               "featureInfoTemplate" : "Pixel colour: *Red={{Red}} Blue={{Blue}} Green={{Green}}*."
+
+## Formatting numbers
+
+The preferred way to format numbers is using the `formats` option, eg:
+
+              "featureInfoTemplate": {
+                "template": "Pixel colour: <b>Red={{Red}} Blue={{Blue}} Green={{Green}}</b>.",
+                "formats": {
+                  "Red": {
+                    "maximumFractionDigits": 2
+                  },
+                  "Green": {
+                    "maximumFractionDigits": 2
+                  },
+                  "Blue": {
+                    "maximumFractionDigits": 2
+                  }
+                }
+              }
+
+The supported format options are `"maximumFractionDigits": X` (to set the number of decimal places to X), `"useGrouping": true` (to show thousands separators), and `"style": "percent"` (eg. to show 0.15 as 15%).
+
+A second method is to use `terria.formatNumber` directly in the template. This accepts an initial JSON string describing the same options as above. To simplify the notation, the quotes around the keys are optional here.
+
+              "featureInfoTemplate": "template": "Pixel colour: <b>Red={{#terria.formatNumber}}{maximumFractionDigits:3}{{Red}}{{/terria.formatNumber}}</b>."
+
+## Other supporting data
+
+In the template, the clicked point's latitude and longitude are also available as `{{terria.coords.latitude}}` and `{{terria.coords.longitude}}`.
+

--- a/wwwroot/test/GeoJSON/two_features.geojson
+++ b/wwwroot/test/GeoJSON/two_features.geojson
@@ -35,6 +35,7 @@
 				"condition":2,
 				"historic#.":-12,
 				"big":1234567,
+				"decimal":3.1415926,
 				"funding_ba":"Capex"
 			}
 		},
@@ -71,6 +72,7 @@
 				"condition":1,
 				"historic#.":-11,
 				"big":234567,
+				"decimal":2.7182818,
 				"funding_ba":"Initial"
 			}
 		}


### PR DESCRIPTION
Fixes #1606.

Use as 

`{{#terria.formatNumber}}{"useGrouping": true, "maximumFractionDigits": 3}{{myValue}}{{/terria.formatNumber}}`

To make the notation easier, the quotes around the JSON keys are optional.

See #1609 for the `newui` version.
