### PR TITLE
Allow dropdownpanels to be wider than the menu button row

### DIFF
--- a/lib/ReactViews/Map/Panels/panel.scss
+++ b/lib/ReactViews/Map/Panels/panel.scss
@@ -22,7 +22,7 @@
   background: $dark;
   color: #fff;
   border: $border-style;
-  max-width: calc(100% - 10px);
+  max-width: calc(100vw - 10px);
 
   position: fixed;
   top: $mobile-header-height;


### PR DESCRIPTION
This is a problem at the moment for the RelatedMaps panel.
