### PR TITLE
add padding

### DIFF
--- a/lib/ReactViews/FeatureInfo/feature-info-section.scss
+++ b/lib/ReactViews/FeatureInfo/feature-info-section.scss
@@ -49,6 +49,7 @@
     border-collapse: collapse;
     border: 1px solid $dark;
     font-size: 13px;
+    padding: 5px;
   }
 }
 


### PR DESCRIPTION
Add a bit padding to `td` in feature info panel to improve readability,
<img width="576" alt="screen shot 2016-08-26 at 12 51 54 pm" src="https://cloud.githubusercontent.com/assets/7508939/17992566/f1cdc000-6b8b-11e6-81b2-fb5d3b786781.png">

before 
<img width="562" alt="screen shot 2016-08-26 at 12 52 07 pm" src="https://cloud.githubusercontent.com/assets/7508939/17992568/f44d62ea-6b8b-11e6-962b-3d5fab4f5469.png">

https://github.com/TerriaJS/nationalmap/blob/master/lib/Views/global.scss#L26
 is no longer needed with this change: 
