### PR TITLE
Permit allowValues as well as allowValue

### DIFF
--- a/lib/Models/WebProcessingServiceCatalogFunction.js
+++ b/lib/Models/WebProcessingServiceCatalogFunction.js
@@ -93,14 +93,20 @@ WebProcessingServiceCatalogFunction.parameterConverters = [
             if (!defined(input.LiteralData)) {
                 return undefined;
             }
-
+            var allowedValues = input.LiteralData.AllowedValues;
             if (defined(input.LiteralData.AllowedValue)) {
+                // OGC 05-007r7 Table 29 specifies AllowedValues as name of values for input, not AllowedValue, but for
+                // backward compatibility, allow AllowedValue.
+                allowedValues = input.LiteralData.AllowedValue;
+            }
+
+            if (defined(allowedValues)) {
                 return new EnumerationParameter({
                     terria: catalogFunction.terria,
                     id: input.Identifier,
                     name: input.Title,
                     description: input.Abstract,
-                    possibleValues: input.LiteralData.AllowedValue.Value.slice(),
+                    possibleValues: allowedValues.Value.slice(),
                     isRequired: (input.minOccurs | 0) > 0
                 });
             } else if (defined(input.LiteralData.AnyValue)) {


### PR DESCRIPTION
For LiteralData in WPS, OGC standard specifies that AllowedValues "Indicates that are finite set of values and ranges allowed for this input, and contains ordered list of all valid values and/or ranges", but we currently have this as AllowedValue.

There are services that use AllowedValue, so to support them I propose we allow both. I've tested this with both AllowedValue and AllowedValues in the service.
