### PR TITLE
Restored ability to draw polygon on map for WPS functions.

### DIFF
--- a/lib/Models/Feature.js
+++ b/lib/Models/Feature.js
@@ -63,7 +63,7 @@ inherit(Entity, Feature);
  * @return {Feature}
  */
 Feature.fromEntity = function(entity) {
-    var feature = new Feature();
+    var feature = new Feature({id: entity.id});
     feature.merge(entity);
 
     for (var i = 0; i < customProperties.length; i++) {

--- a/lib/Models/UserDrawing.js
+++ b/lib/Models/UserDrawing.js
@@ -367,23 +367,29 @@ UserDrawing.prototype._getPointsForShape = function() {
  * @private
  */
 UserDrawing.prototype._clickedExistingPoint = function(features) {
+    var userClickedExistingPoint = false;
 
     if (features.length < 1) {
-        return false;
-    }
-
-    if ((features.length === 1) && (this.pointEntities.entities.values.indexOf(features[0]) === -1)) {
-        // Damn leaflet sometimes puts in a feature that is not in our list.
-        return false;
+        return userClickedExistingPoint;
     }
 
     var that = this;
 
     features.forEach((feature)=> {
-        var index = this.pointEntities.entities.values.indexOf(feature);
+        var index = -1;
+        for (var i=0; i<this.pointEntities.entities.values.length; i++) {
+            var pointFeature = this.pointEntities.entities.values[i];
+            if (pointFeature.id === feature.id) {
+                index = i;
+                break;
+            }
+        }
 
-        // Index is zero if it's the first point, meaning we have a closed shape
-        if (index === 0 && !this.closeLoop && this.allowPolygon) {
+        if (index === -1) {
+            // Probably a layer or feature that has nothing to do with what we're drawing.
+            return;
+        } else if (index === 0 && !this.closeLoop && this.allowPolygon) {
+            // Index is zero if it's the first point, meaning we have a closed shape
             this.polygon = this.otherEntities.entities.add({
                     name: 'User polygon',
                     polygon: {
@@ -400,9 +406,10 @@ UserDrawing.prototype._clickedExistingPoint = function(features) {
             if (typeof that.onPointClicked === "function") {
                 that.onPointClicked(that.pointEntities);
             }
+            userClickedExistingPoint = true;
             return;
-        }
-        else {
+        } else {
+            // User clicked on a point that's not the end of the loop. Remove it.
             this.pointEntities.entities.remove(feature);
             // If it gets down to 2 points, it should stop acting like a polygon.
             if (this.pointEntities.entities.values.length < 2 && this.closeLoop) {
@@ -413,10 +420,11 @@ UserDrawing.prototype._clickedExistingPoint = function(features) {
             if (typeof that.onPointClicked === "function") {
                 that.onPointClicked(that.pointEntities);
             }
+            userClickedExistingPoint = true;
             return;
         }
     });
-    return true;
+    return userClickedExistingPoint;
 };
 
 


### PR DESCRIPTION
ID of feature created from entity now matches id of entity, so stored entities can be compared to newly clicked ones. 

Also handle case in UserDrawing where feature clicked has nothing to do with line/polygon better.
