### PR TITLE
fix data url warning

### DIFF
--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -33,7 +33,7 @@ const AddData = React.createClass({
             localDataType: localDataType[0], // By default select the first item (auto)
             remoteDataType: remoteDataType[0],
             activeTab: 'local', // By default local data tab is active
-            remoteUrl: undefined // By default there's no remote url
+            remoteUrl: '' // By default there's no remote url
         };
     },
 
@@ -158,7 +158,7 @@ const AddData = React.createClass({
                             service:
                         </label>
                         <form className={Styles.urlInput}>
-                            <input value={this.state.remoteUrl || ''} onChange={this.onRemoteUrlChange}
+                            <input value={this.state.remoteUrl} onChange={this.onRemoteUrlChange}
                                    className={Styles.urlInputTextBox}
                                    type='text'
                                    placeholder='e.g. http://data.gov.au/geoserver/wms'/>

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -157,8 +157,8 @@ const AddData = React.createClass({
                         <label className={Styles.label}><strong>Step 2:</strong> Enter the URL of the data file or web
                             service:
                         </label>
-                        <form className={Styles.urlInput} onSubmit={this.handleUrl}>
-                            <input value={this.state.remoteUrl} onChange={this.onRemoteUrlChange}
+                        <form className={Styles.urlInput}>
+                            <input value={this.state.remoteUrl || ''} onChange={this.onRemoteUrlChange}
                                    className={Styles.urlInputTextBox}
                                    type='text'
                                    placeholder='e.g. http://data.gov.au/geoserver/wms'/>

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/add-data.scss
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/add-data.scss
@@ -77,6 +77,7 @@
     composes: field from '../../../../Sass/common/_form.scss';
     width: calc(100% - 50px);
     float: left;
+    font-family: $font-base;
   }
 
   &__btn {


### PR DESCRIPTION
Fixes https://github.com/TerriaJS/terriajs/issues/1879

So React treats `undefined` and `null` as value as uncontrolled element. The reason the error get raised is because the value of the `remoteUrl` is by default `undefined`. To fix it, we just give it a default value of  ''
