### PR TITLE
Newui format number improvements

### DIFF
--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -288,7 +288,8 @@ function mustacheFormatNumberFunction() {
     return function(text, render) {
         // Eg. "{foo:1}hi there".match(optionReg) = ["{foo:1}hi there", "{foo:1}", "hi there"].
         // Note this won't work with nested objects in the options (but these aren't used yet).
-        const optionReg = /^(\{[^}]+\})(.*)/;
+        // Note I use [\s\S]* instead of .* at the end - .* does not match newlines, [\s\S]* does.
+        const optionReg = /^(\{[^}]+\})([\s\S]*)/;
         const components = text.match(optionReg);
         // This regex unfortunately matches double-braced text like {{number}}, so detect that separately and do not treat it as option json.
         const startsWithdoubleBraces = (text.length > 4) && (text[0] === '{') && (text[1] === '{');
@@ -297,7 +298,7 @@ function mustacheFormatNumberFunction() {
             return formatNumberForLocale(render(text));
         }
         // Allow {foo: 1} by converting it to {"foo": 1} for JSON.parse.
-        const quoteReg = /([{,])(\s*)([A-Za-z0-9_\-]+?)\s*:/;
+        const quoteReg = /([{,])(\s*)([A-Za-z0-9_\-]+?)\s*:/g;
         const jsonOptions = components[1].replace(quoteReg, '$1"$3":');
         const options = JSON.parse(jsonOptions);
         return formatNumberForLocale(render(components[2]), options);

--- a/test/ReactViews/FeatureInfoSectionSpec.jsx
+++ b/test/ReactViews/FeatureInfoSectionSpec.jsx
@@ -58,7 +58,7 @@ describe('FeatureInfoSection', function() {
             'foo': 'bar',
             'material': 'steel',
             'material.process.#1': 'smelted',
-            'size': '12345678',
+            'size': '12345678.9012',
             'efficiency': '0.2345678',
             'owner_html': 'Jay<br>Smith',
             'ampersand': 'A & B',
@@ -193,31 +193,38 @@ describe('FeatureInfoSection', function() {
             const template = 'Size: {{size}}';
             const section = <FeatureInfoSection feature={feature} isOpen={true} clock={terria.clock} template={template} viewState={viewState} />;
             const result = getShallowRenderedOutput(section);
-            expect(findAllEqualTo(result, 'Size: 12345678').length).toEqual(1);
+            expect(findAllEqualTo(result, 'Size: 12345678.9012').length).toEqual(1);
         });
 
         it('can format numbers with commas', function() {
             const template = {template: 'Size: {{size}}', formats: {size: {useGrouping: true}}};
             const section = <FeatureInfoSection feature={feature} isOpen={true} clock={terria.clock} template={template} viewState={viewState} />;
             const result = getShallowRenderedOutput(section);
-            expect(findAllEqualTo(result, 'Size: 12' + separator + '345' + separator + '678').length).toEqual(1);
+            expect(findAllEqualTo(result, 'Size: 12' + separator + '345' + separator + '678.9012').length).toEqual(1);
         });
 
         it('can format numbers using terria.formatNumber', function() {
             let template = 'Base: {{#terria.formatNumber}}{{size}}{{/terria.formatNumber}}';
-            template += '  Sep: {{#terria.formatNumber}}{"useGrouping":true}{{size}}{{/terria.formatNumber}}';
+            template += '  Sep: {{#terria.formatNumber}}{"useGrouping":true, "maximumFractionDigits":3}{{size}}{{/terria.formatNumber}}';
             template += '  DP: {{#terria.formatNumber}}{"maximumFractionDigits":3}{{efficiency}}{{/terria.formatNumber}}';
             const section = <FeatureInfoSection feature={feature} isOpen={true} clock={terria.clock} template={template} viewState={viewState} />;
             const result = getShallowRenderedOutput(section);
-            expect(findAllEqualTo(result, 'Base: 12345678  Sep: 12' + separator + '345' + separator + '678  DP: 0.235').length).toEqual(1);
+            expect(findAllEqualTo(result, 'Base: 12345678.9012  Sep: 12' + separator + '345' + separator + '678.901  DP: 0.235').length).toEqual(1);
         });
 
         it('can format numbers using terria.formatNumber without quotes', function() {
-            let template = 'Sep: {{#terria.formatNumber}}{useGrouping:true}{{size}}{{/terria.formatNumber}}';
+            let template = 'Sep: {{#terria.formatNumber}}{useGrouping:true, maximumFractionDigits:3}{{size}}{{/terria.formatNumber}}';
             template += '  DP: {{#terria.formatNumber}}{maximumFractionDigits:3}{{efficiency}}{{/terria.formatNumber}}';
             const section = <FeatureInfoSection feature={feature} isOpen={true} clock={terria.clock} template={template} viewState={viewState} />;
             const result = getShallowRenderedOutput(section);
-            expect(findAllEqualTo(result, 'Sep: 12' + separator + '345' + separator + '678  DP: 0.235').length).toEqual(1);
+            expect(findAllEqualTo(result, 'Sep: 12' + separator + '345' + separator + '678.901  DP: 0.235').length).toEqual(1);
+        });
+
+        it('can handle white text in terria.formatNumber', function() {
+            let template = 'Sep: {{#terria.formatNumber}}{"useGrouping":true, "maximumFractionDigits":3} \n {{size}}{{/terria.formatNumber}}';
+            const section = <FeatureInfoSection feature={feature} isOpen={true} clock={terria.clock} template={template} viewState={viewState} />;
+            const result = getShallowRenderedOutput(section);
+            expect(findAllEqualTo(result, 'Sep: 12' + separator + '345' + separator + '678.901').length).toEqual(1);
         });
 
         it('handles non-numbers terria.formatNumber', function() {


### PR DESCRIPTION
Enhances the #terria.formatNumber capability in two ways:
- handles newlines inside the `{{#...}}...{{/...}}`
- fixes a bug when not using quotes around the format keys, and there are more than two keys.
