### PR TITLE
Munge URLs in comments so Websense doesn't overreact.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Removed the empty circles from non-selected base maps on the Map settings panel.
 * Prevented text from being selected when dragging the compass control.
 * Added the `MeasureTool` to allow users to interactively measure the distance between points.
+* Worked around a problem in the Websense Web Filter that caused it to block access to some of the TerriaJS Web Workers due to a URL in the license text in a comment in a source file.
 
 ### 4.0.2
 

--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -100,6 +100,27 @@ function configureWebpack(terriaJSBasePath, config, devMode, hot, ExtractTextPlu
         })
     });
 
+    // The sprintf module included by Cesium includes a license comment with a big
+    // pile of links, some of which are apparently dodgy and cause Websense to flag
+    // web workers that include the comment as malicious.  So here we munge URLs in
+    // comments so broken security software doesn't consider them links that a user
+    // might actually visit.
+    config.module.loaders.push({
+        test: /\.js?$/,
+        include: path.resolve(cesiumDir, 'Source', 'ThirdParty'),
+        loader: StringReplacePlugin.replace({
+            replacements: [
+                {
+                    pattern: /\/\*[\S\s]*?\*\//g, // find multi-line comments
+                    replacement: function (match) {
+                        // replace http:// and https:// with a spelling-out of it.
+                        return match.replace(/(https?):\/\//g, '$1-colon-slashslash ');
+                    }
+                }
+            ]
+        })
+    });
+
     // Use Babel to compile our JavaScript files.
     config.module.loaders.push({
         test: /\.jsx?$/,


### PR DESCRIPTION
From the comment now in `configureWebpack.js`:

> The sprintf module included by Cesium includes a license comment with a big
> pile of links, some of which are apparently dodgy and cause Websense to flag
> web workers that include the comment as malicious.  So here we munge URLs in
> comments so broken security software doesn't consider them links that a user
> might actually visit.
