### PR TITLE
forceUpdate immediately when knockout observables change

### DIFF
--- a/lib/ReactViews/ObserveModelMixin.js
+++ b/lib/ReactViews/ObserveModelMixin.js
@@ -3,7 +3,6 @@
 import defined from 'terriajs-cesium/Source/Core/defined';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import runLater from '../Core/runLater';
 
 const ObserveModelMixin = {
     componentWillMount() {

--- a/lib/ReactViews/ObserveModelMixin.js
+++ b/lib/ReactViews/ObserveModelMixin.js
@@ -49,15 +49,9 @@ const ObserveModelMixin = {
 
                     if (!updateForced) {
                         updateForced = true;
-                        runLater(function() {
-                            updateForced = false;
-                            if (that.isMounted()) {
-                                that.forceUpdate();
-                            }
-                        }).otherwise(e => {
-                            console.error(`Render error in ${that.constructor.displayName || that.constructor.name}:\n${e.stack}`);
-                            throw e;
-                        });
+                        if (that.isMounted()) {
+                            that.forceUpdate();
+                        }
                     }
                 }
 


### PR DESCRIPTION
In this old commit:
https://github.com/TerriaJS/terriajs/commit/59312d678de1abb7dcfb86d2c2cb63d5379bdcec
I changed `ObserveModelMixin` to batch updates triggered by changes in knockout observables and invoke the `forceUpdate` just once inside a `runLater` callback.

The batching was a performance optimization, because (for some reason) each call to `forceUpdate` results in another call to the component's `render`, even if the render triggered by the previous `forceUpdate` hasn't actually happened yet.

I'm not sure why I did the `runLater` part, though.  Maybe I didn't realize that `forceUpdate` is already deferred; the stack unwinds at least partially before any `render` methods are called.  Or maybe I just thought it couldn't hurt.

But actually it can hurt. Deferring the `forceUpdate` causes #1709 (cursor jumps to the end of the search box when attempting to type in the middle).  This is because React expects the browser DOM and React components to be in agreement by the time the input is handled.  If they're not, it reverts the browser DOM to match the React components, effectively undoing the change the user just made by typing.  Once the re-render actually happens, the components and DOM are both updated to show the user's input again, but that brief "flicker" of the wrong text breaks the cursor position.

So this PR eliminates the `runLater`.  The first observable change triggers a `forceUpdate` immediately, and further changes to the same component are ignored until the re-render happens.

Fixes #1709.
