### PR TITLE
Implement polling using `idColumns` and allowing updates, not just replacements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Made explorer panel not rendered at all when hidden and made the preview map destroy itself when unmounted - this mitigates performance issues from having Leaflet running in the background on very busy vector datasets.
 * Fixed a bug which prevented time-varying CZML feature info from updating.
 * Added support for moving-point csv files, via an `idColumns` array on csv catalog items. By default, feature positions, color and size are interpolated between the known time values; set `isSampled` to false to prevent this. (Color and size are never interpolated when they are drawn from a text column.)
+* Added support for polling csv files with a partial update, and by using `idColumns` to identify features across updates.
 
 ### 4.1.2
 

--- a/lib/Map/TableColumn.js
+++ b/lib/Map/TableColumn.js
@@ -52,7 +52,6 @@ var defaultReplaceWithZeroValues = [];
 * @param {String} [name] The name of the variable.
 * @param {Number[]} [values] An array of values for the variable.
 * @param {Object} [options] Options:
-* @param {Concept} [options.parent] The parent of this variable; if not parent.allowMultiple, parent.toggleActiveItem(variable) is called when toggling on.
 * @param {Boolean} [options.active] Whether the variable should start active.
 * @param {TableStructure} [options.tableStructure] The table structure this column belongs to. Required so that only one column is selected at a time.
 * @param {VarType} [options.type] The variable type (eg. VarType.TIME). If not present, an educated guess is made based on the name and values.
@@ -68,13 +67,15 @@ var defaultReplaceWithZeroValues = [];
 * @param {String} [options.format] A format string for this column. For numbers, this is passed as options to toLocaleString.
 * @param {String} [options.units] The units of this column, if known. Not currently used internally by TableStructure or TableColumn.
 * @param {Boolean} [options.noFinishDates] If true, then finishDates, timeIntervals and clock are not calculated (even if this is a time column).
+* @param {String} [options.color] The string description of the color of this variable, if any.
 */
 var TableColumn = function(name, values, options) {
     this.options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-
+    // Note - if you add more options, be sure to include them in getFullOptions() too.
     VariableConcept.call(this, name, {
         parent: this.options.tableStructure,
-        active: this.options.active
+        active: this.options.active,
+        color: this.options.color
     });
     this.id = defaultValue(this.options.id, this.id); // if options.id is provided, use it to override the default (this.id = this.name).
     this.format = this.options.format;
@@ -439,6 +440,29 @@ function areAllIntegers(array) {
     }
     return true;
 }
