### PR TITLE
fixing catalog alignment

### DIFF
--- a/lib/ReactViews/DataCatalog/data-catalog-group.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog-group.scss
@@ -46,7 +46,7 @@
 
 .folder {
   position: absolute;
-  left: 0;
+  left: 8px;
   top: 5px;
   opacity: 0.5;
   svg{
@@ -88,7 +88,7 @@
   padding-left: $padding;
   padding-top: $padding / 2;
   &--lower-level {
-    margin-left: 7px;
+    margin-left: 20px;
     border-left: 1px solid $grey-lighter;
   }
 }


### PR DESCRIPTION
for the sub group, there is a left padding of 15, so for the subgroup with icon, there should be about `x + (25 - 17) = 15` space on the left of the icon. 

For lower level item, the left margin should increase to match the new icon position. moving 13px to the right looks about right. 
