### PR TITLE
Allow more font-sizing flexibility in the CSS

### DIFF
--- a/lib/ReactViews/BottomDock/Timeline/timeline.scss
+++ b/lib/ReactViews/BottomDock/Timeline/timeline.scss
@@ -12,7 +12,7 @@
   display: table-row;
   color: #fff;
   font-family: $font-base;
-  font-size: 13px;
+  font-size: $font-size-mid-small;
 }
 
 .text-cell {

--- a/lib/ReactViews/Custom/Chart/chart-panel.scss
+++ b/lib/ReactViews/Custom/Chart/chart-panel.scss
@@ -17,7 +17,7 @@
   box-sizing: border-box;
   position: relative;
   background-color: $chart-darker;
-  font-size: 13px;
+  font-size: $font-size-mid-small;
   fill: #fff;
 }
 

--- a/lib/ReactViews/DataCatalog/data-catalog-group.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog-group.scss
@@ -9,7 +9,7 @@
   composes: btn from '../../Sass/common/_buttons.scss';
 
   text-align: left;
-  font-size: 0.8rem;
+  font-size: $font-size-small;
   padding: $padding-small 30px+$padding;
   position: relative;
   width: 100%;
@@ -20,7 +20,7 @@
     display: inline-block;
   }
   @media screen and (max-width: $sm) {
-    font-size: 0.9rem;
+    font-size: $font-size-mid-small;
     padding-top: 10px;
     padding-bottom: 10px;
     border-bottom: 1px solid $grey-lighter;
@@ -95,7 +95,7 @@
 
 .label {
   composes: label from '../../Sass/common/_labels.scss';
-  font-size: 0.8rem;
+  font-size: $font-size-small;
 }
 
 .label--no-results {

--- a/lib/ReactViews/DataCatalog/data-catalog-item.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog-item.scss
@@ -9,7 +9,7 @@
 }
 
 .btn-catalog-item {
-  font-size: 0.8rem;
+  font-size: $font-size-small;
   composes: btn from '../../Sass/common/_buttons.scss';
   @extend %wrap;
   position: relative;
@@ -32,7 +32,7 @@
   }
 
   @media screen and (max-width: $sm) {
-    font-size: 0.9rem;
+    font-size: $font-size-mid-small;
     padding-top: 10px;
     padding-bottom: 10px;
     border-bottom: 1px solid $grey-lighter;

--- a/lib/ReactViews/DataCatalog/data-catalog.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog.scss
@@ -5,7 +5,7 @@
   composes: list-reset from '../../Sass/common/_base.scss';
   composes: scrollbars from '../../Sass/common/_base.scss';
 
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
   overflow-y: auto;
   overflow-x: hidden;
   box-sizing: border-box;
@@ -25,5 +25,5 @@
 
 .label {
   composes: label from '../../Sass/common/_labels.scss';
-  font-size: 0.8rem;
+  font-size: $font-size-small;
 }

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/add-data.scss
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/add-data.scss
@@ -44,7 +44,7 @@
   composes: label from '../../../../Sass/common/_labels.scss';
 
   padding-left: 0;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 }
 
 .dropdown {

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/my-data-tab.scss
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/my-data-tab.scss
@@ -28,7 +28,7 @@
 
 .explanation {
   font-family: $font-base;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 }
 
 .btn--back-to-my-data{
@@ -55,7 +55,7 @@
 
 .h3 {
   composes: h3 from '../../../../Sass/common/_base.scss';
-  font-size: 1.1rem;
+  font-size: $font-size-mid-large;
 }
 
 

--- a/lib/ReactViews/ExplorerWindow/Tabs/data-catalog-tab.scss
+++ b/lib/ReactViews/ExplorerWindow/Tabs/data-catalog-tab.scss
@@ -13,7 +13,7 @@
   composes: list-reset from '../../../Sass/common/_base.scss';
   composes: scrollbars from '../../../Sass/common/_base.scss';
 
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 
   background: $modal-secondary-bg;
   overflow-y: auto;

--- a/lib/ReactViews/ExplorerWindow/explorer-window.scss
+++ b/lib/ReactViews/ExplorerWindow/explorer-window.scss
@@ -60,7 +60,7 @@
   composes: btn-transparent from '../../Sass/common/_buttons.scss';
   composes: btn--secondary from '../../Sass/common/_buttons.scss';
 
-  font-size: 0.7rem;
+  font-size: $font-size-mid-mini;
   padding: 4px 10px;
   margin: 5px;
   font-weight: bold;

--- a/lib/ReactViews/ExplorerWindow/tabs.scss
+++ b/lib/ReactViews/ExplorerWindow/tabs.scss
@@ -88,5 +88,9 @@
 
 .btn--selected {
   background: #fff;
-  color: $modal-selected;
+  @if variable-exists(modal-selected) {
+    color: $modal-selected;
+  } @else {
+    color: $modal-highlight;
+  }
 }

--- a/lib/ReactViews/ExplorerWindow/tabs.scss
+++ b/lib/ReactViews/ExplorerWindow/tabs.scss
@@ -73,7 +73,7 @@
   font-family: $font-pop;
   background: $modal-bg;
   color: $modal-text;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
   padding: $padding $padding*2;
 
   &.btn--tab {

--- a/lib/ReactViews/ExplorerWindow/tabs.scss
+++ b/lib/ReactViews/ExplorerWindow/tabs.scss
@@ -88,5 +88,5 @@
 
 .btn--selected {
   background: #fff;
-  color: $modal-highlight;
+  color: $modal-selected;
 }

--- a/lib/ReactViews/FeatureInfo/feature-info-panel.scss
+++ b/lib/ReactViews/FeatureInfo/feature-info-panel.scss
@@ -111,7 +111,7 @@
   overflow-y: auto;
   overflow-x: auto;
   max-height: calc(80vh - #{$padding*2 + $btn-default-line-height});
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 
   @media print{
     max-height: none;

--- a/lib/ReactViews/FeatureInfo/feature-info-section.scss
+++ b/lib/ReactViews/FeatureInfo/feature-info-section.scss
@@ -19,7 +19,7 @@
   span{
     display: block;
     font-weight: 300;
-    font-size: 13px;
+    font-size: $font-size-mid-small;
   }
   svg{
     height: 20px;
@@ -48,7 +48,7 @@
     position: relative;
     border-collapse: collapse;
     border: 1px solid $dark;
-    font-size: 13px;
+    font-size: $font-size-feature-info;
     padding: 5px;
   }
 }

--- a/lib/ReactViews/Feedback/feedback-button.scss
+++ b/lib/ReactViews/Feedback/feedback-button.scss
@@ -4,7 +4,7 @@
 .feedback {
   background: #fff;
   font-family: $font-base;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
   color: $dark;
   border-radius: 20px;
   box-shadow: $box-shadow;

--- a/lib/ReactViews/Feedback/feedback-form.scss
+++ b/lib/ReactViews/Feedback/feedback-form.scss
@@ -4,7 +4,7 @@
 .form {
   composes: scrollbars from '../../Sass/common/_base.scss';
   font-family: $font-base;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
   z-index: 1;
   position: fixed;
   background: #fff;

--- a/lib/ReactViews/Map/Legend/legend.scss
+++ b/lib/ReactViews/Map/Legend/legend.scss
@@ -10,7 +10,7 @@ $distance-bg: rgba($dark, 0.9);
   background-color: #fff;
   color: $text-dark;
   padding: $padding-small $padding-small;
-  font-size: 0.7rem;
+  font-size: $font-size-mid-mini;
   text-align: center;
   line-height: 1;
   border: 0;

--- a/lib/ReactViews/Map/Panels/SharePanel/share-panel.scss
+++ b/lib/ReactViews/Map/Panels/SharePanel/share-panel.scss
@@ -2,7 +2,7 @@
 @import '../../../../Sass/common/mixins';
 
 .share-panel {
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 }
 
 .dropdown-inner {

--- a/lib/ReactViews/Preview/data-preview.scss
+++ b/lib/ReactViews/Preview/data-preview.scss
@@ -5,7 +5,7 @@
   height: 100%;
   overflow: hidden;
   font-family: $font-base;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 
   @media screen and (max-width: $sm) {
     height: calc(100% - #{$mobile-modal-top-height});
@@ -23,7 +23,7 @@
 .btn--back-to-map {
   composes: btn from '../../Sass/common/_buttons.scss';
   composes: btn--tertiary from '../../Sass/common/_buttons.scss';
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 }
 
 .preview__inner {
@@ -53,7 +53,7 @@
 .h4 {
   composes: h4 from '../../Sass/common/_base.scss';
 
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 }
 
 .h3 {

--- a/lib/ReactViews/Preview/mappable-preview.scss
+++ b/lib/ReactViews/Preview/mappable-preview.scss
@@ -44,10 +44,10 @@
 .h3 {
   composes: h3 from '../../Sass/common/_base.scss';
 
-  font-size: 1.1rem;
+  font-size: $font-size-mid-large;
 }
 .h4 {
   composes: h4 from '../../Sass/common/_base.scss';
 
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 }

--- a/lib/ReactViews/Search/search-header.scss
+++ b/lib/ReactViews/Search/search-header.scss
@@ -3,5 +3,5 @@
 .no-results {
   composes: label from '../../Sass/common/_labels.scss';
   padding-left: $padding;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 }

--- a/lib/ReactViews/Search/sidebar-search.scss
+++ b/lib/ReactViews/Search/sidebar-search.scss
@@ -56,7 +56,7 @@
   composes: btn from '../badge-bar.scss';
   composes: btn--tertiary-dark from '../../Sass/common/_buttons.scss';
   padding: 5px;
-  font-size: 10px;
+  font-size: $font-size-mid-mini;
   border-radius: 2px;
 }
 

--- a/lib/ReactViews/SidePanel/side-panel.scss
+++ b/lib/ReactViews/SidePanel/side-panel.scss
@@ -6,7 +6,7 @@
 }
 .workbenchEmpty{
   color: $text-light;
-  font-size: 0.85rem;
+  font-size: $font-size-mid-small;
   padding: $padding;
   background: $overlay;
   border: dashed 1px rgba(255, 255, 255, 0.5);
@@ -48,7 +48,7 @@
   composes: btn-primary from '../../Sass/common/_buttons.scss';
 
   line-height: $input-height;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
   padding: 0;
 
   svg{

--- a/lib/ReactViews/Workbench/Controls/colorscalerange-section.scss
+++ b/lib/ReactViews/Workbench/Controls/colorscalerange-section.scss
@@ -1,7 +1,7 @@
 @import '~terriajs-variables';
 
 .colorscalerange {
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
   label {
     margin-right: $padding-small;
   }

--- a/lib/ReactViews/Workbench/Controls/concept-viewer.scss
+++ b/lib/ReactViews/Workbench/Controls/concept-viewer.scss
@@ -5,7 +5,7 @@
 
 .root {
   padding: $padding 0 0 0;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
 }
 
 .inner {

--- a/lib/ReactViews/Workbench/Controls/dimension-selector-section.scss
+++ b/lib/ReactViews/Workbench/Controls/dimension-selector-section.scss
@@ -1,7 +1,7 @@
 @import '~terriajs-variables';
 
 .dimension-selector {
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
   label {
     margin-right: $padding-small;
   }

--- a/lib/ReactViews/Workbench/Controls/legend.scss
+++ b/lib/ReactViews/Workbench/Controls/legend.scss
@@ -4,7 +4,7 @@
   composes: clearfix from '../../../Sass/common/_base.scss';
   composes: list-reset from '../../../Sass/common/_base.scss';
   font-family: $font-mono;
-  font-size: 0.85rem;
+  font-size: $font-size-small;
 
   li {
     display: block;

--- a/lib/ReactViews/Workbench/workbench-item.scss
+++ b/lib/ReactViews/Workbench/workbench-item.scss
@@ -101,6 +101,6 @@ $workbench-margin: $padding-small;
 }
 
 .draggable {
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
   cursor: move;
 }

--- a/lib/ReactViews/badge-bar.scss
+++ b/lib/ReactViews/badge-bar.scss
@@ -21,7 +21,7 @@
   li{
     display: inline-block;
     float: left;
-    font-size: 12px;
+    font-size: $font-size-small;
     &:last-child{
       float: right;
     }

--- a/lib/Sass/common/_buttons.scss
+++ b/lib/Sass/common/_buttons.scss
@@ -19,7 +19,7 @@ $btn-setting-size: 35px;
   cursor: pointer;
   line-height: $btn-default-line-height;
   text-decoration: none;
-  font-size: 0.85rem;
+  font-size: $font-size-button;
   font-family: $font-base;
 
   &:focus, &:hover {
@@ -127,7 +127,7 @@ $btn-setting-size: 35px;
 .btn--close-modal {
   @extend .btn--secondary;
 
-  font-size: 0.8rem;
+  font-size: $font-size-small;
   padding: 4px 10px;
   margin: 5px;
   font-weight: bold;
@@ -151,7 +151,7 @@ $btn-setting-size: 35px;
       padding: $padding-small $padding*2.2 $padding-small $padding*1.5;
     }
     top: 0;
-    font-size: 1.1rem;
+    font-size: $font-size-mid-large;
     opacity: 0.5;
   }
   &:before {
@@ -204,7 +204,7 @@ $btn-setting-size: 35px;
   font-family: $font-pop;
   background: $modal-bg;
   color: $modal-text;
-  font-size: 1rem;
+  font-size: $font-size-base;
   padding: $padding $padding*2;
   border-bottom: 2px solid transparent;
   li[aria-selected='true'] & {
@@ -215,7 +215,7 @@ $btn-setting-size: 35px;
 
 
 .btn--map {
-  font-size: 12px;
+  font-size: $font-size-small;
   padding: 5px;
   color: #fff;
   display: block;
@@ -268,5 +268,5 @@ $btn-setting-size: 35px;
 .btn--small, ._buttons__btn-primary.btn--small {
   padding: 4px 9px;
   margin-right: 4px;
-  font-size: 13px;
+  font-size: $font-size-small;
 }

--- a/lib/Sass/common/_buttons.scss
+++ b/lib/Sass/common/_buttons.scss
@@ -54,7 +54,7 @@ $btn-setting-size: 35px;
   padding: $padding;
 
   &:hover, &--hover {
-    background: $color-primary-hover;
+    background: get-hover-color($color-primary);
   }
 }
 
@@ -86,8 +86,8 @@ $btn-setting-size: 35px;
   border-radius: 4px;
 
   &:hover, &:focus {
-    border: 2px solid $color-primary-hover;
-    color: $color-primary-hover;
+    border: 2px solid get-hover-color($color-primary);
+    color: get-hover-color($color-primary);
   }
 }
 

--- a/lib/Sass/common/_buttons.scss
+++ b/lib/Sass/common/_buttons.scss
@@ -54,7 +54,7 @@ $btn-setting-size: 35px;
   padding: $padding;
 
   &:hover, &--hover {
-    background: lighten($color-primary, 10%);
+    background: $color-primary-hover;
   }
 }
 
@@ -86,8 +86,8 @@ $btn-setting-size: 35px;
   border-radius: 4px;
 
   &:hover, &:focus {
-    border: 2px solid lighten($color-primary, 10%);
-    color: lighten($color-primary, 10%);
+    border: 2px solid $color-primary-hover;
+    color: $color-primary-hover;
   }
 }
 

--- a/lib/Sass/common/_form.scss
+++ b/lib/Sass/common/_form.scss
@@ -3,7 +3,7 @@
 
 .input {
   font-family: inherit;
-  font-size: 0.9rem;
+  font-size: $font-size-mid-small;
   box-sizing: border-box;
   margin-top: 0;
   margin-bottom: 0;

--- a/lib/Sass/common/_variables.scss
+++ b/lib/Sass/common/_variables.scss
@@ -7,7 +7,7 @@ $font-mono: monospace, sans-serif;
 $font : $font-base;
 
 $color-primary: #08ABD5;
-$color-primary-hover: lighten($color-primary, 10%);
+@function get-hover-color($base-color) {@return lighten($base-color, 10%);}
 $color-secondary: #06CCFF;
 
 $animation-fast: 0.1s;
@@ -43,7 +43,7 @@ $modal-text: #000;
 $modal-secondary-bg: #f6f6f7;
 $modal-overlay: rgba(#000,0.7);
 $modal-highlight: $color-primary;
-$modal-selected: $color-primary;
+// $modal-selected: $color-primary;  // optionally define this to override $modal-highlight on the selected tab.
 $modal-border: $grey-lighter;
 $modal-content-height: 70vh;
 $modal-header-height: $btn-default-line-height + $padding*2;

--- a/lib/Sass/common/_variables.scss
+++ b/lib/Sass/common/_variables.scss
@@ -54,9 +54,14 @@ $mobile-text: #000;
 $mobile-modal-top-height: 40px;
 
 $font-size-large: 1.3rem;
+$font-size-mid-large: 1.1rem;
 $font-size-base: 1rem;
-$font-size-small: 13px;
-$font-size-mini: 10px;
+$font-size-mid-small: 0.9rem;
+$font-size-feature-info: 0.9rem;
+$font-size-button: 0.85rem;
+$font-size-small: 0.8125rem; // 13px;  // Why did we switch from rem to px here?!
+$font-size-mid-mini: 0.7rem;
+$font-size-mini: 0.625rem; // 10px;
 
 $font-weight-bold: 600;
 $font-weight-medium: 500;

--- a/lib/Sass/common/_variables.scss
+++ b/lib/Sass/common/_variables.scss
@@ -7,6 +7,7 @@ $font-mono: monospace, sans-serif;
 $font : $font-base;
 
 $color-primary: #08ABD5;
+$color-primary-hover: lighten($color-primary, 10%);
 $color-secondary: #06CCFF;
 
 $animation-fast: 0.1s;
@@ -42,6 +43,7 @@ $modal-text: #000;
 $modal-secondary-bg: #f6f6f7;
 $modal-overlay: rgba(#000,0.7);
 $modal-highlight: $color-primary;
+$modal-selected: $color-primary;
 $modal-border: $grey-lighter;
 $modal-content-height: 70vh;
 $modal-header-height: $btn-default-line-height + $padding*2;


### PR DESCRIPTION
Replace all hardcoded `font-size`s with font-sizing sass variables.
This shouldn't have any visual impact, except one or two minor tweaks where existing font-sizes were one-offs, in which case they've been changed to the closest more common size.