### PR TITLE
Allow users to browse for json and json5 files in Add Data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * The marker indicating the location of a search result is now placed correctly on the terrain surface.
 * Region for CatalogFunctions now selected on map rather than preview map
 * Some regions that were previously not selectable (in Analytics) except via autocomplete are now selectable.
+* Allow users to browse for json configuration files when adding "Local Data".
 
 ### 4.5.1
 

--- a/lib/Core/getDataType.js
+++ b/lib/Core/getDataType.js
@@ -91,6 +91,11 @@ module.exports = function (){
               extensions: ['gpx']
           },
           {
+              value: 'json',
+              name: 'JSON',
+              extensions: ['json', 'json5']
+          },
+          {
               value: 'other',
               name: 'Other (use conversion service)'
           },


### PR DESCRIPTION
Currently, you cannot select valid .json (or .json5) files in the file browser window for Add Data. This rectifies that.

Raised in NEII-viewer.