### PR TITLE
Made newly added user data get selected in preview map

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
 * We now preserve the state of the feature information panel when sharing.  This was lost in the transition to the new user interface in 4.0.0.
 * Fixed bug where generic parameters such as strings were not passed through to WPS services.
 * Removed the Australian Hydrography layer, as the source is no longer available.
+* Newly-added user data is now automatically selected for the preview map.
 
 ### 4.3.3
 

--- a/lib/ReactViews/DragDropFile.jsx
+++ b/lib/ReactViews/DragDropFile.jsx
@@ -22,6 +22,7 @@ const DragDropFile = React.createClass({
             .then(addedCatalogItems => {
                 if (addedCatalogItems.length > 0) {
                     this.props.viewState.myDataIsUploadView = false;
+                    this.props.viewState.viewCatalogItem(addedCatalogItems[0]);
                 }
             });
 

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -59,7 +59,7 @@ const AddData = React.createClass({
         addUserFiles(e.target.files, this.props.terria, this.props.viewState, this.state.localDataType)
             .then(addedCatalogItems => {
                 if (addedCatalogItems.length > 0) {
-                    this.props.viewState.myDataIsUploadView = false;
+                    this.onFileAddFinished(addedCatalogItems[0]);
                 }
             });
 
@@ -83,19 +83,20 @@ const AddData = React.createClass({
         }
         addUserCatalogMember(this.props.terria, promise).then(addedItem => {
             if (addedItem && !(addedItem instanceof TerriaError)) {
-                this.props.viewState.myDataIsUploadView = false;
+                this.onFileAddFinished(addedItem);
             }
         });
+    },
+
+    onFileAddFinished(fileToSelect) {
+        this.props.viewState.myDataIsUploadView = false;
+        this.props.viewState.viewCatalogItem(fileToSelect);
     },
 
     onRemoteUrlChange(event) {
         this.setState({
             remoteUrl: event.target.value
         });
-    },
-
-    onFinishDroppingFile() {
-        this.props.viewState.isDraggingDroppingFile = false;
     },
 
     renderTabs() {

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -48,8 +48,10 @@ const MyDataTab = React.createClass({
                     </If>
                     <If condition={this.hasUserAddedData()}>
                         <div className={Styles.addedData}>
-                            <p className={Styles.explanation}>Data added in this way is not saved or made visible to others unless you explicitly share
-                                it by using the Share panel. </p>
+                            <p className={Styles.explanation}>
+                                Data added in this way is not saved or made visible to others unless you explicitly share
+                                it by using the Share panel.
+                            </p>
                             <ul className={Styles.dataCatalog}>
                                 <DataCatalogGroup group={this.props.terria.catalog.userAddedDataGroup}
                                                   viewState={this.props.viewState}/>


### PR DESCRIPTION
Fixes #2057. Simply selects newly added data items. If multiple are added, selects the first.
