### PR TITLE
Master: Use user-provided style rather than picking first

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * CSV columns with up to 21 unique values can now be fully displayed in the legend.  Previously, the number of bins was limited to 9.
 * Added `cycle` option to `tableColumnStyle.colorBinMethod` for enumeration-type CSV columns.  When the number of unique values in the column exceeds the number of color bins available, this option makes TerriaJS color all values by cycling through the available colors, rather than coloring only the most common values and lumping the rest into an "Other" bucket.
 * Metadata and single data files (e.g. KML, GeoJSON) are now consistently cached for one day instead of two weeks.
+* `WebMapServiceCatalogItem` now uses the legend for the `style` specified in `parameters` when possible.  It also now includes the `parameters` when building a `GetLegendGraphic` URL.
 
 ### 3.2.1
 

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -409,8 +409,24 @@ WebMapServiceCatalogItem.prototype.updateFromCapabilities = function(capabilitie
     }
 
     var legendUri, legendMimeType;
-    // There can be multiple styles - just get the first if so.
+    // If style is defined in parameters, use that, but only if a style with that name can be found.
+    // Otherwise use first style in list.
     var style = Array.isArray(thisLayer.Style) ? thisLayer.Style[0] : thisLayer.Style;
+    if (defined(this.parameters.styles)) {
+        var styleName = this.parameters.styles;
+        if (Array.isArray(thisLayer.Style)) {
+            for (var ind=0; ind<thisLayer.Style.length; ind++) {
+                if (thisLayer.Style[ind].Name === styleName) {
+                    style = thisLayer.Style[ind];
+                }
+            }
+        } else {
+            if (thisLayer.style.styleName === styleName) {
+                style = thisLayer.style;
+            }
+        }
+    }
+
     if (style && style.LegendURL) {
         // According to the WMS schema, LegendURL is unbounded.
         var legendUrl = Array.isArray(style.LegendURL) ? style.LegendURL[0] : style.LegendURL;

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -456,6 +456,14 @@ WebMapServiceCatalogItem.prototype.updateFromCapabilities = function(capabilitie
                 // uri.setQuery('height', '300');
 
             }
+            if (defined(this.parameters)) {
+                for (var key in this.parameters) {
+                  if (this.parameters.hasOwnProperty(key)) {
+                    legendUri.setQuery(key,this.parameters[key]);
+                  }
+                }
+            }
+
         }
         var legend = new LegendUrl(legendUri.toString(), legendMimeType);
         updateValue(this, overwrite, '_legendUrl', legend);

