### PR TITLE
Slay the kraken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '5'
+- '5.11.0'
 script:
 - gulp lint docs release
 - gulp test-saucelabs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '5.11.0'
+- '5'
 script:
 - gulp lint docs release
 - gulp test-saucelabs

--- a/buildprocess/karma-saucelabs.conf.js
+++ b/buildprocess/karma-saucelabs.conf.js
@@ -48,7 +48,7 @@ module.exports = function(config) {
         },
 
         // start these browsers
-        browsers: ['sl_chrome', 'sl_safari', 'sl_firefox', 'sl_firefox_esr', 'sl_ie10', 'sl_ie11'], // 'sl_ie9' temporarily disabled
+        browsers: ['sl_ie9'], //, 'sl_safari', 'sl_firefox', 'sl_firefox_esr', 'sl_ie10', 'sl_ie11'], // 'sl_ie9' temporarily disabled
 
         sauceLabels: {
             testName: 'TerriaJS Unit Tests',

--- a/buildprocess/karma-saucelabs.conf.js
+++ b/buildprocess/karma-saucelabs.conf.js
@@ -48,7 +48,7 @@ module.exports = function(config) {
         },
 
         // start these browsers
-        browsers: ['sl_ie9'], //, 'sl_safari', 'sl_firefox', 'sl_firefox_esr', 'sl_ie10', 'sl_ie11'], // 'sl_ie9' temporarily disabled
+        browsers: ['sl_chrome', 'sl_safari', 'sl_firefox', 'sl_firefox_esr', 'sl_ie9', 'sl_ie10', 'sl_ie11'],
 
         sauceLabels: {
             testName: 'TerriaJS Unit Tests',

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-addons-test-utils": "0.14.7",
     "react-dom": "0.14.x",
     "react-shallow-testutils": "^1.0.0",
+    "socket.io": "1.4.7",
     "terriajs-jasmine-ajax": "^3.2.1",
     "terriajs-server": "^1.4.1",
     "webpack-dev-server": "^1.14.1"


### PR DESCRIPTION
socket.io 1.4.8 has a bug that breaks compatibility with IE9, so this PR forces it to 1.4.7.

See socketio/engine.io#407

Fixes #1682 
