### PR TITLE
Default clipToRectangle to true.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Change Log
 ### 4.6.0
 
 * Change in defaults:
-  * The `clipToRectangle` property of raster catalog items (`WebMapServiceCatalogItem`, `ArcGisMapServerCatalogItem`, etc.) now defaults to `true`.  It was `false` in previous releases.  Using `false` prevents features (especially point features) right at the edge of the layer's rectangle from being cut off when the server reports too tight a rectangle, but also causes the layer to load much more slowly in many cases.  Starting in this version, we favor performance and the much more common case that the rectangle can be trusted.
+  * The `clipToRectangle` property of raster catalog items (`WebMapServiceCatalogItem`, `ArcGisMapServerCatalogItem`, etc.) now defaults to `true`.  It was `false` in previous releases.  Using `false` prevents features (especially point features) right at the edge of the layer's rectangle from being cut off when the server reports too tight a rectangle, but also causes the layer to load much more slowly in many cases.  Starting in this version, we favour performance and the much more common case that the rectangle can be trusted.
 * Add support for 'Long' type hint to CSV data for specifying longitude.
 
 ### 4.5.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Change Log
 ### 4.6.0
 
 * Change in defaults:
-  * The `clipToRectangle` property of raster catalog items (WMS, ArcGIS MapServer, etc.) now defaults to `true`.  It was `false` in previous relases.  Using `false` prevents features (especially point features) right at the edge of the layer's rectangle from being cut off when the server reports too tight a rectangle, but also causes the layer to load much more slowly in many cases.
+  * The `clipToRectangle` property of raster catalog items (`WebMapServiceCatalogItem`, `ArcGisMapServerCatalogItem`, etc.) now defaults to `true`.  It was `false` in previous relases.  Using `false` prevents features (especially point features) right at the edge of the layer's rectangle from being cut off when the server reports too tight a rectangle, but also causes the layer to load much more slowly in many cases.  Starting in this version, we favor performance and the much more common case that the rectangle can be trusted.
 * Add support for 'Long' type hint to CSV data for specifying longitude.
 
 ### 4.5.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,10 @@
 Change Log
 ==========
 
-### 4.5.2
+### 4.6.0
 
+* Change in defaults:
+  * The `clipToRectangle` property of raster catalog items (WMS, ArcGIS MapServer, etc.) now defaults to `true`.  It was `false` in previous relases.  Using `false` prevents features (especially point features) right at the edge of the layer's rectangle from being cut off when the server reports too tight a rectangle, but also causes the layer to load much more slowly in many cases.
 * Add support for 'Long' type hint to CSV data for specifying longitude.
 
 ### 4.5.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Change Log
 ### 4.6.0
 
 * Change in defaults:
-  * The `clipToRectangle` property of raster catalog items (`WebMapServiceCatalogItem`, `ArcGisMapServerCatalogItem`, etc.) now defaults to `true`.  It was `false` in previous relases.  Using `false` prevents features (especially point features) right at the edge of the layer's rectangle from being cut off when the server reports too tight a rectangle, but also causes the layer to load much more slowly in many cases.  Starting in this version, we favor performance and the much more common case that the rectangle can be trusted.
+  * The `clipToRectangle` property of raster catalog items (`WebMapServiceCatalogItem`, `ArcGisMapServerCatalogItem`, etc.) now defaults to `true`.  It was `false` in previous releases.  Using `false` prevents features (especially point features) right at the edge of the layer's rectangle from being cut off when the server reports too tight a rectangle, but also causes the layer to load much more slowly in many cases.  Starting in this version, we favor performance and the much more common case that the rectangle can be trusted.
 * Add support for 'Long' type hint to CSV data for specifying longitude.
 
 ### 4.5.1

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -92,14 +92,15 @@ var ImageryLayerCatalogItem = function(terria) {
 
     /**
      * Gets or sets a value indicating whether this dataset should be clipped to the {@link CatalogItem#rectangle}.
-     * If true, no part of the dataset will be displayed outside the rectangle.  This property is false by default because it requires
-     * that the rectangle be highly accurate.  Also, many servers report an extent that does not take into account that the representation
+     * If true, no part of the dataset will be displayed outside the rectangle.  This property is true by default,
+     * leading to better performance and avoiding tile request errors in some cases.  However, it may cause features to
+     * be cut off in some cases, such as if a server reports an extent that does not take into account that the representation
      * of features sometimes require a larger spatial extent than the features themselves.  For example, if a point feature on the edge of
      * the extent is drawn as a circle with a radius of 5 pixels, half of that circle will be cut off.
      * @type {Boolean}
      * @default false
      */
-    this.clipToRectangle = false;
+    this.clipToRectangle = true;
 
     /**
      * Gets or sets a value indicating whether tiles of this catalog item are required to be loaded before terrain

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -93,10 +93,11 @@ var ImageryLayerCatalogItem = function(terria) {
     /**
      * Gets or sets a value indicating whether this dataset should be clipped to the {@link CatalogItem#rectangle}.
      * If true, no part of the dataset will be displayed outside the rectangle.  This property is true by default,
-     * leading to better performance and avoiding tile request errors in some cases.  However, it may cause features to
-     * be cut off in some cases, such as if a server reports an extent that does not take into account that the representation
-     * of features sometimes require a larger spatial extent than the features themselves.  For example, if a point feature on the edge of
-     * the extent is drawn as a circle with a radius of 5 pixels, half of that circle will be cut off.
+     * leading to better performance and avoiding tile request errors that might occur when requesting tiles outside the
+     * server-specified rectangle.  However, it may also cause features to be cut off in some cases, such as if a server
+     * reports an extent that does not take into account that the representation of features sometimes require a larger
+     * spatial extent than the features themselves.  For example, if a point feature on the edge of the extent is drawn
+     * as a circle with a radius of 5 pixels, half of that circle will be cut off.
      * @type {Boolean}
      * @default false
      */


### PR DESCRIPTION
This results in _much_ better performance for some layers, such as the time-dynamic Chlorophyll concentration layer in `#test`.  The downside is that, if a server doesn't account for the size of a graphical representation of a feature when reporting the bounds, features (e.g. points) may be cut off at the edges.  I don't know of any servers that have this problem anymore, so I think changing the default to favor performance in the much more common case is a wise choice.
