### PR TITLE
Show Feature Info even for WFS and ArcGis Feature Servers

### DIFF
--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -61,7 +61,6 @@ const FeatureInfoPanel = React.createClass({
         const {catalogItems, featureCatalogItemPairs} = getFeaturesGroupedByCatalogItems(this.props.terria);
 
         return catalogItems
-            .filter(catalogItem => defined(catalogItem))
             .map((catalogItem, i) => {
                 // From the pairs, select only those with this catalog item, and pull the features out of the pair objects.
                 const features = featureCatalogItemPairs.filter(pair => pair.catalogItem === catalogItem).map(pair => pair.feature);

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -138,7 +138,7 @@ const FeatureInfoSection = React.createClass({
             return Mustache.render(template.name, this.getPropertyValues());
         }
         const feature = this.props.feature;
-        return (feature && feature.name) || '';
+        return (feature && feature.name) || 'Site Data';
     },
 
     isFeatureTimeVarying() {


### PR DESCRIPTION
Previously, if the catalog item could not be identified for feature info, the feature was ignored. 
This was a mistake. It should be shown.

Also, if the title bar of the feature info section would be blank, revert to "Site Data".
