### PR TITLE
Fix up Leaflet picking.

### DIFF
--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -722,8 +722,8 @@ LeafletVisualizer.prototype.visualizersCallback = function(leafletScene, dataSou
     return [new LeafletGeomVisualizer(leafletScene, entities)];
 };
 
-function featureClicked(visualizer, entity) {
-    visualizer._leafletScene.featureClicked.raiseEvent(entity);
+function featureClicked(visualizer, entity, e) {
+    visualizer._leafletScene.featureClicked.raiseEvent(entity, e);
 }
 
 module.exports = LeafletVisualizer;

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -722,8 +722,8 @@ LeafletVisualizer.prototype.visualizersCallback = function(leafletScene, dataSou
     return [new LeafletGeomVisualizer(leafletScene, entities)];
 };
 
-function featureClicked(visualizer, entity, e) {
-    visualizer._leafletScene.featureClicked.raiseEvent(entity, e);
+function featureClicked(visualizer, entity, event) {
+    visualizer._leafletScene.featureClicked.raiseEvent(entity, event);
 }
 
 module.exports = LeafletVisualizer;

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -606,6 +606,13 @@ Cesium.prototype.adjustDisclaimer = function() {
 
 };
 
+/**
+ * Picks features based off a latitude, longitude and (optionally) height.
+ * @param {Object} latlng The position on the earth to pick.
+ * @param {Object} imageryLayerCoords A map of imagery provider urls to the coords used to get features for those imagery
+ *     providers - i.e. x, y, level
+ * @param existingFeatures An optional list of existing features to concatenate the ones found from asynchronous picking to.
+ */
 Cesium.prototype.pickFromLocation = function(latlng, imageryLayerCoords, existingFeatures) {
     var pickPosition = this.scene.globe.ellipsoid.cartographicToCartesian(Cartographic.fromDegrees(latlng.lng, latlng.lat, latlng.height));
     var pickPositionCartographic = Ellipsoid.WGS84.cartesianToCartographic(pickPosition);

--- a/lib/Models/GlobeOrMap.js
+++ b/lib/Models/GlobeOrMap.js
@@ -88,7 +88,7 @@ GlobeOrMap.prototype.isDestroyed = function() {
  *     providers - i.e. x, y, level
  * @param existingFeatures An optional list of existing features to concatenate the ones found from asynchronous picking to.
  */
-GlobeOrMap.prototype.pickFromLocation = function(cartesian) {
+GlobeOrMap.prototype.pickFromLocation = function(latlng, imageryLayerCoords, existingFeatures) {
     throw new DeveloperError('pickFromLocation must be implemented in the derived class.');
 };
 

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -341,6 +341,13 @@ Leaflet.prototype.lowerToBottom = function(item) {
     item._imageryLayer.setZIndex(0);
 };
 
+/**
+ * Picks features based off a latitude, longitude and (optionally) height.
+ * @param {Object} latlng The position on the earth to pick.
+ * @param {Object} imageryLayerCoords A map of imagery provider urls to the coords used to get features for those imagery
+ *     providers - i.e. x, y, level
+ * @param existingFeatures An optional list of existing features to concatenate the ones found from asynchronous picking to.
+ */
 Leaflet.prototype.pickFromLocation = function(latlng, imageryLayerCoords, existingFeatures) {
     pickFeatures(this, latlng, imageryLayerCoords, existingFeatures);
 };
@@ -410,26 +417,25 @@ function createLeafletCredit(attribution) {
 }
 
 /*
-* Feature picking in leaflet is funny because we rely on multiple click events for picking vector features and a single
-* map click event for picking raster features. These can come in in any order, so we handle it like this
+* There are two "listeners" for clicks which are set up in our constructor.
+* - One fires for any click: `map.on('click', ...`.  It calls `pickFeatures`.
+* - One fires only for vector features: `this.scene.featureClicked.addEventListener`. 
+*    It calls `featurePicked`, which calls `pickFeatures` and then adds the feature it found, if any.
+* These events can fire in either order.
+* Billboards do not fire the first event.
 *
-* - Initially, leaflet._pickedFeatures is undefined
-* - When the first click event is triggered (whether is a map or feature click), it starts the asynchronous raster
-*       feature picking, sets terria.pickedFeatures and also spawns a runLater that will clear _pickedFeatures
-* - Each feature pick, including the first, adds a feature to _pickedFeatures.features.
-* - The map click is basically ignored, unless it is the first click event we see.
-* - Once this runLater executes, we can assume that all the click handlers for that one click will have fired, so we
-*       set _pickedFeatures back to undefined (this.terria.pickedFeatures is still set)
-* - When another click happens, it re-initialized _pickedFeatures and the process starts again.
+* Note that `pickFeatures` does nothing if `leaflet._pickedFeatures` is already set. 
+* Otherwise, it sets it, runs `runLater` to clear it, and starts the asynchronous raster feature picking.
 *
-* For most types of features, the map click will be the first click event, which means the raster pick will happen
-* exactly where the user clicked.  Leaflet billboards, however, seem to swallow click events, so if the user clicks
-* on a billboard _only_ the click for that feature will be raised.  That means the raster pick will happen at the
-* location of the billboard, rather than at the actual location that the user clicked.
+* So:
+* If only the first event is received, it triggers the raster-feature picking as desired.
+* If both are received in the order above, the second adds the vector features to the list of raster features as desired.
+* If both are received in the reverse order, the vector-feature click kicks off the same behavior as the other click would have;
+* and when the next click is received, it is ignored - again, as desired.
 */
 
-function featurePicked(leaflet, entity, e) {
-    pickFeatures(leaflet, e.latlng);
+function featurePicked(leaflet, entity, event) {
+    pickFeatures(leaflet, event.latlng);
 
     // Ignore clicks on the feature highlight.
     if (entity && entity.entityCollection && entity.entityCollection.owner && entity.entityCollection.owner.name === GlobeOrMap._featureHighlightName) {

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -342,13 +342,7 @@ Leaflet.prototype.lowerToBottom = function(item) {
 };
 
 Leaflet.prototype.pickFromLocation = function(latlng, imageryLayerCoords, existingFeatures) {
-    prePickFeatures(this);
-
-    if (existingFeatures) {
-        this._pickedFeatures.features = existingFeatures;
-    }
-
-    pickFeatures(this, latlng, imageryLayerCoords);
+    pickFeatures(this, latlng, imageryLayerCoords, existingFeatures);
 };
 
 Leaflet.prototype.addImageryProvider = function(options) {
@@ -415,13 +409,33 @@ function createLeafletCredit(attribution) {
     return element.outerHTML;
 }
 
-function featurePicked(leaflet, entity) {
+/*
+* Feature picking in leaflet is funny because we rely on multiple click events for picking vector features and a single
+* map click event for picking raster features. These can come in in any order, so we handle it like this
+*
+* - Initially, leaflet._pickedFeatures is undefined
+* - When the first click event is triggered (whether is a map or feature click), it starts the asynchronous raster
+*       feature picking, sets terria.pickedFeatures and also spawns a runLater that will clear _pickedFeatures
+* - Each feature pick, including the first, adds a feature to _pickedFeatures.features.
+* - The map click is basically ignored, unless it is the first click event we see.
+* - Once this runLater executes, we can assume that all the click handlers for that one click will have fired, so we
+*       set _pickedFeatures back to undefined (this.terria.pickedFeatures is still set)
+* - When another click happens, it re-initialized _pickedFeatures and the process starts again.
+*
+* For most types of features, the map click will be the first click event, which means the raster pick will happen
+* exactly where the user clicked.  Leaflet billboards, however, seem to swallow click events, so if the user clicks
+* on a billboard _only_ the click for that feature will be raised.  That means the raster pick will happen at the
+* location of the billboard, rather than at the actual location that the user clicked.
+*/
+
+function featurePicked(leaflet, entity, e) {
+    pickFeatures(leaflet, e.latlng);
+
     // Ignore clicks on the feature highlight.
     if (entity && entity.entityCollection && entity.entityCollection.owner && entity.entityCollection.owner.name === GlobeOrMap._featureHighlightName) {
         return;
     }
 
-    prePickFeatures(leaflet);
     leaflet._pickedFeatures.features.push(entity);
 
     if (entity.position) {
@@ -429,28 +443,17 @@ function featurePicked(leaflet, entity) {
     }
 }
 
-/*
-* Feature picking in leaflet is funny because we rely on multiple click events for picking vector features and a single
-* map click event for picking raster features. These can come in in any order, so we handle it like this
-*
-* - Initially, leaflet._pickedFeatures is undefined
-* - When the first click event is triggered, leaflet._pickedFeatures is initialised.
-* - When feature click events happen, the feature that was clicked on is added to _pickedFeatures.features
-* - When the map click event comes through, it starts the asynchronous raster feature picking, sets terria.pickedFeatures
-        and also spawns a runLater that will clear _pickedFeatures
-* - Once this runLater executes, we can assume that all the click handlers for that one click will have fired, so we
-*       set _pickedFeatures back to undefined (this.terria.pickedFeatures is still set)
-* - When another click happens, it re-initialized _pickedFeatures and the process starts again.
-*/
-
-function prePickFeatures(leaflet) {
-    if (!defined(leaflet._pickedFeatures)) {
-        leaflet._pickedFeatures = new PickedFeatures();
+function pickFeatures(leaflet, latlng, tileCoordinates, existingFeatures) {
+    if (defined(leaflet._pickedFeatures)) {
+        // Picking is already in progress.
+        return;
     }
-}
 
-function pickFeatures(leaflet, latlng, tileCoordinates) {
-    prePickFeatures(leaflet);
+    leaflet._pickedFeatures = new PickedFeatures();
+
+    if (defined(existingFeatures)) {
+        leaflet._pickedFeatures.features = existingFeatures;
+    }
 
     // We run this later because vector click events and the map click event can come through in any order, but we can
     // be reasonably sure that all of them will be processed by the time our runLater func is invoked.

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -282,7 +282,7 @@ function loadOpenStreetMapServer(viewModel) {
  * Loads a catalog item from a file.
  */
 function loadFile(viewModel) {
-    return createCatalogItemFromFileOrUrl(viewModel.props.terria, viewModel.state.remoteUrl, viewModel.state.remoteDataType, true);
+    return createCatalogItemFromFileOrUrl(viewModel.props.terria, viewModel.state.remoteUrl, viewModel.state.remoteDataType.value, true);
 }
 
 module.exports = AddData;

--- a/test/Models/LeafletSpec.js
+++ b/test/Models/LeafletSpec.js
@@ -260,11 +260,11 @@ describe('Leaflet Model', function() {
 
                 it('includes vector features with click events both before and after the map click event', function(done) {
                     // vector and map clicks can come in any order.
-                    leaflet.scene.featureClicked.raiseEvent(vectorFeature1);
+                    leaflet.scene.featureClicked.raiseEvent(vectorFeature1, { latlng: latlng });
                     click({
                         latlng: latlng
                     });
-                    leaflet.scene.featureClicked.raiseEvent(vectorFeature2);
+                    leaflet.scene.featureClicked.raiseEvent(vectorFeature2, { latlng: latlng });
 
                     finishPickingPromise();
 
@@ -277,15 +277,15 @@ describe('Leaflet Model', function() {
                 });
 
                 it('resets the picked vector features if a subsequent map click is made', function(done) {
-                    leaflet.scene.featureClicked.raiseEvent(vectorFeature1);
+                    leaflet.scene.featureClicked.raiseEvent(vectorFeature1, { latlng: latlng });
                     click({
                         latlng: latlng
                     });
-                    leaflet.scene.featureClicked.raiseEvent(vectorFeature2);
+                    leaflet.scene.featureClicked.raiseEvent(vectorFeature2, { latlng: latlng });
 
                     // The reset happens in a runLater, which a second click will always come behind in a browser,
                     // but this isn't guaranteed in unit tests because they're just two setTimeouts racing each other,
-                    // so give this a healthy 500ms delay to make sure it comes in behind the 0ms delay in Leaflet.js.
+                    // so give this a healthy 50ms delay to make sure it comes in behind the 0ms delay in Leaflet.js.
                     setTimeout(function() {
                         click({
                             latlng: latlng
@@ -295,7 +295,7 @@ describe('Leaflet Model', function() {
                             expect(terria.pickedFeatures.features.length).toBe(3);
                             expect(terria.pickedFeatures.features[0].name).toBe('1');
                         }).then(done).otherwise(done.fail);
-                    }, 500);
+                    }, 50);
                 });
             });
         });


### PR DESCRIPTION
For unknown reasons, Leaflet billboards (unlike other feature types) swallow click events, so the map click event is never raised when the user clicks on a billboard.  I've reorganized (and simplified, I think) the Leaflet picking to handle this possibility.  The updated comment in the code describes how it works.

Sharing the feature info panel doesn't work, but it doesn't work in the new UI branch before this change either.  I don't _think_ I've made it any worse.

Fixes #1627 
