### PR TITLE
Fix region selection name box when region ID is non-numeric.

### DIFF
--- a/lib/Models/RegionParameter.js
+++ b/lib/Models/RegionParameter.js
@@ -102,7 +102,8 @@ RegionParameter.prototype.findRegionByID = function(regionID) {
     if (typeof regionID === 'string' && regionProvider.regions[0] && typeof regionProvider.regions[0].id === 'number') {
         regionID = parseInt(regionID, 10);
     } else if (typeof regionID === 'string') {
-        var replacedValue = regionProvider._appliedReplacements.serverReplacements[regionID.toLowerCase()];
+        regionID = regionID.toLowerCase();
+        var replacedValue = regionProvider._appliedReplacements.serverReplacements[regionID];
         if (defined(replacedValue)) {
             regionID = replacedValue;
         }


### PR DESCRIPTION
- Select the `Regions like this` function from Terria Analytics.
- Click `Selection region`
- Choose `COUNTRY`
- Click on Australia
- Before this PR, Australia would be selected but its name wouldn't show up in the name box.
