### PR TITLE
Restore behaviour of esri-group and esri-mapServer-group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,9 @@
 Change Log
 ==========
 
-### 5.0.0
+### 4.2.0
 
-* Breaking change: Catalog types `esri-group` or `esri-mapServer-group` were previously synonyms. Now `esri-group` must be used for REST services (eg. URLs ending in `gis/rest/services`), while `esri-mapServer-group` must be used for MapServers (eg. URLs ending in /MapServer).
-* Added support for ArcGis FeatureServers.
+* Added support for ArcGis FeatureServers, using the new catalog types `esri-featureServer` and `esri-featureServer-group`. For backwards compatability, catalog types `esri-group` and `esri-mapServer-group` both continue to work for either REST service endpoints (eg. URLs ending in `gis/rest/services`) or MapServer endpoints (eg. URLs ending in /MapServer). However, the intention is that `esri-group` be for REST services and `esri-mapServer-group` be for MapServers.
 * Enumeration parameter now defaults to what is shown in UI, and if parameter is optional, '' is default.
 * Adds bulk geocoding capability for Australian addresses. So GnafAPI can be used with batches of addresses, if configured.
 * Fixed a bug that caused the selection indicator to get small when near the right edge of the map and to overlap the side panel when past the left edge.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 
 ### 4.2.0
 
-* Added support for ArcGis FeatureServers, using the new catalog types `esri-featureServer` and `esri-featureServer-group`. For backwards compatability, catalog types `esri-group` and `esri-mapServer-group` both continue to work for either REST service endpoints (eg. URLs ending in `gis/rest/services`) or MapServer endpoints (eg. URLs ending in /MapServer). However, the intention is that `esri-group` be for REST services and `esri-mapServer-group` be for MapServers.
+* Added support for ArcGis FeatureServers, using the new catalog types `esri-featureServer` and `esri-featureServer-group`. Catalog type `esri-group` can load REST service, MapServer and FeatureServer endpoints. (For backwards compatability, catalog type `esri-mapServer-group` continues to work for REST service as well as MapServer endpoints.)
 * Enumeration parameter now defaults to what is shown in UI, and if parameter is optional, '' is default.
 * Adds bulk geocoding capability for Australian addresses. So GnafAPI can be used with batches of addresses, if configured.
 * Fixed a bug that caused the selection indicator to get small when near the right edge of the map and to overlap the side panel when past the left edge.

--- a/lib/Core/getDataType.js
+++ b/lib/Core/getDataType.js
@@ -19,19 +19,13 @@ module.exports = function (){
             },
             {
                 value: 'esri-group',
-                name: 'Esri ArcGIS Rest Services'
+                name: 'Esri ArcGIS Server'
             },
