### PR TITLE
Fix major mobile problems

### DIFF
--- a/lib/ReactViewModels/SearchState.js
+++ b/lib/ReactViewModels/SearchState.js
@@ -5,7 +5,6 @@ export default class SearchState {
     constructor(options) {
         this.catalogSearchProvider = options.catalogSearchProvider || new CatalogItemNameSearchProviderViewModel({ terria: options.terria });
         this.locationSearchProviders = options.locationSearchProviders || [];
-        this.unifiedSearchProviders = [this.catalogSearchProvider].concat(this.locationSearchProviders);
 
         this.catalogSearchText = '';
         this.isWaitingToStartCatalogSearch = false;
@@ -43,6 +42,12 @@ export default class SearchState {
             this.unifiedSearchProviders.forEach(provider => {
                 provider.search('');
             });
+        });
+
+        knockout.defineProperty(this, 'unifiedSearchProviders', {
+            get: function() {
+                return [this.catalogSearchProvider].concat(this.locationSearchProviders);
+            }
         });
     }
 

--- a/lib/ReactViewModels/SearchState.js
+++ b/lib/ReactViewModels/SearchState.js
@@ -15,14 +15,18 @@ export default class SearchState {
         this.unifiedSearchText = '';
         this.isWaitingToStartUnifiedSearch = false;
 
-        this.showLocationSearch = true;
+        this.showLocationSearchResults = true;
+
+        this.showMobileLocationSearch = false;
+        this.showMobileCatalogSearch = false;
 
         knockout.track(this, [
             'catalogSearchProvider', 'locationSearchProviders',
             'catalogSearchText', 'isWaitingToStartCatalogSearch',
             'locationSearchText', 'isWaitingToStartLocationSearch',
             'unifiedSearchText', 'isWaitingToStartUnifiedSearch',
-            'showLocationSearch'
+            'showLocationSearchResults',
+            'showMobileLocationSearch', 'showMobileCatalogSearch'
         ]);
 
         knockout.getObservable(this, 'catalogSearchText').subscribe(() => {

--- a/lib/ReactViewModels/ViewState.js
+++ b/lib/ReactViewModels/ViewState.js
@@ -17,7 +17,7 @@ export default class ViewState {
             data: 'data',
             preview: 'preview',
             nowViewing: 'nowViewing',
-            search: 'search'
+            locationSearchResults: 'locationSearchResults'
         });
 
         this.componentOrderOptions = Object.freeze({

--- a/lib/ReactViews/DataCatalog/CatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/CatalogItem.jsx
@@ -14,7 +14,8 @@ const STATE_TO_ICONS = {
     loading: <Icon glyph={Icon.GLYPHS.loader}/>,
     remove: <Icon glyph={Icon.GLYPHS.remove}/>,
     add: <Icon glyph={Icon.GLYPHS.add}/>,
-    stats: <Icon glyph={Icon.GLYPHS.barChart}/>
+    stats: <Icon glyph={Icon.GLYPHS.barChart}/>,
+    preview: <Icon glyph={Icon.GLYPHS.right}/>
 };
 
 /** Dumb catalog item */
@@ -44,7 +45,7 @@ CatalogItem.propTypes = {
     selected: React.PropTypes.bool,
     text: React.PropTypes.string,
     onBtnClick: React.PropTypes.func,
-    btnState: React.PropTypes.oneOf(['loading', 'remove', 'add', 'stats'])
+    btnState: React.PropTypes.oneOf(Object.keys(STATE_TO_ICONS))
 };
 
 export default CatalogItem;

--- a/lib/ReactViews/DataCatalog/DataCatalog.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalog.jsx
@@ -1,0 +1,47 @@
+import DataCatalogMember from './DataCatalogMember.jsx';
+import defined from 'terriajs-cesium/Source/Core/defined';
+import ObserveModelMixin from '../ObserveModelMixin';
+import React from 'react';
+import SearchHeader from '../Search/SearchHeader.jsx';
+import Styles from './data-catalog.scss';
+
+// Displays the data catalog.
+const DataCatalog = React.createClass({
+    mixins: [ObserveModelMixin],
+
+    propTypes: {
+        terria: React.PropTypes.object,
+        viewState: React.PropTypes.object
+    },
+
+    render() {
+        const terria = this.props.terria;
+        const searchState = this.props.viewState.searchState;
+        const isSearching = searchState.catalogSearchText.length > 0;
+        const items = (
+            isSearching ?
+                searchState.catalogSearchProvider.searchResults.map(result => result.catalogItem) :
+                terria.catalog.group.items
+        ).filter(defined);
+
+        return (
+            <ul className={Styles.dataCatalog}>
+                <If condition={isSearching}>
+                    <label className={Styles.label}>Search results</label>
+                    <SearchHeader searchProvider={searchState.catalogSearchProvider}
+                                  isWaitingForSearchToStart={searchState.isWaitingToStartCatalogSearch}/>
+                </If>
+                <For each="item" of={items}>
+                    {item !== this.props.terria.catalog.userAddedDataGroup &&
+                        <DataCatalogMember viewState={this.props.viewState}
+                                           member={item}
+                                           manageIsOpenLocally={isSearching}
+                                           key={item.uniqueId}
+                    />}
+                </For>
+            </ul>
+        );
+    }
+});
+
+module.exports = DataCatalog;

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -51,7 +51,7 @@ const DataCatalogItem = React.createClass({
                 selected={this.isSelected()}
                 text={item.name}
                 btnState={this.getState()}
-                onBtnClick={defined(item.invoke) ? this.setPreviewedItem : this.toggleEnable}
+                onBtnClick={defined(item.invoke) || this.props.viewState.useSmallScreenInterface ? this.setPreviewedItem : this.toggleEnable}
             />
         );
     },
@@ -59,6 +59,8 @@ const DataCatalogItem = React.createClass({
     getState() {
         if (this.props.item.isLoading) {
             return 'loading';
+        } else if (this.props.viewState.useSmallScreenInterface) {
+            return 'preview';
         } else if (this.props.item.isEnabled) {
             return 'remove';
         } else if (!defined(this.props.item.invoke)) {

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -26,6 +26,7 @@ const DataCatalogItem = React.createClass({
 
             // close modal window
             this.props.viewState.explorerPanelIsVisible = false;
+            this.props.viewState.mobileView = null;
         }
     },
 

--- a/lib/ReactViews/DataCatalog/data-catalog.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog.scss
@@ -1,0 +1,23 @@
+@import '~terriajs-variables';
+@import '../../Sass/common/mixins';
+
+.data-catalog {
+  composes: list-reset from '../../Sass/common/_base.scss';
+
+  font-size: 0.9rem;
+
+  background: $modal-secondary-bg;
+  overflow-y: auto;
+  overflow-x: hidden;
+  box-sizing: border-box;
+
+  @media screen and (min-width: $sm) {
+    padding-right: $padding;
+    margin-top: $padding;
+    height: calc(100% - #{$input-height});
+  }
+}
+
+.label {
+  composes: label from '../../Sass/common/_labels.scss';
+}

--- a/lib/ReactViews/DataCatalog/data-catalog.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog.scss
@@ -11,6 +11,8 @@
   overflow-x: hidden;
   box-sizing: border-box;
 
+  height: calc(100vh - #{$mobile-header-height + $modal-header-height});
+
   @media screen and (min-width: $sm) {
     padding-right: $padding;
     margin-top: $padding;

--- a/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
-
+import DataCatalog from '../../DataCatalog/DataCatalog.jsx';
 import DataCatalogMember from '../../DataCatalog/DataCatalogMember.jsx';
 import DataPreview from '../../Preview/DataPreview.jsx';
 import ObserveModelMixin from '../../ObserveModelMixin';
@@ -35,7 +35,8 @@ const DataCatalogTab = React.createClass({
                     <SearchBox searchText={this.props.viewState.searchState.catalogSearchText}
                                onSearchTextChanged={this.changeSearchText}
                                onDoSearch={this.search}/>
-                    {this.renderDataCatalog()}
+                    <DataCatalog terria={this.props.terria}
+                                 viewState={this.props.viewState} />
                 </div>
                 <DataPreview terria={terria}
                              viewState={this.props.viewState}

--- a/lib/ReactViews/FeatureInfo/feature-info-panel.scss
+++ b/lib/ReactViews/FeatureInfo/feature-info-panel.scss
@@ -47,6 +47,7 @@
 .header{
   background: $dark;
   padding-right: $input-height;
+  line-height: $modal-header-height;
 }
 
 .btn {
@@ -73,10 +74,13 @@
     height: 23px;
     width: 23px;
     fill: #ffffff;
+    position: relative;
+    left: 10px;
   }
   position: absolute;
-  top: 3px;
   right: 0;
+  width: $modal-header-height;
+  height: $modal-header-height;
 }
 
 .no-results {

--- a/lib/ReactViews/FeatureInfo/feature-info-section.scss
+++ b/lib/ReactViews/FeatureInfo/feature-info-section.scss
@@ -12,7 +12,7 @@
   position: relative;
   width: 100%;
   background: $dark;
-  min-height: 30px;
+  min-height: 40px;
   margin: 0;
   padding-right: 30px;
   span{
@@ -26,8 +26,8 @@
     fill: #fff;
     float: right;
     position: absolute;
-    top: 5px;
-    right: 0;
+    top: 10px;
+    right: 5px;
   }
 }
 

--- a/lib/ReactViews/Mobile/MobileHeader.jsx
+++ b/lib/ReactViews/Mobile/MobileHeader.jsx
@@ -146,7 +146,6 @@ const MobileHeader = React.createClass({
                 </ul>
                 <MobileModalWindow terria={this.props.terria}
                                    viewState={this.props.viewState}
-                                   searches={this.state.searches}
                 />
             </div>
         );

--- a/lib/ReactViews/Mobile/MobileHeader.jsx
+++ b/lib/ReactViews/Mobile/MobileHeader.jsx
@@ -167,14 +167,16 @@ const MobileHeader = React.createClass({
                                                    onDoSearch={this.searchLocations}
                                                    searchBoxLabel="Search for locations"
                                                    alwaysShowClear={true}
-                                                   onClear={this.closeLocationSearch} />
+                                                   onClear={this.closeLocationSearch}
+                                                   autoFocus={true} />
                                     </When>
                                     <When condition={searchState.showMobileCatalogSearch}>
                                         <SearchBox searchText={searchState.catalogSearchText}
                                                    onSearchTextChanged={this.changeCatalogSearchText}
                                                    onDoSearch={this.searchCatalog}
                                                    searchBoxLabel="Search the catalogue"
-                                                   onClear={this.closeCatalogSearch} />
+                                                   onClear={this.closeCatalogSearch}
+                                                   autoFocus={true} />
                                     </When>
                                 </Choose>
                             </div>

--- a/lib/ReactViews/Mobile/MobileHeader.jsx
+++ b/lib/ReactViews/Mobile/MobileHeader.jsx
@@ -36,10 +36,15 @@ const MobileHeader = React.createClass({
         }
     },
 
-    closeSearch() {
+    closeLocationSearch() {
         this.props.viewState.searchState.showMobileLocationSearch = false;
         this.props.viewState.explorerPanelIsVisible = false;
         this.props.viewState.switchMobileView(null);
+    },
+
+    closeCatalogSearch() {
+        this.props.viewState.searchState.showMobileCatalogSearch = false;
+        this.props.viewState.searchState.catalogSearchText = '';
     },
 
     toggleMenu() {
@@ -162,13 +167,14 @@ const MobileHeader = React.createClass({
                                                    onDoSearch={this.searchLocations}
                                                    searchBoxLabel="Search for locations"
                                                    alwaysShowClear={true}
-                                                   onClear={this.closeSearch} />
+                                                   onClear={this.closeLocationSearch} />
                                     </When>
                                     <When condition={searchState.showMobileCatalogSearch}>
                                         <SearchBox searchText={searchState.catalogSearchText}
                                                    onSearchTextChanged={this.changeCatalogSearchText}
                                                    onDoSearch={this.searchCatalog}
-                                                   searchBoxLabel="Search the catalogue" />
+                                                   searchBoxLabel="Search the catalogue"
+                                                   onClear={this.closeCatalogSearch} />
                                     </When>
                                 </Choose>
                             </div>

--- a/lib/ReactViews/Mobile/MobileModalWindow.jsx
+++ b/lib/ReactViews/Mobile/MobileModalWindow.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import DataCatalogMember from '../DataCatalog/DataCatalogMember.jsx';
+import DataCatalog from '../DataCatalog/DataCatalog.jsx';
 import DataPreview from '../Preview/DataPreview.jsx';
-import defined from 'terriajs-cesium/Source/Core/defined';
 import MobileSearch from './MobileSearch.jsx';
 import WorkbenchList from '../Workbench/WorkbenchList.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -20,32 +19,31 @@ const MobileModalWindow = React.createClass({
     },
 
     renderModalContent() {
-        switch (this.props.viewState.mobileView) {
-            case this.props.viewState.mobileViewOptions.search:
+        const viewState = this.props.viewState;
+        const searchState = viewState.searchState;
+
+        if (viewState.mobileView !== viewState.mobileViewOptions.data &&
+            viewState.mobileView !== viewState.mobileViewOptions.preview &&
+            searchState.showMobileLocationSearch &&
+            searchState.locationSearchText.length > 0) {
+
+            return (<MobileSearch terria={this.props.terria} viewState={this.props.viewState}/>);
+        }
+
+        switch (viewState.mobileView) {
+            case viewState.mobileViewOptions.data:
                 return (
-                    <MobileSearch terria={this.props.terria} viewState={this.props.viewState}/>
+                    <DataCatalog terria={this.props.terria}
+                                 viewState={this.props.viewState} />
                 );
-            case this.props.viewState.mobileViewOptions.data:
-                return (
-                    <ul className={Styles.dataCatalog}>
-                        {this.props.terria.catalog.group.items.filter(defined)
-                            .map((item, i) => (
-                                <DataCatalogMember viewState={this.props.viewState}
-                                                   member={item}
-                                                   key={item.uniqueId}
-                                />
-                            ))
-                        }
-                    </ul>
-                );
-            case this.props.viewState.mobileViewOptions.preview:
+            case viewState.mobileViewOptions.preview:
                 return (
                     <DataPreview terria={this.props.terria}
                                  viewState={this.props.viewState}
                                  previewed={this.props.viewState.previewedItem}
                     />
                 );
-            case this.props.viewState.mobileViewOptions.nowViewing:
+            case viewState.mobileViewOptions.nowViewing:
                 return (
                     <WorkbenchList viewState={this.props.viewState}
                                    terria={this.props.terria}
@@ -59,6 +57,7 @@ const MobileModalWindow = React.createClass({
     onClearMobileUI() {
         this.props.viewState.switchMobileView(null);
         this.props.viewState.explorerPanelIsVisible = false;
+        this.props.viewState.searchState.showMobileLocationSearch = false;
     },
 
     componentWillReceiveProps() {
@@ -78,7 +77,7 @@ const MobileModalWindow = React.createClass({
             [Styles.isOpen]: this.props.viewState.explorerPanelIsVisible && this.props.viewState.mobileView
         });
         const mobileView = this.props.viewState.mobileView;
-        
+
         return (
             <div className={modalClass}>
                 <div className={Styles.modalBg}>

--- a/lib/ReactViews/Mobile/MobileModalWindow.jsx
+++ b/lib/ReactViews/Mobile/MobileModalWindow.jsx
@@ -58,6 +58,8 @@ const MobileModalWindow = React.createClass({
         this.props.viewState.switchMobileView(null);
         this.props.viewState.explorerPanelIsVisible = false;
         this.props.viewState.searchState.showMobileLocationSearch = false;
+        this.props.viewState.searchState.showMobileCatalogSearch = false;
+        this.props.viewState.searchState.catalogSearchText = '';
     },
 
     componentWillReceiveProps() {

--- a/lib/ReactViews/Mobile/MobileSearch.jsx
+++ b/lib/ReactViews/Mobile/MobileSearch.jsx
@@ -29,9 +29,6 @@ const MobileSearch = React.createClass({
                 <div className={Styles.location}>
                     {this.renderLocationResult()}
                 </div>
-                <div className={Styles.data}>
-                    {this.renderDataCatalogResult()}
-                </div>
             </div>
         );
     },

--- a/lib/ReactViews/Mobile/MobileSearch.jsx
+++ b/lib/ReactViews/Mobile/MobileSearch.jsx
@@ -1,10 +1,7 @@
-'use strict';
-// import defined from 'terriajs-cesium/Source/Core/defined';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
 import SearchHeader from '../Search/SearchHeader.jsx';
 import SearchResult from '../Search/SearchResult.jsx';
-// import DataCatalogMember from '../DataCatalog/DataCatalogMember.jsx';
 import Styles from './mobile-search.scss';
 
 // A Location item when doing Bing map searvh or Gazetter search
@@ -20,7 +17,7 @@ const MobileSearch = React.createClass({
         result.clickAction();
         // Close modal window
         this.props.viewState.switchMobileView(null);
-
+        this.props.viewState.searchState.showMobileLocationSearch = false;
     },
 
     render() {
@@ -48,31 +45,6 @@ const MobileSearch = React.createClass({
                 </ul>
             </div>));
     }
-
-    // renderDataCatalogResult() {
-    //     const searchState = this.props.viewState.searchState;
-    //     const search = searchState.unifiedSearchProviders
-    //         .filter(s=> s.constructor.name === 'CatalogItemNameSearchProviderViewModel')[0];
-
-    //     const items = search.searchResults.map(result => result.catalogItem);
-    //     if (searchState.unifiedSearchText.length) {
-    //         return <div key={search.constructor.name}>
-    //             <label className={Styles.label}>{search.name}</label>
-    //             <ul className={Styles.results}>
-    //                 <SearchHeader searchProvider={search}/>
-    //                 {items.filter(defined)
-    //                     .map((item, i) => (
-    //                         <DataCatalogMember viewState={this.props.viewState}
-    //                                            member={item}
-    //                                            manageIsOpenLocally={search.isSearching}
-    //                                            key={item.uniqueId}
-    //                         />
-    //                     ))}
-    //             </ul>
-    //         </div>;
-    //     }
-    //     return null;
-    // }
 });
 
 module.exports = MobileSearch;

--- a/lib/ReactViews/Mobile/MobileSearch.jsx
+++ b/lib/ReactViews/Mobile/MobileSearch.jsx
@@ -1,10 +1,10 @@
 'use strict';
-import defined from 'terriajs-cesium/Source/Core/defined';
+// import defined from 'terriajs-cesium/Source/Core/defined';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
 import SearchHeader from '../Search/SearchHeader.jsx';
 import SearchResult from '../Search/SearchResult.jsx';
-import DataCatalogMember from '../DataCatalog/DataCatalogMember.jsx';
+// import DataCatalogMember from '../DataCatalog/DataCatalogMember.jsx';
 import Styles from './mobile-search.scss';
 
 // A Location item when doing Bing map searvh or Gazetter search
@@ -36,8 +36,7 @@ const MobileSearch = React.createClass({
     renderLocationResult() {
         const that = this;
         const searchState = this.props.viewState.searchState;
-        return searchState.unifiedSearchProviders
-            .filter(search=> search.constructor.name !== 'CatalogItemNameSearchProviderViewModel')
+        return searchState.locationSearchProviders
             .filter(search => search.isSearching || (search.searchResults && search.searchResults.length))
             .map(search => (<div key={search.constructor.name}>
                 <label className={Styles.label}>Locations & Official Place Names</label>
@@ -48,32 +47,32 @@ const MobileSearch = React.createClass({
                     ))}
                 </ul>
             </div>));
-    },
-
-    renderDataCatalogResult() {
-        const searchState = this.props.viewState.searchState;
-        const search = searchState.unifiedSearchProviders
-            .filter(s=> s.constructor.name === 'CatalogItemNameSearchProviderViewModel')[0];
-
-        const items = search.searchResults.map(result => result.catalogItem);
-        if (searchState.unifiedSearchText.length) {
-            return <div key={search.constructor.name}>
-                <label className={Styles.label}>{search.name}</label>
-                <ul className={Styles.results}>
-                    <SearchHeader searchProvider={search}/>
-                    {items.filter(defined)
-                        .map((item, i) => (
-                            <DataCatalogMember viewState={this.props.viewState}
-                                               member={item}
-                                               manageIsOpenLocally={search.isSearching}
-                                               key={item.uniqueId}
-                            />
-                        ))}
-                </ul>
-            </div>;
-        }
-        return null;
     }
+
+    // renderDataCatalogResult() {
+    //     const searchState = this.props.viewState.searchState;
+    //     const search = searchState.unifiedSearchProviders
+    //         .filter(s=> s.constructor.name === 'CatalogItemNameSearchProviderViewModel')[0];
+
+    //     const items = search.searchResults.map(result => result.catalogItem);
+    //     if (searchState.unifiedSearchText.length) {
+    //         return <div key={search.constructor.name}>
+    //             <label className={Styles.label}>{search.name}</label>
+    //             <ul className={Styles.results}>
+    //                 <SearchHeader searchProvider={search}/>
+    //                 {items.filter(defined)
+    //                     .map((item, i) => (
+    //                         <DataCatalogMember viewState={this.props.viewState}
+    //                                            member={item}
+    //                                            manageIsOpenLocally={search.isSearching}
+    //                                            key={item.uniqueId}
+    //                         />
+    //                     ))}
+    //             </ul>
+    //         </div>;
+    //     }
+    //     return null;
+    // }
 });
 
 module.exports = MobileSearch;

--- a/lib/ReactViews/Mobile/mobile-header.scss
+++ b/lib/ReactViews/Mobile/mobile-header.scss
@@ -29,6 +29,7 @@
     composes: btn from '../../Sass/common/_buttons.scss';
     composes: btn-primary from '../../Sass/common/_buttons.scss';
     position: relative;
+    margin: 0 $padding-small;
     padding: $padding $padding $padding $padding*3;
     text-transform: uppercase;
     width: auto;
@@ -44,12 +45,20 @@
 }
 
 .btn-search {
-  display: block;
-  font-size: 20px;
+  composes: btn from '../../Sass/common/_buttons.scss';
+  composes: btn-primary from '../../Sass/common/_buttons.scss';
+  margin: 0 $padding-small;
+  padding: $padding-small;
+  padding-right: $padding;
+  position: relative;
+  text-transform: uppercase;
+  width: 40px;
   svg{
-    height: 30px;
-    width: 30px;
+    height: 28px;
+    width: 28px;
     fill: #fff;
+    position: relative;
+    left: 3px;
   }
 }
 

--- a/lib/ReactViews/Mobile/mobile-header.scss
+++ b/lib/ReactViews/Mobile/mobile-header.scss
@@ -58,7 +58,7 @@
     width: 28px;
     fill: #fff;
     position: relative;
-    left: 3px;
+    left: 2px;
   }
 }
 

--- a/lib/ReactViews/Mobile/mobile-search.scss
+++ b/lib/ReactViews/Mobile/mobile-search.scss
@@ -26,6 +26,10 @@
 
 .location {
   height: calc(100vh - #{$workbench-header + $logo-height});
+
+  @media screen and (max-width : $sm) {
+    height: calc(100vh - #{$mobile-header-height + $modal-header-height});
+  }
 }
 
 @include empty-module("data")

--- a/lib/ReactViews/Mobile/mobile-search.scss
+++ b/lib/ReactViews/Mobile/mobile-search.scss
@@ -24,5 +24,8 @@
   display: block;
 }
 
-@include empty-module("location")
+.location {
+  height: calc(100vh - #{$workbench-header + $logo-height});
+}
+
 @include empty-module("data")

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -26,6 +26,7 @@ const MappablePreview = React.createClass({
             !event.shiftKey && !event.ctrlKey) {
 
             this.props.viewState.explorerPanelIsVisible = false;
+            this.props.viewState.mobileView = null;
         }
     },
 

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -125,8 +125,8 @@ const MappablePreview = React.createClass({
                                     <Choose>
                                         <When condition={catalogItem.dataUrlType.indexOf('wfs') === 0 || catalogItem.dataUrlType.indexOf('wcs') === 0}>
                                             Use the link below to download the data.  See the
-                                            {catalogItem.dataUrlType.indexOf('wfs') === 0 && <a href="http://docs.geoserver.org/latest/en/user/services/wfs/reference.html" target="_blank">Web Feature Service (WFS) documentation</a>}
-                                            {catalogItem.dataUrlType.indexOf('wcs') === 0 && <a href="http://docs.geoserver.org/latest/en/user/services/wcs/reference.html" target="_blank">Web Coverage Service (WCS) documentation</a>}
+                                            {catalogItem.dataUrlType.indexOf('wfs') === 0 && <a href="http://docs.geoserver.org/latest/en/user/services/wfs/reference.html" target="_blank" key="wfs">Web Feature Service (WFS) documentation</a>}
+                                            {catalogItem.dataUrlType.indexOf('wcs') === 0 && <a href="http://docs.geoserver.org/latest/en/user/services/wcs/reference.html" target="_blank" key="wms">Web Coverage Service (WCS) documentation</a>}
                                             for more information on customising URL query parameters.
                                         </When>
                                         <Otherwise>
@@ -134,7 +134,7 @@ const MappablePreview = React.createClass({
                                         </Otherwise>
                                     </Choose>
                                     <br/>
-                                    <a href={catalogItem.dataUrl} target="_blank">{catalogItem.dataUrl}</a>
+                                    <a href={catalogItem.dataUrl} key={catalogItem.dataUrl} target="_blank">{catalogItem.dataUrl}</a>
                                 </p>
                             </If>
                         </If>

--- a/lib/ReactViews/Search/SearchBox.jsx
+++ b/lib/ReactViews/Search/SearchBox.jsx
@@ -17,13 +17,15 @@ export default React.createClass({
         onFocus: React.PropTypes.func,
         searchBoxLabel: React.PropTypes.string,
         onClear: React.PropTypes.func,
-        alwaysShowClear: React.PropTypes.bool
+        alwaysShowClear: React.PropTypes.bool,
+        autoFocus: React.PropTypes.bool
     },
 
     getDefaultProps() {
         return {
             searchBoxLabel: 'Search',
-            alwaysShowClear: false
+            alwaysShowClear: false,
+            autoFocus: false
         };
     },
 
@@ -98,7 +100,8 @@ export default React.createClass({
                        onKeyDown={this.onKeyDown}
                        className={Styles.searchField}
                        placeholder={this.props.searchBoxLabel}
-                       autoComplete='off'/>
+                       autoComplete='off'
+                       autoFocus={this.props.autoFocus} />
                 {(this.props.alwaysShowClear || this.hasValue()) && clearButton}
             </form>
         );

--- a/lib/ReactViews/Search/SearchBox.jsx
+++ b/lib/ReactViews/Search/SearchBox.jsx
@@ -14,7 +14,17 @@ export default React.createClass({
         onSearchTextChanged: React.PropTypes.func.isRequired,
         onDoSearch: React.PropTypes.func.isRequired,
         searchText: React.PropTypes.string.isRequired,
-        onFocus: React.PropTypes.func
+        onFocus: React.PropTypes.func,
+        searchBoxLabel: React.PropTypes.string,
+        onClear: React.PropTypes.func,
+        alwaysShowClear: React.PropTypes.bool
+    },
+
+    getDefaultProps() {
+        return {
+            searchBoxLabel: 'Search',
+            alwaysShowClear: false
+        };
     },
 
     componentWillUnmount() {
@@ -57,6 +67,10 @@ export default React.createClass({
     clearSearch() {
         this.props.onSearchTextChanged('');
         this.search();
+
+        if (this.props.onClear) {
+            this.props.onClear();
+        }
     },
 
     onKeyDown(event) {
@@ -83,9 +97,9 @@ export default React.createClass({
                        onFocus={this.props.onFocus}
                        onKeyDown={this.onKeyDown}
                        className={Styles.searchField}
-                       placeholder='Search'
+                       placeholder={this.props.searchBoxLabel}
                        autoComplete='off'/>
-                {this.hasValue() && clearButton}
+                {(this.props.alwaysShowClear || this.hasValue()) && clearButton}
             </form>
         );
     }

--- a/lib/ReactViews/Search/SidebarSearch.jsx
+++ b/lib/ReactViews/Search/SidebarSearch.jsx
@@ -70,7 +70,7 @@ export default React.createClass({
     },
 
     backToNowViewing() {
-        this.props.viewState.searchState.showLocationSearch = false;
+        this.props.viewState.searchState.showLocationSearchResults = false;
     },
 
     getMarkerIcon() {

--- a/lib/ReactViews/SidePanel/SidePanel.jsx
+++ b/lib/ReactViews/SidePanel/SidePanel.jsx
@@ -32,7 +32,7 @@ const SidePanel = React.createClass({
 
         // Close the search results when the Now Viewing changes (so that it's visible).
         this._nowViewingChangeSubscription = knockout.getObservable(this.props.terria.nowViewing, 'items').subscribe(() => {
-            this.props.viewState.searchState.showLocationSearch = false;
+            this.props.viewState.searchState.showLocationSearchResults = false;
         });
     },
 
@@ -56,7 +56,7 @@ const SidePanel = React.createClass({
     },
 
     startLocationSearch() {
-        this.props.viewState.searchState.showLocationSearch = true;
+        this.props.viewState.searchState.showLocationSearchResults = true;
     },
 
     render() {
@@ -77,7 +77,7 @@ const SidePanel = React.createClass({
                 </div>
                 <div className={Styles.body}>
                     <Choose>
-                        <When condition={searchState.locationSearchText.length > 0 && searchState.showLocationSearch}>
+                        <When condition={searchState.locationSearchText.length > 0 && searchState.showLocationSearchResults}>
                             <SidebarSearch
                                 terria={this.props.terria}
                                 viewState={this.props.viewState}

--- a/lib/ReactViews/Workbench/workbench-item.scss
+++ b/lib/ReactViews/Workbench/workbench-item.scss
@@ -4,7 +4,7 @@
 $workbench-margin: $padding-small - 1px;
 
 .workbench-item {
-  background: $overlay;
+  background: $dark-with-overlay;
   color: #fff;
   font-family: $font-pop;
   margin: $workbench-margin/2 0;

--- a/lib/ReactViews/Workbench/workbench-list.scss
+++ b/lib/ReactViews/Workbench/workbench-list.scss
@@ -10,6 +10,10 @@
   @media print{
     page-break-after : always;
   }
+
+  @media screen and (max-width : $sm) {
+    height: calc(100vh - #{$mobile-header-height + $modal-header-height});
+  }
 }
 
 .is-active {

--- a/lib/Sass/common/_variables.scss
+++ b/lib/Sass/common/_variables.scss
@@ -12,6 +12,7 @@ $color-secondary: #06CCFF;
 $animation-fast: 0.1s;
 
 $dark: #3F4854;
+$dark-with-overlay: #5C636E;
 $dark-lighter: #595B60;
 $grey: #888888;
 $grey-lighter: #ddd;

--- a/test/ReactViews/DataCatalogSpec.jsx
+++ b/test/ReactViews/DataCatalogSpec.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import Terria from '../../lib/Models/Terria';
 import ViewState from '../../lib/ReactViewModels/ViewState';
 
-describe('DataCatalogTab', function() {
+describe('DataCatalog', function() {
     let terria;
     let viewState;
 

--- a/test/ReactViews/DataCatalogTabSpec.jsx
+++ b/test/ReactViews/DataCatalogTabSpec.jsx
@@ -1,6 +1,6 @@
 import CatalogGroup from '../../lib/Models/CatalogGroup';
 import DataCatalogMember from '../../lib/ReactViews/DataCatalog/DataCatalogMember';
-import DataCatalogTab from '../../lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab';
+import DataCatalog from '../../lib/ReactViews/DataCatalog/DataCatalog';
 import {findAllWithType} from 'react-shallow-testutils';
 import {getShallowRenderedOutput} from './MoreShallowTools';
 import React from 'react';
@@ -29,7 +29,7 @@ describe('DataCatalogTab', function() {
         anotherGroup.name = 'Another Group';
         terria.catalog.group.add(anotherGroup);
 
-        const tab = <DataCatalogTab terria={terria} viewState={viewState}/>;
+        const tab = <DataCatalog terria={terria} viewState={viewState}/>;
         const result = getShallowRenderedOutput(tab);
         const memberComponents = findAllWithType(result, DataCatalogMember);
 


### PR DESCRIPTION
This fixes some of the worst problems on mobile:
- The workbench items were unreadable because they used white text on a light background.  Related to #1772,
- The search feature pretty much didn't work at all.  Fixes #1669 
- It wasn't possible to scroll the data catalog.

I'm not totally thrilled with how search is working, but at least it's usable now.  It's contextual, like on desktop.  Sorry, but the catalog search lockup is even worse on slow mobile devices, we need to keep location and catalog search separate for now.

Also some fixes from #1781:
- Remove the quick add button on mobile, replace it with a chevron pointing right
- Top row of feature info should be the same height as the top row of the catalog (the row with the "Done" button) so that the close button can be tapped
- Top row of selected layers should also be that height so that the show/hide button can be tapped
- Search button needs to be wider and have space to the left of it (a divider) to make it more tappable.

This includes #1774 so merge that first.
