### PR TITLE
Assign explicit keys to elements in repeated <Choose>s.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 * Added the ability to pass a LineString to a Web Processing Service.
 * Uses a smarter default column for csv files.
 * Fixed a bug that caused an error message to appear repeatedly when there was an error downloading tiles for a base map.
+* Fixed a bug that caused WMS layer names and WFS type names to not be displayed on the dataset info page.
 
 ### 4.3.3
 

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -76,14 +76,14 @@ const MappablePreview = React.createClass({
                                 <h4 className={Styles.h4}>{catalogItem.typeName} URL</h4>
                                 <Choose>
                                     <When condition={catalogItem.type === 'wms'}>
-                                        <p>
+                                        <p key="wms-description">
                                             This is a <a href="https://en.wikipedia.org/wiki/Web_Map_Service" target="_blank">WMS
                                             service</a>, which generates map images on request. It can be used in GIS software with this
                                             URL:
                                         </p>
                                     </When>
                                     <When condition={catalogItem.type === 'wfs'}>
-                                        <p>
+                                        <p key="wfs-description">
                                             This is a <a href="https://en.wikipedia.org/wiki/Web_Feature_Service" target="_blank">WFS
                                             service</a>, which transfers raw spatial data on request. It can be used in GIS software with this
                                             URL:
@@ -99,12 +99,12 @@ const MappablePreview = React.createClass({
 
                                 <Choose>
                                     <When condition={catalogItem.type === 'wms' || (catalogItem.type === 'esri-mapServer' && typeof catalogItem.layers !== 'undefined')}>
-                                        <p>
+                                        <p key="wms-layers">
                                             Layer name{catalogItem.layers.split(',').length > 1 ? 's' : ''}: {catalogItem.layers}
                                         </p>
                                     </When>
                                     <When condition={catalogItem.type === 'wfs'}>
-                                        <p>
+                                        <p key="wfs-typeNames">
                                             Type name{catalogItem.typeNames.split(',').length > 1 ? 's' : ''}: {catalogItem.typeNames}
                                         </p>
                                     </When>


### PR DESCRIPTION
This avoids a warning from React and also causes the WMS styles and WFS typenames to actually show up on the dataset info page.
