### PR TITLE
Allow HTML inside markdown.

### DIFF
--- a/lib/Core/markdownToHtml.js
+++ b/lib/Core/markdownToHtml.js
@@ -10,7 +10,7 @@ var md = new MarkdownIt({
     linkify: true
 });
 
-var htmlRegex = /(\s)*<(.|\s)*>(\s)*/im;
+var htmlRegex = /^(\s)*<(.|\s)*>/i;
 
 /**
  * Convert a String in markdown format (which includes html) into html format.


### PR DESCRIPTION
Previously, if we saw an HTML tag anywhere in a possibly-markdown string, we would treat it as pure HTML instead of markdown.  But this is incorrect.  HTML is allowed inside markdown.  With this PR, we only disable markdown rendering if the first non-whitespace character is the start of an HTML tag.

Fixes #1780
(I think)
