### PR TITLE
Update spelling to Data Catalogue everywhere

### DIFF
--- a/lib/ReactViews/ExplorerWindow/Tabs.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs.jsx
@@ -21,7 +21,7 @@ const Tabs = React.createClass({
         return {
             tabs: this.props.tabs || [
                 {
-                    name: 'Data Catalog',
+                    name: 'Data Catalogue',
                     title: 'data-catalog',
                     panel: <DataCatalogTab terria={this.props.terria}
                                            viewState={this.props.viewState}

--- a/lib/ReactViews/Search/SidebarSearch.jsx
+++ b/lib/ReactViews/Search/SidebarSearch.jsx
@@ -57,7 +57,7 @@ const SidebarSearch = React.createClass({
                                 <ul className={Styles.btnList}>
                                     <SearchResult clickAction={this.searchInDataCatalog}
                                                   showPin={false}
-                                                  name={`Search ${this.props.viewState.searchState.locationSearchText} in the Data Catalog`}
+                                                  name={`Search ${this.props.viewState.searchState.locationSearchText} in the Data Catalogue`}
                                     />
                                 </ul>
                             </div>


### PR DESCRIPTION
Pending proper localization, this at least makes our spelling of Data Catalogue consistent.

Fixes #1872 and https://github.com/TerriaJS/neii-viewer/issues/64.