### PR TITLE
Make URL to serverconfig service configurable.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 4.3.1
+
+* Added the ability to specify the URL to the `serverConfig` service in `config.json` as `parameters.serverConfigUrl`.
+
 ### 4.3.0
 
 * Added `Terria.batchGeocoder` property.  If set, the batch geocoder is used to resolve addresses in CSV files so that they can be shown as points on the map.

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -419,7 +419,7 @@ Terria.prototype.start = function(options) {
 
         that.serverConfig = new ServerConfig();
         let serverConfig;
-        return that.serverConfig.init().then(function() {
+        return that.serverConfig.init(cp.serverConfigUrl).then(function() {
             // All the "proxyableDomains" bits here are due to a pre-serverConfig mechanism for whitelisting domains.
             // We should deprecate it.
             var pdu = that.configParameters.proxyableDomainsUrl;


### PR DESCRIPTION
This is necessary for e.g. the Northern Australia map because the `serverconfig` service is found at `/serverconfig/` instead of at `/northernaustralia/serverconfig/`
