### PR TITLE
Add optional context for CatalogFunctions

### DIFF
--- a/lib/Models/CatalogFunction.js
+++ b/lib/Models/CatalogFunction.js
@@ -4,9 +4,12 @@
 var arraysAreEqual = require('../Core/arraysAreEqual');
 var CatalogItem = require('./CatalogItem');
 var CatalogMember = require('./CatalogMember');
+var clone = require('terriajs-cesium/Source/Core/clone');
+var createCatalogMemberFromType = require('./createCatalogMemberFromType');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
+var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var inherit = require('../Core/inherit');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var runLater = require('../Core/runLater');
@@ -33,6 +36,13 @@ var CatalogFunction = function(terria) {
      * @type {Boolean}
      */
     this.isLoading = false;
+
+    /**
+     * A catalog item that will be enabled while preparing to invoke this catalog function, in order to
+     * provide context for the function.
+     * @type {CatalogItem}
+     */
+    this.contextItem = undefined;
 
     knockout.track(this, ['isLoading']);
 };
@@ -72,8 +82,56 @@ defineProperties(CatalogFunction.prototype, {
         get : function() {
             return CatalogItem.defaultMetadata;
         }
+    },
+
+    /**
+     * Gets the set of functions used to update individual properties in {@link CatalogMember#updateFromJson}.
+     * When a property name in the returned object literal matches the name of a property on this instance, the value
+     * will be called as a function and passed a reference to this instance, a reference to the source JSON object
+     * literal, and the name of the property.
+     * @memberOf CatalogFunction.prototype
+     * @type {Object}
+     */
+    updaters : {
+        get : function() {
+            return CatalogFunction.defaultUpdaters;
+        }
+    },
+
+    /**
+     * Gets the set of functions used to serialize individual properties in {@link CatalogMember#serializeToJson}.
+     * When a property name on the model matches the name of a property in the serializers object lieral,
+     * the value will be called as a function and passed a reference to the model, a reference to the destination
+     * JSON object literal, and the name of the property.
+     * @memberOf CatalogFunction.prototype
+     * @type {Object}
+     */
+    serializers : {
+        get : function() {
+            return CatalogFunction.defaultSerializers;
+        }
     }
 });
