### PR TITLE
Change the markdown-is-really-just-HTML regex.

### DIFF
--- a/lib/Core/markdownToHtml.js
+++ b/lib/Core/markdownToHtml.js
@@ -10,7 +10,7 @@ var md = new MarkdownIt({
     linkify: true
 });
 
-var htmlRegex = /^(\s)*<(.|\s)*>/i;
+var htmlRegex = /^\s*<[^>]+>/;
 
 /**
  * Convert a String in markdown format (which includes html) into html format.


### PR DESCRIPTION
The old one was totally hanging the browser when processing some text, such the disclaimer for the AREMI `Solar Satellite DNI 2014` dataset.

Fixes the problem @meh9 described in #1778, but not the original #1778 problem.
