### PR TITLE
Doc specifying parameter names must be lowercase.

### DIFF
--- a/lib/Models/WebFeatureServiceCatalogItem.js
+++ b/lib/Models/WebFeatureServiceCatalogItem.js
@@ -62,6 +62,7 @@ var WebFeatureServiceCatalogItem = function(terria) {
 
     /**
      * Gets or sets the additional parameters to pass to the WFS server when requesting geometry.
+     * All parameter names must be entered in lowercase in order to be consistent with references in TerrisJS code.
      * @type {Object}
      */
     this.parameters = {};

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -46,6 +46,7 @@ var WebMapServiceCatalogGroup = function(terria) {
 
     /**
      * Gets or sets the additional parameters to pass to the WMS server when requesting images.
+     * All parameter names must be entered in lowercase in order to be consistent with references in TerrisJS code.
      * If this property is undefiend, {@link WebMapServiceCatalogItem.defaultParameters} is used.
      * @type {Object}
      */

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -65,6 +65,7 @@ var WebMapServiceCatalogItem = function(terria) {
 
     /**
      * Gets or sets the additional parameters to pass to the WMS server when requesting images.
+     * All parameter names must be entered in lowercase in order to be consistent with references in TerrisJS code.
      * If this property is undefined, {@link WebMapServiceCatalogItem.defaultParameters} is used.
      * @type {Object}
      */

--- a/lib/Models/WebMapTileServiceCatalogGroup.js
+++ b/lib/Models/WebMapTileServiceCatalogGroup.js
@@ -44,6 +44,7 @@ var WebMapTileServiceCatalogGroup = function(terria) {
 
     /**
      * Gets or sets the additional parameters to pass to the WMTS server when requesting images.
+     * All parameter names must be entered in lowercase in order to be consistent with references in TerrisJS code.
      * If this property is undefiend, {@link WebMapTileServiceCatalogItem.defaultParameters} is used.
      * @type {Object}
      */

--- a/lib/Models/WebProcessingServiceCatalogItem.js
+++ b/lib/Models/WebProcessingServiceCatalogItem.js
@@ -35,6 +35,7 @@ function WebProcessingServiceCatalogItem(terria) {
 
     /**
      * Gets or sets the parameters to the WPS function.
+     * All parameter names must be entered in lowercase in order to be consistent with references in TerrisJS code.
      * @type {FunctionParameter[]}
      */
     this.parameters = undefined;


### PR DESCRIPTION
I think I got all OGC types that currently accepts `parameters`.
