### PR TITLE
Rely on createCatalogItemFromUrl.register in AddData

### DIFF
--- a/lib/Models/createCatalogItemFromUrl.js
+++ b/lib/Models/createCatalogItemFromUrl.js
@@ -23,6 +23,7 @@ var createCatalogItemFromUrl = function(url, terria, allowLoad, index) {
             return item;
         }
         item.url = url;
+        item.name = url;
         return item.load().yield(item).otherwise(function(e) {
             console.log(e);
             return createCatalogItemFromUrl(url, terria, allowLoad, index + 1);


### PR DESCRIPTION
Fixes #1718.

This should have the advantage that if an end-application like NationalMap does not want to support OpenStreetMap, ESRI or WFS then it really won't be supported, and the code for them shouldn't be included (unless it gets included somewhere else).
