### PR TITLE
Made auto-generated legend titles wrap on non-MS browsers.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,10 @@
 Change Log
 ==========
 
-### 3.3.1
+### 3.4.0
 
 * Fixed a bug that caused the `corsProxyBaseUrl` specified in `config.json` to be ignored.
+* Long auto-generated legend titles now word wrap in most web browsers.
 
 ### 3.3.0
 

--- a/lib/Map/Legend.js
+++ b/lib/Map/Legend.js
@@ -90,9 +90,9 @@ var Legend = function(props) {
     /**
      * Gets or sets the spacing above the color bar.
      * @type {Number}
-     * @default 25
+     * @default 55
      */
-    this.barTop = defaultValue(props.barTop, 25);
+    this.barTop = defaultValue(props.barTop, 55);
 
     /**
      * Gets or sets the forced total width of the legend.
@@ -111,7 +111,7 @@ var Legend = function(props) {
     /**
      * Gets or sets the vertical offset of variable title.
      * @type {Number}
-     * @default 12
+     * @default 17
      */
     this.variableNameTop = defaultValue(props.variableNameTop, 17);
 
@@ -157,6 +157,7 @@ function initSvg(legend) {
     legend._svg.setAttributeNS(legend._svgns, 'version', "1.1");
     legend._svg.setAttributeNS(legend._svgns, 'width', legend.width);
     legend._svg.setAttributeNS(legend._svgns, 'height', legend.height);
+    legend._svg.setAttribute('style', 'height: ' + legend.height + 'px');
     legend._svg.setAttribute('class', 'generated-legend now-viewing-legend-image-background');
 }
 
@@ -191,10 +192,30 @@ function svgElement(legend, element, attributes, className, innerText) {
  * The name of the active data variable, drawn above the ramp or gradient.
  */
 function drawVariableName(legend) {
-    addSvgElement(legend, 'text', {
+    var switchElement =  svgElement(legend, 'switch', {});
+    var outerText = svgElement(legend, 'foreignObject', {
+        requiredFeatures: "http://www.w3.org/TR/SVG11/feature#Extensibility",
+        height: '50',
+        width: legend.width - legend.variableNameLeft,
         x: legend.variableNameLeft,
-        y: legend.variableNameTop
+        y: legend.variableNameTop,
+    });
+
+    var textArea = svgElement(legend, 'p', {
+        xmlns: "http://www.w3.org/1999/xhtml",
     }, 'variable-label', legend.title || '');
+
+
+    var textBox = svgElement(legend, 'text', {
+        x: legend.variableNameLeft,
+        y: legend.variableNameTop,
+    }, 'variable-label', legend.title || '');
+
+    outerText.appendChild(textArea);
+    switchElement.appendChild(outerText);
+    switchElement.appendChild(textBox);
+
+    legend._svg.appendChild(switchElement);
 }
 
 
@@ -395,3 +416,4 @@ Legend.prototype.getLegendUrl = function() {
 };
 
 module.exports = Legend;
+

--- a/lib/Styles/GeneratedLegend.less
+++ b/lib/Styles/GeneratedLegend.less
@@ -1,5 +1,7 @@
 
 .generated-legend {
+    background-color: transparent;
+
      .background {
         fill: hsl(0, 0%, 95%);
         stroke: black;
@@ -9,6 +11,7 @@
    .variable-label {
         font-family: Open Sans-serif, sans-serif;
         font-size: 14px;
+       color: hsl(0, 0%, 30%);
     }
 
     .item-label, .item-label-small {

--- a/lib/Styles/NowViewingTab.less
+++ b/lib/Styles/NowViewingTab.less
@@ -88,7 +88,6 @@
 
 .now-viewing-list {
     position: absolute;
-    overflow: auto;
     top: 40px;
     left: 0;
     right: 0;
@@ -142,6 +141,7 @@
     padding-left: 20px;
     padding-top: 10px;
     padding-bottom: 10px;
+    display: inline-block;
 }
 
 .now-viewing-legend-image-background {


### PR DESCRIPTION
Fixes #1580.

This is a bit awkward because SVG doesn't flow at all. What this does is move the bars down enough to accomodate two lines of text (for all legends, but it looks ok IMHO) then inserts a `<p>` tag inside a `<foreignObject>` in the SVG to handle the auto wrapping. If the browser doesn't support `<foreignObject>` (IE/Edge except IE11) it falls back to what it did before - a one-line `<text>` element that doesn't wrap at all.

Also made auto generated legends a bit nicer in MS browsers in general - no more second white background inherited from non-autogenerated legends.

Also got rid of a second `overflow: auto` inside the sidebar - not sure why that's there? Was causing a horizontal scroll bar for me.