+
+CatalogFunction.defaultUpdaters = clone(CatalogMember.defaultUpdaters);
+
+CatalogFunction.defaultUpdaters.contextItem = function(catalogFunction, json, propertyName, options) {
+    var itemJson = json[propertyName];
+    var itemObject = catalogFunction.contextItem = createCatalogMemberFromType(itemJson.type, catalogFunction.terria);
+    return itemObject.updateFromJson(itemJson, options);
+};
+
+freezeObject(CatalogFunction.defaultUpdaters);
+
+CatalogFunction.defaultSerializers = clone(CatalogMember.defaultSerializers);
+
+CatalogFunction.defaultSerializers.contextItem = function(catalogFunction, json, propertyName, options) {
+    if (defined(catalogFunction.contextItem)) {
+        json[propertyName] = catalogFunction.contextItem.serializeToJson(options);
+    }
+};
+
+freezeObject(CatalogFunction.defaultSerializers);
 
 /**
  * Loads this function, if it's not already loaded.  It is safe to

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -419,12 +419,12 @@ function createLeafletCredit(attribution) {
 /*
 * There are two "listeners" for clicks which are set up in our constructor.
 * - One fires for any click: `map.on('click', ...`.  It calls `pickFeatures`.
-* - One fires only for vector features: `this.scene.featureClicked.addEventListener`. 
+* - One fires only for vector features: `this.scene.featureClicked.addEventListener`.
 *    It calls `featurePicked`, which calls `pickFeatures` and then adds the feature it found, if any.
 * These events can fire in either order.
 * Billboards do not fire the first event.
 *
-* Note that `pickFeatures` does nothing if `leaflet._pickedFeatures` is already set. 
+* Note that `pickFeatures` does nothing if `leaflet._pickedFeatures` is already set.
 * Otherwise, it sets it, runs `runLater` to clear it, and starts the asynchronous raster feature picking.
 *
 * So:
@@ -469,7 +469,7 @@ function pickFeatures(leaflet, latlng, tileCoordinates, existingFeatures) {
         var mapInteractionModeStack = leaflet.terria.mapInteractionModeStack;
         if (defined(mapInteractionModeStack) && mapInteractionModeStack.length > 0) {
             mapInteractionModeStack[mapInteractionModeStack.length - 1].pickedFeatures.pickPosition = newPickLocation;
-        } else {
+        } else if (defined(leaflet.terria.pickedFeatures)) {
             leaflet.terria.pickedFeatures.pickPosition = newPickLocation;
         }
 

--- a/lib/Models/WebProcessingServiceCatalogGroup.js
+++ b/lib/Models/WebProcessingServiceCatalogGroup.js
@@ -136,6 +136,10 @@ WebProcessingServiceCatalogGroup.prototype._load = function() {
                 catalogFunction.description = process.Abstract;
             }
 
+            if (typeof(that.itemProperties) === 'object') {
+                catalogFunction.updateFromJson(that.itemProperties);
+            }
+
             that.items.push(catalogFunction);
         }
     });

--- a/lib/ReactViews/Analytics/InvokeFunction.jsx
+++ b/lib/ReactViews/Analytics/InvokeFunction.jsx
@@ -5,6 +5,7 @@ import ParameterEditor from './ParameterEditor';
 import when from 'terriajs-cesium/Source/ThirdParty/when';
 import TerriaError from '../../Core/TerriaError';
 import renderMarkdownInReact from '../../Core/renderMarkdownInReact';
+import defined from 'terriajs-cesium/Source/Core/defined';
 import Styles from './invoke-function.scss';
 
 const InvokeFunction = React.createClass({
@@ -61,6 +62,11 @@ const InvokeFunction = React.createClass({
         }
 
         knockout.track(this._parameterValues);
+
+        // Enable the context item, if any.
+        if (defined(props.previewed.contextItem)) {
+            props.previewed.contextItem.isEnabled = true;
+        }
     },
 
     getParams() {

--- a/lib/ReactViews/Analytics/InvokeFunction.jsx
+++ b/lib/ReactViews/Analytics/InvokeFunction.jsx
@@ -24,6 +24,10 @@ const InvokeFunction = React.createClass({
         this.initializeParameters(this.props);
     },
 
+    componentWillUnmount() {
+        this.removeContextItem();
+    },
+
     componentWillReceiveProps(nextProps) {
         this.initializeParameters(nextProps);
     },
@@ -64,8 +68,17 @@ const InvokeFunction = React.createClass({
         knockout.track(this._parameterValues);
 
         // Enable the context item, if any.
+        this.removeContextItem();
         if (defined(props.previewed.contextItem)) {
             props.previewed.contextItem.isEnabled = true;
+            this._lastContextItem = props.previewed.contextItem;
+        }
+    },
+
+    removeContextItem() {
+        if (defined(this._lastContextItem)) {
+            this._lastContextItem.isEnabled = false;
+            this._lastContextItem = undefined;
         }
     },
 

--- a/lib/ReactViews/Analytics/parameter-editors.scss
+++ b/lib/ReactViews/Analytics/parameter-editors.scss
@@ -55,8 +55,8 @@
 }
 
 .btn-selector {
-  compose: btn from '../../Sass/common/_buttons.scss';
-  compose: btn-primary from '../../Sass/common/_buttons.scss';
+  composes: btn from '../../Sass/common/_buttons.scss';
+  composes: btn-primary from '../../Sass/common/_buttons.scss';
 }
 
 .map {

--- a/lib/ReactViews/Notification/MapInteractionWindow.jsx
+++ b/lib/ReactViews/Notification/MapInteractionWindow.jsx
@@ -21,7 +21,7 @@ const MapInteractionWindow = React.createClass({
         return (
             <div className={windowClass} aria-hidden={ !interactionMode }>
               <div className={Styles.content}>{interactionMode && interactionMode.message}</div><button type='button' onClick={interactionMode && interactionMode.onCancel}
-                          className='btn btn-primary'>Cancel</button>
+                          className={Styles.btn}>Cancel</button>
             </div>);
     }
 });

--- a/lib/ReactViews/Notification/map-interaction-window.scss
+++ b/lib/ReactViews/Notification/map-interaction-window.scss
@@ -21,3 +21,8 @@
 .content{
   margin-bottom: $padding;
 }
+
+.btn{
+  composes: btn from '../../Sass/common/_buttons.scss';
+  composes: btn-primary from '../../Sass/common/_buttons.scss';
+}


### PR DESCRIPTION
Fixes #1557 

Also fixes some styles on the analytics pages.

Currently this is rigged up to show a `CatalogFunction`'s `contextItem` layer when that function is selected in the catalog UI, even if the catalog UI is not visible.  So if we click Add Data and click a Wave Atlas WPS function, the context layer appears on the map and in the workbench.  Then we can close the catalog panel and the context will still be visible.  If we open the catalog panel and select a different dataset, the context layer will disappear.

For the most part this seems pretty ok, but it can get a little weird in corner cases.  For example:
1. Click on a WPS function so the context appears.
2. Close the catalog panel.
3. Click the `About this dataset` button on the context layer in the Workbench.

The catalog will appear and show the details of the context layer (good!) but the context layer will simultaneously disappear from the workbench because the original WPS item is no longer selected (weird!).
