### PR TITLE
Update value when user moves polygon vertex

### DIFF
--- a/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
@@ -95,7 +95,7 @@ function getPointsLongLats(pointEntities, terria) {
         pointsLongLats.push(points);
     }
     return pointsLongLats;
-};
+}
 
 /**
  * Prompt user to select/draw on map in order to define parameter.


### PR DESCRIPTION
With a WPS polygon input, if the user moves a polygon vertex after creating it, this is not recorded, so the polygon sent to the WPS is the one that existed before the vertex was moved. This fixes that.