### PR TITLE
Remove TableCatalogItem's redundant disableUserChanges

### DIFF
--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -100,14 +100,6 @@ var TableCatalogItem = function(terria, url, options) {
     this.showWarnings = true;
 
     /**
-     * Disable the ability to change the display of the dataset via displayVariablesConcept.
-     * This property is observable.
-     * @type {Boolean}
-     * @default false
-     */
-    this.disableUserChanges = false;
-
-    /**
      * Gets or sets the array of color strings used for chart lines.
      * TODO: make this customizable, eg. use colormap / colorPalette.
      * @type {String[]}
@@ -140,7 +132,7 @@ var TableCatalogItem = function(terria, url, options) {
      */
     this.isSampled = defaultValue(options.isSampled, true);
 
-    knockout.track(this, ['data', 'dataSourceUrl', 'opacity', 'keepOnTop', 'disableUserChanges', 'showWarnings', '_tableStructure', '_dataSource', '_regionMapping']);
+    knockout.track(this, ['data', 'dataSourceUrl', 'opacity', 'keepOnTop', 'showWarnings', '_tableStructure', '_dataSource', '_regionMapping']);
 
     knockout.getObservable(this, 'opacity').subscribe(function(newValue) {
         if (defined(this._regionMapping) && defined(this._regionMapping.updateOpacity)) {
@@ -411,7 +403,6 @@ freezeObject(TableCatalogItem.defaultSerializers);
  */
 TableCatalogItem.defaultPropertiesForSharing = clone(CatalogItem.defaultPropertiesForSharing);
 TableCatalogItem.defaultPropertiesForSharing.push('keepOnTop');
-TableCatalogItem.defaultPropertiesForSharing.push('disableUserChanges');
 TableCatalogItem.defaultPropertiesForSharing.push('opacity');
 TableCatalogItem.defaultPropertiesForSharing.push('tableStyle');
 freezeObject(TableCatalogItem.defaultPropertiesForSharing);


### PR DESCRIPTION
Just a little one that came out of reviewing #2123. `disableUserChanges` is not used anywhere (either in master or the oldui branch), except as introduced in 2123.
