### PR TITLE
remove display name on div

### DIFF
--- a/lib/ReactViews/Custom/registerCustomComponentTypes.js
+++ b/lib/ReactViews/Custom/registerCustomComponentTypes.js
@@ -39,7 +39,7 @@ const chartAttributes = [
     'poll-replace'
 ];
 
-/** 
+/**
  * @private
  */
 function splitStringIfDefined(string) {
@@ -268,7 +268,7 @@ const registerCustomComponentTypes = function(terria) {
                 processNode: function(context, node, children) {
                     const title = node.parent.children[0].children[0].data;
                     const revisedChildren = [
-                        React.createElement('div', {key: 'title', displayName: 'title', className: ChartPreviewStyles.chartTitleFromTable}, title)
+                        React.createElement('div', {key: 'title', className: ChartPreviewStyles.chartTitleFromTable}, title)
                     ].concat(children);
                     return React.createElement(node.name, {key: 'chart', displayName: 'chart', colSpan: 2, className: ChartPreviewStyles.chart}, node.data, revisedChildren);
                 }


### PR DESCRIPTION
@RacingTadpole:

I'm getting an error on Aremi -> All Power Stations: 

```
warning.js:44 Warning: Unknown prop `displayName` on <td> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in td (created by FeatureInfoSection)
    in tr (created by FeatureInfoSection)
    in tbody (created by FeatureInfoSection)
    in table (created by FeatureInfoSection)
    in div (created by FeatureInfoSection)
    in section (created by FeatureInfoSection)
```

Because `displayName` is added to a div. This is fixed after removing it. However, in the warning, it says `Unknown prop`displayName`on <td> tag`, but the displayName is actually added to `div`, so I am not sure why it's complaining about `td`. Any ideas?
