### PR TITLE
Fix ArcGIS test init file, and improve its error message

### DIFF
--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -222,11 +222,11 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
                 that.updateFromMetadata(results[0], {"layers": [results[1]]}, results[2], false, results[1]);
             } else {
                 var message = defined(results[0].error) ? results[0].error.message : 'This dataset returned unusable metadata.';
-                that.terria.error.raiseEvent(new TerriaError({
+                throw new TerriaError({
                     title: 'ArcGIS Mapserver Error',
                     message: '<p>' + message + '</p><p>Please report it by \
 sending an email to <a href="mailto:' + that.terria.supportEmail + '">' + that.terria.supportEmail + '</a>.</p>'
-                }));
+                });
             }
         });
     }

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -22,7 +22,6 @@ var proj4definitions = require ('../Map/Proj4Definitions');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var replaceUnderscores = require('../Core/replaceUnderscores');
-var RuntimeError = require('terriajs-cesium/Source/Core/RuntimeError');
 var TerriaError = require('../Core/TerriaError');
 var unionRectangleArray = require('../Map/unionRectangleArray');
 var URI = require('urijs');
@@ -222,8 +221,12 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
                 // Results of a single layer query. Make it look like a multi layer query result.
                 that.updateFromMetadata(results[0], {"layers": [results[1]]}, results[2], false, results[1]);
             } else {
-                console.error("Unusable ArcGIS Mapserver layers metadata: \n" + layersMetadata);
-                throw new RuntimeError('Unusable ArcGIS Mapserver layers metadata from ' + layersUri.toString() + '. See console log for details.');
+                var message = defined(results[0].error) ? results[0].error.message : 'This dataset returned unusable metadata.';
+                that.terria.error.raiseEvent(new TerriaError({
+                    title: 'ArcGIS Mapserver Error',
+                    message: '<p>' + message + '</p><p>Please report it by \
+sending an email to <a href="mailto:' + that.terria.supportEmail + '">' + that.terria.supportEmail + '</a>.</p>'
+                }));
             }
         });
     }

--- a/lib/ReactViews/Preview/GroupPreview.jsx
+++ b/lib/ReactViews/Preview/GroupPreview.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import DataPreviewSections from './DataPreviewSections';
+import DataPreviewUrl from './DataPreviewUrl.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import Styles from './mappable-preview.scss';
 import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
