### PR TITLE
Newui: Allow Charts to specify column names by original or mapped names

### DIFF
--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -599,19 +599,33 @@ TableStructure.prototype.getColumnWithName = function(name) {
 };
 
 /**
-* Returns the first column with the given name or index, or undefined if none match (or null is passed in).
+* Returns the first column with the given name or id, or undefined if none match.
 *
-* @param {String|Integer|null} nameOrIndex The column name or index.
+* @param {String} nameOrId The column name or id.
 * @returns {TableColumn} The matching column.
 */
-TableStructure.prototype.getColumnWithNameOrIndex = function(nameOrIndex) {
-    if (nameOrIndex === null) {
+TableStructure.prototype.getColumnWithNameOrId = function(nameOrId) {
+    for (var i = 0; i < this.columns.length; i++) {
+        if (this.columns[i].name === nameOrId || this.columns[i].id === nameOrId) {
+            return this.columns[i];
+        }
+    }
+};
+
+/**
+* Returns the first column with the given name, id or index, or undefined if none match (or null is passed in).
+*
+* @param {String|Integer|null} nameIdOrIndex The column name, id or index.
+* @returns {TableColumn} The matching column.
+*/
+TableStructure.prototype.getColumnWithNameIdOrIndex = function(nameIdOrIndex) {
+    if (nameIdOrIndex === null) {
         return undefined;
     }
-    if (isInteger(nameOrIndex)) {
-        return this.columns[nameOrIndex];
+    if (isInteger(nameIdOrIndex)) {
+        return this.columns[nameIdOrIndex];
     }
-    return this.getColumnWithName(nameOrIndex);
+    return this.getColumnWithNameOrId(nameIdOrIndex);
 };
 
 

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -425,7 +425,7 @@ CsvCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
 
 function setActiveTimeColumn(tableStructure, tableStyle) {
     if (typeof tableStyle.timeColumn !== 'undefined') {
-        tableStructure.activeTimeColumn = tableStructure.getColumnWithNameOrIndex(tableStyle.timeColumn);
+        tableStructure.activeTimeColumn = tableStructure.getColumnWithNameIdOrIndex(tableStyle.timeColumn);
         if (defined(tableStructure.activeTimeColumn) && tableStructure.activeTimeColumn.type !== VarType.TIME) {
             tableStructure.activeTimeColumn = tableStructure.columnsByType[VarType.TIME][0];
             throw new DeveloperError('TableStyle.timeColumn "' + tableStyle.timeColumn + '" is not a valid time column.');
@@ -545,7 +545,7 @@ function ensureActiveColumnForNonSpatial(tableStructure) {
 CsvCatalogItem.prototype.activateColumnFromTableStyle = function() {
     var tableStyle = this._tableStyle;
     if (defined(tableStyle) && defined(tableStyle.dataVariable)) {
-        var columnToActivate = this._tableStructure.getColumnWithName(tableStyle.dataVariable);
+        var columnToActivate = this._tableStructure.getColumnWithNameOrId(tableStyle.dataVariable);
         if (columnToActivate) {
             columnToActivate.toggleActive();
         }

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -368,8 +368,8 @@ function loadRegionIds(regionMapping, rawRegionDetails) {
         regionMapping._regionDetails = rawRegionDetails.map(function(rawRegionDetail) {
             return {
                 regionProvider: rawRegionDetail.regionProvider,
-                column: regionMapping._tableStructure.getColumnWithName(rawRegionDetail.variableName),
-                disambigColumn: regionMapping._tableStructure.getColumnWithName(rawRegionDetail.disambigVariableName),
+                column: regionMapping._tableStructure.getColumnWithNameOrId(rawRegionDetail.variableName),
+                disambigColumn: regionMapping._tableStructure.getColumnWithNameOrId(rawRegionDetail.disambigVariableName),
             };
         });
         return regionMapping._regionDetails;

--- a/lib/ReactViews/Chart/Chart.jsx
+++ b/lib/ReactViews/Chart/Chart.jsx
@@ -52,10 +52,10 @@ const Chart = React.createClass({
     },
 
     chartDataArrayFromTableStructure(table) {
-        const xColumn = table.getColumnWithNameOrIndex(this.props.xColumn || 0);
+        const xColumn = table.getColumnWithNameIdOrIndex(this.props.xColumn || 0);
         let yColumns = [table.columns[1]];
         if (defined(this.props.yColumns)) {
-            yColumns = this.props.yColumns.map(yCol=>table.getColumnWithNameOrIndex(yCol));
+            yColumns = this.props.yColumns.map(yCol=>table.getColumnWithNameIdOrIndex(yCol));
         }
         const pointArrays = table.toPointArrays(xColumn, yColumns);
         // The data id should be set to something unique, eg. its source id + column index.

--- a/lib/ReactViews/Chart/ChartExpandButton.jsx
+++ b/lib/ReactViews/Chart/ChartExpandButton.jsx
@@ -157,7 +157,7 @@ function expand(props, url) {
                     column.isActive = activeConcepts[columnNumber];
                 });
             } else if (defined(props.yColumns)) {
-                const activeColumns = props.yColumns.map(nameOrIndex=>tableStructure.getColumnWithNameOrIndex(nameOrIndex));
+                const activeColumns = props.yColumns.map(nameOrIndex=>tableStructure.getColumnWithNameIdOrIndex(nameOrIndex));
                 tableStructure.columns.forEach(column=>{
                     column.isActive = activeColumns.indexOf(column) >= 0;
                 });

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -729,6 +729,42 @@ describe('CsvCatalogItem with region mapping', function() {
         }).otherwise(fail).then(done);
     });
 
+    it('matches mapped region column names', function(done) {
+        csvItem.updateFromJson({
+            data: 'nothing,value\n31000,1',
+            tableStyle: {
+                columns: {
+                    'nothing': {
+                        name: 'lga_code'
+                    }
+                }
+            }
+        });
+        csvItem.load().then(function() {
+            csvItem.isEnabled = true;  // The recolorFunction call is only made once the layer is enabled.
+            var regionDetails = csvItem.regionMapping.regionDetails;
+            expect(regionDetails).toBeDefined();
+        }).otherwise(fail).then(done);
+    });
+
+    it('matches original name of mapped region column names', function(done) {
+        csvItem.updateFromJson({
+            data: 'lga_code,value\n31000,1',
+            tableStyle: {
+                columns: {
+                    'lga_code': {
+                        name: 'something'
+                    }
+                }
+            }
+        });
+        csvItem.load().then(function() {
+            csvItem.isEnabled = true;  // The recolorFunction call is only made once the layer is enabled.
+            var regionDetails = csvItem.regionMapping.regionDetails;
+            expect(regionDetails).toBeDefined();
+        }).otherwise(fail).then(done);
+    });
+
     // TODO: What is this testing?
     xit('matches numeric state IDs with regexes', function(done) {
         csvItem.updateFromJson({data: 'state,value\n3,30\n4,40\n5,50,\n8,80\n9,90'});

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -741,27 +741,23 @@ describe('CsvCatalogItem with region mapping', function() {
             }
         });
         csvItem.load().then(function() {
-            csvItem.isEnabled = true;  // The recolorFunction call is only made once the layer is enabled.
-            var regionDetails = csvItem.regionMapping.regionDetails;
-            expect(regionDetails).toBeDefined();
+            expect(csvItem.regionMapping.regionDetails).toBeDefined();
         }).otherwise(fail).then(done);
     });
 
-    it('matches original name of mapped region column names', function(done) {
+    it('does not match original name of mapped region column names', function(done) {
         csvItem.updateFromJson({
             data: 'lga_code,value\n31000,1',
             tableStyle: {
                 columns: {
                     'lga_code': {
-                        name: 'something'
+                        name: 'something else'
                     }
                 }
             }
         });
         csvItem.load().then(function() {
-            csvItem.isEnabled = true;  // The recolorFunction call is only made once the layer is enabled.
-            var regionDetails = csvItem.regionMapping.regionDetails;
-            expect(regionDetails).toBeDefined();
+            expect(csvItem.regionMapping).not.toBeDefined();
         }).otherwise(fail).then(done);
     });
 


### PR DESCRIPTION
Addresses an issue @axman6 was having:
The problem was a combination of:
- replacing the column names (in fact just capitalising them), and
- specifying the active columns using their uncapitalised names - it only looks on their new names.
  Since there were no uncapitalised names any more, there were no active columns, and so the chart panel didn't show.
  To be consistent with the template behaviour, and to avoid this sort of issue again, this changes it so that both old and new names work when specifying active columns in a `<chart>` tag.
