### PR TITLE
Fix bug in implementing formatNumber function in Mustache

### DIFF
--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -72,11 +72,9 @@ const FeatureInfoSection = React.createClass({
         };
         if (this.props.position) {
             const latLngInRadians = Ellipsoid.WGS84.cartesianToCartographic(this.props.position);
-            terriaData.terria = {
-                coords: {
-                    latitude: CesiumMath.toDegrees(latLngInRadians.latitude),
-                    longitude: CesiumMath.toDegrees(latLngInRadians.longitude)
-                }
+            terriaData.terria.coords = {
+                latitude: CesiumMath.toDegrees(latLngInRadians.latitude),
+                longitude: CesiumMath.toDegrees(latLngInRadians.longitude)
             };
         }
 


### PR DESCRIPTION
A silly small bug - the "formatNumber" function was not making it to the template.
