### PR TITLE
Improve ability of region mapping to turn back on after it goes off

### DIFF
--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -256,19 +256,24 @@ RegionMapping.prototype.setRegionColumnType = function(index) {
     }
 };
 
-/**
- * Explictly hide the imagery layer (if any).
- */
-RegionMapping.prototype.hideImageryLayer = function() {
-    // In this case, the region mapping was on, but has been switched off, so disable the imagery layer.
-    // Record the fact so that we know to turn it on again if active items change again.
+function setHadImageryAtLayerIndex(regionMapping) {
+    // Record that we have had imagery, and which layer it was on, so that we know to turn it on again if active items change again.
     // regionMapping._imageryLayer._layerIndex is not always defined, so use "true" in that case.
-    var regionMapping = this;
-    if (defined(this._imageryLayer)) {
+    if (defined(regionMapping._imageryLayer)) {
         regionMapping._hadImageryAtLayerIndex = regionMapping._imageryLayer._layerIndex;  // Would prefer not to access an internal variable of imageryLayer.
         if (!defined(regionMapping._hadImageryAtLayerIndex)) {
             regionMapping._hadImageryAtLayerIndex = true;
         }
+    }
+}
+
+/**
+ * Explictly hide the imagery layer (if any).
+ */
+RegionMapping.prototype.hideImageryLayer = function() {
+    // The region mapping was on, but has been switched off, so disable the imagery layer.
+    var regionMapping = this;
+    if (defined(regionMapping._imageryLayer)) {
         ImageryLayerCatalogItem.hideLayer(regionMapping._catalogItem, regionMapping._imageryLayer);
         ImageryLayerCatalogItem.disableLayer(regionMapping._catalogItem, regionMapping._imageryLayer);
         regionMapping._imageryLayer = undefined;
@@ -294,6 +299,7 @@ function changedActiveItems(regionMapping) {
     if (defined(regionMapping._regionDetails)) {
         reviseLegendHelper(regionMapping);
         if (!regionMapping._loadingData) {
+            setHadImageryAtLayerIndex(regionMapping);
             if (defined(regionMapping._imageryLayer) || defined(regionMapping._hadImageryAtLayerIndex)) {
                 redisplayRegions(regionMapping);
                 if (defined(regionMapping._imageryLayer) && !defined(regionMapping._regionDetails)) {

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -256,24 +256,19 @@ RegionMapping.prototype.setRegionColumnType = function(index) {
     }
 };
 
-function setHadImageryAtLayerIndex(regionMapping) {
-    // Record that we have had imagery, and which layer it was on, so that we know to turn it on again if active items change again.
-    // regionMapping._imageryLayer._layerIndex is not always defined, so use "true" in that case.
-    if (defined(regionMapping._imageryLayer)) {
-        regionMapping._hadImageryAtLayerIndex = regionMapping._imageryLayer._layerIndex;  // Would prefer not to access an internal variable of imageryLayer.
-        if (!defined(regionMapping._hadImageryAtLayerIndex)) {
-            regionMapping._hadImageryAtLayerIndex = true;
-        }
-    }
-}
-
 /**
  * Explictly hide the imagery layer (if any).
  */
 RegionMapping.prototype.hideImageryLayer = function() {
     // The region mapping was on, but has been switched off, so disable the imagery layer.
+    // We are using _hadImageryAtLayerIndex = true to mean it had an ImageryLayer, but its layer was undefined.
+    // _hadImageryAtLayerIndex = undefined means it did not have an ImageryLayer.
     var regionMapping = this;
     if (defined(regionMapping._imageryLayer)) {
+        regionMapping._hadImageryAtLayerIndex = regionMapping._imageryLayer._layerIndex;  // Would prefer not to access an internal variable of imageryLayer.
+        if (!defined(regionMapping._hadImageryAtLayerIndex)) {
+            regionMapping._hadImageryAtLayerIndex = true;
+        }
         ImageryLayerCatalogItem.hideLayer(regionMapping._catalogItem, regionMapping._imageryLayer);
         ImageryLayerCatalogItem.disableLayer(regionMapping._catalogItem, regionMapping._imageryLayer);
         regionMapping._imageryLayer = undefined;
@@ -299,12 +294,8 @@ function changedActiveItems(regionMapping) {
     if (defined(regionMapping._regionDetails)) {
         reviseLegendHelper(regionMapping);
         if (!regionMapping._loadingData) {
-            setHadImageryAtLayerIndex(regionMapping);
             if (defined(regionMapping._imageryLayer) || defined(regionMapping._hadImageryAtLayerIndex)) {
                 redisplayRegions(regionMapping);
-                if (defined(regionMapping._imageryLayer) && !defined(regionMapping._regionDetails)) {
-                    regionMapping.hideImageryLayer();
-                }
             }
             regionMapping._changed.raiseEvent(regionMapping);
         }
@@ -783,16 +774,8 @@ function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, g
  */
 function redisplayRegions(regionMapping, regionIndices) {
     if (defined(regionMapping._regionDetails)) {
-        // We are using _hadImageryAtLayerIndex = true to mean it had an ImageryLayer, but its layer was undefined.
-        // _hadImageryAtLayerIndex = undefined means it did not have an ImageryLayer.
-        var layerIndex = regionMapping._hadImageryAtLayerIndex === true ? undefined : regionMapping._hadImageryAtLayerIndex;
-        if (defined(regionMapping._imageryLayer)) {
-            layerIndex = regionMapping._imageryLayer._layerIndex;  // Would prefer not to access an internal variable of imageryLayer.
-            ImageryLayerCatalogItem.hideLayer(regionMapping._catalogItem, regionMapping._imageryLayer);
-            ImageryLayerCatalogItem.disableLayer(regionMapping._catalogItem, regionMapping._imageryLayer);
-            regionMapping._imageryLayer = undefined;
-        }
-        setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices);
+        regionMapping.hideImageryLayer();
+        setNewRegionImageryLayer(regionMapping, regionMapping._hadImageryAtLayerIndex, regionIndices);
         if (regionMapping._catalogItem.isShown) {
             ImageryLayerCatalogItem.showLayer(regionMapping._catalogItem, regionMapping._imageryLayer);
         }


### PR DESCRIPTION
With the existing code, if a region-mapped catalog item's regionMapping ever unsets its imageryLayer, it cannot get one back again. In the past I've had to carefully watch out for such situations in the CatalogItem js code (eg. if the query changes and returns an error).  

It turns out the reason is because RegionMapping's `changedActiveItems` function only called `redisplayRegions` if there was already an imagery layer or if `_hadImageryAtLayerIndex` was set. So when there was no imagery layer, you'd need `_hadImageryAtLayerIndex`. But this was never set thanks to a coding error in `changedActiveItems` which put the call to `hideImageryLayer` inside two `if` statements which could never be both true (`if (defined(x) { ... if (!defined(x)) ...}`!).

This change to `RegionMapping.js` simplifies the code a bit, and fixes the problem.