### PR TITLE
Allow explicit color bin boundaries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Improved the appearance of the opacity slider and added a percentage display.
 * Updated to [Cesium](http://cesiumjs.org) 1.23 (from 1.20).  See the [change log](https://github.com/AnalyticalGraphicsInc/cesium/blob/1.23/CHANGES.md) for details.
 * Fixed a bug which prevented feature info showing for Gpx-, Ogr-, WebFeatureService-, ArcGisFeatureServer-, and WebProcessingService- CatalogItems.
+* Added support for `tableStyle.colorBins` as array of values specifying the boundaries between the color bins in the legend, eg. `[3000, 3500, 3900, 4000]`. `colorBins` can still be an integer specifying the number of bins, in which case Terria determines the boundaries.
 
 ### 4.1.2
 

--- a/lib/Models/LegendHelper.js
+++ b/lib/Models/LegendHelper.js
@@ -31,6 +31,8 @@ var defaultNullLabel = '(No value)';
 var defaultNoColumnColorCodes = standardCssColors.highContrast;
 var defaultNoColumnColorAlpha = 0.6;
 
+var defaultNumberOfColorBins = 7;
+
 /**
  * Legends for table columns depend on both the table style and the selected column.
  * This class brings the two together to generate a legend.
@@ -105,29 +107,31 @@ function generateLegend(legendHelper) {
         // There is no colorMap defined, so set a good default.
         if (!defined(tableColumn) || (tableColumn.usesIndicesIntoUniqueValues)) {
             // If no table column is active, color it as if it were an ENUM with the maximum available colors.
-            // Recall tableColumnStyle.colorBins is the number of bins.
-            var colorMapArray = defaultEnumColorCodes;
+            // Recall tableColumnStyle.colorBins is the number of bins
+            // (or an array of boundary values, but for ENUM that doesn't make sense, so ignore in that case).
+            var cssColorStrings = defaultEnumColorCodes;
+            var hasIntegerColorBins = defined(legendHelper.tableColumnStyle.colorBins) && !Array.isArray(legendHelper.tableColumnStyle.colorBins);
             if (defined(tableColumn)) {
                 var desiredBins = tableColumn.uniqueValues.length;
-                if (defined(legendHelper.tableColumnStyle.colorBins)) {
+                if (hasIntegerColorBins) {
                     desiredBins = Math.min(desiredBins, legendHelper.tableColumnStyle.colorBins);
                 }
-                if (desiredBins > colorMapArray.length) {
-                    colorMapArray = defaultLargeEnumColorCodes;
+                if (desiredBins > cssColorStrings.length) {
+                    cssColorStrings = defaultLargeEnumColorCodes;
                 }
 
-                colorBins = Math.min(tableColumn.uniqueValues.length, colorMapArray.length);
+                colorBins = Math.min(tableColumn.uniqueValues.length, cssColorStrings.length);
             } else {
-                colorMapArray = defaultEnumColorCodes;
-                colorBins = colorMapArray.length;
+                cssColorStrings = defaultEnumColorCodes;
+                colorBins = cssColorStrings.length;
             }
 
-            if (defined(legendHelper.tableColumnStyle.colorBins) && legendHelper.tableColumnStyle.colorBins < colorBins) {
+            if (hasIntegerColorBins && legendHelper.tableColumnStyle.colorBins < colorBins) {
                 colorBins = legendHelper.tableColumnStyle.colorBins;
             }
 
-            colorMapArray = colorMapArray.slice(0, colorBins);
-            colorMap = new ColorMap(colorMapArray);
+            cssColorStrings = cssColorStrings.slice(0, colorBins);
+            colorMap = new ColorMap(cssColorStrings);
         } else {
             colorMap = defaultScalarColorMap;
         }
@@ -136,7 +140,7 @@ function generateLegend(legendHelper) {
     }
 
     if (!defined(colorBins)) {
-        colorBins = defaultValue(legendHelper.tableColumnStyle.colorBins, 7);
+        colorBins = defaultValue(legendHelper.tableColumnStyle.colorBins, defaultNumberOfColorBins);
     }
 
     legendHelper._colorGradient = buildColorGradient(colorMap);
@@ -307,8 +311,8 @@ function getColorArrayFromColorGradient(colorGradient, fractionalPosition) {
  * Each element is an object with keys "color" and "upperBound", eg.
  * [ { color: [r, g, b, a], upperBound: 20 } , { color: [r, g, b, a]: upperBound: 80 } ]
  * @private
- * @param  {LegendHelper} legendHelper The legend helper.
- * @param {Integer} colorBins The number of color bins to use.
+ * @param {LegendHelper} legendHelper The legend helper.
+ * @param {Integer|Number[]} colorBins The number of color bins to use, or the boundaries to use.
  * @return {Array} Array of objects with keys "color" and "upperBound".
  */
 function buildBinColors(legendHelper, colorBins) {
@@ -316,6 +320,16 @@ function buildBinColors(legendHelper, colorBins) {
     var tableColumnStyle = legendHelper.tableColumnStyle;
     var colorGradient = legendHelper._colorGradient;
     var regionProvider = legendHelper._regionProvider;
+
+    // If colorBins is an array, just return it in the right format.
+    if (Array.isArray(colorBins)) {
+        return colorBins.map(function(bound, i) {
+            return {
+                upperBound: bound,
+                colorArray: getColorArrayFromColorGradient(colorGradient, i / (colorBins.length - 1))
+            };
+        });
+    }
 
     if (colorBins <= 0 || tableColumnStyle.colorBinMethod.match(/none/i)) {
         return undefined;

--- a/lib/Models/LegendHelper.js
+++ b/lib/Models/LegendHelper.js
@@ -175,9 +175,8 @@ LegendHelper.prototype.legendUrl = function() {
  * @return {Number} The fractional value.
  */
 function getFractionalValue(legendHelper, value) {
-    var minValue = legendHelper.tableColumnStyle.minDisplayValue || legendHelper.tableColumn.minimumValue;
-    var maxValue = legendHelper.tableColumnStyle.maxDisplayValue || legendHelper.tableColumn.maximumValue;
-    var f = (maxValue === minValue) ? 0 : (value - minValue) / (maxValue - minValue);
+    var extremes = getExtremes(legendHelper.tableColumn, legendHelper.tableColumnStyle);
+    var f = (extremes.maximum === extremes.minimum) ? 0 : (value - extremes.minimum) / (extremes.maximum - extremes.minimum);
     if (legendHelper.tableColumnStyle.clampDisplayValue) {
         f = Math.max(0.0, Math.min(1.0, f));
     }
@@ -306,6 +305,23 @@ function getColorArrayFromColorGradient(colorGradient, fractionalPosition) {
     ];
 }
 
+function getExtremes(tableColumn, tableColumnStyle) {
+    if (!defined(tableColumn)) {
+        return {};
+    }
+    var minimumValue = tableColumn.minimumValue;
+    var maximumValue = tableColumn.maximumValue;
+    if ((minimumValue !== maximumValue) && defined(tableColumnStyle)) {
+        if (defined(tableColumnStyle.maxDisplayValue)) {
+            maximumValue = tableColumnStyle.maxDisplayValue;
+        }
+        if (defined(tableColumnStyle.minDisplayValue)) {
+            minimumValue = tableColumnStyle.minDisplayValue;
+        }
+    }
+    return {minimum: minimumValue, maximum: maximumValue};
+}
+
 /**
  * Builds and returns an array describing the legend colors.
  * Each element is an object with keys "color" and "upperBound", eg.
@@ -322,11 +338,24 @@ function buildBinColors(legendHelper, colorBins) {
     var regionProvider = legendHelper._regionProvider;
 
     // If colorBins is an array, just return it in the right format.
-    if (Array.isArray(colorBins)) {
-        return colorBins.map(function(bound, i) {
+    var extremes = getExtremes(tableColumn, tableColumnStyle);
+    if (Array.isArray(colorBins) && defined(extremes.minimum) && defined(extremes.maximum)) {
+        // If the max value is beyond the range, add it to the end.
+        // Do this to be symmetric with min and max.
+        if (colorBins[colorBins.length - 1] < extremes.maximum) {
+            colorBins = colorBins.concat(extremes.maximum);
+        }
+        var numberOfColorBins = colorBins.length;
+        return colorBins.filter(function(bound, i) {
+            // By cutting off all bins equal to or lower than the min value,
+            // the min value will be added as a titleBelow instead of titleAbove.
+            // Since any bins wholy below the min are removed, do the same with max.
+            return (bound > extremes.minimum) && (i === 0 || colorBins[i - 1] < extremes.maximum);
+        }).map(function(bound, i) {
             return {
-                upperBound: bound,
-                colorArray: getColorArrayFromColorGradient(colorGradient, i / (colorBins.length - 1))
+                // Just use the provided bound, but cap it at the max value.
+                upperBound: Math.min(bound, extremes.maximum),
+                colorArray: getColorArrayFromColorGradient(colorGradient, i / (numberOfColorBins - 1))
             };
         });
     }
@@ -481,24 +510,15 @@ function buildLegendProps(legendHelper, colorMap) {
         return undefined;
     }
 
-    var minimumValue = tableColumn.minimumValue;
-    var maximumValue = tableColumn.maximumValue;
-    if (minimumValue !== maximumValue) {
-        if (defined(tableColumnStyle.maxDisplayValue)) {
-            maximumValue = tableColumnStyle.maxDisplayValue;
-        }
-        if (defined(tableColumnStyle.minDisplayValue)) {
-            minimumValue = tableColumnStyle.minDisplayValue;
-        }
-    }
+    var extremes = getExtremes(tableColumn, tableColumnStyle);
 
     function gradientLabelPoints(ticks) {
         var items = [];
         var segments = 2 + ticks;
         for (var i = 1; i <= segments; i++) {
             items.push({
-                titleAbove: convertToStringWithAtMostTwoDecimalPlaces(minimumValue + (maximumValue - minimumValue) * (i / segments), tableColumnStyle),
-                titleBelow: (i === 1) ? convertToStringWithAtMostTwoDecimalPlaces(minimumValue, tableColumnStyle) : undefined
+                titleAbove: convertToStringWithAtMostTwoDecimalPlaces(extremes.minimum + (extremes.maximum - extremes.minimum) * (i / segments), tableColumnStyle),
+                titleBelow: (i === 1) ? convertToStringWithAtMostTwoDecimalPlaces(extremes.minimum, tableColumnStyle) : undefined
             });
         }
 
@@ -571,7 +591,7 @@ function buildLegendProps(legendHelper, colorMap) {
                 return {
                     // these long checks are to avoid showing max and min values when they're identical to the second highest and second lowest numbers
                     titleAbove: (i === 0 || i < binColors.length - 1 || b.upperBound > binColors[i - 1].upperBound) ? convertToStringWithAtMostTwoDecimalPlaces(b.upperBound, tableColumnStyle) : undefined,
-                    titleBelow: (i === 0 && b.upperBound !== minimumValue) ? convertToStringWithAtMostTwoDecimalPlaces(minimumValue, tableColumnStyle) : undefined,
+                    titleBelow: (i === 0 && b.upperBound !== extremes.minimum) ? convertToStringWithAtMostTwoDecimalPlaces(extremes.minimum, tableColumnStyle) : undefined,
                     color: convertColorArrayToCssString(b.colorArray)
                 };
             })

--- a/lib/Models/TableColumnStyle.js
+++ b/lib/Models/TableColumnStyle.js
@@ -31,7 +31,8 @@ var updateFromJson = require('../Core/updateFromJson');
  * @param {String} [options.imageUrl] A string representing an image to display at each point, for lat-long datasets.
  * @param {Object} [options.featureInfoFields] An object of { "myCol": "My column" } properties, defining which columns get displayed in feature info boxes
  *                 and what label is used instead of the column's actual name.
- * @param {Number} [options.colorBins] The number of discrete colours that a color gradient should be quantised into.
+ * @param {Integer|Number[]} [options.colorBins] Either the number of discrete colours that a color gradient should be quantised into (ie. an integer), or
+ *                 an array of values specifying the boundaries between the color bins.
  * @param {String} [options.colorBinMethod] The method for quantising colors: "auto" (default), "ckmeans", "quantile" or "none" (equivalent to colorBins: 0).
  * @param {String|Array} [options.colorMap] Gets or sets a string or {@link ColorMap} array, specifying how to map values to colors.  Setting this property sets
  *                 colorPalette to undefined.  If this property is a string, it specifies a list of CSS colors separated by hyphens (-),
@@ -119,8 +120,9 @@ var TableColumnStyle = function(options) {
     this.featureInfoFields = options.featureInfoFields;
 
     /**
-     * The number of discrete colours that a color gradient should be quantised into.
-     * @type {Number}
+     * Either the number of discrete colours that a color gradient should be quantised into (ie. an integer), or
+     * an array of values specifying the boundaries between the color bins.
+     * @type {Integer|Number[]}
      */
     this.colorBins = options.colorBins;
 

--- a/test/Models/LegendHelperSpec.js
+++ b/test/Models/LegendHelperSpec.js
@@ -57,12 +57,28 @@ describe('LegendHelper', function() {
         expect(legendHelper._binColors.length).toEqual(3);
     });
 
-    it('handles array of colorBins', function() {
+    it('handles array of colorBins covering full range', function() {
         var tableStyle = new TableStyle({colorBins: [0, 2, 6, 10]});
         var legendHelper = new LegendHelper(tableColumn, tableStyle);
         expect(legendHelper).toBeDefined();
         expect(legendHelper.legendUrl()).toBeDefined();  // Do this for its side-effects. Hmmm.
-        expect(legendHelper._binColors.length).toEqual(3);
+        expect(legendHelper._binColors.length).toEqual(3); // Ranges are 1-2, 2-6, 6-9.
+    });
+
+    it('extends array of colorBins to cover full range', function() {
+        var tableStyle = new TableStyle({colorBins: [2, 4, 7]});
+        var legendHelper = new LegendHelper(tableColumn, tableStyle);
+        expect(legendHelper).toBeDefined();
+        expect(legendHelper.legendUrl()).toBeDefined();  // Do this for its side-effects. Hmmm.
+        expect(legendHelper._binColors.length).toEqual(4); // Ranges are 1-2, 2-4, 4-7, 7-9.
+    });
+
+    it('filters array of colorBins if outside range', function() {
+        var tableStyle = new TableStyle({colorBins: [-30, -10, 0, 2, 4, 7, 10, 14, 16]});
+        var legendHelper = new LegendHelper(tableColumn, tableStyle);
+        expect(legendHelper).toBeDefined();
+        expect(legendHelper.legendUrl()).toBeDefined();  // Do this for its side-effects. Hmmm.
+        expect(legendHelper._binColors.length).toEqual(4); // Ranges are 1-2, 2-4, 4-7, 7-9.
     });
 
     it('colors points via a color gradient when colorBins is 0', function() {

--- a/test/Models/LegendHelperSpec.js
+++ b/test/Models/LegendHelperSpec.js
@@ -38,7 +38,7 @@ describe('LegendHelper', function() {
         var tableStyle = new TableStyle({colorMap: 'red-red'});
         var legendHelper = new LegendHelper(tableColumn, tableStyle);
         expect(legendHelper).toBeDefined();
-        expect(legendHelper.legendUrl()).toBeDefined();  // Side-effects. Hmmm.
+        expect(legendHelper.legendUrl()).toBeDefined();  // Do this for its side-effects. Hmmm.
         expect(legendHelper.getColorArrayFromValue(9)).toEqual(legendHelper.getColorArrayFromValue(5));
         expect(legendHelper.getColorArrayFromValue(1)).toEqual(legendHelper.getColorArrayFromValue(5));
         var legend = legendHelper._legend;
@@ -47,6 +47,22 @@ describe('LegendHelper', function() {
         expect(getColorArrayFromCssColorString(legend.items[0].color)).toEqual(legendHelper.getColorArrayFromValue(1));
         expect(getColorArrayFromCssColorString(legend.items[1].color)).toEqual(legendHelper.getColorArrayFromValue(5));
         expect(getColorArrayFromCssColorString(legend.items[2].color)).toEqual(legendHelper.getColorArrayFromValue(9));
+    });
+
+    it('handles integer number of colorBins', function() {
+        var tableStyle = new TableStyle({colorBins: 3});
+        var legendHelper = new LegendHelper(tableColumn, tableStyle);
+        expect(legendHelper).toBeDefined();
+        expect(legendHelper.legendUrl()).toBeDefined();  // Do this for its side-effects. Hmmm.
+        expect(legendHelper._binColors.length).toEqual(3);
+    });
+
+    it('handles array of colorBins', function() {
+        var tableStyle = new TableStyle({colorBins: [0, 2, 6, 10]});
+        var legendHelper = new LegendHelper(tableColumn, tableStyle);
+        expect(legendHelper).toBeDefined();
+        expect(legendHelper.legendUrl()).toBeDefined();  // Do this for its side-effects. Hmmm.
+        expect(legendHelper._binColors.length).toEqual(3);
     });
 
     it('colors points via a color gradient when colorBins is 0', function() {

--- a/wwwroot/test/init/test-tablestyle.json
+++ b/wwwroot/test/init/test-tablestyle.json
@@ -59,6 +59,26 @@
           }
         },
         {
+          "name": "Array of color bins (subset only)",
+          "type": "csv",
+          "url": "/build/TerriaJS/test/csv/3000s.csv",
+          "opacity": 1,
+          "tableStyle": {
+            "colorBins": [3200, 3350, 3800, 3850, 3900],
+            "colorMap": "black-red"
+          }
+        },
+        {
+          "name": "Array of color bins (superset)",
+          "type": "csv",
+          "url": "/build/TerriaJS/test/csv/3000s.csv",
+          "opacity": 1,
+          "tableStyle": {
+            "colorBins": [2000, 2500, 3200, 3350, 3800, 3850, 3900, 5000, 8000],
+            "colorMap": "black-red"
+          }
+        },
+        {
           "name": "Color brewer 10-class Set3",
           "type": "csv",
           "url": "/build/TerriaJS/test/csv/3000s.csv",

--- a/wwwroot/test/init/test-tablestyle.json
+++ b/wwwroot/test/init/test-tablestyle.json
@@ -49,6 +49,16 @@
           }
         },
         {
+          "name": "Array of color bins",
+          "type": "csv",
+          "url": "/build/TerriaJS/test/csv/3000s.csv",
+          "opacity": 1,
+          "tableStyle": {
+            "colorBins": [3000, 3100, 3800, 3850, 3950, 4000],
+            "colorMap": "black-red"
+          }
+        },
+        {
           "name": "Color brewer 10-class Set3",
           "type": "csv",
           "url": "/build/TerriaJS/test/csv/3000s.csv",


### PR DESCRIPTION
Fixes #1551.

Check it out with http://localhost:3003/#build/terriajs/test/init/test-tablestyle.json -> csv color maps and palettes -> Array of color bins*.

Note it is a bit smart about handling the min and max boundaries.
