### PR TITLE
Improve handling of active time columns with changing table data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Change Log
 * Fixed a bug that caused WMS layer names and WFS type names to not be displayed on the dataset info page.
 * We now preserve the state of the feature information panel when sharing.  This was lost in the transition to the new user interface in 4.0.0.
 * Fixed bug where generic parameters such as strings were not passed through to WPS services.
+* Fixed a bug where the chart panel did not update with polled data files.
 
 ### 4.3.3
 

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -700,11 +700,13 @@ TableStructure.prototype.setActiveTimeColumn = function(nameIdOrIndex) {
  * Sorts the rows of the TableStructure by the provided column's values.
  * If the sortColumn is a date/time column, uses its julianDates to sort; otherwise, the values.
  * The tableStructure is given new TableColumns.
+ * If the tableStructure has an activeTimeColumn, it is remapped to the new, sorted, column.
  * @param {TableColumn} sortColumn Column whose values should be sorted.
  * @param {Function} [compareFunction] The compare function passed to Array.prototype.sort().
  */
 TableStructure.prototype.sortBy = function(sortColumn, compareFunction) {
     // With help from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+    var activeTimeColumnIndex = this.columns.indexOf(this.activeTimeColumn);  // We'll need to update this at the end.
     var mappedArray = sortColumn.julianDatesOrValues.map(function(value, i) {
       return { index: i, value: value };
     });
@@ -720,7 +722,11 @@ TableStructure.prototype.sortBy = function(sortColumn, compareFunction) {
         var sortedValues = mappedArray.map(element => column.values[element.index]);
         return new TableColumn(column.name, sortedValues, column.getFullOptions());
     });
+    this.activeTimeColumn = undefined;
     this.columns = sortedColumns;
+    if (activeTimeColumnIndex >= 0) {
+        this.activeTimeColumn = this.columns[activeTimeColumnIndex];
+    }
 };
 
 /**

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -61,11 +61,10 @@ var TableStructure = function(name, options) {
     this.toggleActiveCallback = undefined;
 
     /**
-     * Gets or sets the active time column for this structure,
-     * @memberOf TableStructure.prototype
-     * @type {TableColumn}
+     * Gets or sets the active time column name, id or index.
+     * @type {String|Number|undefined}
      */
-    this.activeTimeColumn = undefined;
+    this.activeTimeColumnNameIdOrIndex = undefined;
 
     // Track sourceFeature as it is shown on the NowViewing panel.
     // Track items so that charts can update live. (Already done by DisplayVariableConcept.)
@@ -126,6 +125,19 @@ defineProperties(TableStructure.prototype, {
         get: function() {
             var address = this.columnsByType[VarType.ADDR][0];
             return (defined(address));
+        }
+    },
+
+    /**
+     * Gets the active time column for this structure.
+     * @memberOf TableStructure.prototype
+     * @type {TableColumn}
+     */
+    activeTimeColumn: {
+        get: function() {
+            if (defined(this.activeTimeColumnNameIdOrIndex)) {
+                return this.getColumnWithNameIdOrIndex(this.activeTimeColumnNameIdOrIndex);
+            }
         }
     }
 });
@@ -617,8 +629,6 @@ TableStructure.prototype.append = function(table2, rowNumbers) {
         updatedColumns.push(new TableColumn(column.name, updatedColumnValuesArrays[columnNumber], column.getFullOptions()));
         return updatedColumns;
     }, []);
-    // activeTimeColumn is not tracked, but columns are, so change activeTimeColumn first.
-    this.activeTimeColumn = getColumnWithSameId(this.activeTimeColumn, updatedColumns);
     this.columns = updatedColumns;
 };
 
