### PR TITLE
Allow drag-and-droppable moving point csvs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Fixed a bug which caused Cesium to crash when plotting a CSV with non-numerical data in the depth column.
 * Refactored Csv, AbsItt and Sdmx-Json catalog items to depend on a common `TableCatalogItem`. Deprecated `CsvCatalogItem.setActiveTimeColumn` in favour of `tableStructure.setActiveTimeColumn`.
 * Fixed css styling of the timeline and added padding to the feature info panel.
+* Default to moving feature csvs if a time, lat, lon and a column named `id` are present.
 
 ### 4.3.2
 

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -23,6 +23,8 @@ var TableStyle = require('../Models/TableStyle');
 var TerriaError = require('../Core/TerriaError');
 var VarType = require('../Map/VarType');
 
+var DEFAULT_ID_COLUMN = 'id';
+
 /**
  * An abstract {@link CatalogItem} representing tabular data.
  * Extend this class for csv or other data by providing two critical functions:
@@ -466,6 +468,7 @@ TableCatalogItem.prototype.initializeFromTableStructure = function(tableStructur
         });
     }
     if (tableStructure.hasLatitudeAndLongitude) {
+        setDefaultIdColumns(item, tableStructure);
         return createDataSourceForLatLong(item, tableStructure);
     }
     var regionMapping = new RegionMapping(item, tableStructure, item._tableStyle);
@@ -494,6 +497,15 @@ TableCatalogItem.prototype.initializeFromTableStructure = function(tableStructur
         }
     });
 };
+
+function setDefaultIdColumns(item, tableStructure) {
+    if (!defined(item.idColumns) &&
+            defined(tableStructure.activeTimeColumn) &&
+            tableStructure.getColumnNames().indexOf(DEFAULT_ID_COLUMN) >= 0) {
+        item.idColumns = [DEFAULT_ID_COLUMN];
+        tableStructure.idColumnNames = item.idColumns;
+    }
+}
 
 /**
  * Creates a datasource based on tableStructure provided and adds it to item. Suitable for TableStructures that contain


### PR DESCRIPTION
Defaults to moving feature csvs if a time, lat, lon and a column named `id` are present. 

Fixes #1998.
