### PR TITLE
NewUI: Add autoPlay as something that can be specified in the config.json

### DIFF
--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -52,8 +52,7 @@ const Timeline = React.createClass({
 
     updateForNewTopLayer() {
         let autoPlay = this.props.terria.configParameters.autoPlay;
-        if(!defined(autoPlay))
-        {
+        if(!defined(autoPlay)) {
             autoPlay = this.props.autoPlay;
         }
         const terria = this.props.terria;

--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -8,6 +8,7 @@ import ClockRange from 'terriajs-cesium/Source/Core/ClockRange';
 import {formatDateTime} from './DateFormats';
 import JulianDate from 'terriajs-cesium/Source/Core/JulianDate';
 import Styles from './timeline.scss';
+import defined from 'terriajs-cesium/Source/Core/defined';
 
 const Timeline = React.createClass({
     propTypes: {
@@ -50,11 +51,16 @@ const Timeline = React.createClass({
     },
 
     updateForNewTopLayer() {
+        let autoPlay = this.props.terria.configParameters.autoPlay;
+        if(!defined(autoPlay))
+        {
+            autoPlay = this.props.autoPlay;
+        }
         const terria = this.props.terria;
         const newTopLayer = terria.timeSeriesStack.topLayer;
 
         // default to playing and looping when shown unless told otherwise
-        if (newTopLayer && this.props.autoPlay) {
+        if (newTopLayer && autoPlay) {
             terria.clock.tick();
             terria.clock.shouldAnimate = true;
         }

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -8,7 +8,6 @@ import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
 import classNames from 'classnames';
 
-
 import formatNumberForLocale from '../../Core/formatNumberForLocale';
 import ObserveModelMixin from '../ObserveModelMixin';
 import propertyGetTimeValues from '../../Core/propertyGetTimeValues';

--- a/lib/ReactViews/StandardUserInterface/MapColumn.jsx
+++ b/lib/ReactViews/StandardUserInterface/MapColumn.jsx
@@ -10,7 +10,6 @@ import ObserveModelMixin from './../ObserveModelMixin';
 import BottomDock from './../BottomDock/BottomDock.jsx';
 import FeatureDetection from 'terriajs-cesium/Source/Core/FeatureDetection';
 
-
 import Styles from './map-column.scss';
 
 const isIE = FeatureDetection.isInternetExplorer();

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -127,7 +127,6 @@ const StandardUserInterface = React.createClass({
                     </aside>
                 </If>
 
-
                 <FeatureInfoPanel terria={terria}
                                   viewState={this.props.viewState}
                 />

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -128,7 +128,6 @@ const StandardUserInterface = React.createClass({
                 </If>
 
 
-
                 <FeatureInfoPanel terria={terria}
                                   viewState={this.props.viewState}
                 />


### PR DESCRIPTION
Previously "autoPlay" could be passed to AnimationViewModel, and this would control whether a layer with animated data would play when activated. That's no longer possible in newui. This adds the ability to specify autoPlay in config.json. AutoPlay still defaults to true.
