### PR TITLE
Fix issue where generic parameters not passed to wps service

### DIFF
--- a/lib/ReactViews/Analytics/GenericParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/GenericParameterEditor.jsx
@@ -11,7 +11,7 @@ const GenericParameterEditor = React.createClass({
     },
 
     onChange(e) {
-        this.props.previewed.setParameterValues(this.props.parameter.id, e.target.value);
+        this.props.previewed.setParameterValue(this.props.parameter.id, e.target.value);
     },
 
     render() {


### PR DESCRIPTION
After this fix, any input entered into GenericParameterEditor input fields is passed to the WPS service.
