### PR TITLE
Add SDMX-JSON CatalogItem

### DIFF
--- a/lib/Core/arrayProduct.js
+++ b/lib/Core/arrayProduct.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var flatten = require('./flatten');
+
+/**
+ * Find the "product" of a set of arrays, equivalent to the python one-liner: list(itertools.product(*pools)).
+ * Eg. [[a,b,c], [d], [e,f]] => [[a,d,e], [a,d,f], [b,d,e], [b,d,f], [c,d,e], [c,d,f]].
+ *
+ * @param  {Array[]} pools The arrays of arrays.
+ * @return {Array[]} The product of the arrays.
+ */
+function arrayProduct(pools) {
+    // This code is based on the python equivalent at https://docs.python.org/2/library/itertools.html#itertools.product :
+    // def product(*args):
+    //     # product('ABCD', 'xy') --> Ax Ay Bx By Cx Cy Dx Dy
+    //     pools = map(tuple, args)
+    //     result = [[]]
+    //     for pool in pools:
+    //         result = [x+[y] for x in result for y in pool]
+    //     for prod in result:
+    //         yield tuple(prod)
+    //
+    // Note for A = [1, 2, 3], B = [10, 20] in python, [a + b for a in A for b in B] = [11, 21, 12, 22, 13, 23].
+    // In js, A.map(function(a) { return B.map(function(b) { return a + b}) }) = [ [ 11, 21 ], [ 12, 22 ], [ 13, 23 ] ].
+    // For A = [[]], B = [1], in python [a+[b] for a in A for b in B] = [[1]].
+    // In js, A.map(function(a) { return B.map(function(b) { return a.concat(b); }) }) = [ [ [ 1 ] ] ].
+    // So we need to flatten the js result to make it match itertool's.
+    var result = [[]];
+    pools.forEach(function(pool) {
+        result = flatten(result.map(function(partialResult) {
+            return pool.map(function(poolMember) {
+                return partialResult.concat(poolMember);
+            });
+        }));
+    });
+    return result;
+}
+
+module.exports = arrayProduct;

--- a/lib/Core/flatten.js
+++ b/lib/Core/flatten.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+ * Flattens an array of arrays, into an array, eg. [[0, 1], [2, 3], [4, 5]] => [0, 1, 2, 3, 4, 5].
+ * Based on the example at
+ *   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce
+ * @private
+ * @param  {Array[]} arrayOfArrays Array of arrays
+ * @return {Array} Flattened array.
+ */
+function flatten(arrayOfArrays) {
+    return arrayOfArrays.reduce(function(a, b) {
+        return a.concat(b);
+    }, []);
+}
+
+module.exports = flatten;

--- a/lib/Map/TableColumn.js
+++ b/lib/Map/TableColumn.js
@@ -722,7 +722,11 @@ TableColumn.sumValues = function() {
     }
     var allValues = columns.map(function(column) { return column.values; });
     var transposed = zip(allValues);
-    return transposed.map(function(rowValues) { return rowValues.reduce(function(x, y) { return (+x) + (+y); }); });
+    return transposed.map(function(rowValues) { return rowValues.reduce(function(x, y) {
+        if (x === null) { return +y; }
+        if (y === null) { return +x; }
+        return (+x) + (+y); });
+    });
 };
 
 /**

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -125,6 +125,12 @@ function getVarTypeFromString(typeString) {
 }
 
 /**
+ * Expose the default display variable types.
+ * @type {Array}
+ */
+TableStructure.defaultDisplayVariableTypes = defaultDisplayVariableTypes;
+
+/**
 * Create a TableStructure from a JSON object, eg. [['x', 'y'], [1, 5], [3, 8], [4, -3]].
 *
 * @param {Object} json Table data as an object (in json format).

--- a/lib/Map/VariableConcept.js
+++ b/lib/Map/VariableConcept.js
@@ -21,6 +21,7 @@ var Concept = require('./Concept');
  * @param {Concept} [options.parent] The parent of this variable; if not parent.allowMultiple, parent.toggleActiveItem(variable) is called when toggling on.
  * @param {Boolean} [options.active] Whether the variable should start active.
  * @param {String} [options.color] The color of this variable, if any.
+ * @param {String} [options.id] The id of this variable; defaults to the name (via the parent class Concept).
  * @param {Boolean} [options.visible] Whether this variable is visible in the NowViewing tab (defaults to True).
  */
 var VariableConcept = function(name, options) {
@@ -52,6 +53,10 @@ var VariableConcept = function(name, options) {
      */
     this.color = options.color;
 
+    if (defined(options.id)) {
+        this.id = options.id;
+    }
+
     knockout.track(this, ['isActive', 'parent', 'hasChildren']);  // name, isSelectable, color already tracked by Concept
 
     knockout.getObservable(this, 'isActive').subscribe(function(nowActive) {
@@ -60,7 +65,6 @@ var VariableConcept = function(name, options) {
             this.color = this.parent.getColorCallback();
         }
     }, this);
-
 };
 
 inherit(Concept, VariableConcept);

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -423,7 +423,13 @@ CsvCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
     return [this.url, this.data];
 };
 