@@ -709,19 +719,29 @@ TableStructure.prototype.merge = function(table2) {
 
 /**
  * Sets the relevant active time column on the table structure, defaulting to the first time column present
- * unless the tableStyle has a 'timeColumn' property.
+ * unless the tableStyle has a 'timeColumn' property. A null timeColumn should explicitly not have a time column, even if one is present.
  * @param {String|Number|undefined} nameIdOrIndex A way to identify the column, eg. from tableStyle.timeColumn.
  */
 TableStructure.prototype.setActiveTimeColumn = function(nameIdOrIndex) {
-    var tableStructure = this;
+
+    function getIndexOfFirstTimeColumn(columns) {
+        var index;
+        for (var i = columns.length - 1; i >= 0; i--) {
+            if (columns[i].type === VarType.TIME) {
+                index = i;
+            }
+        }
+        return index;
+    }
+    // undefined should default to the first time column, null should explicitly have no time column.
     if (typeof nameIdOrIndex !== 'undefined') {
-        tableStructure.activeTimeColumn = tableStructure.getColumnWithNameIdOrIndex(nameIdOrIndex);
-        if (defined(tableStructure.activeTimeColumn) && tableStructure.activeTimeColumn.type !== VarType.TIME) {
-            tableStructure.activeTimeColumn = tableStructure.columnsByType[VarType.TIME][0];
+        this.activeTimeColumnNameIdOrIndex = nameIdOrIndex;
+        if (defined(this.activeTimeColumn) && this.activeTimeColumn.type !== VarType.TIME) {
+            this.activeTimeColumnNameIdOrIndex = getIndexOfFirstTimeColumn(this.columns);
             throw new DeveloperError('"' + nameIdOrIndex + '" is not a valid time column.');
         }
     } else {
-        tableStructure.activeTimeColumn = tableStructure.columnsByType[VarType.TIME][0];
+        this.activeTimeColumnNameIdOrIndex = getIndexOfFirstTimeColumn(this.columns);
     }
 };
 
@@ -729,13 +749,11 @@ TableStructure.prototype.setActiveTimeColumn = function(nameIdOrIndex) {
  * Sorts the rows of the TableStructure by the provided column's values.
  * If the sortColumn is a date/time column, uses its julianDates to sort; otherwise, the values.
  * The tableStructure is given new TableColumns.
- * If the tableStructure has an activeTimeColumn, it is remapped to the new, sorted, column.
  * @param {TableColumn} sortColumn Column whose values should be sorted.
  * @param {Function} [compareFunction] The compare function passed to Array.prototype.sort().
  */
 TableStructure.prototype.sortBy = function(sortColumn, compareFunction) {
     // With help from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
-    var activeTimeColumnIndex = this.columns.indexOf(this.activeTimeColumn);  // We'll need to update this at the end.
     var mappedArray = sortColumn.julianDatesOrValues.map(function(value, i) {
       return { index: i, value: value };
     });
@@ -756,11 +774,7 @@ TableStructure.prototype.sortBy = function(sortColumn, compareFunction) {
         var sortedValues = mappedArray.map(element => column.values[element.index]);
         return new TableColumn(column.name, sortedValues, column.getFullOptions());
     });
-    this.activeTimeColumn = undefined;
     this.columns = sortedColumns;
-    if (activeTimeColumnIndex >= 0) {
-        this.activeTimeColumn = this.columns[activeTimeColumnIndex];
-    }
 };
 
 /**

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -472,6 +472,9 @@ TableCatalogItem.prototype.initializeFromTableStructure = function(tableStructur
     // Sort by the active time column, if available (so charts and derived charts don't double-back on themselves).
     if (defined(tableStructure.activeTimeColumn)) {
         // Note this means we wind up calculating the availabilities in TableColumn twice, which is unnecessarily slow.
+        // Rather than adding complexity to CsvCatalogItem to turn off that calculation initially, and then add it back here,
+        // it may be better to refactor the availability calculation out of TableColumn, as part of the fix for
+        // https://github.com/TerriaJS/terriajs/issues/2018.
         tableStructure.sortBy(tableStructure.activeTimeColumn);
     }
     item._tableStructure = tableStructure;

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -467,13 +467,13 @@ TableCatalogItem.applyTableStyleColumnsToStructure = function(tableStyle, tableS
 TableCatalogItem.prototype.initializeFromTableStructure = function(tableStructure) {
     var item = this;
     var tableStyle = item._tableStyle;
-    // Sort by the time column, if available (so charts and derived charts don't double-back on themselves).
-    var timeColumns = tableStructure.columnsByType[VarType.TIME];
-    if (timeColumns.length > 0) {
-        tableStructure.sortBy(timeColumns[0]);
-    }
 
     tableStructure.setActiveTimeColumn(tableStyle.timeColumn);
+    // Sort by the active time column, if available (so charts and derived charts don't double-back on themselves).
+    if (defined(tableStructure.activeTimeColumn)) {
+        // Note this means we wind up calculating the availabilities in TableColumn twice, which is unnecessarily slow.
+        tableStructure.sortBy(tableStructure.activeTimeColumn);
+    }
     item._tableStructure = tableStructure;
 
     function makeChartable() {

--- a/test/Map/TableStructureSpec.js
+++ b/test/Map/TableStructureSpec.js
@@ -312,7 +312,7 @@ describe('TableStructure', function() {
         var table2 = new TableStructure('bar');  // Only uses idColumnNames on table1.
         table1 = table1.loadFromJson(data);
         table2 = table2.loadFromJson(dat2);
-        table1.activeTimeColumn = table1.columns[0];
+        table1.setActiveTimeColumn(0);
         table1.columns[1].isActive = true;
         table1.columns[1].color = 'blue';
         table1.merge(table2);

--- a/test/Models/TableDataSourceSpec.js
+++ b/test/Models/TableDataSourceSpec.js
@@ -4,7 +4,6 @@
 var loadText = require('terriajs-cesium/Source/Core/loadText');
 var TableDataSource = require('../../lib/Models/TableDataSource');
 var TableStyle = require('../../lib/Models/TableStyle');
-var VarType = require('../../lib/Map/VarType');
 
 
 describe('TableDataSource', function() {

--- a/test/Models/TableDataSourceSpec.js
+++ b/test/Models/TableDataSourceSpec.js
@@ -36,7 +36,7 @@ describe('TableDataSource', function() {
     it('sets the clock when there is an active date column', function(done) {
         loadText('/test/csv/lat_long_enum_moving_date.csv').then(function(text) {
             tableDataSource.loadFromCsv(text);
-            tableDataSource.tableStructure.activeTimeColumn = tableDataSource.tableStructure.columnsByType[VarType.TIME][0];
+            tableDataSource.tableStructure.setActiveTimeColumn();
             expect(tableDataSource.clock).toBeDefined();
         }).then(done).otherwise(done.fail);
     });
@@ -63,7 +63,7 @@ describe('TableDataSource', function() {
             tableDataSource.loadFromCsv(text); // at this point, there's no active time column, so we'll see 13 features, one per row.
             var features = tableDataSource.entities.values;
             expect(features.length).toEqual(13);
-            tableDataSource.tableStructure.activeTimeColumn = tableDataSource.tableStructure.columnsByType[VarType.TIME][0];
+            tableDataSource.tableStructure.setActiveTimeColumn();
             tableDataSource.tableStructure.columns[5].isActive = true; // Just to trigger the feature update process
             expect(tableDataSource.clock).toBeDefined();
             features = tableDataSource.entities.values;


### PR DESCRIPTION
An earlier PR introduced sorting of all tables by their time column, if they had any.  This is a good idea, so charts appear with ordered x-axes.
However, it has the (unproven) potential to interact badly with polled csvs, where features are identified by row number - which is currently the situation with aremi's power stations csv. This csv has a time column, but it is not an active time column - it gives the date of the last generation data.

This PR only sorts by an _active_ time column.

It also cleans up a potential problem where a pre-existing active time column would be left stranded after sorting.
