### PR TITLE
make map menus inactive when explorer open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 ### 4.1.3
 
 * Fixed a bug that caused the selection indicator to get small when near the right edge of the map and to overlap the side panel when past the left edge.
+* Map controls and menus now become translucent while the explorer window (Data Catalog) is visible.
 
 ### 4.1.2
 

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -16,6 +16,7 @@ import ObserveModelMixin from './../ObserveModelMixin';
 import ProgressBar from '../Map/ProgressBar.jsx';
 import SidePanel from './../SidePanel/SidePanel.jsx';
 import processCustomElements from './processCustomElements';
+import classNames from 'classnames';
 import 'inobounce';
 
 import Styles from './standard-user-interface.scss';
@@ -123,15 +124,17 @@ const StandardUserInterface = React.createClass({
                 </div>
 
                 <If condition={!this.props.viewState.hideMapUi()}>
-                    <MenuBar terria={terria}
-                             viewState={this.props.viewState}
-                             allBaseMaps={allBaseMaps}
-                             menuItems={customElements.menu}
-                    />
-                    <MapNavigation terria={terria}
-                                   viewState={this.props.viewState}
-                                   navItems={customElements.nav}
-                    />
+                    <div className = {classNames({[Styles.explorerPanelIsVisible]: this.props.viewState.explorerPanelIsVisible})}>
+                        <MenuBar terria={terria}
+                                 viewState={this.props.viewState}
+                                 allBaseMaps={allBaseMaps}
+                                 menuItems={customElements.menu}
+                        />
+                        <MapNavigation terria={terria}
+                                       viewState={this.props.viewState}
+                                       navItems={customElements.nav}
+                        />
+                    </div>
                 </If>
 
                 <Notification viewState={this.props.viewState}/>
@@ -143,9 +146,11 @@ const StandardUserInterface = React.createClass({
                     </aside>
                 </If>
 
-                <FeatureInfoPanel terria={terria}
-                                  viewState={this.props.viewState}
-                />
+                <div className = {classNames({[Styles.explorerPanelIsVisible]: this.props.viewState.explorerPanelIsVisible})}>
+                    <FeatureInfoPanel terria={terria}
+                                      viewState={this.props.viewState}
+                    />
+                </div>
                 <DragDropFile terria={this.props.terria}
                               viewState={this.props.viewState}
                 />

--- a/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
+++ b/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
@@ -10,6 +10,10 @@
   width: 100%;
 }
 
+.explorerPanelIsVisible{
+  opacity: 0.3;
+}
+
 .sidePanel {
   font-family: $font-pop;
   background: $dark;


### PR DESCRIPTION
This fixes https://github.com/TerriaJS/terriajs/issues/1844
Makes the map menus and featureInfoPanel transparent when explorer window is open