-function setActiveTimeColumn(tableStructure, tableStyle) {
+/**
+ * Sets the relevant active time column on the table structure, defaulting to the first time column present 
+ * unless the tableStyle has a 'timeColumn' property.
+ * @param {TableStructure} tableStructure The table structure.
+ * @param {TableStyle} tableStyle The table style.
+ */
+CsvCatalogItem.setActiveTimeColumn = function(tableStructure, tableStyle) {
     if (typeof tableStyle.timeColumn !== 'undefined') {
         tableStructure.activeTimeColumn = tableStructure.getColumnWithNameOrIndex(tableStyle.timeColumn);
         if (defined(tableStructure.activeTimeColumn) && tableStructure.activeTimeColumn.type !== VarType.TIME) {
@@ -433,7 +439,7 @@ function setActiveTimeColumn(tableStructure, tableStyle) {
     } else {
         tableStructure.activeTimeColumn = tableStructure.columnsByType[VarType.TIME][0];
     }
-}
+};
 
 // Loads the TableStructure, then calls setupTableStructure.
 function loadTableFromCsv(item, csvString) {
@@ -456,7 +462,7 @@ function loadTableFromCsv(item, csvString) {
 // Returns a promise that resolves to true if it is a recognised format.
 function setupTableStructure(item, tableStructure) {
     var tableStyle = item._tableStyle;
-    setActiveTimeColumn(tableStructure, tableStyle);
+    CsvCatalogItem.setActiveTimeColumn(tableStructure, tableStyle);
     item._tableStructure = tableStructure;
     if (tableStructure.hasLatitudeAndLongitude) {
         // Create the TableDataSource and save it to item._dataSource.

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -489,27 +489,31 @@ function setupTableStructure(item, tableStructure) {
             return when(true);
         } else {
             // Non-geospatial data.
-            item.isMappable = false;
-            item._useClock = false;
             tableStructure.name = ''; // No need to show the section title 'Display Variables' in Now Viewing.
             tableStructure.allowMultiple = true;
-            tableStructure.getColorCallback = item.getNextColor.bind(item);
-            // Could hide non-scalar columns here.
             item.activateColumnFromTableStyle();
-            ensureActiveColumnForNonSpatial(tableStructure);
-            // If it's not there already, add it to the catalog's chartable items, so the ChartPanel can pick it up.
-            if (item.terria.catalog.chartableItems.indexOf(item) < 0) {
-                item.terria.catalog.chartableItems.push(item);
-            }
-            // Any derived calculations from this can ignore the need for julianFinishDates and availabilities.
-            tableStructure.columnsByType[VarType.TIME].forEach(function(column) {
-                column.options.noFinishDates = true;
-            });
-
+            item.setChartable();
             return when(true);
         }
     });
 }
+
+CsvCatalogItem.prototype.setChartable = function() {
+    var tableStructure = this._tableStructure;
+    this.isMappable = false;
+    this._useClock = false;
+    tableStructure.getColorCallback = this.getNextColor.bind(this);
+    // Could hide non-scalar columns here.
+    ensureActiveColumnForNonSpatial(tableStructure);
+    // If it's not there already, add it to the catalog's chartable items, so the ChartPanel can pick it up.
+    if (this.terria.catalog.chartableItems.indexOf(this) < 0) {
+        this.terria.catalog.chartableItems.push(this);
+    }
+    // Any derived calculations from this can ignore the need for julianFinishDates and availabilities.
+    tableStructure.columnsByType[VarType.TIME].forEach(function(column) {
+        column.options.noFinishDates = true;
+    });
+};
 
 // An event listened triggered whenever the dataSource or regionMapping changes.
 // Used to know when to redraw the display.

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -670,7 +670,8 @@ function displayFailedAndAmbiguousMatches(regionMapping, failedMatches, ambiguou
 * Destroy the object and release resources
 */
 RegionMapping.prototype.destroy = function() {
-    // Do we need to explicitly unsubscribe from the clock?
+    // TODO: Don't we need to explicitly unsubscribe from the clock?
+    // The comments for destroyObject suggest this is not useful for a RegionMapping object.
     return destroyObject(this);
 };
 

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -251,15 +251,20 @@ function reviseLegendHelper(regionMapping) {
  * @private
  */
 function changedActiveItems(regionMapping) {
-    reviseLegendHelper(regionMapping);
-    if (defined(regionMapping._regionDetails) && !regionMapping._loadingData) {
-        if (defined(regionMapping._imageryLayer) || defined(regionMapping._hadImageryAtLayerIndex)) {
-            redisplayRegions(regionMapping);
-            if (defined(regionMapping._imageryLayer) && !defined(regionMapping._regionDetails)) {
-                regionMapping.hideImageryLayer();
+    if (defined(regionMapping._regionDetails)) {
+        reviseLegendHelper(regionMapping);
+        if (!regionMapping._loadingData) {
+            if (defined(regionMapping._imageryLayer) || defined(regionMapping._hadImageryAtLayerIndex)) {
+                redisplayRegions(regionMapping);
+                if (defined(regionMapping._imageryLayer) && !defined(regionMapping._regionDetails)) {
+                    regionMapping.hideImageryLayer();
+                }
             }
+            regionMapping._changed.raiseEvent(regionMapping);
         }
-        regionMapping._changed.raiseEvent(regionMapping);
+    } else {
+        regionMapping._legendHelper = undefined;
+        regionMapping._legendUrl = undefined;
     }
 }
 

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -1,0 +1,896 @@
+'use strict';
+
+/*global require*/
+var URI = require('urijs');
+
+var clone = require('terriajs-cesium/Source/Core/clone');
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
+var defined = require('terriajs-cesium/Source/Core/defined');
+var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+// var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
+var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
+// var deprecationWarning = require('terriajs-cesium/Source/Core/deprecationWarning');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var loadJson = require('terriajs-cesium/Source/Core/loadJson');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
+
+var arrayProduct = require('../Core/arrayProduct');
+// var arraysAreEqual = require('../Core/arraysAreEqual');
+var CsvCatalogItem = require('./CsvCatalogItem');
+var DisplayVariablesConcept = require('../Map/DisplayVariablesConcept');
+var inherit = require('../Core/inherit');
+var TerriaError = require('../Core/TerriaError');
+var overrideProperty = require('../Core/overrideProperty');
+var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
+var RegionMapping = require('../Models/RegionMapping');
+var TableColumn = require('../Map/TableColumn');
+var TableStructure = require('../Map/TableStructure');
+var VariableConcept = require('../Map/VariableConcept');
+
+/*
+    The SDMX-JSON format.
+    Descriptions of this format are available at:
+    - https://data.oecd.org/api/sdmx-json-documentation/
+    - https://github.com/sdmx-twg/sdmx-json/tree/master/data-message/docs
+    - https://sdmx.org/
+    - http://stats.oecd.org/sdmx-json/ (hosts a handy query builder)
+
+    The URL can be of two types, eg:
+    1. http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA/CABEE_2.LGA2013.1+.A/all?startTime=2013&endTime=2013
+    2. http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA
+
+    For #2, the dimension names and codes come from (in json format):
+    http://stats.oecd.org/sdmx-json/dataflow/<dataset id> (eg. QNA).
+
+    Then access:
+      - result.structure.dimensions.observation[k] for {keyPosition, id, name, values[]} to get the name & id of dimension keyPosition and its array of allowed values (with {id, name}).
+      - result.structure.dimensions.attributes.dataSet has some potentially interesting things such as units, unit multipliers, reference periods (eg. http://stats.oecd.org/sdmx-json/dataflow/QNA).
+      - result.structure.dimensions.attributes.observation has some potentially interesting things such as time formats and status (eg. estimated value, forecast value).
+
+    (Alternatively, in xml format):
+    http://stats.oecd.org/restsdmx/sdmx.ashx/GetDataStructure/<dataset id> (eg. QNA).
+
+    Data comes from:
+    http://stats.oecd.org/sdmx-json/data/<dataset identifier>/<filter expression>/<agency name>[ ?<additional parameters>]
+
+    Eg.
+    http://stats.oecd.org/sdmx-json/data/QNA/AUS+AUT.GDP+B1_GE.CUR+VOBARSA.Q/all?startTime=2009-Q2&endTime=2011-Q4
+
+    An example from the ABS:
+    http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA/CABEE_2.LGA2013.1+.A/all?startTime=2013&endTime=2013
+
+    Then access:
+      - result.structure.dimensions.series[i] for {keyPosition, id, name, values[]} to get the name & id of dimension keyPosition and its array of allowed values (with {id, name}).
+      - result.structure.dimensions.observation[i] for {role, id, name, values[]} to get the name & id of the observations and its array of allowed values (with {id, name}).
+      - result.dataSets[0].series[key].observations[t][0] with key = "xx.yy.zz" where xx is the id of a value from dimension 0, etc, and t is the time index (eg. 0 for a single time).
+
+    Currently, we only parse the first "dataSet" object provided. (This covers all situations of interest to us so far.)
+
+    Time seems to be handled specially, at least by the OECD.
+    Eg.
+      http://stats.oecd.org/sdmx-json/dataflow/QNA shows there are 5 dimensions (result.structure.dimensions.observation): LOCATION, SUBJECT, MEASURE, FREQUENCY, TIME_PERIOD.
+      But http://stats.oecd.org/sdmx-json/data/QNA/.B1_GE.VOBARSA.Q/all only returns 4 dimensions (result.structure.dimensions.series): TIME_PERIOD is gone.
+      Instead, it has become an observation: result.structure.dimensions.observation[0] has property "values" with lots of {id, name} fields, eg. {id: "1960-Q1", name: "Q1-1960"}.
+      And result.dataSets[0].series[key].observations[t] has lots of values for different t, not necessarily including t = 0. (eg. key = "21:0:0:0" starts at t = 140).
+ */
+
+/**
+ * A {@link CatalogItem} representing region-mapped data obtained from SDMX-JSON format.
+ *
+ * @alias SdmxJsonCatalogItem
+ * @constructor
+ * @extends CsvCatalogItem
+ *
+ * @param {Terria} terria The Terria instance.
+ * @param {String} [url] The base URL from which to retrieve the data.
+ */
+var SdmxJsonCatalogItem = function(terria, url) {
+    CsvCatalogItem.call(this, terria, url);
+
+    // The options that should be passed to TableColumn when creating a new column.
+    this._columnOptions = undefined;
+
+    // Allows conversion between the dimensions and the table columns.
+    this._allDimensions = undefined;
+    this._loadedDimensions = undefined;
+
+    // Keep track of whether how many columns appear before the value columns (typically a time and a region column).
+    this._numberOfInitialColumns = undefined;
+
+    // Holds the time_period and region ids, ie. by default ["TIME_PERIOD", "REGION"].
+    this._suppressedIds = [];
+
+    // You cannot select multiple values of the frequency and regiontype ids, ie. by default ["FREQUENCY", "REGIONTYPE"].
+    this._singleValuedIds = [];
+
+    // This is set to the dataflow URL for this data, if relevant.
+    this._dataflowUrl = undefined;
+
+    // The array of Concepts to display in the NowViewing panel.
+    this._concepts = [];
+
+    /**
+     * Gets or sets the 'data' SDMX URL component, eg. 'data' in http://stats.oecd.org/sdmx-json/data/QNA.
+     * Defaults to 'data'.
+     * This property is observable.
+     * @type {String}
+     */
+    this.dataUrlComponent = undefined;
+
+    /**
+     * Gets or sets the 'dataflow' SDMX URL component, eg. 'dataflow' in http://stats.oecd.org/sdmx-json/dataflow/QNA.
+     * Defaults to 'dataflow'.
+     * This property is observable.
+     * @type {String}
+     */
+    this.dataflowUrlComponent = undefined;
+
+    /**
+     * Gets or sets the provider id in the SDMX URL, eg. the final 'all' in http://stats.oecd.org/sdmx-json/data/QNA/.../all.
+     * Defaults to 'all'.
+     * This property is observable.
+     * @type {String}
+     */
+    this.providerId = undefined;
+
+    /**
+     * Gets or sets the SDMX region-type dimension id used with the region code to set the region type.
+     * Usually defaults to 'REGIONTYPE'.
+     * This property is observable.
+     * @type {String}
+     */
+    this.regionTypeDimensionId = undefined;
+
+    /**
+     * Gets or sets the SDMX region dimension id, which is not displayed as a user-choosable dimension. Defaults to 'REGION'.
+     * This property is observable.
+     * @type {String}
+     */
+    this.regionDimensionId = undefined;
+
+    /**
+     * Gets or sets the SDMX frequency dimension id. Defaults to 'FREQUENCY'.
+     * This property is observable.
+     * @type {String}
+     */
+    this.frequencyDimensionId = undefined;
+
+    /**
+     * Gets or sets the SDMX time period dimension id, which is not displayed as a user-choosable dimension. Defaults to 'TIME_PERIOD'.
+     * This property is observable.
+     * @type {String}
+     */
+    this.timePeriodDimensionId = undefined;
+
+    /**
+     * Gets or sets the regiontype directly, which is an alternative to including a regiontype in the data.
+     * Eg. "cnt3" would tell us that we should use cnt3 as the table column name.
+     * By default this is undefined.
+     * This property is observable.
+     * @type {String}
+     */
+    this.regionType = undefined;
+
+    /**
+     * Gets or sets the concepts which are initially selected, eg. {"MEASURE": ["GDP", "GNP"], "FREQUENCY": ["A"]}.
+     * Defaults to the first value in each dimension (when undefined).
+     * This property is observable.
+     * @type {Object}
+     */
+    this.selectedInitially = undefined;
+
+    /**
+     * Gets or sets the startTime to use as part of the ?startTime=...&endTime=... query parameters.
+     * Currently a string, but could be extended to be an object with frequency codes as keys.
+     * By default this is undefined, and not used as part of the query.
+     * This property is observable.
+     * @type {String}
+     */
+    this.startTime = undefined;
+
+    /**
+     * Gets or sets the endTime to use as part of the ?startTime=...&endTime=... query parameters.
+     * Currently a string, but could be extended to be an object with frequency codes as keys.
+     * By default this is undefined, and not used as part of the query.
+     * This property is observable.
+     * @type {String}
+     */
+    this.endTime = undefined;
+
+    /**
+     * Gets or sets each dimension's allowed values, by id. Eg. {"SUBJECT": ["GDP", "GNP"], "FREQUENCY": ["A"]}.
+     * If not defined, all values are allowed.
+     * If a dimension is not present, all values for that dimension are allowed.
+     * Note this will not be applied to regions or time periods.
+     * This property is observable.
+     * @type {Object}
+     */
+    this.whitelist = {};
+
+    // Tracking _concepts makes this a circular object.
+    // _concepts (via concepts) is both set and read in rebuildData.
+    // A solution to this would be to make concepts a Promise, but that would require changing the UI side.
+    knockout.track(this, ['_concepts']);
+
+    overrideProperty(this, 'concepts', {
+        get: function() {
+            return this._concepts;
+        }
+    });
+
+    knockout.defineProperty(this, 'activeConcepts', {
+        get: function() {
+            if (defined(this._concepts) && this._concepts.length > 0) {
+                return this._concepts.map(function(parent) {
+                    return parent.items.filter(function(concept) { return concept.isActive; });
+                });
+            }
+        }
+    });
+
+    knockout.getObservable(this, 'activeConcepts').subscribe(function() {
+        if (!this.isLoading) {
+            changedActiveItems(this);
+        }
+    }, this);
+
+    // knockout.getObservable(this, 'displayPercent').subscribe(rebuildData.bind(null, this), this);
+
+};
+
+inherit(CsvCatalogItem, SdmxJsonCatalogItem);
+
+defineProperties(SdmxJsonCatalogItem.prototype, {
+    /**
+     * Gets the type of data member represented by this instance.
+     * @memberOf SdmxJsonCatalogItem.prototype
+     * @type {String}
+     */
+    type: {
+        get: function() {
+            return 'sdmx-json';
+        }
+    },
+
+    /**
+     * Gets a human-readable name for this type of data source, 'GPX'.
+     * @memberOf SdmxJsonCatalogItem.prototype
+     * @type {String}
+     */
+    typeName: {
+        get: function() {
+            return 'SDMX JSON';
+        }
+    },
+
+    /**
+     * Gets the set of names of the properties to be serialized for this object for a share link.
+     * @memberOf ImageryLayerCatalogItem.prototype
+     * @type {String[]}
+     */
+    propertiesForSharing: {
+        get: function() {
+            return SdmxJsonCatalogItem.defaultPropertiesForSharing;
+        }
+    },
+
+    /**
+     * Gets the set of functions used to serialize individual properties in {@link CatalogMember#serializeToJson}.
+     * When a property name on the model matches the name of a property in the serializers object lieral,
+     * the value will be called as a function and passed a reference to the model, a reference to the destination
+     * JSON object literal, and the name of the property.
+     * @memberOf SdmxJsonCatalogItem.prototype
+     * @type {Object}
+     */
+    serializers: {
+        get: function() {
+            return SdmxJsonCatalogItem.defaultSerializers;
+        }
+    }
+});
+
+/**
+ * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived for a
+ * share link.
+ * @type {String[]}
+ */
+SdmxJsonCatalogItem.defaultPropertiesForSharing = clone(CsvCatalogItem.defaultPropertiesForSharing); // TODO: do we need to add dataUrlComponent etc to this list?
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('regionDimensionId');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('regionTypeDimensionId');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('frequencyDimensionId');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('timePeriodDimensionId');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('whitelist');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('regionType');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('startTime');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('endTime');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('dataUrlComponent');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('dataflowUrlComponent');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('providerId');
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('selectedInitially');
+freezeObject(SdmxJsonCatalogItem.defaultPropertiesForSharing);
+
+SdmxJsonCatalogItem.defaultSerializers = clone(CsvCatalogItem.defaultSerializers);
+freezeObject(SdmxJsonCatalogItem.defaultSerializers);
+
+// Just the items that would influence the load from the abs server or the file
+SdmxJsonCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
+    return [this.url];
+};
+
+// The URL can have two different forms, which require different handling.
+// 1. http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA/CABEE_2.LGA2013.1+.A/all?startTime=2013&endTime=2013
+//    Read data from this URL directly and construct the table and concepts from it.
+// 2. http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA
+//    Do not attempt to hit this URL directly.
+//    Instead get the concepts from .../dataflow/ABS_REGIONAL_LGA, and then, whenever the active concepts are changed,
+//    construct a specific URL like in #1 from those concepts, load the data from it, and construct a table.
+//    If no 'dataflow' URL is recognizable, revert to #1 behaviour.
+// If the URL fits neither form, assume it is a datafile to be handled like #1.
+// You can also force the #1 behaviour by blanking out item.dataflowUrlComponent.
+// This function returns undefined for #1, and the dataflow URL for #2.
+function getDataflowUrl(item) {
+    if (!item.dataflowUrlComponent) {
+        return;
+    }
+    var dataUrlComponent = '/' + item.dataUrlComponent + '/';
+    var dataUrlIndex = (item.url.lastIndexOf(dataUrlComponent));
+    // If the URL contains /data/, look for how many / terms come after it.
+    if (dataUrlIndex >= 0) {
+        var suffix = item.url.slice(dataUrlIndex + dataUrlComponent.length);
+        // eg. suffix would be ABS_REGIONAL_LGA/CABEE_2.LGA2013.1+.A/all...
+        // If it contains a /, and anything after the /, then treat it as #1.
+        if (suffix.indexOf('/') >= 0 && suffix.indexOf('/') < suffix.length - 1) {
+            return;
+        } else {
+            // return the same URL but with /data/ replaced with /dataflow/.
+            var dataflowUrlComponent = '/' + item.dataflowUrlComponent + '/';
+            return item.url.replace(dataUrlComponent, dataflowUrlComponent);
+        }
+    }
+}
+
+SdmxJsonCatalogItem.prototype._load = function() {
+    // Set some defaults.
+    this.regionTypeDimensionId = defaultValue(this.regionTypeDimensionId, 'REGIONTYPE');
+    this.regionDimensionId = defaultValue(this.regionDimensionId, 'REGION');
+    this.frequencyDimensionId = defaultValue(this.frequencyDimensionId, 'FREQUENCY');
+    this.timePeriodDimensionId = defaultValue(this.timePeriodDimensionId, 'TIME_PERIOD');
+    this.providerId = defaultValue(this.providerId, 'all');
+    this.dataUrlComponent = defaultValue(this.dataUrlComponent, 'data');
+    this.dataflowUrlComponent = defaultValue(this.dataflowUrlComponent, 'dataflow');
+
+    this._suppressedIds = [this.regionDimensionId, this.timePeriodDimensionId];
+    this._singleValuedIds = [this.regionTypeDimensionId, this.frequencyDimensionId];
+
+    var tableStyle = this._tableStyle;
+    this._columnOptions = {
+        displayDuration: tableStyle.displayDuration,
+        displayVariableTypes: TableStructure.defaultDisplayVariableTypes,
+        replaceWithNullValues: tableStyle.replaceWithNullValues,
+        replaceWithZeroValues: tableStyle.replaceWithZeroValues
+    };
+
+    // We pass column options to TableStructure too, but they only do anything if TableStructure itself (eg. via fromJson) adds the columns,
+    // which is not the case here.  We will need to pass them to each call to new TableColumn as well.
+    this._tableStructure = new TableStructure(this.name, this._columnOptions);
+
+    this._dataflowUrl = getDataflowUrl(this);
+    if (this._dataflowUrl) {
+        return loadDataflow(this);
+    } else {
+        return loadAndBuildTable(this);
+    }
+};
+
+// An event listened triggered whenever the dataSource or regionMapping changes.
+// Used to know when to redraw the display.
+function dataChanged(item) {
+    item.terria.currentViewer.notifyRepaintRequired();
+}
+
+// Sets the tableStructure's columns to the new columns, redraws the map, and closes the feature info panel.
+function updateColumns(item, newColumns) {
+    item._tableStructure.columns = newColumns;
+    if (item._tableStructure.columns.length === 0) {
+        // Nothing to show, so the attempt to redraw will fail; need to explicitly hide the existing regions.
+        item._regionMapping.hideImageryLayer();
+        item.terria.currentViewer.notifyRepaintRequired();
+    }
+    // Close any picked features, as the description of any associated with this catalog item may change.
+    item.terria.pickedFeatures = undefined;
+}
+
+// // eg. range(5) returns [0, 1, 2, 3, 4].
+// function range(length) {
+//     return Array.apply(null, Array(length)).map(function(x, i) { return i; });
+// }
+
+/**
+ * Returns an array whose elements are objects describing each dimension.
+ * The array has length structureSeries.length (assuming the keyPositions are correct),
+ * and the index of each element is its keyPosition.
+ * Each element is an object with the properties:
+ *   - dimensionId
+ *   - dimensionName
+ *   - values: An array whose elements describe each allowed value of the dimension (eg. countries, measurement types).
+ *             Each element is an object with the properties:
+ *             - id
+ *             - name
+ * If there is a whitelist, only the whitelisted values are included.
+ * @private
+ * @param  {SdmxJsonCatalogItem} item The SDMX-JSON catalog item.
+ * @param  {Array} structureSeries The structure's series property, json.structure.dimensions.series.
+ * @return {Object[]} A description of the dimensions.
+ */
+function buildDimensions(item, structureSeries) {
+    // Store the length of each dimension, in the correct keyPosition.
+    function getWhitelistFilter(dimensionId) {
+        var thisIdsWhitelist = item.whitelist[dimensionId];
+        return function(value) {
+            return !defined(thisIdsWhitelist) || (thisIdsWhitelist.indexOf(value.id) >= 0);
+        };
+    }
+    var result = [];
+    for (var i = 0; i < structureSeries.length; i++) {
+        var thisSeries = structureSeries[i];
+        var keyPosition = defined(thisSeries.keyPosition) ? thisSeries.keyPosition : i; // Since time_period can be an observation, without a keyPosition.
+        result[keyPosition] = {
+            id: thisSeries.id,
+            name: thisSeries.name,
+            // Eg. values: [{id: "BD_2", name: "Births"}, {id: "BD_4", name: "Deaths"}].
+            values: thisSeries.values.filter(getWhitelistFilter(thisSeries.id))
+        };
+    }
+    return result;
+}
+
+// Return dimensions, but removing suppressed dimensions, and dimensions with only one value IN FULLDIMENSIONS.
+// Dimensions and fullDimensions must have the same ordering of dimensions.
+function getShownDimensions(item, dimensions, fullDimensions) {
+    return dimensions.filter(function(dimension, i) {
+        return (item._suppressedIds.indexOf(dimension.id) === -1) && (fullDimensions[i].values.length > 1);
+    });
+}
+
+/**
+ * Calculates all the combinations of values that should appear as either:
+ *   - columns in our table (by passing the "loadedDimensions" for a given dataset), or
+ *   - concepts in the Now Viewing panel (by passing the "fullDimensions", ie. those from the dataflow.)
+ * Does not include suppressed (ie. region or time_period) values.
+ * Returns an object with properties:
+ *   names: An array, each element of which is an array of the names of each relevant dimension value.
+ *   ids:   An array, each element of which is an array of the ids of each relevant dimension value.
+ * @private
+ * @param  {SdmxJsonCatalogItem} item The catalog item.
+ * @param {Object[]} dimensions The output of buildDimensions, either fullDimensions or loadedDimensions.
+ * @param {Object[]} fullDimensions The output of buildDimensions on the dataflow result (or data if no dataflow). Defaults to dimensions.
+ * @return {Object} The values and names of the dimensions to be shown.
+ */
+function calculateShownDimensionCombinations(item, dimensions, fullDimensions) {
+    // Note we need to suppress the time dimension from the dimension list, if any; it appears as an observation instead.
+    // We also need to suppress the regions.
+    // Convert the values into all the combinations we'll need to load into columns,
+    // eg. [[0], [0], [0, 1, 2], [0, 1]] => [[0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 0, 1, 1], [0, 0, 2, 0], [0, 0, 2, 1]].
+    if (!defined(fullDimensions)) {
+        fullDimensions = dimensions;
+    }
+    var valuesArrays = getShownDimensions(item, dimensions, fullDimensions).map(function(dimension) {
+        return dimension.values;
+    });
+
+    var idsArrays = valuesArrays.map(function(values) { return values.map(function(value) { return value.id; }); });
+    var namesArrays = valuesArrays.map(function(values) { return values.map(function(value) { return value.name; }); });
+    return {
+        ids: arrayProduct(idsArrays),
+        names: arrayProduct(namesArrays)
+    };
+}
+
+function getDimensionById(dimensions, id) {
+    var result;
+    for (var i = 0; i < dimensions.length; i++) {
+        if (dimensions[i].id === id) {
+            result = dimensions[i];
+        }
+    }
+    return result;
+}
+
+function getDimensionIndexById(dimensions, id) {
+    var result;
+    for (var i = 0; i < dimensions.length; i++) {
+        if (dimensions[i].id === id) {
+            result = i;
+        }
+    }
+    return result;
+}
+
+function getRegionColumnName(item, dimensions) {
+    var regionTypeDimension = getDimensionById(dimensions, item.regionTypeDimensionId);
+    var regionDimension = getDimensionById(dimensions, item.regionDimensionId);
+    if (defined(regionTypeDimension)) {
+        // If there is a REGIONTYPE dimension, use its id, but add modify it using the principles of csv-geo-au:
+        // Assume the raw data is just missing the word "code", eg. LGA or LGA_2013 should be lga_code or lga_code_2013.
+        // So, if there's a _, replace the last one with _code_; else append _code.
+        var regionTypeId = regionTypeDimension.values[0].id;
+        var underscoreIndex = regionTypeId.lastIndexOf('_');
+        if (underscoreIndex >= 0) {
+            return regionTypeId.slice(0, underscoreIndex) + '_code' + regionTypeId.slice(underscoreIndex);
+        } else {
+            return regionTypeId + '_code';
+        }
+    } else if (defined(regionDimension)) {
+        // Else, if there is a REGION dimension and item.regionType has been defined, return item.regionType (and don't append anything).
+        if (defined(item.regionType) && defined(item.regionType)) {
+            return item.regionType;
+        }
+        // Else, use the REGION dimension id, if present.
+        return regionDimension.id;
+    }
+}
+
+// If there are times 2010, 2011, and regions AUS, MEX,
+// then the table has rows in this order:
+// date, region, ...
+// 2010, AUS
+// 2010, MEX
+// 2011, AUS ... etc.
+function buildRegionAndTimeColumns(item, dimensions) {
+    var regionDimension = getDimensionById(dimensions, item.regionDimensionId);
+    var timePeriodDimension = getDimensionById(dimensions, item.timePeriodDimensionId);
+    if (!defined(regionDimension)) {
+        // No region dimension (with the actual region values in it).
+        return;
+    }
+    var regionValues = [];
+    var timePeriodValues = [];
+    var regionCount = regionDimension.values.length;
+    var timePeriodCount = defined(timePeriodDimension) ? timePeriodDimension.values.length : 1;
+    for (var timePeriodIndex = 0; timePeriodIndex < timePeriodCount; timePeriodIndex++) {
+        for (var regionIndex = 0; regionIndex < regionCount; regionIndex++) {
+            regionValues.push(regionDimension.values[regionIndex].id);
+            if (timePeriodCount > 1) {
+                timePeriodValues.push(timePeriodDimension.values[timePeriodIndex].id);
+            }
+        }
+    }
+    // TODO: for now, only implements the first region type.
+    var regionColumnName = getRegionColumnName(item, dimensions);
+    var regionColumn = new TableColumn(regionColumnName, regionValues, item._columnOptions);
+    if (timePeriodCount > 1) {
+        var timePeriodColumn = new TableColumn('date', timePeriodValues, item._columnOptions);
+        return [timePeriodColumn, regionColumn];
+    } else {
+        return [regionColumn];
+    }
+}
+
+function getIndexOfDimensionValueId(dimension, valueId) {
+    var result;
+    for (var i = 0; i < dimension.values.length; i++) {
+        if (dimension.values[i].id === valueId) {
+            result = i;
+        }
+    }
+    return result;
+}
+
+// Eg. ids = ['GDP', 'METHOD-B'].
+// We want to map this to an array of indices, eg. [12, 1, undefined, 0, 0] for SUBJECT, METHOD, REGION, REGIONTYPE, FREQUENCY (for example),
+// with undefined for any suppressed dimensions and 0 for all single-valued dimensions.
+// This can then easily be turned into the key "12:1:undefined:0:0".
+// The main trick here is we need to suppress time_period from the final array - it is an 'observation' not a dimension.
+function mapDimensionValueIdsToKeyValues(item, loadedDimensions, ids) {
+    var result = [];
+    var nonTimePeriodDimensions = loadedDimensions.filter(function(dimension) {
+        return (item.timePeriodDimensionId !== dimension.id);
+    });
+    var shownDimensions = getShownDimensions(item, loadedDimensions, item._fullDimensions);
+    var shownDimensionIds = shownDimensions.map(function(dimension) { return dimension.id; });
+    for (var dimensionIndex = 0; dimensionIndex < nonTimePeriodDimensions.length; dimensionIndex++) {
+        var outputDimension = nonTimePeriodDimensions[dimensionIndex];
+        var i = shownDimensionIds.indexOf(outputDimension.id);
+        if (i >= 0) {
+            result.push(getIndexOfDimensionValueId(shownDimensions[i], ids[i]));
+        } else if (item._suppressedIds.indexOf(outputDimension.id) >= 0) {
+            result.push(undefined);
+        } else {
+            result.push(0);
+        }
+    }
+    return result;
+}
+
+// Create a column for each combination of (non-region) dimension values.
+// TODO: If we are using the dataflow approach, only create columns for the active concepts (since that's all we'll have data for). (Currently it shows null in those columns.)
+// The column has values for each region.
+function buildValueColumns(item, loadedDimensions, columnCombinations, structureSeries, series) {
+    var thisColumnOptions = clone(item._columnOptions);
+    thisColumnOptions.tableStructure = item._tableStructure;
+    var columns = [];
+    var uniqueValue = (columnCombinations.ids.length <= 1);
+    var regionDimension = getDimensionById(loadedDimensions, item.regionDimensionId);
+    var regionDimensionIndex = getDimensionIndexById(loadedDimensions, item.regionDimensionId);
+    var timePeriodDimension = getDimensionById(loadedDimensions, item.timePeriodDimensionId);
+
+    var regionCount = regionDimension.values.length;
+    var timePeriodCount = defined(timePeriodDimension) ? timePeriodDimension.values.length : 1;
+
+    for (var combinationIndex = 0; combinationIndex < columnCombinations.ids.length; combinationIndex++) {
+        var ids = columnCombinations.ids[combinationIndex];
+        var dimensionIndices = mapDimensionValueIdsToKeyValues(item, loadedDimensions, ids);
+        // The name is just the joined names of all the columns involved, or 'value' if no columns still have names.
+        var combinationName = columnCombinations.names[combinationIndex].filter(function(name) {return !!name; }).join(' ') || 'Value';
+        var combinationId = ids.join(' ') || 'Value';
+        var values = [];
+        for (var timePeriodIndex = 0; timePeriodIndex < timePeriodCount; timePeriodIndex++) {
+            for (var regionIndex = 0; regionIndex < regionCount; regionIndex++) {
+                dimensionIndices[regionDimensionIndex] = regionIndex;
+                var key = dimensionIndices.join(':');
+                if (defined(series[key]) && defined(series[key].observations[timePeriodIndex])) {
+                    values.push(series[key].observations[timePeriodIndex][0]);
+                } else {
+                    values.push(null);
+                }
+            }
+        }
+        thisColumnOptions.id = combinationId; // So we can refer to the dimension in a template by a sequence of ids or names.
+        var column = new TableColumn(combinationName, values, thisColumnOptions);
+        if (uniqueValue) {
+            column.isActive = true;
+        }
+        columns.push(column);
+    }
+    return columns;
+}
+
+// Map the active concepts into arrays of arrays of ids.
+// Eg. Return [['GDP', 'GNP'], ['Q']].
+function calculateActiveConceptIds(concepts) {
+    return concepts.map(function(parent) {
+        return parent.items.filter(function(concept) {
+            return concept.isActive;
+        }).map(function(concept) {
+            return concept.id;
+        });
+    });
+}
+
+// Build out the concepts displayed in the NowViewing panel.
+function buildConcepts(item, fullDimensions, shownDimensionCombinations) {
+    // Only store the combinations as they relate the concepts.
+    // Ie. Drop the trivial (single-valued) dimensions from shownDimensionCombinations.keyValues .
+    // Eg. [[0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 0, 1, 1], [0, 0, 2, 0], [0, 0, 2, 1]]
+    // should become [[0, 0], [0, 1], [1, 0], [1, 1], [2, 0], [2, 1]], as the first two indices are single-valued.
+
+    function isInitiallyActive(dimensionId, value, index) {
+        if (!defined(item.selectedInitially)) {
+            return index === 0;
+        }
+        var dimensionSelectedInitially = item.selectedInitially[dimensionId];
+        if (!defined(dimensionSelectedInitially)) {
+            return index === 0;
+        }
+        return dimensionSelectedInitially.indexOf(value.id) >= 0;
+    }
+
+    var conceptDimensions = getShownDimensions(item, fullDimensions, fullDimensions);
+    return conceptDimensions.map(function(dimension, i) {
+        var allowMultiple = item._singleValuedIds.indexOf(dimension.id) === -1;
+        var concept = new DisplayVariablesConcept(dimension.name, allowMultiple);
+        concept.id = dimension.id;
+        concept.items = dimension.values.map(function(value, index) {
+            return new VariableConcept(value.name, {
+                parent: concept,
+                id: value.id,
+                active: isInitiallyActive(concept.id, value, index)
+            });
+        });
+        return concept;
+    });
+}
+
+// Create columns for the total (and possibly total percentage) values.
+// If <=1 active column, returns [].
+function buildTotalColumns(item, columnCombinations) {
+    // Build a total column equal to the sum of all the active concepts.
+    var thisColumnOptions = clone(item._columnOptions);
+    thisColumnOptions.tableStructure = item._tableStructure;
+    thisColumnOptions.id = 'total selected';
+    var activeConceptIds = calculateActiveConceptIds(item._concepts);
+    if (activeConceptIds.length === 0) {
+        return [];
+    }
+    // Find all the combinations of active concepts.
+    // Eg. [['GDP'], ['METHOD-A', 'METHOD-C'], ['Q']] => [['GDP', 'METHOD-A', 'Q'], ['GDP', 'METHOD-C', 'Q']]
+    var activeCombinations = arrayProduct(activeConceptIds);
+    // Look up which columns these correspond to.
+    // Note we need to convert the arrays to strings for indexOf to work. 
+    // Join with + as we know it cannot appear in an id, since it's used in the URL.
+    // (If this string appears in any id, it will confuse things.)
+    var joinString = '+';
+    var stringifiedCombinations = columnCombinations.ids.map(function(combination) { return combination.join(joinString); });
+    var indicesIntoCombinations = activeCombinations.map(function(activeCombination) {
+        var stringifiedActiveCombination = activeCombination.join(joinString);
+        return stringifiedCombinations.indexOf(stringifiedActiveCombination);
+    });
+    // Slice off the initial region &/or time columns, and only keep the value columns (ignoring total columns which come at the end).
+    var valueColumns = item._tableStructure.columns.slice(item._numberOfInitialColumns, columnCombinations.ids.length + item._numberOfInitialColumns);
+    var includedColumns = valueColumns.filter(function(column, i) { return indicesIntoCombinations.indexOf(i) >= 0; });
+    var totalColumn = new TableColumn('Total selected', TableColumn.sumValues(includedColumns), thisColumnOptions);
+    totalColumn.isActive = true;
+    return [totalColumn];
+}
+
+// Returns the dimension request string, eg. "BD_2+BD_4.LGA_2013..A." appropriate for the active concept values.
+// One trick is that the time dimension can appear in the dataflow, but should not be included in the data (or this request string).
+// Returns undefined if any dimension has no value selected.
+function calculateDimensionRequestString(item, fullDimensions) {
+    var activeConceptIds = calculateActiveConceptIds(item._concepts);
+    var hasAtLeastOneValuePerDimension = activeConceptIds.every(function(list) { return list.length > 0; });
+    if (!hasAtLeastOneValuePerDimension) {
+        return;
+    }
+    var nextConceptIndex = 0;
+    var nonTimePeriodDimensions = fullDimensions.filter(function(dimension) {
+        return (item.timePeriodDimensionId !== dimension.id);
+    });
+    var dimensionRequestArrays = nonTimePeriodDimensions.map(function(dimension, dimensionIndex) {
+        if (dimension.id === item.regionDimensionId) {
+            return ['']; // A missing id loads all ids.
+        }
+        if (dimension.values.length === 1) { // These do not appear as concepts - directly supply the only value's id.
+            return [dimension.values[0].id];
+        } else {
+            return activeConceptIds[nextConceptIndex++];
+        }
+    });
+    return dimensionRequestArrays.map(function(values) {
+        return values.join('+');
+    }).join('.');
+}
+
+// Called when the active column changes.
+// Returns a promise.
+function changedActiveItems(item) {
+    if (!defined(item._dataflowUrl)) {
+        // All the data is already here, just update the total columns.
+        var shownDimensionCombinations = calculateShownDimensionCombinations(item, item._fullDimensions);
+        var columns = item._tableStructure.columns.slice(0, shownDimensionCombinations.ids.length + item._numberOfInitialColumns);
+        if (columns.length > 0) {
+            // TODO: If all the values for a single dimension are deselected, handle it specially.
+            columns = columns.concat(buildTotalColumns(item, shownDimensionCombinations));
+            updateColumns(item, columns);
+        }
+        return when();
+    } else {
+        // Download the data and build the appropriate table.
+        // Eg. by appending /a+b+c.d.e+f.g/all to the url.
+        // These need to be in the order of the original dimensions, not the concepts.
+        var dimensionRequestString = calculateDimensionRequestString(item, item._fullDimensions);
+        if (!defined(dimensionRequestString)) {
+            return; // No value for a dimension, so ignore.
+        }
+        var url = item.url;
+        if (url[url.length - 1] !== '/') {
+            url += '/';
+        }
+        url += dimensionRequestString + '/' + item.providerId;
+        if (defined(item.startTime)) {
+            url += '?startTime=' + item.startTime;
+            if (defined(item.endTime)) {
+                url += '&endTime=' + item.endTime;
+            }
+        } else if (defined(item.endTime)) {
+            url += '?endTime=' + item.endTime;
+        }
+        return loadAndBuildTable(item, url);
+    }
+}
+
+// This is called when the URL gives a datasetId, but no specifics.
+// We start by loading in the structure (without any data) from the dataflow URL.
+function loadDataflow(item) {
+    var dataflowUrl = cleanAndProxyUrl(item, item._dataflowUrl);
+    return loadJson(dataflowUrl).then(function(json) {
+        // Then access:
+        //   - result.structure.dimensions.observation[k] for {keyPosition, id, name, values[]} to get the name & id of dimension keyPosition and its array of allowed values (with {id, name}).
+        //   - result.structure.dimensions.attributes.dataSet has some potentially interesting things such as units, unit multipliers, reference periods (eg. http://stats.oecd.org/sdmx-json/dataflow/QNA).
+        //   - result.structure.dimensions.attributes.observation has some potentially interesting things such as time formats and status (eg. estimated value, forecast value).
+        var structureSeries = json.structure.dimensions.observation;
+
+        item._fullDimensions = buildDimensions(item, structureSeries);
+        if (!defined(getDimensionIndexById(item._fullDimensions, item.regionDimensionId))) {
+            // TODO: Raise an error, or handle case when there are no regions.
+            console.log('No regions defined.');
+            return;
+        }
+        var shownDimensionCombinations = calculateShownDimensionCombinations(item, item._fullDimensions);
+        item._concepts = buildConcepts(item, item._fullDimensions, shownDimensionCombinations);
+        // console.log('concepts', item._concepts);
+        // The rest of the magic occurs because the concepts are made active.
+        // So that the loading flow works properly, make that happen now.
+        return changedActiveItems(item);
+    });
+}
+
+// Return json.structure.dimensions.series, augmented by json.structure.dimensions.observation
+// (because time periods are an observation, not a series.)
+function getStructureSeries(json) {
+    return json.structure.dimensions.series.concat(json.structure.dimensions.observation);
+}
+
+// This is called with item.url when the URL is for a specific data file, ie. dataflow is not used.
+// It is also called with a calculated url when dataflow is used.
+function loadAndBuildTable(item, url) {
+    if (!defined(url)) {
+        url = item.url;
+    }
+    item._regionMapping = new RegionMapping(item, item._tableStructure, item._tableStyle);
+    item._regionMapping.isLoading = true;
+    item._regionMapping.changedEvent.addEventListener(dataChanged.bind(null, item), item);
+    console.log('Downloading', url, 'as', proxyCatalogItemUrl(item, url));
+    return loadJson(proxyCatalogItemUrl(item, url)).then(function(json) {
+        var structureSeries = getStructureSeries(json);
+        var series = json.dataSets[0].series;
+
+        item._loadedDimensions = buildDimensions(item, structureSeries);
+        if (!defined(getDimensionIndexById(item._loadedDimensions, item.regionDimensionId))) {
+            // TODO: Raise an error, or handle case when there are no regions.
+            console.log('No regions defined.');
+            return;
+        }
+        if (!defined(item._fullDimensions)) {
+            // If we didn't come through the dataflow, ie. we've loaded this file directly, then we need to set the concepts now.
+            // In this case, the loaded dimensions are the full set.
+            item._fullDimensions = item._loadedDimensions;
+            var shownDimensionCombinations = calculateShownDimensionCombinations(item, item._fullDimensions);
+            item._concepts = buildConcepts(item, item._fullDimensions, shownDimensionCombinations);
+        }
+
+        var columnCombinations = calculateShownDimensionCombinations(item, item._loadedDimensions, item._fullDimensions);
+        var regionAndTimeColumns = buildRegionAndTimeColumns(item, item._loadedDimensions);
+        item._numberOfInitialColumns = regionAndTimeColumns.length;
+        var valueColumns = buildValueColumns(item, item._loadedDimensions, columnCombinations, structureSeries, series);
+        item._tableStructure.columns = regionAndTimeColumns.concat(valueColumns);
+        // Set the columns and the concepts before building the total column, because it uses them both.
+        var totalColumns = buildTotalColumns(item, columnCombinations); // The region column can't be active, so ok not to pass it.
+        var columns = item._tableStructure.columns.concat(totalColumns);
+        CsvCatalogItem.setActiveTimeColumn(item._tableStructure, item._tableStyle);
+        updateColumns(item, columns);
+        console.log('SDMX-JSON data as a table:', item._tableStructure);
+        return item._regionMapping.loadRegionDetails();
+    }).then(function(regionDetails) {
+        // Can get here with undefined region column name, hence no regionDetails.
+        if (regionDetails) {
+            RegionMapping.setRegionColumnType(regionDetails);
+            // Force a recalc of the imagery.
+            // Required because we load the region details _after_ setting the active column.
+            item._regionMapping.isLoading = false;
+        }
+        return when();
+    }).otherwise(function(e) {
+        item.terria.error.raiseEvent(new TerriaError({
+            sender: item,
+            title: 'No data available',
+            message: (e.message || e.response)
+        }));
+    });
+}
+
+// cleanAndProxyUrl appears in a few catalog items - we should split it into its own Core file.
+
+function cleanUrl(url) {
+    // Strip off the search portion of the URL
+    var uri = new URI(url);
+    uri.search('');
+    return uri.toString();
+}
+
+function cleanAndProxyUrl(catalogItem, url) {
+    return proxyCatalogItemUrl(catalogItem, cleanUrl(url));
+}
+
+
+module.exports = SdmxJsonCatalogItem;

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -377,6 +377,8 @@ SdmxJsonCatalogItem.prototype._load = function() {
     this._regionMapping.changedEvent.addEventListener(dataChanged.bind(null, this), this);  // TODO: not sure we need this.
 
     this._dataflowUrl = getDataflowUrl(this);
+    // If there's a dataflow url, before the data loads show the dataflow url in the data info panel so it does not show a link to _all_ the data, just the structure.
+    this._dataUrl = this._dataflowUrl;
     if (this._dataflowUrl) {
         return loadDataflow(this);
     } else {
@@ -789,6 +791,7 @@ function changedActiveItems(item) {
         } else if (defined(item.endTime)) {
             url += '?endTime=' + item.endTime;
         }
+        item._dataUrl = url; // So the data info panel shows a link to the selected data.
         return loadAndBuildTable(item, url);
     }
 }
@@ -831,7 +834,6 @@ function loadAndBuildTable(item, url) {
     if (!defined(url)) {
         url = item.url;
     }
-    console.log('Downloading', url, 'as', proxyCatalogItemUrl(item, url));
     return loadJson(proxyCatalogItemUrl(item, url)).then(function(json) {
         var structureSeries = getStructureSeries(json);
         var series = json.dataSets[0].series;
@@ -867,7 +869,7 @@ function loadAndBuildTable(item, url) {
         // Setting _regionMapping.isLoading to false then triggers the changed-active-column event.
         item._regionMapping.isLoading = true;
         updateColumns(item, columns);
-        console.log('SDMX-JSON data as a table:', item._tableStructure);
+        console.log('SDMX-JSON data as a table:', item._tableStructure);  // TODO: remove.
         return item._regionMapping.loadRegionDetails();
     }).then(function(regionDetails) {
         // Can get here with undefined region column name, hence no regionDetails.

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -28,55 +28,52 @@ var TableStructure = require('../Map/TableStructure');
 var VariableConcept = require('../Map/VariableConcept');
 var VarType = require('../Map/VarType');
 
-/*
-    The SDMX-JSON format.
-    Descriptions of this format are available at:
-    - https://data.oecd.org/api/sdmx-json-documentation/
-    - https://github.com/sdmx-twg/sdmx-json/tree/master/data-message/docs
-    - https://sdmx.org/
-    - http://stats.oecd.org/sdmx-json/ (hosts a handy query builder)
-
-    The URL can be of two types, eg:
-    1. http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA/CABEE_2.LGA2013.1+.A/all?startTime=2013&endTime=2013
-    2. http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA
-
-    For #2, the dimension names and codes come from (in json format):
-    http://stats.oecd.org/sdmx-json/dataflow/<dataset id> (eg. QNA).
-
-    Then access:
-      - result.structure.dimensions.observation[k] for {keyPosition, id, name, values[]} to get the name & id of dimension keyPosition and its array of allowed values (with {id, name}).
-      - result.structure.dimensions.attributes.dataSet has some potentially interesting things such as units, unit multipliers, reference periods (eg. http://stats.oecd.org/sdmx-json/dataflow/QNA).
-      - result.structure.dimensions.attributes.observation has some potentially interesting things such as time formats and status (eg. estimated value, forecast value).
-
-    (Alternatively, in xml format):
-    http://stats.oecd.org/restsdmx/sdmx.ashx/GetDataStructure/<dataset id> (eg. QNA).
-
-    Data comes from:
-    http://stats.oecd.org/sdmx-json/data/<dataset identifier>/<filter expression>/<agency name>[ ?<additional parameters>]
-
-    Eg.
-    http://stats.oecd.org/sdmx-json/data/QNA/AUS+AUT.GDP+B1_GE.CUR+VOBARSA.Q/all?startTime=2009-Q2&endTime=2011-Q4
-
-    An example from the ABS:
-    http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA/CABEE_2.LGA2013.1+.A/all?startTime=2013&endTime=2013
-
-    Then access:
-      - result.structure.dimensions.series[i] for {keyPosition, id, name, values[]} to get the name & id of dimension keyPosition and its array of allowed values (with {id, name}).
-      - result.structure.dimensions.observation[i] for {role, id, name, values[]} to get the name & id of the observations and its array of allowed values (with {id, name}).
-      - result.dataSets[0].series[key].observations[t][0] with key = "xx.yy.zz" where xx is the id of a value from dimension 0, etc, and t is the time index (eg. 0 for a single time).
-
-    Currently, we only parse the first "dataSet" object provided. (This covers all situations of interest to us so far.)
-
-    Time seems to be handled specially, at least by the OECD.
-    Eg.
-      http://stats.oecd.org/sdmx-json/dataflow/QNA shows there are 5 dimensions (result.structure.dimensions.observation): LOCATION, SUBJECT, MEASURE, FREQUENCY, TIME_PERIOD.
-      But http://stats.oecd.org/sdmx-json/data/QNA/.B1_GE.VOBARSA.Q/all only returns 4 dimensions (result.structure.dimensions.series): TIME_PERIOD is gone.
-      Instead, it has become an observation: result.structure.dimensions.observation[0] has property "values" with lots of {id, name} fields, eg. {id: "1960-Q1", name: "Q1-1960"}.
-      And result.dataSets[0].series[key].observations[t] has lots of values for different t, not necessarily including t = 0. (eg. key = "21:0:0:0" starts at t = 140).
- */
-
 /**
  * A {@link CatalogItem} representing region-mapped data obtained from SDMX-JSON format.
+ *
+ * Descriptions of this format are available at:
+ * - https://data.oecd.org/api/sdmx-json-documentation/
+ * - https://github.com/sdmx-twg/sdmx-json/tree/master/data-message/docs
+ * - https://sdmx.org/
+ * - http://stats.oecd.org/sdmx-json/ (hosts a handy query builder)
+ *
+ * The URL can be of two types, eg:
+ * 1. http://example.com/sdmx-json/data/DATASETID/BD1+BD2.LGA.1+2.A/all?startTime=2013&endTime=2013
+ * 2. http://example.com/sdmx-json/data/DATASETID
+ *
+ * For #2, the dimension names and codes come from (in json format):
+ * http://example.com/sdmx-json/dataflow/DATASETID
+ *
+ * Then access:
+ *   - result.structure.dimensions.observation[k] for {keyPosition, id, name, values[]} to get the name & id of dimension keyPosition and its array of allowed values (with {id, name}).
+ *   - result.structure.dimensions.attributes.dataSet has some potentially interesting things such as units, unit multipliers, reference periods (eg. http://stats.oecd.org/sdmx-json/dataflow/QNA).
+ *   - result.structure.dimensions.attributes.observation has some potentially interesting things such as time formats and status (eg. estimated value, forecast value).
+ *
+ * (Alternatively, in xml format):
+ * http://stats.oecd.org/restsdmx/sdmx.ashx/GetDataStructure/<dataset id> (eg. QNA).
+ *
+ * Data comes from:
+ * http://stats.oecd.org/sdmx-json/data/<dataset identifier>/<filter expression>/<agency name>[ ?<additional parameters>]
+ *
+ * Eg.
+ * http://stats.oecd.org/sdmx-json/data/QNA/AUS+AUT.GDP+B1_GE.CUR+VOBARSA.Q/all?startTime=2009-Q2&endTime=2011-Q4
+ *
+ * An example from the ABS:
+ * http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA/CABEE_2.LGA2013.1+.A/all?startTime=2013&endTime=2013
+ *
+ * Then access:
+ *   - result.structure.dimensions.series[i] for {keyPosition, id, name, values[]} to get the name & id of dimension keyPosition and its array of allowed values (with {id, name}).
+ *   - result.structure.dimensions.observation[i] for {role, id, name, values[]} to get the name & id of the observations and its array of allowed values (with {id, name}).
+ *   - result.dataSets[0].series[key].observations[t][0] with key = "xx.yy.zz" where xx is the id of a value from dimension 0, etc, and t is the time index (eg. 0 for a single time).
+ *
+ * Currently, we only parse the first "dataSet" object provided. (This covers all situations of interest to us so far.)
+ *
+ * Time seems to be handled specially, at least by the OECD.
+ * Eg.
+ *   http://stats.oecd.org/sdmx-json/dataflow/QNA shows there are 5 dimensions (result.structure.dimensions.observation): LOCATION, SUBJECT, MEASURE, FREQUENCY, TIME_PERIOD.
+ *   But http://stats.oecd.org/sdmx-json/data/QNA/.B1_GE.VOBARSA.Q/all only returns 4 dimensions (result.structure.dimensions.series): TIME_PERIOD is gone.
+ *   Instead, it has become an observation: result.structure.dimensions.observation[0] has property "values" with lots of {id, name} fields, eg. {id: "1960-Q1", name: "Q1-1960"}.
+ *   And result.dataSets[0].series[key].observations[t] has lots of values for different t, not necessarily including t = 0. (eg. key = "21:0:0:0" starts at t = 140).
  *
  * @alias SdmxJsonCatalogItem
  * @constructor
@@ -295,19 +292,7 @@ defineProperties(SdmxJsonCatalogItem.prototype, {
  * share link.
  * @type {String[]}
  */
-SdmxJsonCatalogItem.defaultPropertiesForSharing = clone(CsvCatalogItem.defaultPropertiesForSharing); // TODO: do we need to add dataUrlComponent etc to this list?
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('regionDimensionId');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('regionTypeDimensionId');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('frequencyDimensionId');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('timePeriodDimensionId');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('whitelist');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('regionType');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('startTime');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('endTime');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('dataUrlComponent');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('dataflowUrlComponent');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('providerId');
-SdmxJsonCatalogItem.defaultPropertiesForSharing.push('selectedInitially');
+SdmxJsonCatalogItem.defaultPropertiesForSharing = clone(CsvCatalogItem.defaultPropertiesForSharing);
 freezeObject(SdmxJsonCatalogItem.defaultPropertiesForSharing);
 
 SdmxJsonCatalogItem.defaultSerializers = clone(CsvCatalogItem.defaultSerializers);

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -265,9 +265,21 @@ defineProperties(SdmxJsonCatalogItem.prototype, {
  * @type {String[]}
  */
 SdmxJsonCatalogItem.defaultPropertiesForSharing = clone(CsvCatalogItem.defaultPropertiesForSharing);
+SdmxJsonCatalogItem.defaultPropertiesForSharing.push('selectedInitially');
 freezeObject(SdmxJsonCatalogItem.defaultPropertiesForSharing);
 
 SdmxJsonCatalogItem.defaultSerializers = clone(CsvCatalogItem.defaultSerializers);
+SdmxJsonCatalogItem.defaultSerializers.selectedInitially = function(item, json) {
+    // Create the 'selectedInitially' that would start us off with the same active items as are currently shown.
+    json.selectedInitially = {};
+    item._concepts.forEach(function(displayConcept) {
+        json.selectedInitially[displayConcept.id] = displayConcept.items.filter(function(concept) {
+            return concept.isActive;
+        }).map(function(concept) {
+            return concept.id;
+        });
+    });
+};
 freezeObject(SdmxJsonCatalogItem.defaultSerializers);
 
 // Just the items that would influence the load from the abs server or the file

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -26,6 +26,7 @@ var RegionMapping = require('../Models/RegionMapping');
 var TableColumn = require('../Map/TableColumn');
 var TableStructure = require('../Map/TableStructure');
 var VariableConcept = require('../Map/VariableConcept');
+var VarType = require('../Map/VarType');
 
 /*
     The SDMX-JSON format.
@@ -543,27 +544,39 @@ function getRegionColumnName(item, dimensions) {
 function buildRegionAndTimeColumns(item, dimensions) {
     var regionDimension = getDimensionById(dimensions, item.regionDimensionId);
     var timePeriodDimension = getDimensionById(dimensions, item.timePeriodDimensionId);
-    if (!defined(regionDimension)) {
-        // No region dimension (with the actual region values in it).
-        return;
+    if (!defined(regionDimension) && !defined(timePeriodDimension)) {
+        // No region dimension (with the actual region values in it) AND no time dimension - we're done.
+        return [];
     }
     var regionValues = [];
     var timePeriodValues = [];
-    var regionCount = regionDimension.values.length;
+    var regionCount = defined(regionDimension) ? regionDimension.values.length : 1;
     var timePeriodCount = defined(timePeriodDimension) ? timePeriodDimension.values.length : 1;
     for (var timePeriodIndex = 0; timePeriodIndex < timePeriodCount; timePeriodIndex++) {
         for (var regionIndex = 0; regionIndex < regionCount; regionIndex++) {
-            regionValues.push(regionDimension.values[regionIndex].id);
-            if (timePeriodCount > 1) {
+            if (defined(regionDimension)) {
+                regionValues.push(regionDimension.values[regionIndex].id);
+            }
+            if (defined(timePeriodDimension)) {
                 timePeriodValues.push(timePeriodDimension.values[timePeriodIndex].id);
             }
         }
     }
+    var timePeriodColumn;
+    if (defined(timePeriodDimension)) {
+        var thisColumnOptions = clone(item._columnOptions);
+        if (timePeriodCount === 1) {
+            thisColumnOptions.type = VarType.ENUM; // Don't trigger timeline off a single-valued time dimension.
+        }
+        timePeriodColumn = new TableColumn('date', timePeriodValues, thisColumnOptions);
+    }
+    if (!defined(regionDimension)) {
+        return [timePeriodColumn];
+    }
     // TODO: for now, only implements the first region type.
     var regionColumnName = getRegionColumnName(item, dimensions);
     var regionColumn = new TableColumn(regionColumnName, regionValues, item._columnOptions);
-    if (timePeriodCount > 1) {
-        var timePeriodColumn = new TableColumn('date', timePeriodValues, item._columnOptions);
+    if (defined(timePeriodDimension) && defined(regionDimension)) {
         return [timePeriodColumn, regionColumn];
     } else {
         return [regionColumn];
@@ -618,7 +631,7 @@ function buildValueColumns(item, loadedDimensions, columnCombinations, structure
     var regionDimensionIndex = getDimensionIndexById(loadedDimensions, item.regionDimensionId);
     var timePeriodDimension = getDimensionById(loadedDimensions, item.timePeriodDimensionId);
 
-    var regionCount = regionDimension.values.length;
+    var regionCount = defined(regionDimension) ? regionDimension.values.length : 1;
     var timePeriodCount = defined(timePeriodDimension) ? timePeriodDimension.values.length : 1;
 
     for (var combinationIndex = 0; combinationIndex < columnCombinations.ids.length; combinationIndex++) {
@@ -724,6 +737,9 @@ function buildTotalColumns(item, columnCombinations) {
     // Slice off the initial region &/or time columns, and only keep the value columns (ignoring total columns which come at the end).
     var valueColumns = item._tableStructure.columns.slice(item._numberOfInitialColumns, columnCombinations.ids.length + item._numberOfInitialColumns);
     var includedColumns = valueColumns.filter(function(column, i) { return indicesIntoCombinations.indexOf(i) >= 0; });
+    if (includedColumns.length === 0) {
+        return [];
+    }
     var totalColumn = new TableColumn('Total selected', TableColumn.sumValues(includedColumns), thisColumnOptions);
     totalColumn.isActive = true;
     return [totalColumn];
@@ -828,6 +844,10 @@ function getStructureSeries(json) {
     return json.structure.dimensions.series.concat(json.structure.dimensions.observation);
 }
 
+function hasRegionDimension(item) {
+    return defined(getDimensionIndexById(item._loadedDimensions, item.regionDimensionId));
+}
+
 // This is called with item.url when the URL is for a specific data file, ie. dataflow is not used.
 // It is also called with a calculated url when dataflow is used.
 function loadAndBuildTable(item, url) {
@@ -839,10 +859,10 @@ function loadAndBuildTable(item, url) {
         var series = json.dataSets[0].series;
 
         item._loadedDimensions = buildDimensions(item, structureSeries);
-        if (!defined(getDimensionIndexById(item._loadedDimensions, item.regionDimensionId))) {
+        if (!hasRegionDimension(item)) {
             // TODO: Raise an error, or handle case when there are no regions.
             console.log('No regions defined.');
-            return;
+            // item._regionMapping.regionDetails = undefined;
         }
         if (!defined(item._fullDimensions)) {
             // If we didn't come through the dataflow, ie. we've loaded this file directly, then we need to set the concepts now.
@@ -872,12 +892,13 @@ function loadAndBuildTable(item, url) {
         console.log('SDMX-JSON data as a table:', item._tableStructure);  // TODO: remove.
         return item._regionMapping.loadRegionDetails();
     }).then(function(regionDetails) {
-        // Can get here with undefined region column name, hence no regionDetails.
         if (regionDetails) {
             RegionMapping.setRegionColumnType(regionDetails);
             // Force a recalc of the imagery.
             // Required because we load the region details _after_ setting the active column.
             item._regionMapping.isLoading = false;
+        } else {
+            item.setChartable();
         }
         return when();
     }).otherwise(function(e) {

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -373,6 +373,8 @@ SdmxJsonCatalogItem.prototype._load = function() {
     // We pass column options to TableStructure too, but they only do anything if TableStructure itself (eg. via fromJson) adds the columns,
     // which is not the case here.  We will need to pass them to each call to new TableColumn as well.
     this._tableStructure = new TableStructure(this.name, this._columnOptions);
+    this._regionMapping = new RegionMapping(this, this._tableStructure, tableStyle);
+    this._regionMapping.changedEvent.addEventListener(dataChanged.bind(null, this), this);  // TODO: not sure we need this.
 
     this._dataflowUrl = getDataflowUrl(this);
     if (this._dataflowUrl) {
@@ -609,7 +611,7 @@ function buildValueColumns(item, loadedDimensions, columnCombinations, structure
     var thisColumnOptions = clone(item._columnOptions);
     thisColumnOptions.tableStructure = item._tableStructure;
     var columns = [];
-    var uniqueValue = (columnCombinations.ids.length <= 1);
+    var hasNoConcepts = (item._concepts.length === 0);
     var regionDimension = getDimensionById(loadedDimensions, item.regionDimensionId);
     var regionDimensionIndex = getDimensionIndexById(loadedDimensions, item.regionDimensionId);
     var timePeriodDimension = getDimensionById(loadedDimensions, item.timePeriodDimensionId);
@@ -637,7 +639,9 @@ function buildValueColumns(item, loadedDimensions, columnCombinations, structure
         }
         thisColumnOptions.id = combinationId; // So we can refer to the dimension in a template by a sequence of ids or names.
         var column = new TableColumn(combinationName, values, thisColumnOptions);
-        if (uniqueValue) {
+        if (hasNoConcepts) {
+            // If there are no concepts displayed to the user, there is only one value column, and we won't add a "total" column.
+            // So make this column active.
             column.isActive = true;
         }
         columns.push(column);
@@ -699,7 +703,7 @@ function buildTotalColumns(item, columnCombinations) {
     thisColumnOptions.tableStructure = item._tableStructure;
     thisColumnOptions.id = 'total selected';
     var activeConceptIds = calculateActiveConceptIds(item._concepts);
-    if (activeConceptIds.length === 0) {
+    if (item._concepts.length === 0 || activeConceptIds.length === 0) {
         return [];
     }
     // Find all the combinations of active concepts.
@@ -827,9 +831,6 @@ function loadAndBuildTable(item, url) {
     if (!defined(url)) {
         url = item.url;
     }
-    item._regionMapping = new RegionMapping(item, item._tableStructure, item._tableStyle);
-    item._regionMapping.isLoading = true;
-    item._regionMapping.changedEvent.addEventListener(dataChanged.bind(null, item), item);
     console.log('Downloading', url, 'as', proxyCatalogItemUrl(item, url));
     return loadJson(proxyCatalogItemUrl(item, url)).then(function(json) {
         var structureSeries = getStructureSeries(json);
@@ -858,6 +859,13 @@ function loadAndBuildTable(item, url) {
         var totalColumns = buildTotalColumns(item, columnCombinations); // The region column can't be active, so ok not to pass it.
         var columns = item._tableStructure.columns.concat(totalColumns);
         CsvCatalogItem.setActiveTimeColumn(item._tableStructure, item._tableStyle);
+        // We want to update the columns, which can of course update the region column.
+        // RegionMapping watches for changes in the active column and tries to redisplay it if so.
+        // However it does not expect the region column to change - regionDetails does not auto-update its column.
+        // Set regionMapping.isLoading true to prevent this.
+        // Once _regionMapping.loadRegionDetails() is done, it updates regionDetails.
+        // Setting _regionMapping.isLoading to false then triggers the changed-active-column event.
+        item._regionMapping.isLoading = true;
         updateColumns(item, columns);
         console.log('SDMX-JSON data as a table:', item._tableStructure);
         return item._regionMapping.loadRegionDetails();

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -36,6 +36,10 @@ var VarType = require('../Map/VarType');
     - https://sdmx.org/
     - http://stats.oecd.org/sdmx-json/ (hosts a handy query builder)
 
+    If this implementation reaches its limits we should consider using:
+    - https://github.com/airosa/sdmxjsonlib
+    especially mapComponentsToArray, mapComponentsToObject and mapDataSetsToArray.
+
     The URL can be of two types, eg:
     1. http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA/CABEE_2.LGA2013.1+.A/all?startTime=2013&endTime=2013
     2. http://stat.abs.gov.au/sdmx-json/data/ABS_REGIONAL_LGA

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -22,6 +22,7 @@ var GpxCatalogItem = require('./GpxCatalogItem');
 var KmlCatalogItem = require('./KmlCatalogItem');
 var OgrCatalogItem = require('./OgrCatalogItem');
 var OpenStreetMapCatalogItem = require('./OpenStreetMapCatalogItem');
+var SdmxJsonCatalogItem = require('./SdmxJsonCatalogItem');
 var SocrataCatalogGroup = require('./SocrataCatalogGroup');
 var UrlTemplateCatalogItem = require('./UrlTemplateCatalogItem');
 var WebFeatureServiceCatalogGroup = require('./WebFeatureServiceCatalogGroup');
@@ -56,6 +57,7 @@ var registerCatalogMembers = function() {
     createCatalogMemberFromType.register('kmz', KmlCatalogItem);
     createCatalogMemberFromType.register('ogr', OgrCatalogItem);
     createCatalogMemberFromType.register('open-street-map', OpenStreetMapCatalogItem);
+    createCatalogMemberFromType.register('sdmx-json', SdmxJsonCatalogItem);
     createCatalogMemberFromType.register('socrata', SocrataCatalogGroup);
     createCatalogMemberFromType.register('url-template', UrlTemplateCatalogItem);
     createCatalogMemberFromType.register('wfs', WebFeatureServiceCatalogItem);
@@ -79,12 +81,13 @@ var registerCatalogMembers = function() {
     createCatalogItemFromUrl.register(matchesExtension('kmz'), KmlCatalogItem);
     createCatalogItemFromUrl.register(matchesExtension('topojson'), GeoJsonCatalogItem);
 
-    //These items work by trying to match a URL, then loading the data. If it fails, they move on.
+    // These items work by trying to match a URL, then loading the data. If it fails, they move on.
     createCatalogItemFromUrl.register(matchesUrl(/\/WMTS\b/i), WebMapTileServiceCatalogGroup, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/wfs/i), WebFeatureServiceCatalogGroup, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/wms/i), WebMapServiceCatalogGroup, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/arcgis\/rest\/.*\/\d+\b/i), ArcGisMapServerCatalogItem, true);
     createCatalogItemFromUrl.register(matchesUrl(/\/ArcGis\/rest\//i), ArcGisCatalogGroup, true);
+    createCatalogItemFromUrl.register(matchesUrl(/\/sdmx-json\//i), SdmxJsonCatalogItem, true);
 
     // These don't even try to match a URL, they're just total fallbacks. We really, really want something to work.
     createCatalogItemFromUrl.register(undefined, WebMapServiceCatalogGroup, true);

--- a/test/Core/arrayProductSpec.js
+++ b/test/Core/arrayProductSpec.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/*global require, fail*/
+var arrayProduct = require('../../lib/Core/arrayProduct');
+
+describe('arrayProduct', function() {
+
+    it('works with one array of one', function() {
+        var test = [[1]];
+        var target = [[1]];
+        expect(arrayProduct(test)).toEqual(target);
+    });
+
+    it('works with several arrays of one', function() {
+        var test = [[1], [2], [3], [4]];
+        var target = [[1, 2, 3, 4]];
+        expect(arrayProduct(test)).toEqual(target);
+    });
+
+    it('works with one array of two', function() {
+        var test = [[1, 10]];
+        var target = [[1], [10]];
+        expect(arrayProduct(test)).toEqual(target);
+    });
+
+    it('works with an array of two in first place', function() {
+        var test = [[1, 10], [2], [3], [4]];
+        var target = [[1, 2, 3, 4], [10, 2, 3, 4]];
+        expect(arrayProduct(test)).toEqual(target);
+    });
+
+    it('works with arrays of two in the first two places', function() {
+        var test = [[1, 10], [2, 20], [3], [4]];
+        // Actually the order of the subarrays is not important.
+        var target = [[1, 2, 3, 4], [1, 20, 3, 4], [10, 2, 3, 4], [10, 20, 3, 4]];
+        expect(arrayProduct(test)).toEqual(target);
+    });
+
+    it('works with arrays of two in the first three places', function() {
+        var test = [[1, 10], [2, 20], [3, 30], [4]];
+        // Actually the order of the subarrays is not important.
+        var target =  [[ 1, 2, 3, 4], [1, 2, 30, 4], [1, 20, 3, 4], [1, 20, 30, 4], [10, 2, 3, 4], [10, 2, 30, 4], [10, 20, 3, 4], [10, 20, 30, 4]];
+        expect(arrayProduct(test)).toEqual(target);
+    });
+
+    it('works with an array of two in the final place', function() {
+        var test = [[1], [2], [3], [4, 40]];
+        var target = [[1, 2, 3, 4], [1, 2, 3, 40]];
+        expect(arrayProduct(test)).toEqual(target);
+    });
+
+    it('works with an array of two in the final two places', function() {
+        var test = [[1], [2], [3, 30], [4, 40]];
+        var target = [[1, 2, 3, 4], [1, 2, 3, 40], [1, 2, 30, 4], [1, 2, 30, 40]];
+        expect(arrayProduct(test)).toEqual(target);
+    });
+
+});

--- a/test/Models/AbsIttCatalogItemSpec.js
+++ b/test/Models/AbsIttCatalogItemSpec.js
@@ -6,61 +6,6 @@ var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var Terria = require('../../lib/Models/Terria');
 var AbsIttCatalogItem = require('../../lib/Models/AbsIttCatalogItem');
 
-describe('AbsIttCatalogItem._generateAllCombinations', function() {
-
-    it('works with one code and one concept', function() {
-        var test = [[1]];
-        var target = [[1]];
-        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
-    });
-
-    it('works with one code per concept', function() {
-        var test = [[1], [2], [3], [4]];
-        var target = [[1, 2, 3, 4]];
-        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
-    });
-
-    it('works with two codes in a single concept', function() {
-        var test = [[1, 10]];
-        var target = [[1], [10]];
-        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
-    });
-
-    it('works with two codes in first concept', function() {
-        var test = [[1, 10], [2], [3], [4]];
-        var target = [[1, 2, 3, 4], [10, 2, 3, 4]];
-        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
-    });
-
-    it('works with two codes in first two concepts', function() {
-        var test = [[1, 10], [2, 20], [3], [4]];
-        // Actually the order of the subarrays is not important.
-        var target = [[1, 2, 3, 4], [1, 20, 3, 4], [10, 2, 3, 4], [10, 20, 3, 4]];
-        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
-    });
-
-    it('works with two codes in first three concepts', function() {
-        var test = [[1, 10], [2, 20], [3, 30], [4]];
-        // Actually the order of the subarrays is not important.
-        var target =  [[ 1, 2, 3, 4], [1, 2, 30, 4], [1, 20, 3, 4], [1, 20, 30, 4], [10, 2, 3, 4], [10, 2, 30, 4], [10, 20, 3, 4], [10, 20, 30, 4]];
-        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
-    });
-
-    it('works with two codes in last concept', function() {
-        var test = [[1], [2], [3], [4, 40]];
-        var target = [[1, 2, 3, 4], [1, 2, 3, 40]];
-        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
-    });
-
-    it('works with two codes in last two concepts', function() {
-        var test = [[1], [2], [3, 30], [4, 40]];
-        var target = [[1, 2, 3, 4], [1, 2, 3, 40], [1, 2, 30, 4], [1, 2, 30, 40]];
-        expect(AbsIttCatalogItem._generateAllCombinations(test)).toEqual(target);
-    });
-
-});
-
-
 describe('AbsIttCatalogItem', function() {
     var terria;
     var item;

--- a/test/Models/SdmxJsonCatalogItemSpec.js
+++ b/test/Models/SdmxJsonCatalogItemSpec.js
@@ -1,0 +1,157 @@
+'use strict';
+
+/*global require, fail*/
+var loadText = require('terriajs-cesium/Source/Core/loadText');
+var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
+
+var Terria = require('../../lib/Models/Terria');
+var SdmxJsonCatalogItem = require('../../lib/Models/SdmxJsonCatalogItem');
+
+describe('SdmxJsonCatalogItem', function() {
+    var terria;
+    var item;
+
+    beforeEach(function() {
+        terria = new Terria({
+            baseUrl: './'
+        });
+        item = new SdmxJsonCatalogItem(terria);
+    });
+
+    it('can update from json', function() {
+        item.updateFromJson({
+            name: 'Name',
+            description: 'Description',
+            rectangle: [-10, 10, -20, 20],
+            url: 'http://foo.bar',
+            dataUrlComponent: 'atad'
+        });
+        expect(item.name).toBe('Name');
+        expect(item.description).toBe('Description');
+        expect(item.rectangle).toEqual(Rectangle.fromDegrees(-10, 10, -20, 20));
+        expect(item.type).toBe('sdmx-json');
+        expect(item.url.indexOf('http://foo.bar')).toBe(0);
+        expect(item.dataUrlComponent).toBe('atad');
+    });
+
+    it('can be round-tripped with serializeToJson and updateFromJson', function() {
+        item.updateFromJson({
+            name: 'Name',
+            id: 'Id',
+            description: 'Description',
+            rectangle: [-10, 10, -20, 20],
+            url: 'http://foo.bar/',
+            dataUrlComponent: 'atad'
+        });
+        var json = item.serializeToJson();
+        var reconstructed = new SdmxJsonCatalogItem(terria);
+        reconstructed.updateFromJson(json);
+        // item.concepts has a circular dependency via its __knockoutSubscribable property,
+        // with itself being a subscriber, so it will not equal reconstructed.concepts.
+        // So check the arrays are equal, and then remove them before comparing the rest of the item.
+        expect(item.concepts.slice(), reconstructed.concepts.slice());
+        delete item.concepts;
+        delete item._concepts;
+        delete reconstructed.concepts;
+        delete reconstructed._concepts;
+        // for (var i = Object.keys(item).length - 1; i >= 0; i--) {
+        //     var k = Object.keys(item)[i];
+        //     console.log(k);
+        //     expect(reconstructed[k]).toEqual(item[k]);
+        // }
+
+        expect(reconstructed.name).toEqual(item.name);
+        expect(reconstructed.id).toEqual(item.id);
+        expect(reconstructed.description).toEqual(item.description);
+        expect(reconstructed.rectangle).toEqual(item.rectangle);
+        expect(reconstructed.url).toEqual(item.url);
+        expect(reconstructed.dataUrlComponent).toEqual(item.dataUrlComponent);
+    });
+
+    describe('loading', function() {
+        var regionMappingJson, lgaData;
+        var dataflowFoo, dataFooBD2;
+        beforeEach(function(done) {
+            when.all([
+                loadText('test/SDMX-JSON/dataflow-foo.json').then(function(text) { dataflowFoo = text; }),
+                loadText('test/SDMX-JSON/data-foo-BD2-2013.json').then(function(text) { dataFooBD2 = text; }),
+                loadText('data/regionMapping.json').then(function(text) { regionMappingJson = text; }),
+                loadText('data/regionids/region_map-FID_LGA_2015_AUST_LGA_CODE15.json').then(function(text) { lgaData = text; })
+            ]).then(function() {
+                jasmine.Ajax.install();
+                jasmine.Ajax.stubRequest(/.*/).andError(); // Fail all requests by default.
+                jasmine.Ajax.stubRequest('http://sdmx.example.com/sdmx-json/dataflow/FOO').andReturn({responseText: dataflowFoo});
+                jasmine.Ajax.stubRequest('http://sdmx.example.com/sdmx-json/data/FOO/BD_2..A/all?startTime=2013&endTime=2013').andReturn({responseText: dataFooBD2});
+                jasmine.Ajax.stubRequest('data/regionMapping.json').andReturn({responseText: regionMappingJson});
+                jasmine.Ajax.stubRequest('data/regionids/region_map-FID_LGA_2015_AUST_LGA_CODE15.json').andReturn({responseText: lgaData});
+            }).then(done).otherwise(done.fail);
+        });
+
+        afterEach(function() {
+            jasmine.Ajax.uninstall();
+        });
+
+        it('works with a specific SDMX-JSON file', function(done) {
+            item.updateFromJson({
+                name: 'Foo',
+                url: 'http://sdmx.example.com/sdmx-json/data/FOO/BD_2..A/all?startTime=2013&endTime=2013'
+            });
+            item.load().then(function() {
+                var regionDetails = item.regionMapping.regionDetails;
+                expect(regionDetails).toBeDefined();
+                var columnNames = item.tableStructure.getColumnNames();
+                expect(columnNames.length).toEqual(2);
+                expect(columnNames[0]).toEqual('LGA_code_2013');
+                expect(item.tableStructure.columns[1].values).toEqual([1140, 535, 79, 12, 38]);
+            }).otherwise(fail).then(done);
+        });
+
+        // I'm not sure we want this test.
+        it('gracefully handles a non-SDMX URL', function(done) {
+            item.updateFromJson({
+                name: 'Name',
+                url: 'http://example.com'
+            });
+            item.load().then(function() {
+                return item.dataSource.regionPromise;
+            }).otherwise(function(e) {
+                // We actually want this to fail; if it doesn't get here, will say SPEC HAS NO EXPECTATIONS.
+                expect(true).toBe(true);
+            }).then(done);
+        });
+
+        // TODO: (this is old)
+        // it('works with selectedInitially parameter', function(done) {
+        //     item.updateFromJson({
+        //         name: 'Name',
+        //         datasetId: 'foo',
+        //         url: 'http://abs.example.com',
+        //         filter: ["REGIONTYPE.SA4"]  // Should use SA4 now
+        //     });
+        //     item.load().then(function() {
+        //         var regionDetails = item.regionMapping.regionDetails;
+        //         expect(regionDetails).toBeDefined();
+        //         var columnNames = item.tableStructure.getColumnNames();
+        //         expect(columnNames.slice(0, 3)).toEqual(["sa4_code_2011", "Year", "0-1 years"]);
+        //         var percentage = item.tableStructure.activeItems[0].values[0];
+        //         expect(percentage).toEqual(12.5);  // 26 / 208 * 100
+        //     }).otherwise(fail).then(done);
+        // });
+
+        it('is less than 2000 characters when serialised to JSON then URLEncoded', function(done) {
+            item.updateFromJson({
+                name: 'Name',
+                description: 'Description',
+                url: 'http://abs.example.com/',
+                dataUrlComponent: 'foo'
+            });
+            item.load().then(function() {
+                var url = encodeURIComponent(JSON.stringify(item.serializeToJson()));
+                expect(url.length).toBeLessThan(2000);
+            }).otherwise(fail).then(done);
+        });
+
+    });
+
+});

--- a/test/Models/SdmxJsonCatalogItemSpec.js
+++ b/test/Models/SdmxJsonCatalogItemSpec.js
@@ -71,11 +71,12 @@ describe('SdmxJsonCatalogItem', function() {
 
     describe('loading', function() {
         var regionMappingJson, lgaData;
-        var dataflowFoo, dataFooBD2;
+        var dataflowFoo, dataFooBD2, dataFoo2;
         beforeEach(function(done) {
             when.all([
                 loadText('test/SDMX-JSON/dataflow-foo.json').then(function(text) { dataflowFoo = text; }),
                 loadText('test/SDMX-JSON/data-foo-BD2-2013.json').then(function(text) { dataFooBD2 = text; }),
+                loadText('test/SDMX-JSON/data-foo2-2013.json').then(function(text) { dataFoo2 = text; }),
                 loadText('data/regionMapping.json').then(function(text) { regionMappingJson = text; }),
                 loadText('data/regionids/region_map-FID_LGA_2015_AUST_LGA_CODE15.json').then(function(text) { lgaData = text; })
             ]).then(function() {
@@ -83,6 +84,7 @@ describe('SdmxJsonCatalogItem', function() {
                 jasmine.Ajax.stubRequest(/.*/).andError(); // Fail all requests by default.
                 jasmine.Ajax.stubRequest('http://sdmx.example.com/sdmx-json/dataflow/FOO').andReturn({responseText: dataflowFoo});
                 jasmine.Ajax.stubRequest('http://sdmx.example.com/sdmx-json/data/FOO/BD_2..A/all?startTime=2013&endTime=2013').andReturn({responseText: dataFooBD2});
+                jasmine.Ajax.stubRequest('http://sdmx.example.com/sdmx-json/data/FOO2/BD_2+BD_4..A../all?startTime=2013&endTime=2013').andReturn({responseText: dataFoo2});
                 jasmine.Ajax.stubRequest('data/regionMapping.json').andReturn({responseText: regionMappingJson});
                 jasmine.Ajax.stubRequest('data/regionids/region_map-FID_LGA_2015_AUST_LGA_CODE15.json').andReturn({responseText: lgaData});
             }).then(done).otherwise(done.fail);
@@ -92,18 +94,49 @@ describe('SdmxJsonCatalogItem', function() {
             jasmine.Ajax.uninstall();
         });
 
-        it('works with a specific SDMX-JSON file', function(done) {
+        it('works with a simple SDMX-JSON file', function(done) {
             item.updateFromJson({
                 name: 'Foo',
                 url: 'http://sdmx.example.com/sdmx-json/data/FOO/BD_2..A/all?startTime=2013&endTime=2013'
             });
             item.load().then(function() {
+                // Expect it to have realised this is regional data.
                 var regionDetails = item.regionMapping.regionDetails;
                 expect(regionDetails).toBeDefined();
+                // Expect it to have created the right table of data (with no time dimension).
                 var columnNames = item.tableStructure.getColumnNames();
                 expect(columnNames.length).toEqual(2);
                 expect(columnNames[0]).toEqual('LGA_code_2013');
+                expect(item.tableStructure.columns[0].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
                 expect(item.tableStructure.columns[1].values).toEqual([1140, 535, 79, 12, 38]);
+                // Expect it not to show any concepts to the user.
+                expect(item.concepts.length).toEqual(0);
+            }).otherwise(fail).then(done);
+        });
+
+        it('works with a two-concept SDMX-JSON file', function(done) {
+            item.updateFromJson({
+                name: 'Foo2',
+                url: 'http://sdmx.example.com/sdmx-json/data/FOO2/BD_2+BD_4..A../all?startTime=2013&endTime=2013'
+            });
+            item.load().then(function() {
+                // Expect it to have realised this is regional data.
+                var regionDetails = item.regionMapping.regionDetails;
+                expect(regionDetails).toBeDefined();
+                // Expect it to have created the right table of data (with no time dimension).
+                var columnNames = item.tableStructure.getColumnNames();
+                expect(columnNames.length).toEqual(6);
+                expect(columnNames[0]).toEqual('LGA_code_2013');
+                expect(item.tableStructure.columns[0].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
+                expect(item.tableStructure.columns[1].values).toEqual([1140, 535, 79, 12, 38]);
+                expect(item.tableStructure.columns[2].values).toEqual([2140, 2535, 2179, 2112, 2138]);
+                expect(item.tableStructure.columns[3].values).toEqual([140, 35, 179, 112, 138]);
+                expect(item.tableStructure.columns[4].values).toEqual([1140, 1035, 579, 1512, 2138]);
+                expect(item.tableStructure.columns[5].values).toEqual([1140, 535, 79, 12, 38]);
+                // Expect it to show 2 concepts to the user, each with 2 sub items.
+                expect(item.concepts.length).toEqual(2);
+                expect(item.concepts[0].items.length).toEqual(2);
+                expect(item.concepts[1].items.length).toEqual(2);
             }).otherwise(fail).then(done);
         });
 

--- a/test/Models/SdmxJsonCatalogItemSpec.js
+++ b/test/Models/SdmxJsonCatalogItemSpec.js
@@ -109,10 +109,11 @@ describe('SdmxJsonCatalogItem', function() {
                 expect(regionDetails).toBeDefined();
                 // Expect it to have created the right table of data (with no time dimension).
                 var columnNames = item.tableStructure.getColumnNames();
-                expect(columnNames.length).toEqual(2);
-                expect(columnNames[0]).toEqual('LGA_code_2013');
-                expect(item.tableStructure.columns[0].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
-                expect(item.tableStructure.columns[1].values).toEqual([1140, 535, 79, 12, 38]);
+                expect(columnNames.length).toEqual(3);
+                expect(columnNames[1]).toEqual('LGA_code_2013');
+                expect(item.tableStructure.columns[0].values).toEqual(['2013', '2013', '2013', '2013', '2013']);
+                expect(item.tableStructure.columns[1].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
+                expect(item.tableStructure.columns[2].values).toEqual([1140, 535, 79, 12, 38]);
                 // Expect it not to show any concepts to the user.
                 expect(item.concepts.length).toEqual(0);
             }).otherwise(fail).then(done);
@@ -129,14 +130,15 @@ describe('SdmxJsonCatalogItem', function() {
                 expect(regionDetails).toBeDefined();
                 // Expect it to have created the right table of data (with no time dimension).
                 var columnNames = item.tableStructure.getColumnNames();
-                expect(columnNames.length).toEqual(6);
-                expect(columnNames[0]).toEqual('LGA_code_2013');
-                expect(item.tableStructure.columns[0].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
-                expect(item.tableStructure.columns[1].values).toEqual([1140, 535, 79, 12, 38]);
-                expect(item.tableStructure.columns[2].values).toEqual([2140, 2535, 2179, 2112, 2138]);
-                expect(item.tableStructure.columns[3].values).toEqual([140, 35, 179, 112, 138]);
-                expect(item.tableStructure.columns[4].values).toEqual([1140, 1035, 579, 1512, 2138]);
-                expect(item.tableStructure.columns[5].values).toEqual([1140, 535, 79, 12, 38]);
+                expect(columnNames.length).toEqual(7);
+                expect(columnNames[1]).toEqual('LGA_code_2013');
+                expect(item.tableStructure.columns[0].values).toEqual(['2013', '2013', '2013', '2013', '2013']);
+                expect(item.tableStructure.columns[1].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
+                expect(item.tableStructure.columns[2].values).toEqual([1140, 535, 79, 12, 38]);
+                expect(item.tableStructure.columns[3].values).toEqual([2140, 2535, 2179, 2112, 2138]);
+                expect(item.tableStructure.columns[4].values).toEqual([140, 35, 179, 112, 138]);
+                expect(item.tableStructure.columns[5].values).toEqual([1140, 1035, 579, 1512, 2138]);
+                expect(item.tableStructure.columns[6].values).toEqual([1140, 535, 79, 12, 38]);
                 // Expect it to show 2 concepts to the user, each with 2 sub items.
                 expect(item.concepts.length).toEqual(2);
                 expect(item.concepts[0].items.length).toEqual(2);
@@ -157,11 +159,12 @@ describe('SdmxJsonCatalogItem', function() {
                 expect(regionDetails).toBeDefined();
                 // Expect it to have created the right table of data (with no time dimension).
                 var columnNames = item.tableStructure.getColumnNames();
-                expect(columnNames.length).toEqual(3); // It shows a single concept and so always shows a total column.
-                expect(columnNames[0]).toEqual('LGA_code_2013');
-                expect(item.tableStructure.columns[0].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
-                expect(item.tableStructure.columns[1].values).toEqual([1140, 535, 79, 12, 38]);
-                expect(item.tableStructure.columns[1].values).toEqual(item.tableStructure.columns[2].values);
+                expect(columnNames.length).toEqual(4); // It shows a single concept and so always shows a total column.
+                expect(columnNames[1]).toEqual('LGA_code_2013');
+                expect(item.tableStructure.columns[0].values).toEqual(['2013', '2013', '2013', '2013', '2013']);
+                expect(item.tableStructure.columns[1].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
+                expect(item.tableStructure.columns[2].values).toEqual([1140, 535, 79, 12, 38]);
+                expect(item.tableStructure.columns[3].values).toEqual(item.tableStructure.columns[2].values);
                 // Expect it to show the birth/death concept to the user.
                 expect(item.concepts.length).toEqual(1);
             }).otherwise(fail).then(done);
@@ -183,12 +186,13 @@ describe('SdmxJsonCatalogItem', function() {
                 expect(regionDetails).toBeDefined();
                 // Expect it to have created the right table of data (with no time dimension).
                 var columnNames = item.tableStructure.getColumnNames();
-                expect(columnNames.length).toEqual(4); // Region, BD_2, BD_4 and a total.
-                expect(columnNames[0]).toEqual('LGA_code_2013');
-                expect(item.tableStructure.columns[0].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
-                expect(item.tableStructure.columns[1].values).toEqual([1140, 535, 79, 12, 38]);
-                expect(item.tableStructure.columns[2].values).toEqual([140, 235, 279, 812, 338]);
-                expect(item.tableStructure.columns[3].values).toEqual([1280, 770, 358, 824, 376]);
+                expect(columnNames.length).toEqual(5); // Region, BD_2, BD_4 and a total.
+                expect(columnNames[1]).toEqual('LGA_code_2013');
+                expect(item.tableStructure.columns[0].values).toEqual(['2013', '2013', '2013', '2013', '2013']);
+                expect(item.tableStructure.columns[1].values).toEqual(['17100', '56520', '54970', '10300', '29399']);
+                expect(item.tableStructure.columns[2].values).toEqual([1140, 535, 79, 12, 38]);
+                expect(item.tableStructure.columns[3].values).toEqual([140, 235, 279, 812, 338]);
+                expect(item.tableStructure.columns[4].values).toEqual([1280, 770, 358, 824, 376]);
                 // Expect it to show the birth/death concept to the user.
                 expect(item.concepts.length).toEqual(1);
             }).otherwise(fail).then(done);

--- a/test/Models/SdmxJsonCatalogItemSpec.js
+++ b/test/Models/SdmxJsonCatalogItemSpec.js
@@ -45,6 +45,8 @@ describe('SdmxJsonCatalogItem', function() {
             dataUrlComponent: 'atad'
         });
         var json = item.serializeToJson();
+        // This json should include selectedInitially.
+        expect(json.selectedInitially).toBeDefined();
         var reconstructed = new SdmxJsonCatalogItem(terria);
         reconstructed.updateFromJson(json);
         // item.concepts has a circular dependency via its __knockoutSubscribable property,

--- a/wwwroot/data/regionMapping.json
+++ b/wwwroot/data/regionMapping.json
@@ -588,7 +588,7 @@
       "server": "http://geoserver.nationalmap.nicta.com.au/region_map/ows",
       "regionProp": "ISO3",
       "aliases": [
-        "iso3",
+        "cnt3",
         "iso3",
         "country"
       ],

--- a/wwwroot/test/SDMX-JSON/data-foo-2013.json
+++ b/wwwroot/test/SDMX-JSON/data-foo-2013.json
@@ -1,0 +1,152 @@
+{
+    "header": {
+        "id": "foo",
+        "test": true
+    },
+    "dataSets": [{
+        "action": "Information",
+        "series": {
+            "0:0:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1140.0, null]
+                }
+            },
+            "0:0:1:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [535.0, null]
+                }
+            },
+            "0:0:2:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [79.0, null]
+                }
+            },
+            "0:0:3:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [12.0, null]
+                }
+            },
+            "0:0:4:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [38.0, null]
+                }
+            },
+            "1:0:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [140.0, null]
+                }
+            },
+            "1:0:1:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [235.0, null]
+                }
+            },
+            "1:0:2:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [279.0, null]
+                }
+            },
+            "1:0:3:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [812.0, null]
+                }
+            },
+            "1:0:4:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [338.0, null]
+                }
+            }        
+        }
+    }],
+    "structure": {
+        "name": "foo",
+        "description": "Foo Example",
+        "dimensions": {
+            "series": [{
+                "keyPosition": 0,
+                "id": "MEASURE",
+                "name": "Data Item",
+                "values": [{
+                    "id": "BD_2",
+                    "name": "Births"
+                }, {
+                    "id": "BD_4",
+                    "name": "Deaths"
+                }]
+            }, {
+                "keyPosition": 1,
+                "id": "REGIONTYPE",
+                "name": "Region Type",
+                "values": [{
+                    "id": "LGA_2013",
+                    "name": "Local Government Areas (2013)"
+                }]
+            }, {
+                "keyPosition": 2,
+                "id": "REGION",
+                "name": "Region",
+                "values": [{
+                    "id": "17100",
+                    "name": "Strathfield (A)"
+                }, {
+                    "id": "56520",
+                    "name": "Narrogin (T)"
+                }, {
+                    "id": "54970",
+                    "name": "Laverton (S)"
+                }, {
+                    "id": "10300",
+                    "name": "Balranald (A)"
+                }, {
+                    "id": "29399",
+                    "name": "Unincorporated Vic"
+                }]
+            }, {
+                "keyPosition": 3,
+                "id": "FREQUENCY",
+                "name": "Frequency",
+                "values": [{
+                    "id": "A",
+                    "name": "Annual"
+                }],
+                "role": "FREQ"
+            }],
+            "observation": [{
+                "id": "TIME_PERIOD",
+                "name": "Time",
+                "values": [{
+                    "id": "2013",
+                    "name": "2013"
+                }],
+                "role": "TIME_PERIOD"
+            }]
+        },
+        "attributes": {
+            "dataSet": [],
+            "series": [{
+                "id": "TIME_FORMAT",
+                "name": "Time Format",
+                "values": [{
+                    "id": "P1Y",
+                    "name": "Annual"
+                }]
+            }],
+            "observation": [{
+                "id": "OBS_STATUS",
+                "name": "Observation Status",
+                "values": []
+            }]
+        },
+        "annotations": []
+    }
+}

--- a/wwwroot/test/SDMX-JSON/data-foo-BD2-2011_2013.json
+++ b/wwwroot/test/SDMX-JSON/data-foo-BD2-2011_2013.json
@@ -1,0 +1,135 @@
+{
+    "header": {
+        "id": "foo",
+        "test": true
+    },
+    "dataSets": [{
+        "action": "Information",
+        "series": {
+            "0:0:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1140.0, null],
+                    "1": [1141.0, null],
+                    "2": [1142.0, null]
+                }
+            },
+            "0:0:1:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [535.0, null],
+                    "1": [536.0, null],
+                    "2": [537.0, null]
+                }
+            },
+            "0:0:2:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [79.0, null],
+                    "1": [78.0, null],
+                    "2": [77.0, null]
+                }
+            },
+            "0:0:3:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [12.0, null],
+                    "1": [13.0, null],
+                    "2": [11.0, null]
+                }
+            },
+            "0:0:4:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [38.0, null],
+                    "1": [28.0, null],
+                    "2": [18.0, null]
+                }
+            }
+        }
+    }],
+    "structure": {
+        "name": "foo",
+        "description": "Foo Example",
+        "dimensions": {
+            "series": [{
+                "keyPosition": 0,
+                "id": "MEASURE",
+                "name": "Data Item",
+                "values": [{
+                    "id": "BD_2",
+                    "name": "Births"
+                }]
+            }, {
+                "keyPosition": 1,
+                "id": "REGIONTYPE",
+                "name": "Region Type",
+                "values": [{
+                    "id": "LGA_2013",
+                    "name": "Local Government Areas (2013)"
+                }]
+            }, {
+                "keyPosition": 2,
+                "id": "REGION",
+                "name": "Region",
+                "values": [{
+                    "id": "17100",
+                    "name": "Strathfield (A)"
+                }, {
+                    "id": "56520",
+                    "name": "Narrogin (T)"
+                }, {
+                    "id": "54970",
+                    "name": "Laverton (S)"
+                }, {
+                    "id": "10300",
+                    "name": "Balranald (A)"
+                }, {
+                    "id": "29399",
+                    "name": "Unincorporated Vic"
+                }]
+            }, {
+                "keyPosition": 3,
+                "id": "FREQUENCY",
+                "name": "Frequency",
+                "values": [{
+                    "id": "A",
+                    "name": "Annual"
+                }],
+                "role": "FREQ"
+            }],
+            "observation": [{
+                "id": "TIME_PERIOD",
+                "name": "Time",
+                "values": [{
+                    "id": "2011",
+                    "name": "2011"
+                }, {
+                    "id": "2012",
+                    "name": "2012"
+                }, {
+                    "id": "2013",
+                    "name": "2013"
+                }],
+                "role": "TIME_PERIOD"
+            }]
+        },
+        "attributes": {
+            "dataSet": [],
+            "series": [{
+                "id": "TIME_FORMAT",
+                "name": "Time Format",
+                "values": [{
+                    "id": "P1Y",
+                    "name": "Annual"
+                }]
+            }],
+            "observation": [{
+                "id": "OBS_STATUS",
+                "name": "Observation Status",
+                "values": []
+            }]
+        },
+        "annotations": []
+    }
+}

--- a/wwwroot/test/SDMX-JSON/data-foo-BD2-2013.json
+++ b/wwwroot/test/SDMX-JSON/data-foo-BD2-2013.json
@@ -1,0 +1,119 @@
+{
+    "header": {
+        "id": "foo",
+        "test": true
+    },
+    "dataSets": [{
+        "action": "Information",
+        "series": {
+            "0:0:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1140.0, null]
+                }
+            },
+            "0:0:1:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [535.0, null]
+                }
+            },
+            "0:0:2:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [79.0, null]
+                }
+            },
+            "0:0:3:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [12.0, null]
+                }
+            },
+            "0:0:4:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [38.0, null]
+                }
+            }
+        }
+    }],
+    "structure": {
+        "name": "foo",
+        "description": "Foo Example",
+        "dimensions": {
+            "series": [{
+                "keyPosition": 0,
+                "id": "MEASURE",
+                "name": "Data Item",
+                "values": [{
+                    "id": "BD_2",
+                    "name": "Births"
+                }]
+            }, {
+                "keyPosition": 1,
+                "id": "REGIONTYPE",
+                "name": "Region Type",
+                "values": [{
+                    "id": "LGA_2013",
+                    "name": "Local Government Areas (2013)"
+                }]
+            }, {
+                "keyPosition": 2,
+                "id": "REGION",
+                "name": "Region",
+                "values": [{
+                    "id": "17100",
+                    "name": "Strathfield (A)"
+                }, {
+                    "id": "56520",
+                    "name": "Narrogin (T)"
+                }, {
+                    "id": "54970",
+                    "name": "Laverton (S)"
+                }, {
+                    "id": "10300",
+                    "name": "Balranald (A)"
+                }, {
+                    "id": "29399",
+                    "name": "Unincorporated Vic"
+                }]
+            }, {
+                "keyPosition": 3,
+                "id": "FREQUENCY",
+                "name": "Frequency",
+                "values": [{
+                    "id": "A",
+                    "name": "Annual"
+                }],
+                "role": "FREQ"
+            }],
+            "observation": [{
+                "id": "TIME_PERIOD",
+                "name": "Time",
+                "values": [{
+                    "id": "2013",
+                    "name": "2013"
+                }],
+                "role": "TIME_PERIOD"
+            }]
+        },
+        "attributes": {
+            "dataSet": [],
+            "series": [{
+                "id": "TIME_FORMAT",
+                "name": "Time Format",
+                "values": [{
+                    "id": "P1Y",
+                    "name": "Annual"
+                }]
+            }],
+            "observation": [{
+                "id": "OBS_STATUS",
+                "name": "Observation Status",
+                "values": []
+            }]
+        },
+        "annotations": []
+    }
+}

