### PR TITLE
Animate explorer panel hiding

### DIFF
--- a/lib/ReactViews/ExplorerWindow/explorer-window.scss
+++ b/lib/ReactViews/ExplorerWindow/explorer-window.scss
@@ -18,6 +18,7 @@
     right: 0;
     left: 0;
     visibility: hidden;
+    @include transition(all 0.3s);
 
     &.is-open {
       visibility: visible;


### PR DESCRIPTION
Something that @philipgrimmett picked up on when we were discussing #1726 is that the explorer panel animates when shown, but not when hidden. This fixes that
