### PR TITLE
Fix "download as csv" in Feature Info

### DIFF
--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -58,13 +58,16 @@ const FeatureInfoSection = React.createClass({
         }
     },
 
-    getTemplateData() {
-        const propertyData = propertyValues(
+    getPropertyValues() {
+        return propertyValues(
             this.props.feature,
             this.props.clock,
             this.props.template && this.props.template.formats
         );
+    },
 
+    getTemplateData() {
+        const propertyData = this.getPropertyValues();
         if (defined(propertyData)) {
 
             propertyData.terria = {
@@ -78,7 +81,6 @@ const FeatureInfoSection = React.createClass({
                 };
             }
         }
-
         return propertyData;
     },
 
@@ -144,7 +146,10 @@ const FeatureInfoSection = React.createClass({
     render() {
         const catalogItemName = (this.props.catalogItem && this.props.catalogItem.name) || '';
         const fullName = (catalogItemName ? (catalogItemName + ' - ') : '') + this.renderDataTitle();
-        const templateData = this.getTemplateData();
+        const templateData = this.getPropertyValues();
+        if (defined(templateData)) {
+            delete templateData._terria_columnAliases;
+        }
 
         return (
             <li className={classNames(Styles.section)}>


### PR DESCRIPTION
Removes extra objects from template data before sending to Download button.

Fixes #1664.