--- a/wwwroot/test/SDMX-JSON/data-foo2-2013.json
+++ b/wwwroot/test/SDMX-JSON/data-foo2-2013.json
@@ -1,0 +1,223 @@
+{
+    "header": {
+        "id": "two concept example",
+        "test": true
+    },
+    "dataSets": [{
+        "action": "Information",
+        "series": {
+            "0:0:0:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1140.0, null]
+                }
+            },
+            "0:0:1:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [535.0, null]
+                }
+            },
+            "0:0:2:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [79.0, null]
+                }
+            },
+            "0:0:3:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [12.0, null]
+                }
+            },
+            "0:0:4:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [38.0, null]
+                }
+            },
+            "1:0:0:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [140.0, null]
+                }
+            },
+            "1:0:1:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [35.0, null]
+                }
+            },
+            "1:0:2:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [179.0, null]
+                }
+            },
+            "1:0:3:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [112.0, null]
+                }
+            },
+            "1:0:4:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [138.0, null]
+                }
+            },
+            "0:0:0:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2140.0, null]
+                }
+            },
+            "0:0:1:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2535.0, null]
+                }
+            },
+            "0:0:2:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2179.0, null]
+                }
+            },
+            "0:0:3:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2112.0, null]
+                }
+            },
+            "0:0:4:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2138.0, null]
+                }
+            },
+            "1:0:0:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1140.0, null]
+                }
+            },
+            "1:0:1:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1035.0, null]
+                }
+            },
+            "1:0:2:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [579.0, null]
+                }
+            },
+            "1:0:3:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1512.0, null]
+                }
+            },
+            "1:0:4:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2138.0, null]
+                }
+            }
+        }
+    }],
+    "structure": {
+         "name": "two concept example",
+        "description": "two concept example",
+        "dimensions": {
+            "series": [{
+                "keyPosition": 0,
+                "id": "MEASURE",
+                "name": "Data Item",
+                "values": [{
+                    "id": "BD_2",
+                    "name": "Births"
+                }, {
+                    "id": "BD_4",
+                    "name": "Deaths"
+                }]
+            }, {
+                "keyPosition": 1,
+                "id": "REGIONTYPE",
+                "name": "Region Type",
+                "values": [{
+                    "id": "LGA_2013",
+                    "name": "Local Government Areas (2013)"
+                }]
+            }, {
+                "keyPosition": 2,
+                "id": "REGION",
+                "name": "Region",
+                "values": [{
+                    "id": "17100",
+                    "name": "Strathfield (A)"
+                }, {
+                    "id": "56520",
+                    "name": "Narrogin (T)"
+                }, {
+                    "id": "54970",
+                    "name": "Laverton (S)"
+                }, {
+                    "id": "10300",
+                    "name": "Balranald (A)"
+                }, {
+                    "id": "29399",
+                    "name": "Unincorporated Vic"
+                }]
+            }, {
+                "keyPosition": 3,
+                "id": "FREQUENCY",
+                "name": "Frequency",
+                "values": [{
+                    "id": "A",
+                    "name": "Annual"
+                }],
+                "role": "FREQ"
+            }, {
+                "keyPosition": 4,
+                "id": "AGE",
+                "name": "Age",
+                "values": [{
+                    "id": "0-20",
+                    "name": "0 - 20 Years"
+                }, {
+                    "id": "21+",
+                    "name": "21+ Years"
+                }]
+            }],
+            "observation": [{
+                "id": "TIME_PERIOD",
+                "name": "Time",
+                "values": [{
+                    "id": "2013",
+                    "name": "2013"
+                }],
+                "role": "TIME_PERIOD"
+            }]
+        },
+        "attributes": {
+            "dataSet": [],
+            "series": [{
+                "id": "TIME_FORMAT",
+                "name": "Time Format",
+                "values": [{
+                    "id": "P1Y",
+                    "name": "Annual"
+                }]
+            }],
+            "observation": [{
+                "id": "OBS_STATUS",
+                "name": "Observation Status",
+                "values": []
+            }]
+        },
+        "annotations": []
+    }
+}

