### PR TITLE
Fix add data with non-WMS URL

### DIFF
--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -97,7 +97,7 @@ const AddData = React.createClass({
                 loadFunctions = wmsThenWfs.concat(others);
             }
 
-            promise = loadAuto(that, loadFunctions);
+            promise = loadAuto(that, loadFunctions, 0);
         } else if (that.state.remoteDataType.value === 'wms-getCapabilities') {
             promise = loadWms(that);
         } else if (that.state.remoteDataType.value === 'wfs-getCapabilities') {
@@ -208,9 +208,7 @@ const AddData = React.createClass({
  * @returns {Promise}
  */
 function loadAuto(viewModel, loadFunctions, index) {
-    index = 0;
     const loadFunction = loadFunctions[index];
-
     return loadFunction(viewModel).otherwise(function () {
         return loadAuto(viewModel, loadFunctions, index + 1);
     });


### PR DESCRIPTION
Fixes #1684.  Was getting stuck in an infinite loop!

However this raises another issue - we have hardcoded all the catalog items to check for into `AddData.jsx`, ie. `registerCatalogMembers`'s calls to `createCatalogItemFromUrl` are ignored. Also, we should write some tests for `AddData.jsx`. New issue on the way... 
