### PR TITLE
Show Feature Info for more CatalogItems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * Legend images that fail to load are now hidden entirely.
 * Improved the appearance of the opacity slider and added a percentage display.
 * Updated to [Cesium](http://cesiumjs.org) 1.23 (from 1.20).  See the [change log](https://github.com/AnalyticalGraphicsInc/cesium/blob/1.23/CHANGES.md) for details.
+* Fixed a bug which prevented feature info showing for Gpx-, Ogr-, WebFeatureService-, ArcGisFeatureServer-, and WebProcessingService- CatalogItems.
 
 ### 4.1.2
 

--- a/lib/Models/GpxCatalogItem.js
+++ b/lib/Models/GpxCatalogItem.js
@@ -93,6 +93,16 @@ defineProperties(GpxCatalogItem.prototype, {
             result.serviceErrorMessage = 'This service does not have any details available.';
             return result;
         }
+    },
+    /**
+     * Gets the data source associated with this catalog item.
+     * @memberOf GpxCatalogItem.prototype
+     * @type {DataSource}
+     */
+    dataSource : {
+        get : function() {
+            return defined(this._geoJsonItem) ? this._geoJsonItem.dataSource : undefined;
+        }
     }
 });
 

--- a/lib/Models/OgrCatalogItem.js
+++ b/lib/Models/OgrCatalogItem.js
@@ -88,6 +88,16 @@ defineProperties(OgrCatalogItem.prototype, {
             result.serviceErrorMessage = 'This service does not have any details available.';
             return result;
         }
+    },
+    /**
+     * Gets the data source associated with this catalog item.
+     * @memberOf OgrCatalogItem.prototype
+     * @type {DataSource}
+     */
+    dataSource : {
+        get : function() {
+            return defined(this._geoJsonItem) ? this._geoJsonItem.dataSource : undefined;
+        }
     }
 });
 

--- a/lib/Models/WebFeatureServiceCatalogItem.js
+++ b/lib/Models/WebFeatureServiceCatalogItem.js
@@ -180,6 +180,16 @@ defineProperties(WebFeatureServiceCatalogItem.prototype, {
         get : function() {
             return WebFeatureServiceCatalogItem.defaultSerializers;
         }
+    },
+    /**
+     * Gets the data source associated with this catalog item.
+     * @memberOf WebFeatureServiceCatalogItem.prototype
+     * @type {DataSource}
+     */
+    dataSource : {
+        get : function() {
+            return defined(this._geoJsonItem) ? this._geoJsonItem.dataSource : undefined;
+        }
     }
 });
 

--- a/lib/Models/WebProcessingServiceCatalogItem.js
+++ b/lib/Models/WebProcessingServiceCatalogItem.js
@@ -31,7 +31,7 @@ var xml2json = require('../ThirdParty/xml2json');
 function WebProcessingServiceCatalogItem(terria) {
     CatalogItem.call(this, terria);
 
-    this._geojsonCatalogItem = undefined;
+    this._geoJsonItem = undefined;
 
     /**
      * Gets or sets the parameters to the WPS function.
@@ -94,7 +94,7 @@ defineProperties(WebProcessingServiceCatalogItem.prototype, {
      */
     dataSource : {
         get : function() {
-            return defined(this._geojsonCatalogItem) ? this._geojsonCatalogItem.dataSource : undefined;
+            return defined(this._geoJsonItem) ? this._geoJsonItem.dataSource : undefined;
         }
     }
 });
