### PR TITLE
Show contextItem during location selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Improved rendering speed when changing the display variable for large lat/lon csv files.
 * Default to moving feature csvs if a time, lat, lon and a column named `id` are present.
 * Fixed a bug so units flow through to charts of moving csv features.
+* ContextItem now shown during location selection.
 
 ### 4.3.2
 

--- a/lib/ReactViews/Analytics/InvokeFunction.jsx
+++ b/lib/ReactViews/Analytics/InvokeFunction.jsx
@@ -4,7 +4,6 @@ import ParameterEditor from './ParameterEditor';
 import when from 'terriajs-cesium/Source/ThirdParty/when';
 import TerriaError from '../../Core/TerriaError';
 import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
-import defined from 'terriajs-cesium/Source/Core/defined';
 import Styles from './invoke-function.scss';
 
 const InvokeFunction = React.createClass({
@@ -14,20 +13,6 @@ const InvokeFunction = React.createClass({
         terria: React.PropTypes.object,
         previewed: React.PropTypes.object,
         viewState: React.PropTypes.object
-    },
-
-    componentWillMount() {
-        this.enableContextItem(this.props);
-    },
-
-    componentWillUnmount() {
-        this.removeContextItem();
-    },
-
-    componentWillReceiveProps(nextProps) {
-        // This will be called when component is already mounted but props change, for example if you go from one WPS
-        // item to another.
-        this.enableContextItem(nextProps);
     },
 
     submit() {
@@ -51,21 +36,6 @@ const InvokeFunction = React.createClass({
                 this.props.previewed.terria.error.raiseEvent(e);
             }
             return undefined;
-        }
-    },
-
-    enableContextItem(props) {
-        this.removeContextItem();
-        if (defined(props.previewed.contextItem)) {
-            props.previewed.contextItem.isEnabled = true;
-            this._lastContextItem = props.previewed.contextItem;
-        }
-    },
-
-    removeContextItem() {
-        if (defined(this._lastContextItem)) {
-            this._lastContextItem.isEnabled = false;
-            this._lastContextItem = undefined;
         }
     },
 

--- a/lib/ReactViews/Notification/MapInteractionWindow.jsx
+++ b/lib/ReactViews/Notification/MapInteractionWindow.jsx
@@ -5,12 +5,43 @@ import React from 'react';
 import parseCustomHtmlToReact from '../Custom/parseCustomHtmlToReact';
 import Styles from './map-interaction-window.scss';
 import classNames from 'classnames';
+import defined from 'terriajs-cesium/Source/Core/defined';
 
 const MapInteractionWindow = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object
+        terria: React.PropTypes.object,
+        viewState: React.PropTypes.object
+    },
+
+    componentWillUnmount() {
+        this.removeContextItem();
+    },
+
+    componentWillReceiveProps(nextProps) {
+        // Only enable context item if MapInteractionWindow is rendering
+        const interactionMode = this.props.terria.mapInteractionModeStack && this.props.terria.mapInteractionModeStack[this.props.terria.mapInteractionModeStack.length - 1];
+        if (defined(interactionMode)) {
+            this.enableContextItem(nextProps);
+        } else {
+            this.removeContextItem();
+        }
+    },
+
+    enableContextItem(props) {
+        this.removeContextItem();
+        if (defined(props.viewState.previewedItem) && defined(props.viewState.previewedItem.contextItem)) {
+            props.viewState.previewedItem.contextItem.isEnabled = true;
+            this._lastContextItem = props.viewState.previewedItem.contextItem;
+        }
+    },
+
+    removeContextItem() {
+        if (defined(this._lastContextItem)) {
+            this._lastContextItem.isEnabled = false;
+            this._lastContextItem = undefined;
+        }
     },
 
     render() {

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -143,7 +143,7 @@ const StandardUserInterface = React.createClass({
                 </If>
 
                 <Notification viewState={this.props.viewState}/>
-                <MapInteractionWindow terria={terria}/>
+                <MapInteractionWindow terria={terria} viewState={this.props.viewState}/>
 
                 <If condition={this.props.terria.configParameters.feedbackUrl && !this.props.viewState.hideMapUi()}>
                     <aside className={Styles.feedback}>


### PR DESCRIPTION
Fixes #1942. It seems that the contextItem was displayed according to whether the invokeFunction panel was displayed, but when location selection occurs, this is hidden. I think it should instead be the responsibility of MapInteractionWindow, which controls all location selection (point, line, rectangle, polygon). 