--- a/wwwroot/test/SDMX-JSON/data-nonspatial.json
+++ b/wwwroot/test/SDMX-JSON/data-nonspatial.json
@@ -1,0 +1,269 @@
+{
+    "header": {
+        "id": "Non-spatial",
+        "test": true
+    },
+    "dataSets": [{
+        "action": "Information",
+        "series": {
+            "0:0:0:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1140.0, null],
+					"1": [11140.0, null],
+					"2": [21140.0, null]
+                }
+            },
+            "0:0:1:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [535.0, null],
+					"1": [1535.0, null],
+					"2": [2535.0, null]
+                }
+            },
+            "0:0:2:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [79.0, null],
+					"1": [179.0, null],
+					"2": [279.0, null]
+                }
+            },
+            "0:0:3:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [12.0, null],
+					"1": [112.0, null],
+					"2": [212.0, null]
+                }
+            },
+            "0:0:4:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [38.0, null],
+					"1": [138.0, null],
+					"2": [238.0, null]
+                }
+            },
+            "1:0:0:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [140.0, null],
+					"1": [1140.0, null],
+					"2": [2140.0, null]
+                }
+            },
+            "1:0:1:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [35.0, null],
+					"1": [135.0, null],
+					"2": [235.0, null]
+                }
+            },
+            "1:0:2:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [179.0, null],
+					"1": [1179.0, null],
+					"2": [2179.0, null]
+                }
+            },
+            "1:0:3:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [112.0, null],
+					"1": [1112.0, null],
+					"2": [2112.0, null]
+                }
+            },
+            "1:0:4:0:0": {
+                "attributes": [0],
+                "observations": {
+                    "0": [138.0, null],
+					"1": [1138.0, null],
+					"2": [2138.0, null]
+                }
+            },
+            "0:0:0:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2140.0, null],
+					"1": [12140.0, null],
+					"2": [22140.0, null]
+                }
+            },
+            "0:0:1:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2535.0, null],
+					"1": [12535.0, null],
+					"2": [22535.0, null]
+                }
+            },
+            "0:0:2:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2179.0, null],
+					"1": [12179.0, null],
+					"2": [22179.0, null]
+                }
+            },
+            "0:0:3:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2112.0, null],
+					"1": [12112.0, null],
+					"2": [22112.0, null]
+                }
+            },
+            "0:0:4:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2138.0, null],
+					"1": [12138.0, null],
+					"2": [22138.0, null]
+                }
+            },
+            "1:0:0:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1140.0, null],
+					"1": [11140.0, null],
+					"2": [21140.0, null]
+                }
+            },
+            "1:0:1:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1035.0, null],
+					"1": [11035.0, null],
+					"2": [21035.0, null]
+                }
+            },
+            "1:0:2:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [579.0, null],
+					"1": [1579.0, null],
+					"2": [2579.0, null]
+                }
+            },
+            "1:0:3:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [1512.0, null],
+					"1": [11512.0, null],
+					"2": [21512.0, null]
+                }
+            },
+            "1:0:4:0:1": {
+                "attributes": [0],
+                "observations": {
+                    "0": [2138.0, null],
+					"1": [12138.0, null],
+					"2": [22138.0, null]
+                }
+            }
+        }
+    }],
+    "structure": {
+        "name": "Non-spatial data",
+        "description": "Non-spatial data",
+        "dimensions": {
+            "series": [{
+                "keyPosition": 0,
+                "id": "MEASURE",
+                "name": "Data Item",
+                "values": [{
+                    "id": "BD_2",
+                    "name": "Births"
+                }, {
+                    "id": "BD_4",
+                    "name": "Deaths"
+                }]
+            }, {
+                "keyPosition": 1,
+                "id": "SOMETHING",
+                "name": "Something",
+                "values": [{
+                    "id": "Number",
+                    "name": "Number"
+                }]
+            }, {
+                "keyPosition": 2,
+                "id": "EDUCATION",
+                "name": "Education",
+                "values": [{
+                    "id": "Primary",
+                    "name": "Primary school only"
+                }, {
+                    "id": "Secondary",
+                    "name": "Secondary school only"
+                }, {
+                    "id": "Tertiary",
+                    "name": "Undergraduate degree"
+                }, {
+                    "id": "Postgrad",
+                    "name": "Postgraduate degree"
+                }, {
+                    "id": "None",
+                    "name": "None"
+                }]
+            }, {
+                "keyPosition": 3,
+                "id": "FREQUENCY",
+                "name": "Frequency",
+                "values": [{
+                    "id": "A",
+                    "name": "Annual"
+                }],
+                "role": "FREQ"
+            }, {
+                "keyPosition": 4,
+                "id": "AGE",
+                "name": "Age",
+                "values": [{
+                    "id": "0-20",
+                    "name": "0 - 20 Years"
+                }, {
+                    "id": "21+",
+                    "name": "21+ Years"
+                }]
+            }],
+            "observation": [{
+                "id": "TIME_PERIOD",
+                "name": "Time",
+                "values": [{
+                    "id": "2011",
+                    "name": "2011"
+                }, {
+                    "id": "2012",
+                    "name": "2012"
+                }, {
+                    "id": "2013",
+                    "name": "2013"
+                }],
+                "role": "TIME_PERIOD"
+            }]
+        },
+        "attributes": {
+            "dataSet": [],
+            "series": [{
+                "id": "TIME_FORMAT",
+                "name": "Time Format",
+                "values": [{
+                    "id": "P1Y",
+                    "name": "Annual"
+                }]
+            }],
+            "observation": [{
+                "id": "OBS_STATUS",
+                "name": "Observation Status",
+                "values": []
+            }]
+        },
+        "annotations": []
+    }
+}

