### PR TITLE
Use new version of style-loader to work around Chrome sourcemap bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "sass-loader": "^3.2.0",
     "simple-statistics": "^2.0.0",
     "string-replace-webpack-plugin": "0.0.3",
-    "style-loader": "^0.13.1",
+    "style-loader": "git://github.com/TerriaJS/style-loader#chromeWorkaround",
     "superagent": "^2.0.0",
     "terriajs-cesium": "1.20.1",
     "togeojson": "^0.13.0",


### PR DESCRIPTION
This should fix the "Unable to load sourcemap" problem we've all been seeing in Chrome 51.  You'll also need the NationalMap PR I'm about to open, and you'll need to make sure you remove all occurrences of `style-loader` from any of your `node_modules` directories and then re-reun `npm install` or `npmgitdev install`.
