### PR TITLE
Fix several Add Data problems

### DIFF
--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -39,7 +39,7 @@ const DataCatalogItem = React.createClass({
         this.props.viewState.viewCatalogItem(this.props.item);
         // mobile switch to nowvewing
         this.props.viewState.switchMobileView(this.props.viewState.mobileViewOptions.preview);
-        if (this.props.viewState.previewedItem.isEnabled === true &&
+        if (this.props.item.isEnabled === true &&
             this.props.viewState.closeModalAfterAdd === true &&
             !event.shiftKey && !event.ctrlKey) {
 

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -109,8 +109,7 @@ const AddData = React.createClass({
         }
 
         addUserCatalogMember(this.props.terria, promise).then(() => {
-            const userCatalog = that.props.terria.catalog.userAddedDataGroup;
-            that.props.updateCatalog(userCatalog);
+            this.props.viewState.myDataIsUploadView = false;
         });
     },
 

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -21,7 +21,7 @@ const MappablePreview = React.createClass({
 
     toggleOnMap(event) {
         this.props.previewed.toggleEnabled();
-        if (this.props.viewState.previewedItem.isEnabled === true &&
+        if (this.props.previewed.isEnabled === true &&
             this.props.viewState.closeModalAfterAdd &&
             !event.shiftKey && !event.ctrlKey) {
 


### PR DESCRIPTION
Fixes #1665 
(actually the "view the galaxy" problem seems to no longer exist, but this fixes new problems when trying to do the same thing).
- Fixed an exception when adding new user data due to an attempted call of a function that doesn't exist.  I think the intention was to switch to the list of user datasets, so that's what I've done.
- Fixed an exception when attempting to add user-added data to the map, because it was incorrectly assuming that the added item would be the view state's `previewedItem`, but user-data has a separate preview.
