### PR TITLE
make opacity slider look like design

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Fixed a bug that caused the selection indicator to get small when near the right edge of the map and to overlap the side panel when past the left edge.
 * Map controls and menus now become translucent while the explorer window (Data Catalog) is visible.
 * Legend images that fail to load are now hidden entirely.
+* Improved the appearance of the opacity slider and added a percentage display.
 
 ### 4.1.2
 

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
@@ -24,7 +24,7 @@ const OpacitySection = React.createClass({
         }
         return (
             <div className={Styles.opacity}>
-                <label htmlFor="opacity">Opacity: </label>
+                <label htmlFor="opacity">Opacity: {parseInt(item.opacity * 100, 10)} %</label>
                 <RangeSlider className={Styles.rangeSlider} name='opacity' min={0} max={100} step={1} value={item.opacity * 100 | 0} onChange={this.changeOpacity}/>
             </div>
         );

--- a/lib/ReactViews/Workbench/Controls/opacity-section.scss
+++ b/lib/ReactViews/Workbench/Controls/opacity-section.scss
@@ -12,7 +12,7 @@
     width: 80px;
   }
   input[type=range] {
-    width: 175px;
+    width: calc(100% - 85px);
   }
 }
 
@@ -20,7 +20,7 @@
   height: 2px;
   border-radius: 5px;
   background: $border-color;
-  width: 175px;
+  width: calc(100% - 85px);
   float: left;
   margin-top: 7px;
 

--- a/lib/ReactViews/Workbench/Controls/opacity-section.scss
+++ b/lib/ReactViews/Workbench/Controls/opacity-section.scss
@@ -1,11 +1,15 @@
 @import '~terriajs-variables';
 
 .opacity {
+  composes: clearfix from '../../../Sass/common/_base.scss';
   padding: $padding 0;
   border-bottom: 1px solid $border-color;
   font-size: $font-size-mini;
+
   label {
     margin-right: $padding-small;
+    float: left;
+    width: 80px;
   }
   input[type=range] {
     width: 175px;
@@ -13,10 +17,12 @@
 }
 
 .rangeSlider {
-  height: 10px;
+  height: 2px;
   border-radius: 5px;
   background: $border-color;
-  margin-top: 5px;
+  width: 175px;
+  float: left;
+  margin-top: 7px;
 
   :global {
     .rangeslider__fill {
@@ -28,12 +34,11 @@
     }
 
     .rangeslider__handle {
-      width: 20px;
-      height: 20px;
+      width: 12px;
+      height: 12px;
       border-radius: 20px;
-      top: -15px;
+      top: -7px;
       background: #fff;
-      border: 1px solid #ccc;
       display: inline-block;
       position: relative;
     }


### PR DESCRIPTION
Fixes https://github.com/TerriaJS/terriajs/issues/1846, make opacity look like better
<img width="347" alt="screen shot 2016-07-21 at 11 26 52 am" src="https://cloud.githubusercontent.com/assets/7508939/17008637/655997e6-4f36-11e6-9ff9-2eff93a495f6.png">

Note that it stops working after hot reload, need to refresh the page
