### PR TITLE
shorten url btn style

### DIFF
--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
@@ -148,9 +148,7 @@ const SharePanel = React.createClass({
                         </div>
                         <If condition={this.isUrlShortenable()}>
                             <div className={classNames(DropdownStyles.section, Styles.shortenUrl)}>
-                                <button
-                                    className={classNames(Styles.btn, {[Styles.btnCheckboxOn]: this.shouldShorten(), [Styles.btnCheckboxOff]: !this.shouldShorten()})}
-                                    onClick={this.onShortenClicked}>
+                                <button onClick={this.onShortenClicked}>
                                     {this.shouldShorten() ? <Icon glyph={Icon.GLYPHS.checkboxOn}/> : <Icon glyph={Icon.GLYPHS.checkboxOff}/>}
                                     Shorten the share URL using a web service
                                 </button>

--- a/lib/ReactViews/Map/Panels/SharePanel/share-panel.scss
+++ b/lib/ReactViews/Map/Panels/SharePanel/share-panel.scss
@@ -48,6 +48,8 @@
 .shorten-url {
   button {
     text-align: left;
+    border: 0px;
+    background: transparent;
   }
   svg{
     display: inline;


### PR DESCRIPTION
I can't actually test this on my local, can someone test this please? 
Problem is: 
<img width="300" alt="screen shot 2016-08-26 at 9 35 18 am" src="https://cloud.githubusercontent.com/assets/7508939/17990371/5fca7d64-6b78-11e6-9b6d-a09438992029.png">
should be:
<img width="303" alt="screen shot 2016-08-26 at 10 32 30 am" src="https://cloud.githubusercontent.com/assets/7508939/17990374/6c7a848c-6b78-11e6-9683-1309ecff8b20.png">