-            {
-                value: 'esri-mapServer-group',
-                name: 'Esri ArcGIS MapServer'
-            },
+            // esri-group is registered with ArcGisCatalogGroup, which can read REST, MapServer and FeatureServer groups.
+            // So we do not need to explicitly include esri-mapServer-group or esri-featureServer-group here.
             {
                 value: 'esri-mapServer',
                 name: 'Esri ArcGIS MapServer (single layer)'
-            },
-            {
-                value: 'esri-featureServer-group',
-                name: 'Esri ArcGIS FeatureServer'
             },
             {
                 value: 'esri-featureServer',

--- a/lib/Models/ArcGisCatalogGroup.js
+++ b/lib/Models/ArcGisCatalogGroup.js
@@ -9,7 +9,6 @@ var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
-var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var TerriaError = require('../Core/TerriaError');
 var CatalogGroup = require('./CatalogGroup');

--- a/lib/Models/ArcGisCatalogGroup.js
+++ b/lib/Models/ArcGisCatalogGroup.js
@@ -9,6 +9,7 @@ var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var TerriaError = require('../Core/TerriaError');
 var CatalogGroup = require('./CatalogGroup');
@@ -120,7 +121,15 @@ ArcGisCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
 };
 
 ArcGisCatalogGroup.prototype._load = function() {
-    return loadRest(this);
+    if (/\/MapServer\/?$/i.test(this.url)) {
+        // This functionality really belongs in ArcGisMapServerCatalogGroup, but is included
+        // here for backwards compatibility, so that type esri-mapServer-group
+        // can work for both Rest and MapServer endpoints.
+        // We could even make this work for featureServers too.
+        return ArcGisMapServerCatalogGroup.loadMapServer(this);
+    } else {
+        return loadRest(this);
+    }
 };
 
 function loadRest(catalogGroup) {

--- a/lib/Models/ArcGisCatalogGroup.js
+++ b/lib/Models/ArcGisCatalogGroup.js
@@ -120,12 +120,11 @@ ArcGisCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
 };
 
 ArcGisCatalogGroup.prototype._load = function() {
+    // Allow ArcGisCatalogGroup to function like an ArcGisMapServerCatalogGroup or an ArcGisFeatureServerCatalogGroup. 
     if (/\/MapServer\/?$/i.test(this.url)) {
-        // This functionality really belongs in ArcGisMapServerCatalogGroup, but is included
-        // here for backwards compatibility, so that type esri-mapServer-group
-        // can work for both Rest and MapServer endpoints.
-        // We could even make this work for featureServers too.
         return ArcGisMapServerCatalogGroup.loadMapServer(this);
+    } else if (/\/FeatureServer\/?$/i.test(this.url)) {
+        return ArcGisFeatureServerCatalogGroup.loadFeatureServer(this);
     } else {
         return loadRest(this);
     }

--- a/lib/Models/ArcGisFeatureServerCatalogGroup.js
+++ b/lib/Models/ArcGisFeatureServerCatalogGroup.js
@@ -123,6 +123,12 @@ ArcGisFeatureServerCatalogGroup.prototype._load = function() {
     return loadFeatureServer(this);
 };
 
+// loadFeatureServer is exposed so that ArcGisCatalogGroup can call it,
+// to load a MapServer as if it were an ArcGisFeatureServerCatalogGroup.
+ArcGisFeatureServerCatalogGroup.loadFeatureServer = function(catalogGroup) {
+    return loadFeatureServer(catalogGroup);
+};
+
 function loadFeatureServer(catalogGroup) {
     var terria = catalogGroup.terria;
     var uri = new URI(catalogGroup.url).addQuery('f', 'json');

--- a/lib/Models/ArcGisMapServerCatalogGroup.js
+++ b/lib/Models/ArcGisMapServerCatalogGroup.js
@@ -123,6 +123,12 @@ ArcGisMapServerCatalogGroup.prototype._load = function() {
     return loadMapServer(this);
 };
 
+// loadMapServer is exposed so that ArcGisCatalogGroup can call it,
+// to load a MapServer as if it were an ArcGisMapServerCatalogGroup.
+ArcGisMapServerCatalogGroup.loadMapServer = function(catalogGroup) {
+    return loadMapServer(catalogGroup);
+};
+
 function loadMapServer(catalogGroup) {
     function getJson(segment) {
         var uri = new URI(catalogGroup.url)

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -56,7 +56,8 @@ var registerCatalogMembers = function() {
     createCatalogMemberFromType.register('esri-featureServer', ArcGisFeatureServerCatalogItem);
     createCatalogMemberFromType.register('esri-featureServer-group', ArcGisFeatureServerCatalogGroup);
     createCatalogMemberFromType.register('esri-mapServer', ArcGisMapServerCatalogItem);
-    createCatalogMemberFromType.register('esri-mapServer-group', ArcGisMapServerCatalogGroup);
+    //createCatalogMemberFromType.register('esri-mapServer-group', ArcGisMapServerCatalogGroup);
+    createCatalogMemberFromType.register('esri-mapServer-group', ArcGisCatalogGroup);
     createCatalogMemberFromType.register('geojson', GeoJsonCatalogItem);
     createCatalogMemberFromType.register('gpx', GpxCatalogItem);
     createCatalogMemberFromType.register('group', CatalogGroup);

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -57,7 +57,7 @@ var registerCatalogMembers = function() {
     createCatalogMemberFromType.register('esri-featureServer-group', ArcGisFeatureServerCatalogGroup);
     createCatalogMemberFromType.register('esri-mapServer', ArcGisMapServerCatalogItem);
     //createCatalogMemberFromType.register('esri-mapServer-group', ArcGisMapServerCatalogGroup);
-    createCatalogMemberFromType.register('esri-mapServer-group', ArcGisCatalogGroup);
+    createCatalogMemberFromType.register('esri-mapServer-group', ArcGisCatalogGroup); // For backwards compatibility.
     createCatalogMemberFromType.register('geojson', GeoJsonCatalogItem);
     createCatalogMemberFromType.register('gpx', GpxCatalogItem);
     createCatalogMemberFromType.register('group', CatalogGroup);


### PR DESCRIPTION
PR #1882 introduced breaking changes to the catalog:

> Catalog types `esri-group` or `esri-mapServer-group` were previously synonyms. Now `esri-group` must be used for REST services (eg. URLs ending in `gis/rest/services`), while `esri-mapServer-group` must be used for MapServers (eg. URLs ending in /MapServer).

This PR makes the two types interchangeable again, while keeping the new FeatureServer functionality.

It does it by making `ArcGisCatalogGroup` function load just like an `ArcGisMapServerCatalogGroup` if it sees `MapServer` in the URL.

It also extends the capability of `ArcGisCatalogGroup` (and hence `esri-group`) so that it can handle FeatureServers too.