--- a/wwwroot/test/SDMX-JSON/dataflow-foo.json
+++ b/wwwroot/test/SDMX-JSON/dataflow-foo.json
@@ -1,0 +1,121 @@
+{
+    "header": {
+        "id": "foo",
+        "test": true
+    },
+    "structure": {
+        "name": "foo",
+        "description": "Foo Example",
+        "dimensions": {
+            "observation": [{
+                "keyPosition": 0,
+                "id": "MEASURE",
+                "name": "Data Item",
+                "values": [{
+                    "id": "BD_2",
+                    "name": "Births"
+                }, {
+                    "id": "BD_4",
+                    "name": "Deaths"
+                }]
+            }, {
+                "keyPosition": 1,
+                "id": "REGIONTYPE",
+                "name": "Region Type",
+                "values": [{
+                    "id": "LGA_2013",
+                    "name": "Local Government Areas (2013)"
+                }]
+            }, {
+                "keyPosition": 2,
+                "id": "REGION",
+                "name": "Region",
+                "values": [{
+                    "id": "17100",
+                    "name": "Strathfield (A)"
+                }, {
+                    "id": "56520",
+                    "name": "Narrogin (T)"
+                }, {
+                    "id": "54970",
+                    "name": "Laverton (S)"
+                }, {
+                    "id": "10300",
+                    "name": "Balranald (A)"
+                }, {
+                    "id": "29399",
+                    "name": "Unincorporated Vic"
+                }]
+            }, {
+                "keyPosition": 3,
+                "id": "FREQUENCY",
+                "name": "Frequency",
+                "values": [{
+                    "id": "A",
+                    "name": "Annual"
+                }],
+                "role": "FREQ"
+            }, {
+                "keyPosition": 4,
+                "id": "TIME_PERIOD",
+                "name": "Time",
+                "values": [{
+                    "id": "2008",
+                    "name": "2008"
+                }, {
+                    "id": "2009",
+                    "name": "2009"
+                }, {
+                    "id": "2010",
+                    "name": "2010"
+                }, {
+                    "id": "2011",
+                    "name": "2011"
+                }, {
+                    "id": "2012",
+                    "name": "2012"
+                }, {
+                    "id": "2013",
+                    "name": "2013"
+                }],
+                "role": "TIME_PERIOD"
+            }]
+        },
+        "attributes": {
+            "observation": [{
+                "id": "TIME_FORMAT",
+                "name": "Time Format",
+                "values": [{
+                    "id": "P1Y",
+                    "name": "Annual"
+                }, {
+                    "id": "P1M",
+                    "name": "Annual"
+                }, {
+                    "id": "P3M",
+                    "name": "Quarterly"
+                }, {
+                    "id": "P6M",
+                    "name": "Half-yearly"
+                }, {
+                    "id": "P1D",
+                    "name": "Daily"
+                }]
+            }, {
+                "id": "OBS_STATUS",
+                "name": "Observation Status",
+                "values": [{
+                    "id": "n",
+                    "name": "not available for publication but included in totals"
+                }, {
+                    "id": "o",
+                    "name": "nil or rounded to zero"
+                }, {
+                    "id": "v",
+                    "name": "not available for publication but included in totals"
+                }]
+            }]
+        },
+        "annotations": []
+    }
+}

