### PR TITLE
Fix extra whitespace in a multiline error.

### DIFF
--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -500,8 +500,8 @@ is invalid.  The catalogue item has been hidden from the map.  You may re-show i
                 sender: catalogItem,
                 title: 'Unable to display dataset',
                 message: '\
-    "' + catalogItem.name + '" cannot be shown in 2D because it does not support the standard Web Mercator (EPSG:3857) projection.  \
-    Please switch to 3D if it is supported on your system, update the dataset to support the projection, or use a different dataset.'
+"' + catalogItem.name + '" cannot be shown in 2D because it does not support the standard Web Mercator (EPSG:3857) projection.  \
+Please switch to 3D if it is supported on your system, update the dataset to support the projection, or use a different dataset.'
             });
 
             if (globeOrMap === catalogItem.terria.currentViewer) {


### PR DESCRIPTION
It causes TerriaJS to render it as preformatted text.

Fixes #1796
