### PR TITLE
Fix legend for column with all null replaced values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 ### 4.5.0
 
 * Added the ability to drag existing points when creating a `UserDrawing`.
+* Fixed a bug that could cause nonsensical legends for CSV columns with all null values.
 
 ### 4.4.1
 

--- a/lib/Map/TableColumn.js
+++ b/lib/Map/TableColumn.js
@@ -93,13 +93,15 @@ var TableColumn = function(name, values, options) {
         this.setTypeAndSubTypeFromName();
     }
 
-    if ((this._type === VarType.SCALAR) && (this._numericalValues.length > 0)) {
+    var isNumerical = function(value) { return typeof value === 'number'; };
+
+    if ((this._type === VarType.SCALAR) && (values.some(isNumerical))) {
         // Before setting this._values, replace '-' and 'NA' etc with zero/null. Min/max values ignore nulls.
         this._values = replaceValues(values, this._replaceWithZeroValues, this._replaceWithNullValues);
     } else {
         this._values = values;
     }
-    this._numericalValues = this._values && this._values.filter(function(value) { return typeof value === 'number'; });
+    this._numericalValues = this._values && this._values.filter(isNumerical);
 
     var nonNullValues = this._values.filter(function(value) {return value !== null;});
     this._minimumValue = Math.min.apply(null, nonNullValues);  // Note: a single NaN value makes this NaN (hence replaceValues above).

--- a/lib/Map/TableColumn.js
+++ b/lib/Map/TableColumn.js
@@ -93,13 +93,14 @@ var TableColumn = function(name, values, options) {
         this.setTypeAndSubTypeFromName();
     }
 
-    this._numericalValues = values && values.filter(function(value) { return typeof value === 'number'; });
     if ((this._type === VarType.SCALAR) && (this._numericalValues.length > 0)) {
         // Before setting this._values, replace '-' and 'NA' etc with zero/null. Min/max values ignore nulls.
         this._values = replaceValues(values, this._replaceWithZeroValues, this._replaceWithNullValues);
     } else {
         this._values = values;
     }
+    this._numericalValues = this._values && this._values.filter(function(value) { return typeof value === 'number'; });
+
     var nonNullValues = this._values.filter(function(value) {return value !== null;});
     this._minimumValue = Math.min.apply(null, nonNullValues);  // Note: a single NaN value makes this NaN (hence replaceValues above).
     this._maximumValue = Math.max.apply(null, nonNullValues);

--- a/lib/Models/LegendHelper.js
+++ b/lib/Models/LegendHelper.js
@@ -456,6 +456,10 @@ function buildBinColors(legendHelper, colorBins) {
     var i;
     var numericalValues = tableColumn.numericalValues;
 
+    if (numericalValues.length === 0) {
+        return [];
+    }
+
     // Must ask for fewer clusters than the number of items.
     var binCount = Math.min(colorBins, numericalValues.length);
 

--- a/test/Map/TableColumnSpec.js
+++ b/test/Map/TableColumnSpec.js
@@ -28,6 +28,12 @@ describe('TableColumn', function() {
         expect(tableColumn.type).toEqual(VarType.SCALAR);
     });
 
+    it('replaces null values before generating numericalValues', function() {
+        var data = [0,0,0];
+        var tableColumn = new TableColumn('x', data.slice(), {replaceWithNullValues: [0]});
+        expect(tableColumn.numericalValues.slice()).toEqual([]);
+    });
+
     it('treats hyphens, blanks and NA as strings in string data', function() {
         var data = ['%', '-', '!', 'NA', ''];
         var tableColumn = new TableColumn('x', data.slice());

--- a/wwwroot/test/init/csv.json
+++ b/wwwroot/test/init/csv.json
@@ -138,6 +138,15 @@
                     "nullLabel": "blank"
                 }
             },
+             {
+                "name": "CSV with all values replaced with null",
+                "type": "csv",
+                "data": "longitude,latitude,val\n134,-26,0\n121,-33,\n124,-32,",
+                "tableStyle": {
+                    "replaceWithNullValues": [0],
+                    "nullLabel": "blank"
+                }
+            },
             {
                 "name": "CSV with explicit enum colors",
                 "type": "csv",


### PR DESCRIPTION
Changing the order of null replacements and the generation of `numericalValues` leads to several improvements including not running ckmeans/quantile on null values, and it also fixes the following legend bug:

![pasted image at 2016_09_13 17_40](https://cloud.githubusercontent.com/assets/13863530/18467741/8eeab44a-79e4-11e6-954e-3c2900f98470.png)
