### PR TITLE
Fixes WPS parameter selection.

### DIFF
--- a/lib/Models/CatalogFunction.js
+++ b/lib/Models/CatalogFunction.js
@@ -29,6 +29,7 @@ var CatalogFunction = function(terria) {
 
     this._loadingPromise = undefined;
     this._lastLoadInfluencingValues = undefined;
+    this._parameters = [];
 
     /**
      * Gets or sets a value indicating whether the group is currently loading.  This property
@@ -44,7 +45,16 @@ var CatalogFunction = function(terria) {
      */
     this.contextItem = undefined;
 
-    knockout.track(this, ['isLoading']);
+    /**
+     * Gets or sets the current values entered by the user for this WPS process.
+     * Keys are elements of this._parameters.
+     * For tracking to work properly, treat as immutable; use this.setParameterValue().
+     * This property is observable.
+     * @type {Object}
+     */
+    this.parameterValues = {};
+
+    knockout.track(this, ['isLoading', 'parameterValues']);
 };
 
 inherit(CatalogMember, CatalogFunction);
@@ -194,6 +204,33 @@ CatalogFunction.prototype.load = function() {
  */
 CatalogFunction.prototype.invoke = function(parameters) {
     throw new DeveloperError('invoke must be implemented in the derived class.');
+};
+
+/**
+ * If any parameters are missing from parameter values, fill them with their default values.
+ * @param  {Object} parameterValues
+ * @return {Object} A new object to replace parameterValues.
+ */
+CatalogFunction.prototype.applyParameterDefaultValues = function(parameterValues) {
+    var result = clone(parameterValues);
+    for (var i = 0; i < this.parameters.length; i++) {
+        var parameter = this.parameters[i];
+        if (!(parameter.id in result)) {
+            result[parameter.id] = parameter.defaultValue;
+        }
+    }
+    return result;
+};
+
+/**
+ * Update a single parameter in this.parameterValues.
+ * Treats as immutable to track properly.
+ * @param {String} parameterId
+ */
+CatalogFunction.prototype.setParameterValue = function(parameterId, value) {
+    var updatedParameterValues = clone(this.parameterValues);
+    updatedParameterValues[parameterId] = value;
+    this.parameterValues = updatedParameterValues;
 };
 
 module.exports = CatalogFunction;

--- a/lib/Models/PlacesLikeMeFunction.js
+++ b/lib/Models/PlacesLikeMeFunction.js
@@ -94,13 +94,16 @@ PlacesLikeMeFunction.prototype.load = function() {
 
 /**
  * Invokes the process.
- * @param {Object} parameters The parameters to the process.  Each required parameter in {@link CatalogProcess#parameters} must have a corresponding key in this object.
+ * @param {Object} parameterValues The parameter values for the process.  Each required parameter in {@link CatalogProcess#parameters} must have a corresponding key in this object.
  * @return {ResultPendingCatalogItem} The result of invoking this process.  Because the process typically proceeds asynchronously, the result is a temporary
  *         catalog item that resolves to the real one once the process finishes.
  */
-PlacesLikeMeFunction.prototype.invoke = function(parameters) {
-    var region = this._regionParameter.getValue(parameters);
-    var data = this._dataParameter.getValue(parameters);
+PlacesLikeMeFunction.prototype.invoke = function(parameterValues) {
+    if (!defined(parameterValues)) {
+        parameterValues = this.applyParameterDefaultValues(this.parameterValues);
+    }
+    var region = this._regionParameter.getValue(parameterValues);
+    var data = this._dataParameter.getValue(parameterValues);
 
     if (!defined(region)) {
         throw new TerriaError({

--- a/lib/Models/PlacesLikeMeFunction.js
+++ b/lib/Models/PlacesLikeMeFunction.js
@@ -114,7 +114,7 @@ PlacesLikeMeFunction.prototype.invoke = function(parameterValues) {
 
     var request = {
         algorithm: 'placeslikeme',
-        boundaries_name: parameters.regionType.regionType,
+        boundaries_name: parameterValues.regionType.regionType,
         region_codes: data.regionCodes,
         columns: data.columnHeadings,
         table: data.table,
@@ -123,10 +123,10 @@ PlacesLikeMeFunction.prototype.invoke = function(parameterValues) {
         }
     };
 
-    var regionProvider = parameters[this._regionTypeParameter.id];
+    var regionProvider = parameterValues[this._regionTypeParameter.id];
     var regionIndex = regionProvider.regions.indexOf(region);
 
-    var regionName = parameters.region.id;
+    var regionName = parameterValues.region.id;
     if (regionIndex >= 0) {
         regionName = regionProvider.regionNames[regionIndex] || regionName;
     }
@@ -137,7 +137,7 @@ PlacesLikeMeFunction.prototype.invoke = function(parameterValues) {
     return invokeTerriaAnalyticsService(this.terria, name, this.url, request).then(function(invocationResult) {
         var result = invocationResult.result;
 
-        var csv = parameters.regionType.aliases[0] + ',Likeness\n';
+        var csv = parameterValues.regionType.aliases[0] + ',Likeness\n';
 
         var likeness = result.likeness;
         if (data.regionCodes.length !== likeness.length) {
@@ -161,13 +161,13 @@ PlacesLikeMeFunction.prototype.invoke = function(parameterValues) {
             // {"color": "rgba(255,255,255,1.00)", "offset": 0},
             // {"color": "rgba(0,0,255,1.0)", "offset": 1}
         var description = 'This is the result of invoking "' + that.name + '" at ' + invocationResult.startDate + ' with these parameters:\n\n';
-        description += ' * ' + parameters.regionType.regionType + ' Region: ' + regionName + ' (' + parameters.region.id + ')\n';
+        description += ' * ' + parameterValues.regionType.regionType + ' Region: ' + regionName + ' (' + parameterValues.region.id + ')\n';
         description += ' * Characteristics: ' + data.columnHeadings.join(', ') + '\n';
 
         catalogItem.description = description;
 
         extendLoad(catalogItem, function() {
-            return updateRectangleFromRegion(catalogItem, parameters.regionType, region);
+            return updateRectangleFromRegion(catalogItem, parameterValues.regionType, region);
         });
 
         catalogItem.isEnabled = true;

--- a/lib/Models/RegionTypeParameter.js
+++ b/lib/Models/RegionTypeParameter.js
@@ -3,6 +3,8 @@
 /*global require*/
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+
 var FunctionParameter = require('./FunctionParameter');
 var inherit = require('../Core/inherit');
 var RegionProviderList = require('../Map/RegionProviderList');
@@ -25,9 +27,13 @@ var RegionProviderList = require('../Map/RegionProviderList');
 var RegionTypeParameter = function(options) {
     FunctionParameter.call(this, options);
 
+    this._regionProviderPromise = undefined;
     this._regionProviderList = undefined;
 
     this.validRegionTypes = options.validRegionTypes;
+
+    // Track this so that defaultValue can update once regionProviderList is known.
+    knockout.track(this, ['_regionProviderList']);
 };
 
 inherit(FunctionParameter, RegionTypeParameter);
@@ -42,18 +48,41 @@ defineProperties(RegionTypeParameter.prototype, {
         get: function() {
             return 'regionType';
         }
+    },
+
+    defaultValue: {
+        get: function() {
+            const nowViewingItems = this.terria.nowViewing.items;
+            if (nowViewingItems.length > 0) {
+                for (let i = 0; i < nowViewingItems.length; ++i) {
+                    const item = nowViewingItems[i];
+                    if (defined(item.regionMapping) && defined(item.regionMapping.regionDetails) && item.regionMapping.regionDetails.length > 0) {
+                        return item.regionMapping.regionDetails[0].regionProvider;
+                    }
+                }
+            }
+            if (defined(this._regionProviderList) && this._regionProviderList.length > 0) {
+                return this._regionProviderList[0];
+            }
+            // No defaults available; have we requested the region providers yet?
+            this.getAllRegionTypes();
+        }
     }
 });
 
 /**
  * Gets all list of region types that may be selected for this parameter.
+ * Also caches the promise in this._regionProviderPromise, and the promise result in
+ * this._regionProviderList.
  * @return {Promise.<RegionProvider[]>} [description]
  */
 RegionTypeParameter.prototype.getAllRegionTypes = function() {
     var that = this;
-    return RegionProviderList.fromUrl(this.terria.configParameters.regionMappingDefinitionsUrl, this.terria.corsProxy).then(function(regionProviderList) {
+    if (defined(this._regionProviderPromise)) {
+        return this._regionProviderPromise;
+    }
+    this._regionProviderPromise = RegionProviderList.fromUrl(this.terria.configParameters.regionMappingDefinitionsUrl, this.terria.corsProxy).then(function(regionProviderList) {
         var result;
-
         if (!defined(that.validRegionTypes)) {
             result = regionProviderList.regionProviders;
         } else {
@@ -61,9 +90,10 @@ RegionTypeParameter.prototype.getAllRegionTypes = function() {
                 return that.validRegionTypes.indexOf(regionProvider.regionType) >= 0;
             });
         }
-
+        that._regionProviderList = result;
         return result;
     });
+    return this._regionProviderPromise;
 };
 
 module.exports = RegionTypeParameter;

--- a/lib/Models/SpatialDetailingFunction.js
+++ b/lib/Models/SpatialDetailingFunction.js
@@ -4,6 +4,7 @@
 var BooleanParameter = require('./BooleanParameter');
 var CatalogFunction = require('./CatalogFunction');
 var CsvCatalogItem = require('./CsvCatalogItem');
+var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var inherit = require('../Core/inherit');
 var invokeTerriaAnalyticsService = require('./invokeTerriaAnalyticsService');
@@ -103,40 +104,43 @@ SpatialDetailingFunction.prototype.load = function() {
 
 /**
  * Invokes the process.
- * @param {Object} parameters The parameters to the process.  Each required parameter in {@link CatalogProcess#parameters} must have a corresponding key in this object.
+ * @param {Object} parameterValues The parameter values for the process.  Each required parameter in {@link CatalogProcess#parameters} must have a corresponding key in this object.
  * @return {AsyncProcessResultCatalogItem} The result of invoking this process.  Because the process typically proceeds asynchronously, the result is a temporary
  *         catalog item that resolves to the real one once the process finishes.
  */
-SpatialDetailingFunction.prototype.invoke = function(parameters) {
-    var value = this._dataParameter.getValue(parameters);
+SpatialDetailingFunction.prototype.invoke = function(parameterValues) {
+    if (!defined(parameterValues)) {
+        parameterValues = this.applyParameterDefaultValues(this.parameterValues);
+    }
+    var value = this._dataParameter.getValue(parameterValues);
 
     var request = {
         algorithm: 'spatialdetailing',
-        boundaries_name: parameters.coarseDataRegionType.regionType,
+        boundaries_name: parameterValues.coarseDataRegionType.regionType,
         region_codes: value.regionCodes,
         columns: value.columnHeadings[0],
         table: value.singleSelectValues,
         parameters: {
-            disagg_boundaries_name: parameters.regionTypeToPredict.regionType,
-            mean_agg: parameters[this._isMeanAggregationParameter.id]
+            disagg_boundaries_name: parameterValues.regionTypeToPredict.regionType,
+            mean_agg: parameterValues[this._isMeanAggregationParameter.id]
         }
     };
 
     var predictedCharacteristic;
-    for (var characteristicName in parameters.data) {
-        if (parameters.data.hasOwnProperty(characteristicName) && parameters.data[characteristicName]) {
+    for (var characteristicName in parameterValues.data) {
+        if (parameterValues.data.hasOwnProperty(characteristicName) && parameterValues.data[characteristicName]) {
             predictedCharacteristic = characteristicName;
             break;
         }
     }
 
-    var name = 'Spatial detailing of ' + value.columnHeadings[0] + ' at ' + parameters.regionTypeToPredict.regionType;
+    var name = 'Spatial detailing of ' + value.columnHeadings[0] + ' at ' + parameterValues.regionTypeToPredict.regionType;
 
     var that = this;
     return invokeTerriaAnalyticsService(this.terria, name, this.url, request).then(function(invocationResult) {
         var result = invocationResult.result;
 
-        var csv = parameters['regionTypeToPredict'].regionType + ',Predicted ' + predictedCharacteristic + ' (Quality: ' + result.Quality + '),Lower bound of 95% confidence interval,Upper bound of 95% confidence interval\n';
+        var csv = parameterValues['regionTypeToPredict'].regionType + ',Predicted ' + predictedCharacteristic + ' (Quality: ' + result.Quality + '),Lower bound of 95% confidence interval,Upper bound of 95% confidence interval\n';
 
         var predictedValues = result.disagg_mean;
         var predictedRegions = result.disagg_regions;
@@ -157,10 +161,10 @@ SpatialDetailingFunction.prototype.invoke = function(parameters) {
         catalogItem.dataUrl = invocationResult.url;
 
         var description = 'This is the result of invoking "' + that.name + '" at ' + invocationResult.startDate + ' with these parameters:\n\n';
-        description += ' * Region type to predict: ' + parameters.regionTypeToPredict.regionType + '\n';
-        description += ' * Coarse data region type: ' + parameters.coarseDataRegionType.regionType + '\n';
+        description += ' * Region type to predict: ' + parameterValues.regionTypeToPredict.regionType + '\n';
+        description += ' * Coarse data region type: ' + parameterValues.coarseDataRegionType.regionType + '\n';
 
-        if (parameters.isMeanAggregation) {
+        if (parameterValues.isMeanAggregation) {
             description += ' * Treat values as a mean aggregation.\n';
         } else {
             description += ' * Treat values as a sum aggregation.\n';

--- a/lib/Models/WebProcessingServiceCatalogFunction.js
+++ b/lib/Models/WebProcessingServiceCatalogFunction.js
@@ -1,7 +1,6 @@
 'use strict';
 
 /*global require*/
-var clone = require('terriajs-cesium/Source/Core/clone');
 var ResultPendingCatalogItem = require('./ResultPendingCatalogItem');
 var RectangleParameter = require('./RectangleParameter');
 var PolygonParameter = require('./PolygonParameter');

--- a/lib/Models/WebProcessingServiceCatalogFunction.js
+++ b/lib/Models/WebProcessingServiceCatalogFunction.js
@@ -28,7 +28,6 @@ var xml2json = require('../ThirdParty/xml2json');
 function WebProcessingServiceCatalogFunction(terria) {
     CatalogFunction.call(this, terria);
 
-    this._parameters = [];
     this._statusSupported = false;
     this._storeSupported = false;
 
@@ -44,16 +43,7 @@ function WebProcessingServiceCatalogFunction(terria) {
      */
     this.identifier = undefined;
 
-    /**
-     * Gets or sets the current values entered by the user for this WPS process.
-     * Keys are elements of this._parameters.
-     * For tracking to work properly, treat as immutable; use this.setParameterValue().
-     * This property is observable.
-     * @type {Object}
-     */
-    this.parameterValues = {};
-
-    knockout.track(this, ['_parameters', 'url', 'identifier', 'inputs', 'parameterValues']);
+    knockout.track(this, ['_parameters', 'url', 'identifier', 'inputs']);
 }
 
 inherit(CatalogFunction, WebProcessingServiceCatalogFunction);
@@ -559,32 +549,5 @@ sending an email to <a href="mailto:'+catalogFunction.terria.supportEmail+'">'+c
         }, 500);
     }
 }
-
-/**
- * If any parameters are missing from parameter values, fill them with their default values.
- * @param  {Object} parameterValues
- * @return {Object} A new object to replace parameterValues.
- */
-WebProcessingServiceCatalogFunction.prototype.applyParameterDefaultValues = function(parameterValues) {
-    var result = clone(parameterValues);
-    for (var i = 0; i < this.parameters.length; i++) {
-        var parameter = this.parameters[i];
-        if (!(parameter.id in result)) {
-            result[parameter.id] = parameter.defaultValue;
-        }
-    }
-    return result;
-};
-
-/**
- * Update a single parameter in this.parameterValues.
- * Treats as immutable to track properly.
- * @param  {String} parameterId
- */
-WebProcessingServiceCatalogFunction.prototype.setParameterValue = function(parameterId, value) {
-    var updatedParameterValues = clone(this.parameterValues);
-    updatedParameterValues[parameterId] = value;
-    this.parameterValues = updatedParameterValues;
-};
 
 module.exports = WebProcessingServiceCatalogFunction;

--- a/lib/Models/WebProcessingServiceCatalogFunction.js
+++ b/lib/Models/WebProcessingServiceCatalogFunction.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /*global require*/
+var clone = require('terriajs-cesium/Source/Core/clone');
 var ResultPendingCatalogItem = require('./ResultPendingCatalogItem');
 var RectangleParameter = require('./RectangleParameter');
 var PolygonParameter = require('./PolygonParameter');
@@ -43,7 +44,16 @@ function WebProcessingServiceCatalogFunction(terria) {
      */
     this.identifier = undefined;
 
-    knockout.track(this, ['_parameters', 'url', 'identifier', 'inputs']);
+    /**
+     * Gets or sets the current values entered by the user for this WPS process.
+     * Keys are elements of this._parameters.
+     * For tracking to work properly, treat as immutable; use this.setParameterValue().
+     * This property is observable.
+     * @type {Object}
+     */
+    this.parameterValues = {};
+
+    knockout.track(this, ['_parameters', 'url', 'identifier', 'inputs', 'parameterValues']);
 }
 
 inherit(CatalogFunction, WebProcessingServiceCatalogFunction);
@@ -400,9 +410,18 @@ sending an email to <a href="mailto:'+that.terria.supportEmail+'">'+that.terria.
     });
 };
 
-WebProcessingServiceCatalogFunction.prototype.invoke = function(parameters) {
+/**
+ * Invoke the WPS function with the provided parameterValues.
+ * @param  {Object} [parameterValues] Defaults to this.parameterValues,
+ *          with each parameter falling back to defaultParameterValues if not provided.
+ * @return {Promise}
+ */
+WebProcessingServiceCatalogFunction.prototype.invoke = function(parameterValues) {
     var now = new Date();
     var timestamp = sprintf("%04d-%02d-%02dT%02d:%02d:%02d", now.getFullYear(), now.getMonth() + 1, now.getDate(), now.getHours(), now.getMinutes(), now.getSeconds());
+    if (!defined(parameterValues)) {
+        parameterValues = this.applyParameterDefaultValues(this.parameterValues);
+    }
 
     var asyncResult = new ResultPendingCatalogItem(this.terria);
     asyncResult.name = this.name + ' ' + timestamp;
@@ -414,7 +433,7 @@ WebProcessingServiceCatalogFunction.prototype.invoke = function(parameters) {
             return previousValue +
                 '<tr>' +
                     '<td style="vertical-align: middle">' + parameter.name + '</td>' +
-                    '<td>' + parameter.formatValueAsString(parameters[parameter.id]) + '</td>' +
+                    '<td>' + parameter.formatValueAsString(parameterValues[parameter.id]) + '</td>' +
                 '</tr>';
         }, '') +
         '</table>';
@@ -429,7 +448,7 @@ WebProcessingServiceCatalogFunction.prototype.invoke = function(parameters) {
         request: 'Execute',
         version: '1.0.0',
         Identifier: this.identifier,
-        DataInputs: createWpsDataInputsFromParameters(this, parameters)
+        DataInputs: createWpsDataInputsFromParameters(this, parameterValues)
     });
 
     if (this._statusSupported) {
@@ -444,7 +463,7 @@ WebProcessingServiceCatalogFunction.prototype.invoke = function(parameters) {
 
     var that = this;
     var promise = loadXML(url).then(function(xml) {
-        return handleExecuteResponse(that, parameters, asyncResult, xml);
+        return handleExecuteResponse(that, parameterValues, asyncResult, xml);
     });
 
     asyncResult.loadPromise = promise;
@@ -470,9 +489,9 @@ function createParameterFromWpsInput(catalogFunction, input) {
     });
 }
 
-function createWpsDataInputsFromParameters(catalogFunction, parameters) {
+function createWpsDataInputsFromParameters(catalogFunction, parameterValues) {
     return catalogFunction.parameters.map(function(parameter) {
-        var value = parameters[parameter.id];
+        var value = parameterValues[parameter.id];
         return parameter.converter.functionParameterToInput(catalogFunction, parameter, value);
     }).filter(function(convertedParameter) {
         return defined(convertedParameter);
@@ -540,5 +559,32 @@ sending an email to <a href="mailto:'+catalogFunction.terria.supportEmail+'">'+c
         }, 500);
     }
 }
+
+/**
+ * If any parameters are missing from parameter values, fill them with their default values.
+ * @param  {Object} parameterValues
+ * @return {Object} A new object to replace parameterValues.
+ */
+WebProcessingServiceCatalogFunction.prototype.applyParameterDefaultValues = function(parameterValues) {
+    var result = clone(parameterValues);
+    for (var i = 0; i < this.parameters.length; i++) {
+        var parameter = this.parameters[i];
+        if (!(parameter.id in result)) {
+            result[parameter.id] = parameter.defaultValue;
+        }
+    }
+    return result;
+};
+
+/**
+ * Update a single parameter in this.parameterValues.
+ * Treats as immutable to track properly.
+ * @param  {String} parameterId
+ */
+WebProcessingServiceCatalogFunction.prototype.setParameterValue = function(parameterId, value) {
+    var updatedParameterValues = clone(this.parameterValues);
+    updatedParameterValues[parameterId] = value;
+    this.parameterValues = updatedParameterValues;
+};
 
 module.exports = WebProcessingServiceCatalogFunction;

--- a/lib/Models/WhyAmISpecialFunction.js
+++ b/lib/Models/WhyAmISpecialFunction.js
@@ -94,13 +94,16 @@ WhyAmISpecialFunction.prototype.load = function() {
 
 /**
  * Invokes the process.
- * @param {Object} parameters The parameters to the process.  Each required parameter in {@link CatalogProcess#parameters} must have a corresponding key in this object.
+ * @param {Object} parameterValues The parameter values for the process.  Each required parameter in {@link CatalogProcess#parameters} must have a corresponding key in this object.
  * @return {AsyncProcessResultCatalogItem} The result of invoking this process.  Because the process typically proceeds asynchronously, the result is a temporary
  *         catalog item that resolves to the real one once the process finishes.
  */
-WhyAmISpecialFunction.prototype.invoke = function(parameters) {
-    var region = this._regionParameter.getValue(parameters);
-    var data = this._dataParameter.getValue(parameters);
+WhyAmISpecialFunction.prototype.invoke = function(parameterValues) {
+    if (!defined(parameterValues)) {
+        parameterValues = this.applyParameterDefaultValues(this.parameterValues);
+    }
+    var region = this._regionParameter.getValue(parameterValues);
+    var data = this._dataParameter.getValue(parameterValues);
 
     if (!defined(region)) {
         throw new TerriaError({
@@ -111,7 +114,7 @@ WhyAmISpecialFunction.prototype.invoke = function(parameters) {
 
     var request = {
         algorithm: 'whyamispecial',
-        boundaries_name: parameters.regionType.regionType,
+        boundaries_name: parameterValues.regionType.regionType,
         region_codes: data.regionCodes,
         columns: data.columnHeadings,
         table: data.table,
@@ -120,10 +123,10 @@ WhyAmISpecialFunction.prototype.invoke = function(parameters) {
         }
     };
 
-    var regionProvider = parameters[this._regionTypeParameter.id];
+    var regionProvider = parameterValues[this._regionTypeParameter.id];
     var regionIndex = regionProvider.regions.indexOf(region);
 
-    var regionName = parameters.region.id;
+    var regionName = parameterValues.region.id;
     if (regionIndex >= 0) {
         regionName = regionProvider.regionNames[regionIndex] || regionName;
     }
@@ -146,7 +149,7 @@ WhyAmISpecialFunction.prototype.invoke = function(parameters) {
         catalogItem.dataUrl = invocationResult.url;
 
         var description = 'This is the result of invoking "' + that.name + '" at ' + invocationResult.startDate + ' with these parameters:\n\n';
-        description += ' * ' + parameters.regionType.regionType + ' Region: ' + regionName + ' (' + parameters.region.id + ')\n';
+        description += ' * ' + parameterValues.regionType.regionType + ' Region: ' + regionName + ' (' + parameterValues.region.id + ')\n';
         description += ' * Characteristics: ' + data.columnHeadings.join(', ') + '\n';
 
         catalogItem.description = description;

--- a/lib/ReactViews/Analytics/BooleanParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/BooleanParameterEditor.jsx
@@ -7,26 +7,27 @@ const BooleanParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
         previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        parameterValues: React.PropTypes.object
+        parameter: React.PropTypes.object
     },
 
     onClick() {
-        this.props.parameterValues[this.props.parameter.id] = !this.props.parameterValues[this.props.parameter.id];
+        const value = this.props.previewed.parameterValues[this.props.parameter.id];
+        this.props.previewed.setParameterValue(this.props.parameter.id, !value);
     },
 
     renderRadio(state) {
         let name;
         let description;
         let classNames;
+        const value = this.props.previewed.parameterValues[this.props.parameter.id];
         if (state === true) {
             name = this.props.parameter.trueName || this.props.parameter.name;
             description = this.props.parameter.trueDescription || this.props.parameter.description;
-            classNames = this.props.parameterValues[this.props.parameter.id] && this.props.parameterValues[this.props.parameter.id] === true ? Styles.btnRadioOn : Styles.btnRadioOff;
+            classNames = value && value === true ? Styles.btnRadioOn : Styles.btnRadioOff;
         } else {
             name = this.props.parameter.falseName || this.props.parameter.name;
             description = this.props.parameter.falseDescription || this.props.parameter.description;
-            classNames = this.props.parameterValues[this.props.parameter.id] && this.props.parameterValues[this.props.parameter.id] === true ? Styles.btnRadioOff : Styles.btnRadioOn;
+            classNames = value && value === true ? Styles.btnRadioOff : Styles.btnRadioOn;
 
         }
         return (

--- a/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
@@ -7,8 +7,7 @@ const DateTimeParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
         previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        parameterValues: React.PropTypes.object
+        parameter: React.PropTypes.object
     },
 
     getInitialState() {
@@ -17,7 +16,7 @@ const DateTimeParameterEditor = React.createClass({
 
     getDateTime() {
         const dateTimeBreakOut = {};
-        const timeDate = this.props.parameterValues[this.props.parameter.id];
+        const timeDate = this.props.previewed.parameterValues[this.props.parameter.id];
         if (timeDate !== undefined) {
             const splits = timeDate.split('T');
             dateTimeBreakOut.date = splits[0];
@@ -37,11 +36,11 @@ const DateTimeParameterEditor = React.createClass({
     },
 
     setDateTime(dateTime) {
+        let value;
         if (dateTime.date && dateTime.time) {
-            this.props.parameterValues[this.props.parameter.id] = dateTime.date + 'T' + dateTime.time;
-        } else {
-            this.props.parameterValues[this.props.parameter.id] = undefined;
+            value = dateTime.date + 'T' + dateTime.time;
         }
+        this.props.previewed.setParameterValue(this.props.parameter.id, value);
     },
 
     onChangeDate(e) {

--- a/lib/ReactViews/Analytics/EnumerationParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/EnumerationParameterEditor.jsx
@@ -7,24 +7,23 @@ const EnumerationParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
         previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        parameterValues: React.PropTypes.object
+        parameter: React.PropTypes.object
     },
 
     getInitialState() {
         return {
-            value: this.props.parameterValues[this.props.parameter.id]
+            value: this.props.previewed.parameterValues[this.props.parameter.id]
         };
     },
 
     onChange(e) {
-        this.props.parameterValues[this.props.parameter.id] = e.target.value;
+        this.props.previewed.setParameterValue(this.props.parameter.id, e.target.value);
     },
 
     render() {
         return (<select className={Styles.field}
                         onChange={this.onChange}
-                        value={this.props.parameterValues[this.props.parameter.id]}
+                        value={this.props.previewed.parameterValues[this.props.parameter.id]}
                 >
                     {this.props.parameter.possibleValues.map((v, i)=>
                         <option value={v} key={i}>{v}</option>)}

--- a/lib/ReactViews/Analytics/GenericParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/GenericParameterEditor.jsx
@@ -7,19 +7,18 @@ const GenericParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
         previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        parameterValues: React.PropTypes.object
+        parameter: React.PropTypes.object
     },
 
     onChange(e) {
-        this.props.parameterValues[this.props.parameter.id] = e.target.value;
+        this.props.previewed.setParameterValues(this.props.parameter.id, e.target.value);
     },
 
     render() {
         return (<input className={Styles.field}
                        type="text"
                        onChange={this.onChange}
-                       value={this.props.parameterValues[this.props.parameter.id]}
+                       value={this.props.previewed.parameterValues[this.props.parameter.id]}
                 />);
     }
 });

--- a/lib/ReactViews/Analytics/InvokeFunction.jsx
+++ b/lib/ReactViews/Analytics/InvokeFunction.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import ObserveModelMixin from '../ObserveModelMixin';
 import ParameterEditor from './ParameterEditor';
 import when from 'terriajs-cesium/Source/ThirdParty/when';

--- a/lib/ReactViews/Analytics/InvokeFunction.jsx
+++ b/lib/ReactViews/Analytics/InvokeFunction.jsx
@@ -18,8 +18,6 @@ const InvokeFunction = React.createClass({
     },
 
     componentWillMount() {
-        this._parameterValues = {};
-        this.defaultPropsIfNeeded(this.props);
         this.enableContextItem(this.props);
     },
 
@@ -29,21 +27,13 @@ const InvokeFunction = React.createClass({
 
     componentWillReceiveProps(nextProps) {
         // This will be called when component is already mounted but props change, for example if you go from one WPS
-        // item to another. In that instance, we'll need to clear parameter values.
-        this._parameterValues = {};
-        this.defaultPropsIfNeeded(nextProps);
+        // item to another.
         this.enableContextItem(nextProps);
-    },
-
-    componentWillUpdate(nextProps, nextState) {
-        // This is needed as componentWillReceiveProps may be called before it has parameters. But if parameters have
-        // already been set (defaulted or set by user) nothing will change.
-        this.defaultPropsIfNeeded(nextProps);
     },
 
     submit() {
         try {
-            const promise = when(this.props.previewed.invoke(this._parameterValues))
+            const promise = when(this.props.previewed.invoke())
                 .otherwise(terriaError => {
                     if (terriaError instanceof TerriaError) {
                         this.props.previewed.terria.error.raiseEvent(terriaError);
@@ -63,17 +53,6 @@ const InvokeFunction = React.createClass({
             }
             return undefined;
         }
-    },
-
-    defaultPropsIfNeeded(props) {
-        const parameters = props.previewed.parameters;
-        for (let i = 0; i < parameters.length; ++i) {
-            const parameter = parameters[i];
-            if (!(parameter.id in this._parameterValues)) {
-                this._parameterValues[parameter.id] = parameter.defaultValue;
-            }
-        }
-        knockout.track(this._parameterValues);
     },
 
     enableContextItem(props) {
@@ -100,7 +79,6 @@ const InvokeFunction = React.createClass({
                          parameter={param}
                          viewState={this.props.viewState}
                          previewed={this.props.previewed}
-                         parameterValues={this._parameterValues}
         />
     );},
 

--- a/lib/ReactViews/Analytics/ParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/ParameterEditor.jsx
@@ -20,7 +20,6 @@ const ParameterEditor = React.createClass({
     propTypes: {
         parameter: React.PropTypes.object,
         viewState: React.PropTypes.object,
-        parameterValues: React.PropTypes.object,
         previewed: React.PropTypes.object
     },
 
@@ -33,64 +32,54 @@ const ParameterEditor = React.createClass({
                     previewed={this.props.previewed}
                     viewState={this.props.viewState}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />);
             case 'rectangle':
                 return <RectangleParameterEditor
                     previewed={this.props.previewed}
                     viewState={this.props.viewState}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />;
             case 'polygon':
                 return <PolygonParameterEditor
                     previewed={this.props.previewed}
                     viewState={this.props.viewState}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />;
             case 'enumeration':
                 return <EnumerationParameterEditor
                     previewed={this.props.previewed}
                     viewState={this.props.viewState}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />;
             case 'dateTime':
                 return <DateTimeParameterEditor
                     previewed={this.props.previewed}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />;
             case 'region':
                 return <RegionParameterEditor
                     previewed={this.props.previewed}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />;
             case 'regionType':
                 return <RegionTypeParameterEditor
                     previewed={this.props.previewed}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />;
             case 'regionData':
                 return <RegionDataParameterEditor
                     previewed={this.props.previewed}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />;
             case 'boolean':
                 return <BooleanParameterEditor
                     previewed={this.props.previewed}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />;
             default:
                 return <GenericParameterEditor
                     previewed={this.props.previewed}
                     parameter={this.props.parameter}
-                    parameterValues={this.props.parameterValues}
                 />;
         }
     },

--- a/lib/ReactViews/Analytics/PointParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PointParameterEditor.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Cartographic from 'terriajs-cesium/Source/Core/Cartographic';
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
+import clone from 'terriajs-cesium/Source/Core/clone';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
@@ -17,13 +18,12 @@ const PointParameterEditor = React.createClass({
     propTypes: {
         previewed: React.PropTypes.object,
         parameter: React.PropTypes.object,
-        viewState: React.PropTypes.object,
-        parameterValues: React.PropTypes.object
+        viewState: React.PropTypes.object
     },
 
     getInitialState() {
         return {
-            value: ''
+            value: this.getValue()
         };
     },
 
@@ -35,7 +35,7 @@ const PointParameterEditor = React.createClass({
     },
 
     getValue() {
-        const cartographic = this.props.parameterValues[this.props.parameter.id];
+        const cartographic = this.props.previewed.parameterValues[this.props.parameter.id];
         if (defined(cartographic)) {
             return CesiumMath.toDegrees(cartographic.longitude) + ',' + CesiumMath.toDegrees(cartographic.latitude);
         } else {
@@ -46,7 +46,8 @@ const PointParameterEditor = React.createClass({
     setValue(value) {
         const coordinates = value.split(',');
         if (coordinates.length >= 2) {
-            this.props.parameterValues[this.props.parameter.id] = Cartographic.fromDegrees(parseFloat(coordinates[0]), parseFloat(coordinates[1]));
+            const value = Cartographic.fromDegrees(parseFloat(coordinates[0]), parseFloat(coordinates[1]));
+            this.props.previewed.setParameterValue(this.props.parameter.id, value);
         }
     },
 
@@ -67,12 +68,10 @@ const PointParameterEditor = React.createClass({
 
         knockout.getObservable(pickPointMode, 'pickedFeatures').subscribe(function (pickedFeatures) {
             if (defined(pickedFeatures.pickPosition)) {
-                that.props.parameterValues[that.props.parameter.id] = Ellipsoid.WGS84.cartesianToCartographic(pickedFeatures.pickPosition);
+                const value = Ellipsoid.WGS84.cartesianToCartographic(pickedFeatures.pickPosition);
+                that.props.previewed.setParameterValue(that.props.parameter.id, value);
                 terria.mapInteractionModeStack.pop();
                 that.props.viewState.openAddData();
-                that.setState({
-                    value: that.getValue()
-                });
             }
         });
 

--- a/lib/ReactViews/Analytics/PointParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PointParameterEditor.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import Cartographic from 'terriajs-cesium/Source/Core/Cartographic';
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
-import clone from 'terriajs-cesium/Source/Core/clone';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
@@ -66,7 +65,7 @@ const PointParameterEditor = React.createClass({
         });
         terria.mapInteractionModeStack.push(pickPointMode);
 
-        knockout.getObservable(pickPointMode, 'pickedFeatures').subscribe(function (pickedFeatures) {
+        knockout.getObservable(pickPointMode, 'pickedFeatures').subscribe(function(pickedFeatures) {
             if (defined(pickedFeatures.pickPosition)) {
                 const value = Ellipsoid.WGS84.cartesianToCartographic(pickedFeatures.pickPosition);
                 that.props.previewed.setParameterValue(that.props.parameter.id, value);
@@ -85,7 +84,7 @@ const PointParameterEditor = React.createClass({
                        type="text"
                        onChange={this.onTextChange}
                        value={this.state.value}/>
-                <button type='button' onClick={this.selectPointOnMap} className={Styles.btnSelector}>
+                <button type="button" onClick={this.selectPointOnMap} className={Styles.btnSelector}>
                     Select location
                 </button>
             </div>

--- a/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
-import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
 import defined from 'terriajs-cesium/Source/Core/defined';
+import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
 
 import UserDrawing from '../../Models/UserDrawing';
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -14,13 +14,12 @@ const PolygonParameterEditor = React.createClass({
     propTypes: {
         previewed: React.PropTypes.object,
         parameter: React.PropTypes.object,
-        viewState: React.PropTypes.object,
-        parameterValues: React.PropTypes.object
+        viewState: React.PropTypes.object
     },
 
     getInitialState() {
         return {
-            value: "",
+            value: this.getValue(),
             userDrawing: new UserDrawing(
                 {
                     terria: this.props.previewed.terria,
@@ -38,19 +37,23 @@ const PolygonParameterEditor = React.createClass({
     },
 
     getValue() {
-        const pointsLongLats = this.props.parameterValues[this.props.parameter.id][0];
+        const rawValue = this.props.previewed.parameterValues[this.props.parameter.id];
+        if (!defined(rawValue) || rawValue.length < 1) {
+            return '';
+        }
+        const pointsLongLats = rawValue[0];
 
-        let polygon = "";
-        for (let i=0; i<pointsLongLats.length; i++) {
-            polygon += "[" + pointsLongLats[i][0].toFixed(3) + ", " + pointsLongLats[i][1].toFixed(3) + "]";
-            if (i !== pointsLongLats.length-1) {
-                polygon += ", ";
+        let polygon = '';
+        for (let i = 0; i < pointsLongLats.length; i++) {
+            polygon += '[' + pointsLongLats[i][0].toFixed(3) + ', ' + pointsLongLats[i][1].toFixed(3) + ']';
+            if (i !== pointsLongLats.length - 1) {
+                polygon += ', ';
             }
         }
-        if (defined(polygon)) {
-            return "[" + polygon + "]";
+        if (polygon.length > 0) {
+            return '[' + polygon + ']';
         } else {
-            return "";
+            return '';
         }
     },
 
@@ -62,9 +65,6 @@ const PolygonParameterEditor = React.createClass({
 
     onCleanUp() {
         this.props.viewState.openAddData();
-        this.setState({
-            value: this.getValue()
-        });
     },
 
     onPointClicked(pointEntities) {
@@ -79,7 +79,7 @@ const PolygonParameterEditor = React.createClass({
             points.push(CesiumMath.toDegrees(cartographic.latitude));
             pointsLongLats.push(points);
         }
-        this.props.parameterValues[this.props.parameter.id] = [pointsLongLats];
+        this.props.previewed.setParameterValue(this.props.parameter.id, [pointsLongLats]);
     },
 
     selectPolygonOnMap() {
@@ -94,7 +94,7 @@ const PolygonParameterEditor = React.createClass({
                        type="text"
                        onChange={this.onTextChange}
                        value={this.state.value}/>
-                <button type='button'
+                <button type="button"
                         onClick={this.selectPolygonOnMap}
                         className={Styles.btnSelector}>
                     Click to draw polygon

--- a/lib/ReactViews/Analytics/RectangleParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RectangleParameterEditor.jsx
@@ -17,13 +17,12 @@ const RectangleParameterEditor = React.createClass({
     propTypes: {
         previewed: React.PropTypes.object,
         parameter: React.PropTypes.object,
-        viewState: React.PropTypes.object,
-        parameterValues: React.PropTypes.object
+        viewState: React.PropTypes.object
     },
 
     getInitialState() {
         return {
-            value: ''
+            value: this.getValue()
         };
     },
 
@@ -35,7 +34,7 @@ const RectangleParameterEditor = React.createClass({
     },
 
     getValue() {
-        const rect = this.props.parameterValues[this.props.parameter.id];
+        const rect = this.props.previewed.parameterValues[this.props.parameter.id];
         if (defined(rect)) {
             return this.outputDegrees(Rectangle.southwest(rect).longitude) + ',' + this.outputDegrees(Rectangle.southwest(rect).latitude) + ' ' + this.outputDegrees(Rectangle.northeast(rect).longitude) + ',' + this.outputDegrees(Rectangle.northeast(rect).latitude);
         } else {
@@ -56,7 +55,7 @@ const RectangleParameterEditor = React.createClass({
                 coords.push(Cartographic.fromDegrees(parseFloat(coordinates[0]), parseFloat(coordinates[1])));
             }
         }
-        this.props.parameterValues[this.props.parameter.id] = Rectangle.fromCartographicArray(coords);
+        this.props.previewed.setParameterValue(this.props.parameter.id, Rectangle.fromCartographicArray(coords));
     },
 
     selectRectangleOnMap() {
@@ -77,15 +76,12 @@ const RectangleParameterEditor = React.createClass({
         terria.selectBox = true;
         terria.mapInteractionModeStack.push(pickPointMode);
 
-        knockout.getObservable(pickPointMode, 'pickedFeatures').subscribe(function (pickedFeatures) {
+        knockout.getObservable(pickPointMode, 'pickedFeatures').subscribe(function(pickedFeatures) {
             if (pickedFeatures instanceof Rectangle) {
-                that.props.parameterValues[that.props.parameter.id] = pickedFeatures;
+                that.props.previewed.setParameterValue(that.props.parameter.id, pickedFeatures);
                 terria.mapInteractionModeStack.pop();
                 terria.selectBox = false;
                 that.props.viewState.openAddData();
-                that.setState({
-                    value: that.getValue()
-                });
             }
         });
 
@@ -99,7 +95,7 @@ const RectangleParameterEditor = React.createClass({
                        type="text"
                        onChange={this.onTextChange}
                        value={this.state.value}/>
-                <button type='button'
+                <button type="button"
                         onClick={this.selectRectangleOnMap}
                         className={Styles.btnSelector}>
                     Click to draw rectangle

--- a/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
@@ -14,8 +14,7 @@ const RegionDataParameterEditor = React.createClass({
 
     propTypes: {
         previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        parameterValues: React.PropTypes.object
+        parameter: React.PropTypes.object
     },
 
     componentWillMount() {
@@ -27,19 +26,19 @@ const RegionDataParameterEditor = React.createClass({
     },
 
     getValue() {
-        return this.props.parameterValues[this.props.parameter.id];
+        return this.props.previewed.parameterValues[this.props.parameter.id];
     },
 
     setValue(value) {
-        this.props.parameterValues[this.props.parameter.id] = value;
+        this.props.previewed.setParameterValue(this.props.parameter.id, value);
     },
 
     regionProvider() {
-        return this.props.parameter.getRegionProvider(this.props.parameterValues);
+        return this.props.parameter.getRegionProvider(this.props.previewed.parameterValues);
     },
 
     catalogItemsWithMatchingRegion() {
-        return this.props.parameter.getEnabledItemsWithMatchingRegionType(this.props.parameterValues);
+        return this.props.parameter.getEnabledItemsWithMatchingRegionType(this.props.previewed.parameterValues);
     },
 
     toggleActive(catalogItem, column) {

--- a/lib/ReactViews/Analytics/RegionParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionParameterEditor.jsx
@@ -20,12 +20,10 @@ const RegionParameterEditor = React.createClass({
 
     propTypes: {
         previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        parameterValues: React.PropTypes.object,
+        parameter: React.PropTypes.object
     },
 
     componentWillMount() {
-
         this._lastPickedFeatures = undefined;
         this._loadingRegionProvider = undefined;
         this._selectedRegionCatalogItem = undefined;
@@ -71,7 +69,7 @@ const RegionParameterEditor = React.createClass({
                 }
                 const feature = pickedFeatures.features[0];
                 that._lastRegionFeature = feature.data;
-                that.regionValue = that.props.parameter.findRegionByID(feature.properties[that.regionProvider.regionProp], that.props.parameterValues);
+                that.regionValue = that.props.parameter.findRegionByID(feature.properties[that.regionProvider.regionProp], that.props.previewed.parameterValues);
 
                 if (defined(that._selectedRegionCatalogItem)) {
                     that._selectedRegionCatalogItem.isEnabled = false;
@@ -88,13 +86,13 @@ const RegionParameterEditor = React.createClass({
 
         knockout.defineProperty(this, 'regionValue', {
             get: function() {
-                return this.props.parameter.getValue(this.props.parameterValues);
+                return this.props.parameter.getValue(this.props.previewed.parameterValues);
             },
             set: function(value) {
                 if (defined(value) && defined(value.realRegion)) {
                     value = value.realRegion;
                 }
-                this.props.parameterValues[this.props.parameter.id] = value;
+                this.props.previewed.setParameterValue(this.props.parameter.id, value);
                 this._displayValue = undefined;
                 this.updateMapFromValue(this);
             }
@@ -102,7 +100,7 @@ const RegionParameterEditor = React.createClass({
 
         knockout.defineProperty(this, 'regionProvider', {
             get: function() {
-                return this.props.parameter.getRegionProvider(this.props.parameterValues);
+                return this.props.parameter.getRegionProvider(this.props.previewed.parameterValues);
             }
         });
 
@@ -232,7 +230,7 @@ const RegionParameterEditor = React.createClass({
 
         const value = this.regionValue;
         const parameter = this.props.parameter;
-        const parameterValues = this.props.parameterValues;
+        const parameterValues = this.props.previewed.parameterValues;
         const terria = this.props.previewed.terria;
 
         const that = this;

--- a/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
@@ -8,8 +8,7 @@ const RegionTypeParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
         previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        parameterValues: React.PropTypes.object
+        parameter: React.PropTypes.object
     },
 
     getInitialState() {
@@ -23,7 +22,8 @@ const RegionTypeParameterEditor = React.createClass({
     },
 
     onChange(e) {
-        this.props.parameterValues[this.props.parameter.id] = this.state.regionProviders.filter(r=> r.regionType === e.target.value)[0];
+        const value = this.state.regionProviders.filter(r=> r.regionType === e.target.value)[0];
+        this.props.previewed.setParameterValue(this.props.parameter.id, value);
     },
 
     getDefaultValue() {
@@ -36,7 +36,7 @@ const RegionTypeParameterEditor = React.createClass({
                 }
             }
         }
-        if(this.state.regionProviders.length) {
+        if (this.state.regionProviders.length) {
             return this.state.regionProviders[0];
         }
     },
@@ -51,12 +51,13 @@ const RegionTypeParameterEditor = React.createClass({
     },
 
     render() {
-        if(!defined(this.props.parameterValues[this.props.parameter.id])) {
-            this.props.parameterValues[this.props.parameter.id] = this.getDefaultValue();
+        if (!defined(this.props.previewed.parameterValues[this.props.parameter.id])) {
+            this.props.previewed.setParameterValue(this.props.parameter.id, this.getDefaultValue());
         }
+        const rawValue = this.props.previewed.parameterValues[this.props.parameter.id];
         return <select className={Styles.field}
                        onChange={this.onChange}
-                       value={this.props.parameterValues[this.props.parameter.id] ? this.props.parameterValues[this.props.parameter.id].regionType : ''}>
+                       value={defined(rawValue) ? rawValue.regionType : ''}>
                        {this.state.regionProviders.map((r, i)=>
                         (<option value={r.regionType}
                                  key={i}

--- a/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
@@ -51,10 +51,10 @@ const RegionTypeParameterEditor = React.createClass({
     },
 
     render() {
-        if (!defined(this.props.previewed.parameterValues[this.props.parameter.id])) {
-            this.props.previewed.setParameterValue(this.props.parameter.id, this.getDefaultValue());
+        let rawValue = this.props.previewed.parameterValues[this.props.parameter.id];
+        if (!defined(rawValue)) {
+            rawValue = this.getDefaultValue();
         }
-        const rawValue = this.props.previewed.parameterValues[this.props.parameter.id];
         return <select className={Styles.field}
                        onChange={this.onChange}
                        value={defined(rawValue) ? rawValue.regionType : ''}>

--- a/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
@@ -26,21 +26,6 @@ const RegionTypeParameterEditor = React.createClass({
         this.props.previewed.setParameterValue(this.props.parameter.id, value);
     },
 
-    getDefaultValue() {
-        const nowViewingItems = this.props.previewed.terria.nowViewing.items;
-        if(nowViewingItems.length > 0) {
-            for (let i = 0; i < nowViewingItems.length; ++i) {
-                const item = nowViewingItems[i];
-                if (defined(item.regionMapping) && defined(item.regionMapping.regionDetails) && item.regionMapping.regionDetails.length > 0) {
-                    return item.regionMapping.regionDetails[0].regionProvider;
-                }
-            }
-        }
-        if (this.state.regionProviders.length) {
-            return this.state.regionProviders[0];
-        }
-    },
-
     getAllOptions() {
         const that = this;
         this.props.parameter.getAllRegionTypes().then(function(_regionProviders) {
@@ -53,7 +38,7 @@ const RegionTypeParameterEditor = React.createClass({
     render() {
         let rawValue = this.props.previewed.parameterValues[this.props.parameter.id];
         if (!defined(rawValue)) {
-            rawValue = this.getDefaultValue();
+            rawValue = this.props.parameter.defaultValue;
         }
         return <select className={Styles.field}
                        onChange={this.onChange}


### PR DESCRIPTION
Fixes #1933 and fixes #1918.

A recent change meant that the entire ExplorerPanel, and hence any InvokeFunction component, is unmounted while you click out a point/polygon/rectangle/etc on the map.

This required a complete reworking of how the selected data is stored, moving it from `InvokeFunction` to `WebProcessingServiceCatalogFunction`.
