### PR TITLE
CkanCatalogGroup's `filterQuery` items can now be specified as objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * New `ServerConfig` object which provides configuration information about the server, including which domains can be proxied for. This changes the way CorsProxy is initialised.
 * Added partial support for the SDMX-JSON format.
 * `UserDrawing` added for drawing lines and polygons on the map.
+* CkanCatalogGroup's `filterQuery` items can now be specified as objects instead of URL-encoded strings.
 
 ### 3.5.0
 

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -49,17 +49,19 @@ var CkanCatalogGroup = function(terria) {
     this.dataCustodian = undefined;
 
     /**
-     * Gets or sets the filter query to pass to CKAN when querying the available data sources and their groups.  Each string in the
+     * Gets or sets the filter query to pass to CKAN when querying the available data sources and their groups. Each item in the
      * array causes an independent request to the CKAN, and the results are concatenated.  The
      * search string is equivalent to what would be in the parameters segment of the url calling the CKAN search api.
      * See the [Solr documentation](http://wiki.apache.org/solr/CommonQueryParameters#fq) for information about filter queries.
-     *   To get all the datasets with wms resources the query array would be ['fq=res_format%3awms']
-     *   To get all the datasets in the Surface Water group it would be ['q=groups%3dSurface%20Water&fq=res_format%3aWMS']
-     *   And to get both wms and esri-mapService datasets it would be ['q=res_format:WMS', 'q=res_format:%22Esri%20REST%22' ]
+     * Each item can be either a URL-encoded string ("fq=res_format%3awms") or an object ({ fq: 'res_format:wms' }). The latter
+     * format is easier to work with.
+     *   To get all the datasets with wms resources: [{ fq: 'res_format%3awms' }]
+     *   To get all wms/WMS datasets in the Surface Water group: [{q: 'groups=Surface Water', fq: 'res_format:WMS' }]
+     *   To get both wms and esri-mapService datasets: [{q: 'res_format:WMS'}, {q: 'res_format:"Esri REST"' }]
      *   To get all datasets with no filter, you can use ['']
      * This property is required.
      * This property is observable.
-     * @type {String[]}
+     * @type {String[]|Object[]}
      * @editoritemstitle Filter
      */
     this.filterQuery = undefined;
@@ -372,23 +374,32 @@ CkanCatalogGroup.prototype._load = function() {
     var that = this;
 
     var promises = [];
-    if (!defined(this.filterQuery) || !Array.isArray(this.filterQuery) || typeof this.filterQuery[0] !== 'string') {
+    if (!(defined(this.filterQuery) && Array.isArray(this.filterQuery) && (typeof this.filterQuery[0] === 'string' || typeof this.filterQuery[0] === 'object'))) {
         throw new TerriaError({
                 title: 'Error loading CKAN catalogue',
                 message: 'The definition for this CKAN catalogue does not have a valid filter query.'
             });
 
     }
-    for (var i = 0; i < this.filterQuery.length; i++) {
-        var url = new URI(this.url)
+    this.filterQuery.forEach(function(query) {
+        var uri = new URI(this.url)
             .segment('api/3/action/package_search')
-            .addQuery({ rows: 100000 })
-            .toString();
-        url += '&' + this.filterQuery[i]; // filterQuery[i] is expected to be aleady URL-encoded and begin with a query like 'fq='
-        var promise = loadJson(proxyCatalogItemUrl(this, url, '1d'));
+            .addQuery({ rows: 100000 });
+
+        if (typeof query === 'object') {
+            // query is an object of non-encoded parameters, like { fq: "res_format:wms OR WMS" }
+            Object.keys(query).forEach(key =>  uri.addQuery(key, query[key]));
+        }
+        var uristring = uri.toString();
+        
+        if (typeof query === 'string') {
+            // query is expected to be URL-encoded and begin with a query like 'fq='
+            uristring += '&' + query; 
+        } 
+        var promise = loadJson(proxyCatalogItemUrl(this, uristring, '1d'));
 
         promises.push(promise);
-    }
+    });
 
     return when.all(promises).then( function(queryResults) {
         if (!defined(queryResults)) {


### PR DESCRIPTION
instead of URL-encoded strings.
