### PR TITLE
Stopped notification button clicks from propagating

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 
 * Added the ability to drag existing points when creating a `UserDrawing`.
 * Fixed a bug that could cause nonsensical legends for CSV columns with all null values.
+* Fixed a bug that prevented the Share panel from being used at all if the URL shortening service encountered an error.
 
 ### 4.4.1
 

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -17,13 +17,15 @@ const NotificationWindow = React.createClass({
         onDeny: React.PropTypes.func.isRequired
     },
 
-    confirm() {
+    confirm(e) {
+        e.stopPropagation();
         if (this.props.onConfirm) {
             this.props.onConfirm();
         }
     },
 
-    deny() {
+    deny(e) {
+        e.stopPropagation();
         if (this.props.onDeny) {
             this.props.onDeny();
         }


### PR DESCRIPTION
Fixes #1934. 

There are a number of elements on the screen that close if a click event happens outside them (dropdown panels), but also rely on the notification window to display errors. This results in fun situations like 1934, where if url shortening breaks then a message pops up, and if you dismiss the message it also closes the dropdown panel with the checkbox to turn off url shortening, thus preventing you from ever getting a share link.