--- a/test/Models/WebMapServiceCatalogItemSpec.js
+++ b/test/Models/WebMapServiceCatalogItemSpec.js
@@ -73,7 +73,7 @@ describe('WebMapServiceCatalogItem', function() {
                               "foo": "bar" }
             });
             wmsItem.load().then(function() {
-                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/request=GetLegendGraphic?secondUrl&styles=jet2&foo=bar', 'image/gif'));
+                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/foo?request=GetLegendGraphic&secondUrl&styles=jet2&foo=bar', 'image/gif'));
                 done();
             }).otherwise(function(e) {
                 fail(e);
@@ -107,7 +107,7 @@ describe('WebMapServiceCatalogItem', function() {
                 layers: 'single_period'
             });
             wmsItem.load().then(function() {
-                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/request=GetLegendGraphic?firstUrl', 'image/gif'));
+                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/foo?request=GetLegendGraphic&firstUrl', 'image/gif'));
                 done();
             }).otherwise(function(e) {
                 fail(e);
@@ -122,7 +122,7 @@ describe('WebMapServiceCatalogItem', function() {
                 layers: 'single_period'
             });
             wmsItem.load().then(function() {
-                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/request=GetLegendGraphic?firstUrl', 'image/gif'));
+                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/foo?request=GetLegendGraphic&firstUrl', 'image/gif'));
                 done();
             }).otherwise(function(e) {
                 fail(e);
@@ -137,7 +137,7 @@ describe('WebMapServiceCatalogItem', function() {
                 layers: 'single_period'
             });
             wmsItem.load().then(function() {
-                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/request=GetLegendGraphic?firstUrl', 'image/gif'));
+                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/foo?request=GetLegendGraphic&firstUrl', 'image/gif'));
                 done();
             }).otherwise(function(e) {
                 fail(e);

--- a/test/Models/WebMapServiceCatalogItemSpec.js
+++ b/test/Models/WebMapServiceCatalogItemSpec.js
@@ -64,6 +64,42 @@ describe('WebMapServiceCatalogItem', function() {
             });
         });
 
+        it('incorporates parameters if legendUrl comes from style', function(done) {
+            wmsItem.updateFromJson({
+                url: 'http://example.com',
+                metadataUrl: 'test/WMS/multiple_style_legend_url.xml',
+                layers: 'single_period',
+                parameters: { "styles": "jet2",
+                              "foo": "bar" }
+            });
+            wmsItem.load().then(function() {
+                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/request=GetLegendGraphic?secondUrl&styles=jet2&foo=bar', 'image/gif'));
+                done();
+            }).otherwise(function(e) {
+                fail(e);
+                done();
+            });
+
+        });
+
+        it('incorporates parameters if legendUrl is created from scratch', function(done) {
+            wmsItem.updateFromJson({
+                url: 'http://foo.com/bar',
+                metadataUrl: 'test/WMS/no_legend_url.xml',
+                layers: 'single_period',
+                parameters: { "alpha": "beta",
+                              "foo": "bar" }
+            });
+            wmsItem.load().then(function() {
+                expect(wmsItem.legendUrl.url.indexOf('http://foo.com/bar?service=WMS&version=1.1.0&request=GetLegendGraphic&format=image%2Fpng&transparent=True&layer=single_period&alpha=beta&foo=bar')).toBe(0);
+                done();
+            }).otherwise(function(e) {
+                fail(e);
+                done();
+            });
+
+        });
+
         it('is read from XML when specified with a single style', function(done) {
             wmsItem.updateFromJson({
                 url: 'http://example.com',
@@ -71,7 +107,7 @@ describe('WebMapServiceCatalogItem', function() {
                 layers: 'single_period'
             });
             wmsItem.load().then(function() {
-                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/legendUrl', 'image/gif'));
+                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/request=GetLegendGraphic?firstUrl', 'image/gif'));
                 done();
             }).otherwise(function(e) {
                 fail(e);
@@ -79,14 +115,14 @@ describe('WebMapServiceCatalogItem', function() {
             });
         });
 
-        it('is read from the first style tag when XML specifies multiple styles for a layer', function(done) {
+        it('is read from the first style tag when XML specifies multiple styles for a layer, provided style is unspecified', function(done) {
             wmsItem.updateFromJson({
                 url: 'http://example.com',
                 metadataUrl: 'test/WMS/multiple_style_legend_url.xml',
                 layers: 'single_period'
             });
             wmsItem.load().then(function() {
-                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/legendUrl', 'image/gif'));
+                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/request=GetLegendGraphic?firstUrl', 'image/gif'));
                 done();
             }).otherwise(function(e) {
                 fail(e);
@@ -101,7 +137,7 @@ describe('WebMapServiceCatalogItem', function() {
                 layers: 'single_period'
             });
             wmsItem.load().then(function() {
-                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/legendUrl', 'image/gif'));
+                expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/request=GetLegendGraphic?firstUrl', 'image/gif'));
                 done();
             }).otherwise(function(e) {
                 fail(e);

--- a/wwwroot/test/WMS/multiple_style_legend_url.xml
+++ b/wwwroot/test/WMS/multiple_style_legend_url.xml
@@ -102,7 +102,7 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/legendUrl"/>
+                                        xlink:href="http://www.example.com/request=GetLegendGraphic?firstUrl"/>
                     </LegendURL>
                 </Style>
 
@@ -114,7 +114,7 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/wrongLegendUrl"/>
+                                        xlink:href="http://www.example.com/request=GetLegendGraphic?secondUrl"/>
                     </LegendURL>
                 </Style>
             </Layer>

--- a/wwwroot/test/WMS/multiple_style_legend_url.xml
+++ b/wwwroot/test/WMS/multiple_style_legend_url.xml
@@ -102,7 +102,7 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/request=GetLegendGraphic?firstUrl"/>
+                                        xlink:href="http://www.example.com/foo?request=GetLegendGraphic&amp;firstUrl"/>
                     </LegendURL>
                 </Style>
 
@@ -114,7 +114,7 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/request=GetLegendGraphic?secondUrl"/>
+                                        xlink:href="http://www.example.com/foo?request=GetLegendGraphic&amp;secondUrl"/>
                     </LegendURL>
                 </Style>
             </Layer>

--- a/wwwroot/test/WMS/single_style_legend_url.xml
+++ b/wwwroot/test/WMS/single_style_legend_url.xml
@@ -102,7 +102,7 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/request=GetLegendGraphic?firstUrl"/>
+                                        xlink:href="http://www.example.com/foo?request=GetLegendGraphic&amp;firstUrl"/>
                     </LegendURL>
                 </Style>
             </Layer>

--- a/wwwroot/test/WMS/single_style_legend_url.xml
+++ b/wwwroot/test/WMS/single_style_legend_url.xml
@@ -102,7 +102,7 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/legendUrl"/>
+                                        xlink:href="http://www.example.com/request=GetLegendGraphic?firstUrl"/>
                     </LegendURL>
                 </Style>
             </Layer>

--- a/wwwroot/test/WMS/single_style_multiple_legend_urls.xml
+++ b/wwwroot/test/WMS/single_style_multiple_legend_urls.xml
@@ -102,13 +102,13 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/request=GetLegendGraphic?firstUrl"/>
+                                        xlink:href="http://www.example.com/foo?request=GetLegendGraphic&amp;firstUrl"/>
                     </LegendURL>
                     <LegendURL width="72" height="72">
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/request=GetLegendGraphic?secondUrl"/>
+                                        xlink:href="http://www.example.com/foo?request=GetLegendGraphic&amp;secondUrl"/>
                     </LegendURL>
                 </Style>
             </Layer>

--- a/wwwroot/test/WMS/single_style_multiple_legend_urls.xml
+++ b/wwwroot/test/WMS/single_style_multiple_legend_urls.xml
@@ -102,13 +102,13 @@
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/legendUrl"/>
+                                        xlink:href="http://www.example.com/request=GetLegendGraphic?firstUrl"/>
                     </LegendURL>
                     <LegendURL width="72" height="72">
                         <Format>image/gif</Format>
                         <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
                                         xlink:type="simple"
-                                        xlink:href="http://www.example.com/wrongLegendUrl"/>
+                                        xlink:href="http://www.example.com/request=GetLegendGraphic?secondUrl"/>
                     </LegendURL>
                 </Style>
             </Layer>


### PR DESCRIPTION
Styles can be passed as a parameter to style the WMS layer, but it is ignored for GetLegendGraphic, which currently uses the URL from the first style if a list is provided. Now it uses the specified style if provided, but otherwise chooses the first style as it previously did.

GEOGLAM requires this change in both master and newui. I'm intending to submit a separate PR for merge into newui.
