### PR TITLE
Fixes polling for lat/lon csvs (we broke it accidentally)

### DIFF
--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -511,6 +511,7 @@ function createDataSourceForLatLong(item, tableStructure) {
     // Activate a column. This needed to wait until we had a dataSource, so it can trigger the legendHelper build.
     item.activateColumnFromTableStyle();
     ensureActiveColumn(tableStructure);
+    item.startPolling();
     return when(true); // We're done - nothing to wait for.
 }
 


### PR DESCRIPTION
We accidentally dropped the call to `startPolling` when we merged gnaf support and my TableCatalogItem change. This puts it back.