@@ -21,6 +23,8 @@ const GroupPreview = React.createClass({
     },
 
     render() {
+        const metadataItem = this.props.previewed.nowViewingCatalogItem || this.props.previewed;
+
         return (
             <div>
                 <h3>{this.props.previewed.name}</h3>
@@ -35,6 +39,19 @@ const GroupPreview = React.createClass({
                                 </div>
                             </When>
                         </Choose>
+
+                        <DataPreviewSections metadataItem={metadataItem}/>
+
+                        <If condition={metadataItem.dataCustodian}>
+                            <div>
+                                <h4 className={Styles.h4}>Data Custodian</h4>
+                                {parseCustomMarkdownToReact(metadataItem.dataCustodian, {catalogItem: metadataItem})}
+                            </div>
+                        </If>
+
+                        <If condition={metadataItem.url && metadataItem.url.length && !metadataItem.hideSource}>
+                            <DataPreviewUrl metadataItem={metadataItem}/>
+                        </If>
                     </div>
                 </div>
             </div>

--- a/lib/ReactViews/Preview/GroupPreview.jsx
+++ b/lib/ReactViews/Preview/GroupPreview.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import DataPreviewSections from './DataPreviewSections';
-import DataPreviewUrl from './DataPreviewUrl.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import Styles from './mappable-preview.scss';
 import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
@@ -23,8 +21,6 @@ const GroupPreview = React.createClass({
     },
 
     render() {
-        const metadataItem = this.props.previewed.nowViewingCatalogItem || this.props.previewed;
-
         return (
             <div>
                 <h3>{this.props.previewed.name}</h3>
@@ -39,19 +35,6 @@ const GroupPreview = React.createClass({
                                 </div>
                             </When>
                         </Choose>
-
-                        <DataPreviewSections metadataItem={metadataItem}/>
-
-                        <If condition={metadataItem.dataCustodian}>
-                            <div>
-                                <h4 className={Styles.h4}>Data Custodian</h4>
-                                {parseCustomMarkdownToReact(metadataItem.dataCustodian, {catalogItem: metadataItem})}
-                            </div>
-                        </If>
-
-                        <If condition={metadataItem.url && metadataItem.url.length && !metadataItem.hideSource}>
-                            <DataPreviewUrl metadataItem={metadataItem}/>
-                        </If>
                     </div>
                 </div>
             </div>

--- a/wwwroot/test/init/arcgis.json
+++ b/wwwroot/test/init/arcgis.json
@@ -7,14 +7,14 @@
         {
           "name": "Gravity Anomaly (single dynamic layer)",
           "type": "esri-mapServer",
-          "url": "http://www.ga.gov.au/gisimg/rest/services/earth_science/Geoscience_Australia_National_Geophysical_Grids/MapServer/6",
+          "url": "http://services.ga.gov.au/gis/rest/services/Geophysical_Grids/MapServer/9",
           "attribution" : "Plain text <a href=\"test\">hello</a>",
           "featureInfoTemplate" : "<h1> Heading1</h1> <h2> Heading2</h2> <h3> Heading3</h3> <h4> Heading4</h4> <h5> Heading5</h5> <h6> Heading6</h6> <p><mark> Marked text </makr></p><p><s> Strike through text </s></p><p><u> Underlined text </u></p><p><small> Small text </small></p><p><strong> Bold text </strong></p><ul><li> Default unordered list </li><li> Default unordered list </li></ul><ol><li> Default ordered list </li><li> Default ordered list </li></ol><ul class='circle'><li> circle unordered list </li><li> circle unordered list </li></ul><ul class='square'><li> square unordered list </li><li> square unordered list </li></ul><ol class='upper-roman'><li> Upper Roman ordered list </li><li> Upper Roman ordered list </li></ol><ol class='lower-alpha'><li> Lower Alpha ordered list </li><li> Lower Alpha ordered list </li></ol><ul class='list-reset'><li> list without list style </li><li> list without list style </li></ul><p class='center'> center align text</p><p class='right-align'> right align text</p><p class='justify'> justified text</p>"
         },
         {
           "name": "Gravity Anomaly two",
           "type": "esri-mapServer",
-          "url": "http://www.ga.gov.au/gisimg/rest/services/earth_science/Geoscience_Australia_National_Geophysical_Grids/MapServer/6",
+          "url": "http://services.ga.gov.au/gis/rest/services/Geophysical_Grids/MapServer/9",
           "attribution" :
             {
               "text" : "test attribution which is a link",
@@ -25,7 +25,7 @@
         {
           "name": "Gravity Anomaly with partials",
           "type": "esri-mapServer",
-          "url": "http://www.ga.gov.au/gisimg/rest/services/earth_science/Geoscience_Australia_National_Geophysical_Grids/MapServer/6",
+          "url": "http://services.ga.gov.au/gis/rest/services/Geophysical_Grids/MapServer/9",
           "attribution" :
             {
               "text" : "test attribution which is a link",
@@ -38,8 +38,15 @@
               "footer": "<br>Thank you for clicking here.</br>"
             }
           }
+        },
+        {
+          "name": "Bad link",
+          "type": "esri-mapServer",
+          "url": "http://www.ga.gov.au/gisimg/rest/services/earth_science/Geoscience_Australia_National_Geophysical_Grids/MapServer/6",
         }
-      ]
+      ],
+      // This shows how you can display descriptive info on a group in the Data preview panel.
+      "description": "<h3>This is an ArcGIS server group</h3><p>It has some interesting gravity anomaly data items in it.</p>"
     }
   ]
 }


### PR DESCRIPTION
`CatalogGroup` instances do not have `nowViewingCatalogItem`, `dataCustodian` or `url` properties. So we might as well get rid of the code that checks for them and displays them in the preview pane.

I may have misunderstood something here, so please check this.

Also adds a `description` property (and fixes the URLs) to `#build/terriajs/test/init/arcgis.json` so you can at least see a description. (Adding `url` or `dataCustodian` doesn't work, because they never get put on the instance, which is how I found this issue.)

Also, since the arcgis test group I happened to test this on had some links that weren't working, I took the opportunity to update them, and improve the error handling of ArcGis items (try the "bad link" item to see it). (That really ought to be a separate PR, but these are both so tiny, I've combined them.)