### PR TITLE
Force cursor to be arrow over leaflet map

### DIFF
--- a/lib/Sass/global/_leaflet.scss
+++ b/lib/Sass/global/_leaflet.scss
@@ -1,6 +1,7 @@
 // This makes Leaflet work in hot mode
 :global {
   .leaflet-container {
+    cursor: auto!important;
     position: absolute;
     top: 0;
     right: 0;


### PR DESCRIPTION
This is how it was in oldui, and how it is in 3D. Fixes https://github.com/TerriaJS/terriajs/issues/1878.
