### PR TITLE
hide legend image if there is an error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 
 * Fixed a bug that caused the selection indicator to get small when near the right edge of the map and to overlap the side panel when past the left edge.
 * Map controls and menus now become translucent while the explorer window (Data Catalog) is visible.
+* Legend images that fail to load are now hidden entirely.
 
 ### 4.1.2
 

--- a/lib/ReactViews/Workbench/Controls/Legend.jsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.jsx
@@ -55,7 +55,7 @@ const Legend = React.createClass({
                                     <When condition={legend.isImage && legend.insertDirectly}>
                                         <li key={i}
                                             onError={this.onImageError.bind(this, legend)}
-                                            className={Styles.legendSvg, {[Styles.legendImagehasError]: legend.imageHasError}}
+                                            className={classNames(Styles.legendSvg , {[Styles.legendImagehasError]: legend.imageHasError})}
                                             dangerouslySetInnerHTML={legend.safeSvgContent}
                                         />
                                     </When>

--- a/lib/ReactViews/Workbench/Controls/Legend.jsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.jsx
@@ -1,14 +1,13 @@
 'use strict';
 
+import classNames from 'classnames';
 import defined from 'terriajs-cesium/Source/Core/defined';
-
+import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import Loader from '../../Loader.jsx';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import proxyCatalogItemUrl from '../../../Models/proxyCatalogItemUrl';
-import classNames from 'classnames';
-import Styles from './legend.scss';
-
 import React from 'react';
+import Styles from './legend.scss';
 
 const Legend = React.createClass({
     mixins: [ObserveModelMixin],
@@ -16,29 +15,55 @@ const Legend = React.createClass({
         item: React.PropTypes.object
     },
 
-    onImageError(legend) {
-        legend.imageHasError = true;
-        this.forceUpdate();
-    },
-
     componentWillMount() {
-        this.legends = this.getLegends();
+        this.legendsWithError = {};
     },
 
-    getLegends() {
-        if (defined(this.props.item.legendUrls)) {
-            return this.props.item.legendUrls.map((legendUrl)=>{
-                return {
-                    url: proxyCatalogItemUrl(this.catalogMember, legendUrl.url),
-                    isImage: legendUrl.isImage(),
-                    imageHasError: false,
-                    onImageError: this.onImageError,
-                    insertDirectly: !!legendUrl.safeSvgContent, // we only insert content we generated ourselves, not arbitrary SVG from init files.
-                    safeSvgContent: {__html: legendUrl.safeSvgContent}
-                };
-            });
+    onImageError(legend) {
+        this.legendsWithError[legend.url] = true;
+    },
+
+    doesLegendHaveError(legend) {
+        const hasError = this.legendsWithError[legend.url];
+        if (!defined(hasError)) {
+            this.legendsWithError[legend.url] = false;
+            knockout.track(this.legendsWithError, [legend.url]);
         }
-        return [];
+        return this.legendsWithError[legend.url];
+    },
+
+    renderLegend(legendUrl, i) {
+        const isImage = legendUrl.isImage();
+        const insertDirectly = !!legendUrl.safeSvgContent; // we only insert content we generated ourselves, not arbitrary SVG from init files.
+        const safeSvgContent = {__html: legendUrl.safeSvgContent};
+        const proxiedUrl = proxyCatalogItemUrl(this.catalogMember, legendUrl.url);
+
+        return (
+            <Choose>
+                <When condition={isImage && insertDirectly}>
+                    <li key={i}
+                        onError={this.onImageError.bind(this, legendUrl)}
+                        className={classNames(Styles.legendSvg , {[Styles.legendImagehasError]: this.doesLegendHaveError(legendUrl)})}
+                        dangerouslySetInnerHTML={safeSvgContent}
+                    />
+                </When>
+                <When condition={isImage}>
+                    <li key={proxiedUrl} className={classNames({[Styles.legendImagehasError]: this.doesLegendHaveError(legendUrl)})}>
+                        <a onError={this.onImageError.bind(this, legendUrl)}
+                           href={proxiedUrl}
+                           target="_blank">
+                            <img src={proxiedUrl}/>
+                        </a>
+                    </li>
+                </When>
+                <Otherwise>
+                    <li key={proxiedUrl}>
+                        <a href={proxiedUrl}
+                           target="_blank">Open legend in a separate tab
+                        </a>
+                    </li>
+                </Otherwise>
+            </Choose>);
     },
 
     render() {
@@ -50,32 +75,8 @@ const Legend = React.createClass({
                             <li className={Styles.loader}><Loader message={this.props.item.loadingMessage}/></li>
                         </When>
                         <Otherwise>
-                            <For each="legend" index="i" of={this.legends}>
-                                <Choose>
-                                    <When condition={legend.isImage && legend.insertDirectly}>
-                                        <li key={i}
-                                            onError={this.onImageError.bind(this, legend)}
-                                            className={classNames(Styles.legendSvg , {[Styles.legendImagehasError]: legend.imageHasError})}
-                                            dangerouslySetInnerHTML={legend.safeSvgContent}
-                                        />
-                                    </When>
-                                    <When condition={legend.isImage}>
-                                        <li key={legend.url} className={classNames({[Styles.legendImagehasError]: legend.imageHasError})}>
-                                            <a onError={this.onImageError.bind(this, legend)}
-                                               href={legend.url}
-                                               target="_blank">
-                                                <img src={legend.url}/>
-                                            </a>
-                                        </li>
-                                    </When>
-                                    <Otherwise>
-                                        <li key={legend.url}>
-                                            <a href={legend.url}
-                                               target="_blank">Open legend in a separate tab
-                                            </a>
-                                        </li>
-                                    </Otherwise>
-                                </Choose>
+                            <For each="legend" index="i" of={this.props.item.legendUrls}>
+                                {this.renderLegend(legend, i)}
                             </For>
                         </Otherwise>
                     </Choose>

--- a/lib/ReactViews/Workbench/Controls/Legend.jsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.jsx
@@ -5,6 +5,7 @@ import defined from 'terriajs-cesium/Source/Core/defined';
 import Loader from '../../Loader.jsx';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import proxyCatalogItemUrl from '../../../Models/proxyCatalogItemUrl';
+import classNames from 'classnames';
 import Styles from './legend.scss';
 
 import React from 'react';
@@ -17,6 +18,11 @@ const Legend = React.createClass({
 
     onImageError(legend) {
         legend.imageHasError = true;
+        this.forceUpdate();
+    },
+
+    componentWillMount() {
+        this.legends = this.getLegends();
     },
 
     getLegends() {
@@ -30,7 +36,7 @@ const Legend = React.createClass({
                     insertDirectly: !!legendUrl.safeSvgContent, // we only insert content we generated ourselves, not arbitrary SVG from init files.
                     safeSvgContent: {__html: legendUrl.safeSvgContent}
                 };
-            }).filter(legendUrl => !legendUrl.imageHasError);
+            });
         }
         return [];
     },
@@ -44,17 +50,17 @@ const Legend = React.createClass({
                             <li className={Styles.loader}><Loader message={this.props.item.loadingMessage}/></li>
                         </When>
                         <Otherwise>
-                            <For each="legend" index="i" of={this.getLegends()}>
+                            <For each="legend" index="i" of={this.legends}>
                                 <Choose>
                                     <When condition={legend.isImage && legend.insertDirectly}>
                                         <li key={i}
                                             onError={this.onImageError.bind(this, legend)}
-                                            className={Styles.legendSvg}
+                                            className={Styles.legendSvg, {[Styles.legendImagehasError]: legend.imageHasError}}
                                             dangerouslySetInnerHTML={legend.safeSvgContent}
                                         />
                                     </When>
                                     <When condition={legend.isImage}>
-                                        <li key={legend.url}>
+                                        <li key={legend.url} className={classNames({[Styles.legendImagehasError]: legend.imageHasError})}>
                                             <a onError={this.onImageError.bind(this, legend)}
                                                href={legend.url}
                                                target="_blank">

--- a/lib/ReactViews/Workbench/Controls/legend.scss
+++ b/lib/ReactViews/Workbench/Controls/legend.scss
@@ -7,6 +7,9 @@
   li {
     display: block;
   }
+  .legendImagehasError{
+    display: none;
+  }
 }
 
 .legend__inner {
@@ -44,4 +47,3 @@
      fill: #fff;
   }
 }
-


### PR DESCRIPTION
This fixes https://github.com/TerriaJS/terriajs/issues/1773

It makes the legend image behaves the same with the old UI: when there is an error loading the legend image, the image is hidden: 

<img width="341" alt="screen shot 2016-07-20 at 4 44 24 pm" src="https://cloud.githubusercontent.com/assets/7508939/16977429/3fb84bb0-4e99-11e6-9fba-cfb6adba78f9.png">