--- a/wwwroot/test/init/sdmx.json
+++ b/wwwroot/test/init/sdmx.json
@@ -6,121 +6,110 @@
         "isOpen": true,
         "items": [
             {
-                "name": "Example 1",
-                "type": "sdmx-json",
-                "url": "data/abs_sdmx_example1.json"
-            },
-            {
-                "name": "Example 2",
-                "type": "sdmx-json",
-                "url": "data/abs_sdmx_example2.json"
-            },
-            {
-                "name": "Two dimensions",
-                "type": "sdmx-json",
-                "url": "/data/sdmx_example3.json",
-                "dataflowUrlComponent": ""
-            },
-            {
-                "name": "Non-spatial",
-                "type": "sdmx-json",
-                "url": "data/sdmx_example4.json"
-            },
-            {
-                "name": "OECD Annual GDP VOBARSA (online)",
-                "type": "sdmx-json",
-                "url": "http://stats.oecd.org/sdmx-json/data/QNA/.B1_GE.VOBARSA.A/all",
-                "regionDimensionId": "LOCATION",
-                "regionType": "ISO3",
-                "featureInfoTemplate": {
-                    "template": "<p>Annual {{date}} GDP: {{Value}}</p><p>(expenditure approach, seasonally adjusted, units TBC)</p>",
-                    "formats": {
-                        "Value": {
-                            "maximumFractionDigits": 0,
-                            "useGrouping": true
-                        }
+                "name": "Local files",
+                "type": "group",
+                "isOpen": true,
+                "items": [
+                    {
+                        "name": "Simple example",
+                        "type": "sdmx-json",
+                        "url": "build/TerriaJS/test/SDMX-JSON/data-foo-2013.json",
+                        "dataflowUrlComponent": ""
+                    },
+                    {
+                        "name": "Two dimensions",
+                        "type": "sdmx-json",
+                        "url": "build/TerriaJS/test/SDMX-JSON/data-foo2-2013.json",
+                        "dataflowUrlComponent": ""
+                    },
+                    {
+                        "name": "Time varying",
+                        "type": "sdmx-json",
+                        "url": "build/TerriaJS/test/SDMX-JSON/data-foo-BD2-2011_2013.json",
+                        "dataflowUrlComponent": ""
+                    },
+                    {
+                        "name": "Non-spatial",
+                        "type": "sdmx-json",
+                        "url": "build/TerriaJS/test/SDMX-JSON/data-nonspatial.json",
+                        "dataflowUrlComponent": ""
                     }
-                }
+                ]
             },
             {
-                "name": "OECD Annual GDP VOBARSA (local copy)",
-                "type": "sdmx-json",
-                "url": "data/oecd_qna_example.json",
-                "regionDimensionId": "LOCATION",
-                "regionType": "ISO3",
-                "featureInfoTemplate": {
-                    "template": "<p>Annual {{date}} GDP: {{Value}}</p><p>(expenditure approach, seasonally adjusted, units TBC)</p>",
-                    "formats": {
-                        "Value": {
-                            "maximumFractionDigits": 0,
-                            "useGrouping": true
-                        }
-                    }
-                },
-                "tableStyle": {
-                    "columns": {
-                        "Value": {
-                            "format": {
-                                "maximumFractionDigits": 2,
-                                "useGrouping": true
+                "name": "OECD data",
+                "type": "group",
+                "isOpen": true,
+                "items": [
+                    {
+                        "name": "Annual GDP VOBARSA (online)",
+                        "type": "sdmx-json",
+                        "url": "http://stats.oecd.org/sdmx-json/data/QNA/.B1_GE.VOBARSA.A/all",
+                        "regionDimensionId": "LOCATION",
+                        "regionType": "ISO3",
+                        "featureInfoTemplate": {
+                            "template": "<p>Annual {{date}} GDP: {{Value}}</p><p>(expenditure approach, seasonally adjusted, units TBC)</p>",
+                            "formats": {
+                                "Value": {
+                                    "maximumFractionDigits": 0,
+                                    "useGrouping": true
+                                }
                             }
                         }
+                    },
+                    {
+                        "name": "Quarterly National Accounts (QNA)",
+                        "type": "sdmx-json",
+                        "url": "http://stats.oecd.org/sdmx-json/data/QNA",
+                        "regionDimensionId": "LOCATION",
+                        "regionType": "ISO3",
+                        "startTime": "1970",
+                        "endTime": "2016",
+                        "whitelist": {
+                            "SUBJECT": [
+                                "B1_GA", "B1_GE", "B1GD"
+                            ],
+                            "MEASURE": [
+                                "VOBARSA", "VPVOBARSA", "LNBQRSA"
+                            ],
+                            "FREQUENCY": [
+                                "A"
+                            ]
+                        },
+                        "selectedInitially": {
+                            "SUBJECT": [
+                                "B1_GE"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "OECD QNA 2005 only",
+                        "type": "sdmx-json",
+                        "url": "http://stats.oecd.org/sdmx-json/data/QNA",
+                        "regionDimensionId": "LOCATION",
+                        "regionType": "ISO3",
+                        "startTime": "2005",
+                        "endTime": "2005",
+                        "whitelist": {
+                            "SUBJECT": [
+                                "B1_GE", "B1_GA", "B1GD"
+                            ],
+                            "MEASURE": [
+                                "VOBARSA", "VPVOBARSA", "LNBQRSA"
+                            ],
+                            "FREQUENCY": [
+                                "A"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "Economic Outlook 97 Annual Projections, June 2015",
+                        "type": "sdmx-json",
+                        "url": "http://stats.oecd.org/sdmx-json/data/EO97_INTERNET",
+                        "regionDimensionId": "LOCATION",
+                        "regionType": "ISO3"
                     }
-                }
-            },
-            {
-                "name": "OECD Some QNA (local copy)",
-                "type": "sdmx-json",
-                "url": "data/oecd_qna2.json",
-                "regionDimensionId": "LOCATION",
-                "regionType": "ISO3"
-            },
-            {
-                "name": "OECD QNA",
-                "type": "sdmx-json",
-                "url": "http://stats.oecd.org/sdmx-json/data/QNA",
-                "regionDimensionId": "LOCATION",
-                "regionType": "ISO3",
-                "startTime": "1970",
-                "endTime": "2016",
-                "whitelist": {
-                    "SUBJECT": [
-                        "B1_GE", "B1_GA", "B1GD"
-                    ],
-                    "MEASURE": [
-                        "VOBARSA", "VPVOBARSA", "LNBQRSA"
-                    ],
-                    "FREQUENCY": [
-                        "A"
-                    ]
-                }
-            },
-            {
-                "name": "OECD QNA 2005 only",
-                "type": "sdmx-json",
-                "url": "http://stats.oecd.org/sdmx-json/data/QNA",
-                "regionDimensionId": "LOCATION",
-                "regionType": "ISO3",
-                "startTime": "2005",
-                "endTime": "2005",
-                "whitelist": {
-                    "SUBJECT": [
-                        "B1_GE", "B1_GA", "B1GD"
-                    ],
-                    "MEASURE": [
-                        "VOBARSA", "VPVOBARSA", "LNBQRSA"
-                    ],
-                    "FREQUENCY": [
-                        "A"
-                    ]
-                }
-            },
-            {
-                "name": "Economic Outlook 97 Annual Projections, June 2015",
-                "type": "sdmx-json",
-                "url": "http://stats.oecd.org/sdmx-json/data/EO97_INTERNET",
-                "regionDimensionId": "LOCATION",
-                "regionType": "ISO3"
+                ]
             }
         ]
     }]

--- a/wwwroot/test/init/sdmx.json
+++ b/wwwroot/test/init/sdmx.json
@@ -114,6 +114,13 @@
                         "A"
                     ]
                 }
+            },
+            {
+                "name": "Economic Outlook 97 Annual Projections, June 2015",
+                "type": "sdmx-json",
+                "url": "http://stats.oecd.org/sdmx-json/data/EO97_INTERNET",
+                "regionDimensionId": "LOCATION",
+                "regionType": "ISO3"
             }
         ]
     }]

