### PR TITLE
Fix 3 issues: time-varying csvs & feature info charts, polled csvs & feature info, missing data in charts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Change Log
 * Newly-added user data is now automatically selected for the preview map.
 * Fixed a bug where selecting a new column on a moving point csv file did not update the chart in the feature info panel.
 * Fixed dropdowns dropping from the bounds of the screen in safari.
+* Fixed a bug which prevented the feature info panel from updating with polled lat/lon csvs.
 
 ### 4.3.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Change Log
 * Fixed bug where generic parameters such as strings were not passed through to WPS services.
 * Removed the Australian Hydrography layer, as the source is no longer available.
 * Newly-added user data is now automatically selected for the preview map.
+* Fixed a bug where selecting a new column on a moving point csv file did not update the chart in the feature info panel.
 
 ### 4.3.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Change Log
 * Fixed a bug where selecting a new column on a moving point csv file did not update the chart in the feature info panel.
 * Fixed dropdowns dropping from the bounds of the screen in safari.
 * Fixed a bug which prevented the feature info panel from updating with polled lat/lon csvs.
+* Improved handing of missing data in charts, so that it is ignored instead of shown as 0.
 
 ### 4.3.3
 

--- a/lib/Charts/LineChart.js
+++ b/lib/Charts/LineChart.js
@@ -170,10 +170,12 @@ function render(element, state) {
         .on('mouseover', fade(g, 0.33))
         .on('mouseout', fade(g, 1));
 
-    // update
+    // Update.
+    // If there are undefined or null y-values, just ignore them. This works well for initial and final undefined values,
+    // and simply interpolates over intermediate ones. This may not be what we want.
     lines
         .transition(t)
-        .attr('d', line => getPathForUnits(line.units || Scales.unknownUnits)(line.points))
+        .attr('d', line => getPathForUnits(line.units || Scales.unknownUnits)(line.points.filter(point => defined(point.y))))
         .style('opacity', 1)
         .style('stroke', d => defined(d.color) ? d.color : '');
 

--- a/lib/Models/Polling.js
+++ b/lib/Models/Polling.js
@@ -14,7 +14,7 @@ import updateFromJson from '../Core/updateFromJson';
  * @param {Object} [options] The values of the properties of the new instance.
  * @param {String|Number} [options.seconds] The number of seconds to wait before polling for new data.
  * @param {String} [options.url] The URL from which to poll for new data.
- * @param {Boolean} [options.replace] Should the newly polled data replace the existing data (true), or update it (false)?
+ * @param {Boolean} [options.replace] Should the newly polled data replace the existing data (true), or be appended to it (false)?
  */
 var Polling = function(options) {
 
@@ -39,7 +39,7 @@ var Polling = function(options) {
     this.url = options.url;
 
     /**
-     * Gets or sets a flag which says whether polled data should replace the existing data, or update it.
+     * Gets or sets a flag which says whether polled data should replace the existing data, or appended to it.
      * If defined, the data received is added to the existing TableStructure. Otherwise, it replaces the TableStructure.
      * @type {Boolean}
      * @default false

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -576,7 +576,7 @@ function setDefaultIdColumns(item, tableStructure) {
  */
 function createDataSourceForLatLong(item, tableStructure) {
     // Create the TableDataSource and save it to item._dataSource.
-    item._dataSource = new TableDataSource(tableStructure, item._tableStyle, item.name);
+    item._dataSource = new TableDataSource(tableStructure, item._tableStyle, item.name, (item.polling.seconds > 0));
     item._dataSource.changedEvent.addEventListener(dataChanged.bind(null, item), item);
     // Activate a column. This needed to wait until we had a dataSource, so it can trigger the legendHelper build.
     item.activateColumnFromTableStyle();

--- a/lib/ReactViews/Custom/Chart/Chart.jsx
+++ b/lib/ReactViews/Custom/Chart/Chart.jsx
@@ -79,7 +79,7 @@ const Chart = React.createClass({
         // Returns a promise that resolves to an array of ChartData.
         const that = this;
         if (defined(data)) {
-            // Nothing to do - the data was provided.
+            // Nothing to do - the data was provided (either as props.data or props.tableStructure).
             return when(data);
         } else if (defined(url)) {
             return loadIntoTableStructure(url)
@@ -88,10 +88,6 @@ const Chart = React.createClass({
                     // It looks better to create a blank chart than no chart.
                     return [];
                 });
-        } else if (defined(that.props.tableStructure)) {
-            // We were given a tableStructure, just convert it to a chartDataArray.
-            const chartDataArray = that.chartDataArrayFromTableStructure(that.props.tableStructure);
-            return when(chartDataArray);
         }
     },
 
@@ -129,7 +125,7 @@ const Chart = React.createClass({
     },
 
     componentDidUpdate() {
-        // Update the chart with props.data, if present.
+        // Update the chart with props.data or props.tableStructure, if present.
         // If the data came from a URL, there are three possibilities:
         // 1. The URL has changed.
         // 2. The URL is the same and therefore we do not want to reload it.
@@ -206,8 +202,15 @@ const Chart = React.createClass({
             margin = {top: 0, right: 0, bottom: 0, left: 0};
         }
 
+        let chartData;
+        if (defined(this.props.data)) {
+            chartData = this.props.data;
+        } else if (defined(this.props.tableStructure)) {
+            chartData = this.chartDataArrayFromTableStructure(this.props.tableStructure);
+        }
+
         return {
-            data: this.props.data,
+            data: chartData,
             domain: this.props.domain,
             width: '100%',
             height: defaultValue(this.props.height, defaultHeight),

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -444,7 +444,6 @@ function getTimeSeriesChartContext(catalogItem, feature, getChartData) {
                 const idAttribute = 'id="' + result.id + '" ';
                 const unitsAttribute = 'column-units = "' + result.units + '" ';
                 result.chart = '<chart ' + xAttribute + yAttribute + unitsAttribute + idAttribute + '>' + result.data + '</chart>';
-                console.log(result.chart);
                 return result;
             }
         }

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -444,6 +444,7 @@ function getTimeSeriesChartContext(catalogItem, feature, getChartData) {
                 const idAttribute = 'id="' + result.id + '" ';
                 const unitsAttribute = 'column-units = "' + result.units + '" ';
                 result.chart = '<chart ' + xAttribute + yAttribute + unitsAttribute + idAttribute + '>' + result.data + '</chart>';
+                console.log(result.chart);
                 return result;
             }
         }

--- a/wwwroot/test/csv/lat_lon_enum_date_id.csv
+++ b/wwwroot/test/csv/lat_lon_enum_date_id.csv
@@ -1,15 +1,15 @@
-lat,lon,enum,date,id,value
--36,145,foo,2015-08-01,feature A,13
--36,145,bar,2015-08-02,feature A,5
--36,145,foo,2015-08-04,feature A,15
--36,145,bar,2015-08-05,feature A,7
--36,145,foo,2015-08-06,feature A,10
--21,115,moving,2015-08-01,feature B,4
--37,136,foo,2015-08-02,feature B,15
--23,155,going!,2015-08-03,feature B,5
--33,130,bar,2015-08-04,feature B,14
--20,150,moving,2015-08-05,feature B,6
--37,140,going!,2015-08-06,feature B,13
--30,145.5,blip,2015-08-02,feature C,16
--33,140,blip,2015-08-03,feature D,16
-,144.5,gone,2015-08-05,feature D,14
+lat,lon,enum,date,id,value,level
+-36,145,foo,2015-08-01,feature A,13,50
+-36,145,bar,2015-08-02,feature A,5,60
+-36,145,foo,2015-08-04,feature A,15,70
+-36,145,bar,2015-08-05,feature A,7,55
+-36,145,foo,2015-08-06,feature A,10,66
+-21,115,moving,2015-08-01,feature B,4,33
+-37,136,foo,2015-08-02,feature B,15,55
+-23,155,going!,2015-08-03,feature B,5,41
+-33,130,bar,2015-08-04,feature B,14,22
+-20,150,moving,2015-08-05,feature B,6,77
+-37,140,going!,2015-08-06,feature B,13,47
+-30,145.5,blip,2015-08-02,feature C,16,10
+-33,140,blip,2015-08-03,feature D,16,50
+,144.5,gone,2015-08-05,feature D,14,80


### PR DESCRIPTION
Fixes three issues: 
- A new `props.tableStructure` on a Chart did not trigger a d3 update, which prevented Feature Info charts based on time-varying csvs from updating.
- Missing data in a chart was shown as 0. It is now ignored.
- Polled lat/lon csv files were not having their Feature Info panel update (eg. AREMI power stations).