@@ -104,10 +104,10 @@ WebProcessingServiceCatalogItem.prototype._getValuesThatInfluenceLoad = function
 };
 
 WebProcessingServiceCatalogItem.prototype._load = function() {
-    if (defined(this._geojsonCatalogItem)) {
-        this._geojsonCatalogItem._hide();
-        this._geojsonCatalogItem._disable();
-        this._geojsonCatalogItem = undefined;
+    if (defined(this._geoJsonItem)) {
+        this._geoJsonItem._hide();
+        this._geoJsonItem._disable();
+        this._geoJsonItem = undefined;
     }
 
     var geojson;
@@ -268,12 +268,12 @@ WebProcessingServiceCatalogItem.prototype._load = function() {
         }
 
         if (defined(geojson)) {
-            that._geojsonCatalogItem = new GeoJsonCatalogItem(that.terria);
-            that._geojsonCatalogItem.name = that.name;
-            that._geojsonCatalogItem.data = geojson;
-            return that._geojsonCatalogItem.load().then(function() {
+            that._geoJsonItem = new GeoJsonCatalogItem(that.terria);
+            that._geoJsonItem.name = that.name;
+            that._geoJsonItem.data = geojson;
+            return that._geoJsonItem.load().then(function() {
                 if (!defined(that.rectangle)) {
-                    that.rectangle = that._geojsonCatalogItem.rectangle;
+                    that.rectangle = that._geoJsonItem.rectangle;
                 }
             });
         }
@@ -281,26 +281,26 @@ WebProcessingServiceCatalogItem.prototype._load = function() {
 };
 
 WebProcessingServiceCatalogItem.prototype._enable = function() {
-    if (defined(this._geojsonCatalogItem)) {
-        this._geojsonCatalogItem._enable();
+    if (defined(this._geoJsonItem)) {
+        this._geoJsonItem._enable();
     }
 };
 
 WebProcessingServiceCatalogItem.prototype._disable = function() {
-    if (defined(this._geojsonCatalogItem)) {
-        this._geojsonCatalogItem._disable();
+    if (defined(this._geoJsonItem)) {
+        this._geoJsonItem._disable();
     }
 };
 
 WebProcessingServiceCatalogItem.prototype._show = function() {
-    if (defined(this._geojsonCatalogItem)) {
-        this._geojsonCatalogItem._show();
+    if (defined(this._geoJsonItem)) {
+        this._geoJsonItem._show();
     }
 };
 
 WebProcessingServiceCatalogItem.prototype._hide = function() {
-    if (defined(this._geojsonCatalogItem)) {
-        this._geojsonCatalogItem._hide();
+    if (defined(this._geoJsonItem)) {
+        this._geoJsonItem._hide();
     }
 };
 

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -61,7 +61,6 @@ const FeatureInfoPanel = React.createClass({
         const {catalogItems, featureCatalogItemPairs} = getFeaturesGroupedByCatalogItems(this.props.terria);
 
         return catalogItems
-            .filter(catalogItem => defined(catalogItem))
             .map((catalogItem, i) => {
                 // From the pairs, select only those with this catalog item, and pull the features out of the pair objects.
                 const features = featureCatalogItemPairs.filter(pair => pair.catalogItem === catalogItem).map(pair => pair.feature);

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -61,6 +61,7 @@ const FeatureInfoPanel = React.createClass({
         const {catalogItems, featureCatalogItemPairs} = getFeaturesGroupedByCatalogItems(this.props.terria);
 
         return catalogItems
+            .filter(catalogItem => defined(catalogItem))
             .map((catalogItem, i) => {
                 // From the pairs, select only those with this catalog item, and pull the features out of the pair objects.
                 const features = featureCatalogItemPairs.filter(pair => pair.catalogItem === catalogItem).map(pair => pair.feature);
@@ -187,8 +188,12 @@ function determineCatalogItem(nowViewing, feature) {
     // "Data sources" (eg. czml, geojson, kml, csv) have an entity collection defined on the entity
     // (and therefore the feature).
     // Then match up the data source on the feature with a now-viewing item's data source.
+    //
+    // Gpx, Ogr, WebFeatureServiceCatalogItem, ArcGisFeatureServerCatalogItem, WebProcessingServiceCatalogItem
+    // all have a this._geoJsonItem, which we also need to check.
     let result;
     let i;
+    let item;
     if (defined(feature.entityCollection) && defined(feature.entityCollection.owner)) {
         const dataSource = feature.entityCollection.owner;
 
@@ -199,8 +204,9 @@ function determineCatalogItem(nowViewing, feature) {
         }
 
         for (i = nowViewing.items.length - 1; i >= 0; i--) {
-            if (nowViewing.items[i].dataSource === dataSource) {
-                result = nowViewing.items[i];
+            item = nowViewing.items[i];
+            if (item.dataSource === dataSource || (defined(item._geoJsonItem) && item._geoJsonItem.dataSource === dataSource)) {
+                result = item;
                 break;
             }
         }

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -205,7 +205,7 @@ function determineCatalogItem(nowViewing, feature) {
 
         for (i = nowViewing.items.length - 1; i >= 0; i--) {
             item = nowViewing.items[i];
-            if (item.dataSource === dataSource || (defined(item._geoJsonItem) && item._geoJsonItem.dataSource === dataSource)) {
+            if (item.dataSource === dataSource) {
                 result = item;
                 break;
             }

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -138,7 +138,7 @@ const FeatureInfoSection = React.createClass({
             return Mustache.render(template.name, this.getPropertyValues());
         }
         const feature = this.props.feature;
-        return (feature && feature.name) || '';
+        return (feature && feature.name) || 'Site Data';
     },
 
     isFeatureTimeVarying() {


### PR DESCRIPTION
As a result of #1797, which was a fix for #1787, a number of catalog item types stopped showing their feature info (Gpx, Ogr, WebFeatureServiceCatalogItem, ArcGisFeatureServerCatalogItem, WebProcessingServiceCatalogItem).

This fixes that.

This is a better solution than #1883.