--- a/wwwroot/test/init/sdmx.json
+++ b/wwwroot/test/init/sdmx.json
@@ -1,0 +1,121 @@
+
+{
+    "catalog": [{
+        "name": "SDMX-JSON testing",
+        "type": "group",
+        "isOpen": true,
+        "items": [
+            {
+                "name": "Example 1",
+                "type": "sdmx-json",
+                "url": "data/abs_sdmx_example1.json"
+            },
+            {
+                "name": "Example 2",
+                "type": "sdmx-json",
+                "url": "data/abs_sdmx_example2.json"
+            },
+            {
+                "name": "Two dimensions",
+                "type": "sdmx-json",
+                "url": "/data/sdmx_example3.json",
+                "dataflowUrlComponent": ""
+            },
+            {
+                "name": "Non-spatial",
+                "type": "sdmx-json",
+                "url": "data/sdmx_example4.json"
+            },
+            {
+                "name": "OECD Annual GDP VOBARSA (online)",
+                "type": "sdmx-json",
+                "url": "http://stats.oecd.org/sdmx-json/data/QNA/.B1_GE.VOBARSA.A/all",
+                "regionDimensionId": "LOCATION",
+                "regionType": "ISO3",
+                "featureInfoTemplate": {
+                    "template": "<p>Annual {{date}} GDP: {{Value}}</p><p>(expenditure approach, seasonally adjusted, units TBC)</p>",
+                    "formats": {
+                        "Value": {
+                            "maximumFractionDigits": 0,
+                            "useGrouping": true
+                        }
+                    }
+                }
+            },
+            {
+                "name": "OECD Annual GDP VOBARSA (local copy)",
+                "type": "sdmx-json",
+                "url": "data/oecd_qna_example.json",
+                "regionDimensionId": "LOCATION",
+                "regionType": "ISO3",
+                "featureInfoTemplate": {
+                    "template": "<p>Annual {{date}} GDP: {{Value}}</p><p>(expenditure approach, seasonally adjusted, units TBC)</p>",
+                    "formats": {
+                        "Value": {
+                            "maximumFractionDigits": 0,
+                            "useGrouping": true
+                        }
+                    }
+                },
+                "tableStyle": {
+                    "columns": {
+                        "Value": {
+                            "format": {
+                                "maximumFractionDigits": 2,
+                                "useGrouping": true
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "name": "OECD Some QNA (local copy)",
+                "type": "sdmx-json",
+                "url": "data/oecd_qna2.json",
+                "regionDimensionId": "LOCATION",
+                "regionType": "ISO3"
+            },
+            {
+                "name": "OECD QNA",
+                "type": "sdmx-json",
+                "url": "http://stats.oecd.org/sdmx-json/data/QNA",
+                "regionDimensionId": "LOCATION",
+                "regionType": "ISO3",
+                "startTime": "1970",
+                "endTime": "2016",
+                "whitelist": {
+                    "SUBJECT": [
+                        "B1_GE", "B1_GA", "B1GD"
+                    ],
+                    "MEASURE": [
+                        "VOBARSA", "VPVOBARSA", "LNBQRSA"
+                    ],
+                    "FREQUENCY": [
+                        "A"
+                    ]
+                }
+            },
+            {
+                "name": "OECD QNA 2005 only",
+                "type": "sdmx-json",
+                "url": "http://stats.oecd.org/sdmx-json/data/QNA",
+                "regionDimensionId": "LOCATION",
+                "regionType": "ISO3",
+                "startTime": "2005",
+                "endTime": "2005",
+                "whitelist": {
+                    "SUBJECT": [
+                        "B1_GE", "B1_GA", "B1GD"
+                    ],
+                    "MEASURE": [
+                        "VOBARSA", "VPVOBARSA", "LNBQRSA"
+                    ],
+                    "FREQUENCY": [
+                        "A"
+                    ]
+                }
+            }
+        ]
+    }]
+}
+


### PR DESCRIPTION
This adds a new catalog item which can read the SDMX-JSON format used by the OECD and (soon) the ABS, per #1514.  Try out the demos at http://localhost:3003/#build/terriajs/test/init/sdmx.json .

This should handle the following cases -
- a TIME_PERIOD dimension
- multiple frequencies
- multiple region types (though this is waiting for an example to test)
- both specific datafile and generic API endpoints
- ability to set the initially selected values in json
- a REGION dimension with no REGIONTYPE dimension

Some limitations:
- It can’t handle hierarchical dimensions (eg. like the ABS-ITT currently has for Age->0-4 years->0,1,2,3,4)
- It does not display units or other attributes, which would be great. In particular it shouldn't try to add values with different units.
- It does display non-spatial data on a chart, but this needs more thought, since it only displays the total, and the way of choosing which concepts to display doesn't make intuitive sense here. 
- It doesn't offer a "show as % of regional population" option.

I'm submitting this PR now, even without any live catalog items using it, because there are a few small changes to other files that we may as well bed down now.
