### PR TITLE
Reverse the order of items in ArcGIS legends to match the order used by ArcGIS itself

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 4.5.1
+
+* The order of the legend for an `ArcGisMapServerCatalogItem` now matches the order used by ArcGIS itself.
+
 ### 4.5.0
 
 * Added support for the Sensor Observation Service format, via the `SensorObservationServiceCatalogItem`.

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -606,6 +606,7 @@ ArcGisMapServerCatalogItem.prototype.loadLegendFromJson = function(json) {
         return;
     }
     return when.all(itemPromises).then(function(items) {
+        items.reverse();
         options.items = items;
         return (that._generatedLegendUrl = new Legend(options).getLegendUrl());
     }).otherwise(function(error) {

--- a/test/Models/ArcGisMapServerCatalogItemSpec.js
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.js
@@ -183,7 +183,8 @@ describe('ArcGisMapServerCatalogItem', function() {
         item.updateFromJson({url: url});
         spyOn(Legend.prototype, 'drawSvg').and.callFake(function() {
             expect(this.items.length).toBe(2);
-            expect(this.items[1].title).toBe('Wrecks');
+            expect(this.items[0].title).toBe('Wrecks');
+            expect(this.items[1].title).toBe('Offshore Rocks');
             console.log(this);
             return '';
         });


### PR DESCRIPTION
Fixes #1692 
