### PR TITLE
NewUI: Added ability to format timeslider tics and timeline label

### DIFF
--- a/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
@@ -7,6 +7,8 @@ import WrappedTimeline from 'terriajs-cesium/Source/Widgets/Timeline/Timeline';
 import JulianDate from 'terriajs-cesium/Source/Core/JulianDate';
 import {formatDateTime, formatDate, formatTime} from './DateFormats';
 import Styles from '!style-loader!css-loader?modules&sourceMap!sass-loader?sourceMap!./cesium-timeline.scss';
+import defined from 'terriajs-cesium/Source/Core/defined';
+import dateFormat from 'dateformat';
 
 const CesiumTimeline = React.createClass({
     propTypes: {
@@ -18,6 +20,13 @@ const CesiumTimeline = React.createClass({
         this.cesiumTimeline = new WrappedTimeline(this.timelineContainer, this.props.terria.clock);
 
         this.cesiumTimeline.makeLabel = time => {
+            if (defined(this.props.terria.timeSeriesStack.topLayer)) {
+                const layer = this.props.terria.timeSeriesStack.topLayer;
+                if (defined(layer.dateFormat.timelineTic)) {
+                    return dateFormat(JulianDate.toDate(time), layer.dateFormat.timelineTic);
+                }
+            }
+
             const totalDays = JulianDate.daysDifference(this.props.terria.clock.stopTime, this.props.terria.clock.startTime);
             if (totalDays > 14) {
                 return formatDate(JulianDate.toDate(time), this.locale);

--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -9,6 +9,7 @@ import {formatDateTime} from './DateFormats';
 import JulianDate from 'terriajs-cesium/Source/Core/JulianDate';
 import Styles from './timeline.scss';
 import defined from 'terriajs-cesium/Source/Core/defined';
+import dateFormat from 'dateformat';
 
 const Timeline = React.createClass({
     propTypes: {
@@ -35,8 +36,15 @@ const Timeline = React.createClass({
 
         this.removeTickEvent = this.props.terria.clock.onTick.addEventListener(clock => {
             const time = clock.currentTime;
+            let currentTime;
+            if (defined(this.props.terria.timeSeriesStack.topLayer) && defined(this.props.terria.timeSeriesStack.topLayer.dateFormat.currentTime)) {
+                currentTime = dateFormat(time, this.props.terria.timeSeriesStack.topLayer.dateFormat.currentTime);
+            } else {
+                currentTime = formatDateTime(JulianDate.toDate(time), this.props.locale);
+            }
+
             this.setState({
-                currentTimeString: formatDateTime(JulianDate.toDate(time), this.props.locale)
+                currentTimeString: currentTime
             });
         });
 

--- a/test/ReactViews/TimelineSpec.jsx
+++ b/test/ReactViews/TimelineSpec.jsx
@@ -1,0 +1,61 @@
+'use strict';
+
+/*global require,expect*/
+// import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+
+// Note getMountedInstance will be built into React 15, and not available in v2.0.0 of react-shallow-testutils
+// cf. https://github.com/sheepsteak/react-shallow-testutils/commit/8daa3c2361acfa6ec45f533cf7eea5751c51bf24
+import {getMountedInstance} from 'react-shallow-testutils';
+
+const Terria = require('../../lib/Models/Terria');
+
+const ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
+import Timeline from '../../lib/ReactViews/BottomDock/Timeline/Timeline';
+import JulianDate from 'terriajs-cesium/Source/Core/JulianDate';
+const DataSourceClock = require('terriajs-cesium/Source/DataSources/DataSourceClock');
+
+function getMounted(jsx) {
+    const renderer = ReactTestUtils.createRenderer();
+    renderer.render(jsx);
+    return getMountedInstance(renderer);
+}
+
+describe('Timeline', function() {
+    describe('dateTime format', function() {
+        let terria;
+        let catalogItem;
+
+        beforeEach(function() {
+            terria = new Terria({
+                baseUrl: './',
+            });
+            // Set time
+            catalogItem = new ImageryLayerCatalogItem(terria);
+            catalogItem.clock = new DataSourceClock();
+        });
+
+        it('currentTime should be used if provided', function() {
+            const timeline = <Timeline terria={terria}/>;
+            catalogItem.dateFormat.currentTime = "mmm";
+            terria.timeSeriesStack.addLayerToTop(catalogItem);
+            terria.clock.currentTime = JulianDate.fromIso8601('2016-01-01');
+            terria.clock.onTick.raiseEvent(terria.clock);
+
+            const result = getMounted(timeline);
+            expect(result.state.currentTimeString).toBe('Jan');
+        });
+
+        it('currentTime should not be used if not provided', function() {
+            const timeline = <Timeline terria={terria}/>;
+            terria.timeSeriesStack.addLayerToTop(catalogItem);
+            terria.clock.currentTime = JulianDate.fromIso8601('2016-01-01');
+            terria.clock.onTick.raiseEvent(terria.clock);
+
+            const result = getMounted(timeline);
+            expect(result.state.currentTimeString).toBe('01/01/2016, 00:00:00');
+        });
+    });
+});
+


### PR DESCRIPTION
Previously in master, we could control the label format on the timeslider (tics, and label on left). This is the same feature ported to newui. Note that because of changes in how timeslider works, the implementation is different from master.

Any maps that used this feature previously will need to be updated, because the way of specifying format in config.json has changed. 
Old:

```
"dateFormat":
 {
    "currentTime": "mmmm yyyy",
    "timelineTic": "yyyy"
 }
```

New, using javascript toLocaleDateString/toLocaleTimeString options for both currentTime and timelineTic:

```
"dateFormat":
{
    "currentTime": {"month": "short", "year": "numeric"},
     "timelineTic": {"year": "numeric"}
}
```
