### PR TITLE
PolylineGlowMaterialProperty in Leaflet

### DIFF
--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -15,6 +15,7 @@ var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
 var Property = require('terriajs-cesium/Source/DataSources/Property');
 var writeTextToCanvas = require('terriajs-cesium/Source/Core/writeTextToCanvas');
+var PolylineGlowMaterialProperty = require('terriajs-cesium/Source/DataSources/PolylineGlowMaterialProperty');
 
 
 var defaultColor = Color.WHITE;
@@ -652,8 +653,16 @@ LeafletGeomVisualizer.prototype._updatePolyline = function(entity, time, entityH
     for (var p = 0; p < carts.length; p++) {
         latlngs.push(L.latLng( CesiumMath.toDegrees(carts[p].latitude), CesiumMath.toDegrees(carts[p].longitude)));
     }
-    var color = Property.getValueOrDefault(polylineGraphics._material.color, time, defaultColor);
-    var width = Property.getValueOrDefault(polylineGraphics._width, time, defaultWidth);
+
+    var color;
+    var width;
+    if (polylineGraphics._material instanceof PolylineGlowMaterialProperty) {
+        color = defaultColor;
+        width = defaultWidth;
+    } else {
+        color = Property.getValueOrDefault(polylineGraphics._material.color, time, defaultColor);
+        width = Property.getValueOrDefault(polylineGraphics._width, time, defaultWidth);
+    }
 
     var polylineOptions = {
         color: color.toCssColorString(),

--- a/wwwroot/test/CZML/glowing_polyline.czml
+++ b/wwwroot/test/CZML/glowing_polyline.czml
@@ -1,0 +1,28 @@
+[
+ {
+    "id" : "document",
+    "name" : "Glowing Polyline",
+    "version" : "1.0"
+ },
+ {
+    "id" : "blueLine",
+    "name" : "Glowing blue line on the surface",
+    "polyline" : {
+      "positions" : {
+        "cartographicDegrees" : [
+          -75, 37, 0,
+          -125, 37, 0
+        ]
+      },
+      "material" : {
+        "polylineGlow" : {
+          "color" : {
+            "rgba" : [0, 0, 0, 255],
+            "glowPower" : 0.2
+          }
+        }
+      },
+      "width" : 10
+    }
+  }
+]


### PR DESCRIPTION
A PolylineGlowMaterialProperty with colour (0, 0, 0, 0.1) produces a white with subtle black falloff outline in Cesium map. However, Leaflet doesn't know much about PolylineGlowMaterialProperty and produces a line that is flat shaded (0, 0, 0, 0.1), so barely visible.

As far as I could tell, Leaflet doesn't have anything similar to PolylineGlowMaterialProperty. We could try to fake it by replacing leaflet line with polyon that has white fill and specified colour stroke, or by drawing specified colour line and then white line on top, but both of those options are very hacky though and would require large changes in Leaflet. 

This PR changes line to use default line properties for Leaflet if PolylineGlowMaterialProperty is in use.