+
+/**
+ * Returns the options you would pass to recreate this column.
+ * @return {Object} An options parameter suitable for passing to new TableColumn().
+ */
+TableColumn.prototype.getFullOptions = function() {
+    return {
+        tableStructure: this.parent,
+        active: this.isActive,
+        id: this.id,
+        format: this.format,
+        units: this.units,
+        unallowedTypes: this._unallowedTypes,
+        replaceWithZeroValues: this._replaceWithZeroValues,
+        replaceWithNullValues: this._replaceWithNullValues,
+        type: this._type,
+        subtype: this._subtype,
+        displayDuration: this.displayDuration,
+        noFinishDates: this.options.noFinishDates,
+        displayVariableTypes: this._displayVariableTypes,
+        color: this.color
+    };
+};
 
 /**
  * Simple check to try to guess date format, based on max value of first position.

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -533,10 +533,13 @@ TableStructure.prototype.append = function(table2, rowNumbers) {
         }
         updatedColumnValueses.push(this.columns[columnNumber].values.concat(valuesToAdd));
     }
-    this.columns = this.columns.reduce((updatedColumns, column, columnNumber) => {
-        updatedColumns.push(new TableColumn(column.name, updatedColumnValueses[columnNumber], column.options));
+    var updatedColumns = this.columns.reduce((updatedColumns, column, columnNumber) => {
+        updatedColumns.push(new TableColumn(column.name, updatedColumnValueses[columnNumber], column.getFullOptions()));
         return updatedColumns;
     }, []);
+    // activeTimeColumn is not tracked, but columns are, so change activeTimeColumn first.
+    this.activeTimeColumn = getColumnWithSameId(this.activeTimeColumn, updatedColumns);
+    this.columns = updatedColumns;
 };
 
 /**
@@ -556,11 +559,22 @@ TableStructure.prototype.replaceRows = function(table2, replacementMap) {
             }
         }
     }
-    this.columns = this.columns.reduce((updatedColumns, column, columnNumber) => {
-        updatedColumns.push(new TableColumn(column.name, updatedColumnValueses[columnNumber], column.options));
+    var updatedColumns = this.columns.reduce((updatedColumns, column, columnNumber) => {
+        updatedColumns.push(new TableColumn(column.name, updatedColumnValueses[columnNumber], column.getFullOptions()));
         return updatedColumns;
     }, []);
+    this.columns = updatedColumns;
 };
+
+function getColumnWithSameId(column1, columns) {
+    if (defined(column1)) {
+        var matchingColumns = columns.filter(column => column.id === column1.id);
+        if (matchingColumns.length !== 1) {
+            throw new DeveloperError('Ambiguous column: ' + column1.name);
+        }
+        return matchingColumns[0];
+    }
+}
 
 /**
  * Merges table2 into this table.
@@ -579,14 +593,7 @@ TableStructure.prototype.merge = function(table2) {
     var table2RowNumbersMap = table2.getIdMapping(this.idColumnNames);
     var rowsFromTable2ToAppend = [];  // An array of row numbers.
     var rowsToReplace = {};  // Properties are {table 1 row number: table 2 row number}.
-    var table2ActiveTimeColumn;
-    if (defined(this.activeTimeColumn)) {
-        var table2ActiveTimeColumns = table2.columns.filter(column => column.id === this.activeTimeColumn.id);
-        if (table2ActiveTimeColumns.length !== 1) {
-            throw new DeveloperError('Cannot merge tables with ambiguous time column.');
-        }
-        table2ActiveTimeColumn = table2ActiveTimeColumns[0];
-    }
+    var table2ActiveTimeColumn = getColumnWithSameId(this.activeTimeColumn, table2.columns);
     for (var key in table2RowNumbersMap) {
         if (table2RowNumbersMap.hasOwnProperty(key)) {
             var table2RowNumbers = table2RowNumbersMap[key];
@@ -602,10 +609,10 @@ TableStructure.prototype.merge = function(table2) {
                     var table2RowNumber = table2RowNumbers[i];
                     // Is there a row with this key and this datetime already?
                     var table1Dates = table1RowNumbersMap[key].map(rowNumber => this.activeTimeColumn.dates[rowNumber].toString());
-                    var table1Index = table1Dates.indexOf(table2ActiveTimeColumn.dates[table2RowNumber].toString());
-                    if (table1Index >= 0) {
-                        // Yes, so replace it.
-                        rowsToReplace[table1Index] = table2RowNumber;
+                    var table1DatesIndex = table1Dates.indexOf(table2ActiveTimeColumn.dates[table2RowNumber].toString());
+                    if (table1DatesIndex >= 0) {
+                        // Yes, so replace it. (Noting table1DatesIndex is an index into table1RowNumbersMap[key].)
+                        rowsToReplace[table1RowNumbersMap[key][table1DatesIndex]] = table2RowNumber;
                     } else {
                         // This is a new datetime, so append the row.
                         rowsFromTable2ToAppend.push(table2RowNumber);

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -525,16 +525,16 @@ TableStructure.prototype.append = function(table2, rowNumbers) {
     if (this.columns.length !== table2.columns.length) {
         throw new DeveloperError('Cannot add tables with different numbers of columns.');
     }
-    var updatedColumnValueses = [];
+    var updatedColumnValuesArrays = [];
     for (var columnNumber = 0; columnNumber < table2.columns.length; columnNumber++) {
         var valuesToAdd = table2.columns[columnNumber].values;
         if (defined(rowNumbers)) {
             valuesToAdd = valuesToAdd.filter((_, rowNumber) => rowNumbers.indexOf(rowNumber) >= 0);
         }
-        updatedColumnValueses.push(this.columns[columnNumber].values.concat(valuesToAdd));
+        updatedColumnValuesArrays.push(this.columns[columnNumber].values.concat(valuesToAdd));
     }
     var updatedColumns = this.columns.reduce((updatedColumns, column, columnNumber) => {
-        updatedColumns.push(new TableColumn(column.name, updatedColumnValueses[columnNumber], column.getFullOptions()));
+        updatedColumns.push(new TableColumn(column.name, updatedColumnValuesArrays[columnNumber], column.getFullOptions()));
         return updatedColumns;
     }, []);
     // activeTimeColumn is not tracked, but columns are, so change activeTimeColumn first.
@@ -549,18 +549,18 @@ TableStructure.prototype.append = function(table2, rowNumbers) {
  * @param {Object} replacementMap An object whose properties are {table 1 row number: table 2 row number}.
  */
 TableStructure.prototype.replaceRows = function(table2, replacementMap) {
-    var updatedColumnValueses = [];
+    var updatedColumnValuesArrays = [];
     for (var columnNumber = 0; columnNumber < table2.columns.length; columnNumber++) {
-        updatedColumnValueses.push(this.columns[columnNumber].values);
+        updatedColumnValuesArrays.push(this.columns[columnNumber].values);
         for (var table1RowNumber in replacementMap) {
             if (replacementMap.hasOwnProperty(table1RowNumber)) {
                 var table2RowNumber = replacementMap[table1RowNumber];
-                updatedColumnValueses[columnNumber][table1RowNumber] = table2.columns[columnNumber].values[table2RowNumber];
+                updatedColumnValuesArrays[columnNumber][table1RowNumber] = table2.columns[columnNumber].values[table2RowNumber];
             }
         }
     }
     var updatedColumns = this.columns.reduce((updatedColumns, column, columnNumber) => {
-        updatedColumns.push(new TableColumn(column.name, updatedColumnValueses[columnNumber], column.getFullOptions()));
+        updatedColumns.push(new TableColumn(column.name, updatedColumnValuesArrays[columnNumber], column.getFullOptions()));
         return updatedColumns;
     }, []);
     this.columns = updatedColumns;

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -526,10 +526,14 @@ TableStructure.prototype.append = function(table2, rowNumbers) {
         throw new DeveloperError('Cannot add tables with different numbers of columns.');
     }
     var updatedColumnValuesArrays = [];
+    function mapRowNumberToValue(valuesToAdd) {
+        return rowNumber => valuesToAdd[rowNumber];
+    }
     for (var columnNumber = 0; columnNumber < table2.columns.length; columnNumber++) {
         var valuesToAdd = table2.columns[columnNumber].values;
         if (defined(rowNumbers)) {
-            valuesToAdd = valuesToAdd.filter((_, rowNumber) => rowNumbers.indexOf(rowNumber) >= 0);
+            valuesToAdd = rowNumbers.map(mapRowNumberToValue(valuesToAdd));
+            // Could also do: valuesToAdd = valuesToAdd.filter((_, rowNumber) => rowNumbers.indexOf(rowNumber) >= 0);
         }
         updatedColumnValuesArrays.push(this.columns[columnNumber].values.concat(valuesToAdd));
     }

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -3,7 +3,6 @@
 
 var dateFormat = require('dateformat');
 
-var clone = require('terriajs-cesium/Source/Core/clone');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -599,25 +599,26 @@ TableStructure.prototype.merge = function(table2) {
     var rowsFromTable2ToAppend = [];  // An array of row numbers.
     var rowsToReplace = {};  // Properties are {table 1 row number: table 2 row number}.
     var table2ActiveTimeColumn = getColumnWithSameId(this.activeTimeColumn, table2.columns);
-    for (var key in table2RowNumbersMap) {
-        if (table2RowNumbersMap.hasOwnProperty(key)) {
-            var table2RowNumbers = table2RowNumbersMap[key];
-            if (!defined(table1RowNumbersMap[key])) {
-                // This key appears in table 2, but not in table 1.
+    for (var featureIdString in table2RowNumbersMap) {
+        if (table2RowNumbersMap.hasOwnProperty(featureIdString)) {
+            var table2RowNumbersForThisFeature = table2RowNumbersMap[featureIdString];
+            var table1RowNumbersForThisFeature = table1RowNumbersMap[featureIdString];
+            if (!defined(table1RowNumbersForThisFeature)) {
+                // This feature appears in table 2, but not in table 1.
                 // Add all these rows to table 1.
-                rowsFromTable2ToAppend = rowsFromTable2ToAppend.concat(table2RowNumbers);
+                rowsFromTable2ToAppend = rowsFromTable2ToAppend.concat(table2RowNumbersForThisFeature);
             } else if (!this.activeTimeColumn) {
-                // The key is in both tables, and there is no time column, so just replace table 1's.
-                rowsToReplace[table1RowNumbersMap[key][0]] = table2RowNumbers[0];
+                // The feature is in both tables, and there is no time column, so just replace table 1's.
+                rowsToReplace[table1RowNumbersForThisFeature[0]] = table2RowNumbersForThisFeature[0];
             } else {
-                for (var i = 0; i < table2RowNumbers.length; i++) {
-                    var table2RowNumber = table2RowNumbers[i];
-                    // Is there a row with this key and this datetime already?
-                    var table1Dates = table1RowNumbersMap[key].map(rowNumber => this.activeTimeColumn.dates[rowNumber].toString());
+                for (var i = 0; i < table2RowNumbersForThisFeature.length; i++) {
+                    var table2RowNumber = table2RowNumbersForThisFeature[i];
+                    // Is there a row with this feature and this datetime already?
+                    var table1Dates = table1RowNumbersForThisFeature.map(rowNumber => this.activeTimeColumn.dates[rowNumber].toString());
                     var table1DatesIndex = table1Dates.indexOf(table2ActiveTimeColumn.dates[table2RowNumber].toString());
                     if (table1DatesIndex >= 0) {
-                        // Yes, so replace it. (Noting table1DatesIndex is an index into table1RowNumbersMap[key].)
-                        rowsToReplace[table1RowNumbersMap[key][table1DatesIndex]] = table2RowNumber;
+                        // Yes, so replace it. (Noting table1DatesIndex is an index into table1RowNumbersForThisFeature.)
+                        rowsToReplace[table1RowNumbersForThisFeature[table1DatesIndex]] = table2RowNumber;
                     } else {
                         // This is a new datetime, so append the row.
                         rowsFromTable2ToAppend.push(table2RowNumber);

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -559,10 +559,9 @@ TableStructure.prototype.replaceRows = function(table2, replacementMap) {
             }
         }
     }
-    var updatedColumns = this.columns.reduce((updatedColumns, column, columnNumber) => {
-        updatedColumns.push(new TableColumn(column.name, updatedColumnValuesArrays[columnNumber], column.getFullOptions()));
-        return updatedColumns;
-    }, []);
+    var updatedColumns = this.columns.map((column, columnNumber) =>
+        new TableColumn(column.name, updatedColumnValuesArrays[columnNumber], column.getFullOptions())
+    );
     this.columns = updatedColumns;
 };
 

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -3,6 +3,7 @@
 
 var dateFormat = require('dateformat');
 
+var clone = require('terriajs-cesium/Source/Core/clone');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
@@ -466,9 +467,15 @@ TableStructure.prototype.getColumnWithNameIdOrIndex = function(nameIdOrIndex) {
     return this.getColumnWithNameOrId(nameIdOrIndex);
 };
 
-
-function getIdColumns(tableStructure) {
-    return tableStructure.idColumnNames.map(function(name) { return tableStructure.getColumnWithNameIdOrIndex(name); });
+// idColumnNames are an optional override of tableStructure.idColumnNames.
+function getIdColumns(tableStructure, idColumnNames) {
+    if (!defined(idColumnNames)) {
+        idColumnNames = tableStructure.idColumnNames;
+    }
+    if (!defined(idColumnNames)) {
+        return [];
+    }
+    return idColumnNames.map(function(name) { return tableStructure.getColumnWithNameIdOrIndex(name); });
 }
 
 function getIdStringForRowNumber(idColumns, rowNumber) {
@@ -488,11 +495,16 @@ TableStructure.prototype.getIdStringForRowNumber = function(rowNumber) {
 
 /**
  * Returns a mapping from the idColumnNames to all the rows in the table with that id.
+ * If no columnIdNames are defined, returns undefined.
+ * @param {Array} [idColumnNames] Provide if you wish to override this table's own idColumnNames.
  * @return {Object} An object with keys equal to idStrings (use tableStructure.getIdStringForRowNumber(i) to get this)
  *         and values equal to an array of rowNumbers.
  */
-TableStructure.prototype.getIdMapping = function() {
-    var idColumns = getIdColumns(this);
+TableStructure.prototype.getIdMapping = function(idColumnNames) {
+    var idColumns = getIdColumns(this, idColumnNames);
+    if (idColumns.length === 0) {
+        return {};
+    }
     return idColumns[0].values.reduce(function(result, value, rowNumber) {
         var idString = getIdStringForRowNumber(idColumns, rowNumber);
         if (!defined(result[idString])) {
@@ -503,6 +515,111 @@ TableStructure.prototype.getIdMapping = function() {
     }, {});
 };
 
+/**
+ * Appends table2 to this table. If rowNumbers are provided, only takes those
+ * row numbers from table2.
+ * Changes all the columns in one go, to avoid partial updates from tracked values.
+ * @param {TableStructure} table2 The table to add to this one.
+ * @param {Integer[]} [rowNumbers] The row numbers from table2 to add (defaults to all).
+ */
+TableStructure.prototype.append = function(table2, rowNumbers) {
+    if (this.columns.length !== table2.columns.length) {
+        throw new DeveloperError('Cannot add tables with different numbers of columns.');
+    }
+    var updatedColumnValueses = [];
+    for (var columnNumber = 0; columnNumber < table2.columns.length; columnNumber++) {
+        var valuesToAdd = table2.columns[columnNumber].values;
+        if (defined(rowNumbers)) {
+            valuesToAdd = valuesToAdd.filter((_, rowNumber) => rowNumbers.indexOf(rowNumber) >= 0);
+        }
+        updatedColumnValueses.push(this.columns[columnNumber].values.concat(valuesToAdd));
+    }
+    this.columns = this.columns.reduce((updatedColumns, column, columnNumber) => {
+        updatedColumns.push(new TableColumn(column.name, updatedColumnValueses[columnNumber], column.options));
+        return updatedColumns;
+    }, []);
+};
+
+/**
+ * Replace specific rows in this table with rows in table2.
+ * Changes all the columns in one go, to avoid partial updates from tracked values.
+ * @param {TableStructure} table2 The table whose rows should replace this table's rows.
+ * @param {Object} replacementMap An object whose properties are {table 1 row number: table 2 row number}.
+ */
+TableStructure.prototype.replaceRows = function(table2, replacementMap) {
+    var updatedColumnValueses = [];
+    for (var columnNumber = 0; columnNumber < table2.columns.length; columnNumber++) {
+        updatedColumnValueses.push(this.columns[columnNumber].values);
+        for (var table1RowNumber in replacementMap) {
+            if (replacementMap.hasOwnProperty(table1RowNumber)) {
+                var table2RowNumber = replacementMap[table1RowNumber];
+                updatedColumnValueses[columnNumber][table1RowNumber] = table2.columns[columnNumber].values[table2RowNumber];
+            }
+        }
+    }
+    this.columns = this.columns.reduce((updatedColumns, column, columnNumber) => {
+        updatedColumns.push(new TableColumn(column.name, updatedColumnValueses[columnNumber], column.options));
+        return updatedColumns;
+    }, []);
+};
+
+/**
+ * Merges table2 into this table.
+ * Uses this.idColumnNames (and this.activeTimeColumn, if present) to identify matching rows.
+ * Changes all the columns in one go, to avoid partial updates from tracked values.
+ * @param  {TableStructure} table2 The table to merge into this one.
+ */
+TableStructure.prototype.merge = function(table2) {
+    if (!defined(this.idColumnNames)) {
+        throw new DeveloperError('Cannot merge tables without id columns.');
+    }
+    if (this.columns.length !== table2.columns.length) {
+        throw new DeveloperError('Cannot merge tables with different numbers of columns.');
+    }
+    var table1RowNumbersMap = this.getIdMapping();
+    var table2RowNumbersMap = table2.getIdMapping(this.idColumnNames);
+    var rowsFromTable2ToAppend = [];  // An array of row numbers.
+    var rowsToReplace = {};  // Properties are {table 1 row number: table 2 row number}.
+    var table2ActiveTimeColumn;
+    if (defined(this.activeTimeColumn)) {
+        var table2ActiveTimeColumns = table2.columns.filter(column => column.id === this.activeTimeColumn.id);
+        if (table2ActiveTimeColumns.length !== 1) {
+            throw new DeveloperError('Cannot merge tables with ambiguous time column.');
+        }
+        table2ActiveTimeColumn = table2ActiveTimeColumns[0];
+    }
+    for (var key in table2RowNumbersMap) {
+        if (table2RowNumbersMap.hasOwnProperty(key)) {
+            var table2RowNumbers = table2RowNumbersMap[key];
+            if (!defined(table1RowNumbersMap[key])) {
+                // This key appears in table 2, but not in table 1.
+                // Add all these rows to table 1.
+                rowsFromTable2ToAppend = rowsFromTable2ToAppend.concat(table2RowNumbers);
+            } else if (!this.activeTimeColumn) {
+                // The key is in both tables, and there is no time column, so just replace table 1's.
+                rowsToReplace[table1RowNumbersMap[key][0]] = table2RowNumbers[0];
+            } else {
+                for (var i = 0; i < table2RowNumbers.length; i++) {
+                    var table2RowNumber = table2RowNumbers[i];
+                    // Is there a row with this key and this datetime already?
+                    var table1Dates = table1RowNumbersMap[key].map(rowNumber => this.activeTimeColumn.dates[rowNumber].toString());
+                    var table1Index = table1Dates.indexOf(table2ActiveTimeColumn.dates[table2RowNumber].toString());
+                    if (table1Index >= 0) {
+                        // Yes, so replace it.
+                        rowsToReplace[table1Index] = table2RowNumber;
+                    } else {
+                        // This is a new datetime, so append the row.
+                        rowsFromTable2ToAppend.push(table2RowNumber);
+                    }
+                }
+            }
+        }
+    }
+    // Replace existing rows from Table 2.
+    this.replaceRows(table2, rowsToReplace);
+    // Append new rows from Table 2.
+    this.append(table2, rowsFromTable2ToAppend);
+};
 
 /**
  * Destroy the object and release resources. Is this necessary?

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -530,10 +530,12 @@ TableStructure.prototype.append = function(table2, rowNumbers) {
         return rowNumber => valuesToAdd[rowNumber];
     }
     for (var columnNumber = 0; columnNumber < table2.columns.length; columnNumber++) {
-        var valuesToAdd = table2.columns[columnNumber].values;
+        var valuesToAdd;
         if (defined(rowNumbers)) {
-            valuesToAdd = rowNumbers.map(mapRowNumberToValue(valuesToAdd));
+            valuesToAdd = rowNumbers.map(mapRowNumberToValue(table2.columns[columnNumber].values));
             // Could also do: valuesToAdd = valuesToAdd.filter((_, rowNumber) => rowNumbers.indexOf(rowNumber) >= 0);
+        } else {
+            valuesToAdd = table2.columns[columnNumber].values;
         }
         updatedColumnValuesArrays.push(this.columns[columnNumber].values.concat(valuesToAdd));
     }

--- a/lib/Map/VariableConcept.js
+++ b/lib/Map/VariableConcept.js
@@ -20,7 +20,7 @@ var Concept = require('./Concept');
  * @param {Object} [options] Options:
  * @param {Concept} [options.parent] The parent of this variable; if not parent.allowMultiple, parent.toggleActiveItem(variable) is called when toggling on.
  * @param {Boolean} [options.active] Whether the variable should start active.
- * @param {String} [options.color] The color of this variable, if any.
+ * @param {String} [options.color] The string description of the color of this variable, if any.
  * @param {String} [options.id] The id of this variable; defaults to the name (via the parent class Concept).
  * @param {Boolean} [options.visible] Whether this variable is visible in the NowViewing tab (defaults to True).
  */

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -649,9 +649,13 @@ CsvCatalogItem.prototype.startPolling = function() {
                     if (polling.replace) {
                         item._tableStructure.columns = newTable.columns;
                     } else {
-                        // TODO: The default will be to update into csvItem._tableStructure, but this is not yet implemented.
-                        console.log('Only polling.replace = true has been implemented.');
-                        throw new DeveloperError('Only polling.replace = true has been implemented.');
+                        if (defined(item.idColumns)) {
+                            // TODO: The default will be to update into csvItem._tableStructure, but this is not yet implemented.
+                            console.log('Only polling.replace = true has been implemented with idColumns.');
+                            throw new DeveloperError('Only polling.replace = true has been implemented with idColumns.');
+                        } else {
+                            item._tableStructure.appendTable(newTable);
+                        }
                     }
                 });
             }

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -650,11 +650,9 @@ CsvCatalogItem.prototype.startPolling = function() {
                         item._tableStructure.columns = newTable.columns;
                     } else {
                         if (defined(item.idColumns)) {
-                            // TODO: The default will be to update into csvItem._tableStructure, but this is not yet implemented.
-                            console.log('Only polling.replace = true has been implemented with idColumns.');
-                            throw new DeveloperError('Only polling.replace = true has been implemented with idColumns.');
+                            item._tableStructure.merge(newTable);
                         } else {
-                            item._tableStructure.appendTable(newTable);
+                            item._tableStructure.append(newTable);
                         }
                     }
                 });

--- a/test/Map/TableStructureSpec.js
+++ b/test/Map/TableStructureSpec.js
@@ -260,17 +260,22 @@ describe('TableStructure', function() {
 
     it('can merge tables with dates', function() {
         var data = [['year', 'id', 'lat', 'lon'], [1970, 'A', 16.8, 5.2], [1971, 'B', 16.2, 5.2]];
-        var dat2 = [['year', 'id', 'lat', 'lon'], [1970, 'A', 12, 8], [1971, 'A', 13, 9], [1975, 'C', 15, 5.5]];
+        var dat2 = [['year', 'id', 'lat', 'lon'], [1975, 'C', 15, 5.5], [1970, 'A', 12, 8], [1971, 'A', 13, 9]];
         var options = {idColumnNames: ['id']};
         var table1 = new TableStructure('foo', options);
         var table2 = new TableStructure('bar');  // Only uses idColumnNames on table1.
         table1 = table1.loadFromJson(data);
         table2 = table2.loadFromJson(dat2);
         table1.activeTimeColumn = table1.columns[0];
+        table1.columns[1].isActive = true;
+        table1.columns[1].color = 'blue';
         table1.merge(table2);
-        expect(table1.columns[0].values.slice()).toEqual([1970, 1971, 1971, 1975]);
-        expect(table1.columns[1].values.slice()).toEqual(['A', 'B', 'A', 'C']);
-        expect(table1.columns[2].values.slice()).toEqual([12, 16.2, 13, 15]);
+        expect(table1.columns[0].values.slice()).toEqual([1970, 1971, 1975, 1971]);
+        expect(table1.activeTimeColumn.dates.length).toEqual(4); // ie. activeTimeColumn updates too.
+        expect(table1.columns[1].values.slice()).toEqual(['A', 'B', 'C', 'A']);
+        expect(table1.columns[2].values.slice()).toEqual([12, 16.2, 15, 13]);
+        expect(table1.columns[1].isActive).toBe(true); // ie. Don't lose options on the columns.
+        expect(table1.columns[1].color).toEqual('blue');
     });
 
     it('can merge tables without dates', function() {

--- a/wwwroot/test/csv/lat_lon_enum_date_id_update.csv
+++ b/wwwroot/test/csv/lat_lon_enum_date_id_update.csv
@@ -1,6 +1,9 @@
 lat,lon,enum,date,id,value
 -20,100,hovering,2015-08-05,feature B,13
 -37,110,going!,2015-08-06,feature B,6
+-30,142,going!,2015-08-07,feature B,16
 -30,145.5,bonk,2015-08-02,feature C,13
--33,140,bonk,2015-08-01,feature E,4
--36,142.5,moo,2015-08-05,feature E,16
+-20,135,bonk,2015-08-01,feature E,4
+-36,143,moo,2015-08-07,feature E,16
+-25,150,hovering,2015-08-01,feature F,15
+-30,100,moo,2015-08-07,feature F,5

--- a/wwwroot/test/csv/lat_lon_enum_date_id_update.csv
+++ b/wwwroot/test/csv/lat_lon_enum_date_id_update.csv
@@ -4,6 +4,11 @@ lat,lon,enum,date,id,value
 -30,142,going!,2015-08-07,feature B,16
 -30,145.5,bonk,2015-08-02,feature C,13
 -20,135,bonk,2015-08-01,feature E,4
--36,143,moo,2015-08-07,feature E,16
--25,150,hovering,2015-08-01,feature F,15
--30,100,moo,2015-08-07,feature F,5
+-36,143,moo,2015-08-02,feature E,16
+-30,150,hovering,2015-08-01,feature F,5
+-30,120,hovering,2015-08-02,feature F,15
+-36,120,moo,2015-08-03,feature F,5
+-36,150,hovering,2015-08-04,feature F,15
+-30,150,hovering,2015-08-05,feature F,5
+-30,120,hovering,2015-08-06,feature F,15
+-36,120,moo,2015-08-07,feature F,5


### PR DESCRIPTION
Fixes #1922.  Also makes polling work for moving features csv files (#1924). Merge after #1924.

To try it out, go to http://localhost:3003/#build/terriajs/test/init/polling.json, and try the "Moving features updated/replaced in 20s" datasets.
