### PR TITLE
Show the x-axis ticks in the feature info panel, if no x-label available

### DIFF
--- a/lib/Charts/LineChart.js
+++ b/lib/Charts/LineChart.js
@@ -279,13 +279,14 @@ function render(element, state) {
         // Recall the x-axis-grid lines only extended up; we need to translate the ticks down to the bottom of the plot.
         g.selectAll('.x.axis line').attr('transform', 'translate(0,' + (size.plotHeight - y0) + ')');
     }
-    // If mini or no data, hide the ticks, but not the axis, so the x-axis label can still be shown.
+    // If mini with label, or no data: hide the ticks, but not the axis, so the x-axis label can still be shown.
+    var hasXLabel = defined(state.axisLabel) && defined(state.axisLabel.x);
     g.select('.x.axis')
         .selectAll('.tick')
         .transition(t)
-        .style('opacity', (state.mini || !hasData) ? 1e-6 : 1);
+        .style('opacity', ((state.mini && hasXLabel) || !hasData) ? 1e-6 : 1);
 
-    if (defined(state.axisLabel) && defined(state.axisLabel.x)) {
+    if (hasXLabel) {
         g.select('.x.axis .label')
             .style('text-anchor', 'middle')
             .text(state.axisLabel.x)


### PR DESCRIPTION
Fixes #2058, eg.
![image](https://cloud.githubusercontent.com/assets/1757858/18496693/4478a962-7a6b-11e6-9138-e5120a076afd.png)
but if an x-label is provided we get that instead, eg.
![image](https://cloud.githubusercontent.com/assets/1757858/18496958/d84cf51a-7a6d-11e6-8698-19511372811b.png)
