### PR TITLE
Change old browser region mapping message

### DIFF
--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -630,18 +630,17 @@ function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, g
 
     var terria = globeOrMap.terria;
 
-    // Inform the user that region mapping will not be supported in old browsers in the future.
-    if (!terria.configParameters.regionMappingOldBrowserNotifiedThisSession && typeof ArrayBuffer === 'undefined') {
-        terria.configParameters.regionMappingOldBrowserNotifiedThisSession = true;
-        terria.error.raiseEvent(new TerriaError({
+    // Inform the user that region mapping is not supported in old browsers.
+    if (typeof ArrayBuffer === 'undefined') {
+        throw new TerriaError({
             sender: catalogItem,
             title: terria.configParameters.oldBrowserRegionMappingTitle || 'Outdated Web Browser',
             message: terria.configParameters.oldBrowserRegionMappingMessage ||
-                'You are using a very old web browser that will not be able to use "region mapped" datasets like this one in a future ' +
-                'version of ' + terria.appName + '.  Please upgrade to the latest version of Google Chrome, ' +
+                'You are using a very old web browser that cannot display "region mapped" datasets such as this one.  Please upgrade to ' +
+                'the latest version of Google Chrome, ' +
                 'Mozilla Firefox, Microsoft Edge, Microsoft Internet Explorer 11, or Apple Safari as soon as possible.  Please contact us ' +
                 'at <a href="mailto:' + terria.supportEmail + '">' + terria.supportEmail + '</a> if you have any concerns.'
-        }));
+        });
     }
 
     var regionDetail = regionMapping._regionDetails[0];

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -628,21 +628,6 @@ function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, g
 
     globeOrMap = defaultValue(globeOrMap, catalogItem.terria.currentViewer);
 
-    var terria = globeOrMap.terria;
-
-    // Inform the user that region mapping is not supported in old browsers.
-    if (typeof ArrayBuffer === 'undefined') {
-        throw new TerriaError({
-            sender: catalogItem,
-            title: terria.configParameters.oldBrowserRegionMappingTitle || 'Outdated Web Browser',
-            message: terria.configParameters.oldBrowserRegionMappingMessage ||
-                'You are using a very old web browser that cannot display "region mapped" datasets such as this one.  Please upgrade to ' +
-                'the latest version of Google Chrome, ' +
-                'Mozilla Firefox, Microsoft Edge, Microsoft Internet Explorer 11, or Apple Safari as soon as possible.  Please contact us ' +
-                'at <a href="mailto:' + terria.supportEmail + '">' + terria.supportEmail + '</a> if you have any concerns.'
-        });
-    }
-
     var regionDetail = regionMapping._regionDetails[0];
     var legendHelper = regionMapping._legendHelper;
     if (!defined(legendHelper)) {
@@ -672,6 +657,21 @@ function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, g
 
     switch (regionDetail.regionProvider.serverType) {
     case "MVT":
+        var terria = globeOrMap.terria;
+
+        // Inform the user that region mapping is not supported in old browsers.
+        if (typeof ArrayBuffer === 'undefined') {
+            throw new TerriaError({
+                sender: catalogItem,
+                title: terria.configParameters.oldBrowserRegionMappingTitle || 'Outdated Web Browser',
+                message: terria.configParameters.oldBrowserRegionMappingMessage ||
+                    'You are using a very old web browser that cannot display "region mapped" datasets such as this one.  Please upgrade to ' +
+                    'the latest version of Google Chrome, ' +
+                    'Mozilla Firefox, Microsoft Edge, Microsoft Internet Explorer 11, or Apple Safari as soon as possible.  Please contact us ' +
+                    'at <a href="mailto:' + terria.supportEmail + '">' + terria.supportEmail + '</a> if you have any concerns.'
+            });
+        }
+
         regionImageryProvider = new MapboxVectorTileImageryProvider({
             url: proxyCatalogItemUrl(catalogItem, regionDetail.regionProvider.server),
             layerName: regionDetail.regionProvider.layerName,


### PR DESCRIPTION
Region mapping will no longer work in old browsers as of TerriaJS/nationalmap#345. Change the message to an exception and throw it every time an outdated browser user tries to open a region mapped layer (not just the first time).
