### PR TITLE
NewUI: Use user-provided style rather than picking first

### DIFF
--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -409,8 +409,24 @@ WebMapServiceCatalogItem.prototype.updateFromCapabilities = function(capabilitie
     }
 
     var legendUri, legendMimeType;
-    // There can be multiple styles - just get the first if so.
+    // If style is defined in parameters, use that, but only if a style with that name can be found.
+    // Otherwise use first style in list.
     var style = Array.isArray(thisLayer.Style) ? thisLayer.Style[0] : thisLayer.Style;
+    if (defined(this.parameters.styles)) {
+        var styleName = this.parameters.styles;
+        if (Array.isArray(thisLayer.Style)) {
+            for (var ind=0; ind<thisLayer.Style.length; ind++) {
+                if (thisLayer.Style[ind].Name === styleName) {
+                    style = thisLayer.Style[ind];
+                }
+            }
+        } else {
+            if (thisLayer.style.styleName === styleName) {
+                style = thisLayer.style;
+            }
+        }
+    }
+
     if (style && style.LegendURL) {
         // According to the WMS schema, LegendURL is unbounded.
         var legendUrl = Array.isArray(style.LegendURL) ? style.LegendURL[0] : style.LegendURL;

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -8,7 +8,6 @@ import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
 import classNames from 'classnames';
 
-
 import formatNumberForLocale from '../../Core/formatNumberForLocale';
 import ObserveModelMixin from '../ObserveModelMixin';
 import propertyGetTimeValues from '../../Core/propertyGetTimeValues';

--- a/lib/ReactViews/StandardUserInterface/MapColumn.jsx
+++ b/lib/ReactViews/StandardUserInterface/MapColumn.jsx
@@ -10,7 +10,6 @@ import ObserveModelMixin from './../ObserveModelMixin';
 import BottomDock from './../BottomDock/BottomDock.jsx';
 import FeatureDetection from 'terriajs-cesium/Source/Core/FeatureDetection';
 
-
 import Styles from './map-column.scss';
 
 const isIE = FeatureDetection.isInternetExplorer();

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -127,8 +127,6 @@ const StandardUserInterface = React.createClass({
                     </aside>
                 </If>
 
-
-
                 <FeatureInfoPanel terria={terria}
                                   viewState={this.props.viewState}
                 />


### PR DESCRIPTION
Styles can be passed as a parameter to style the WMS layer, but it is ignored for GetLegendGraphic, which currently uses the URL from the first style if a list is provided. Now it uses the specified style if provided, but otherwise chooses the first style as it previously did.

GEOGLAM requires this change in both master and newui.
