### PR TITLE
Fix name of shareurl in feedback message to server

### DIFF
--- a/lib/Models/sendFeedback.js
+++ b/lib/Models/sendFeedback.js
@@ -36,7 +36,7 @@ function sendFeedback(options) {
             title: options.title,
             name: options.name,
             email: options.email,
-            shareURL: shareURL,
+            shareLink: shareURL,
             comment: options.comment
         }),
         headers: {


### PR DESCRIPTION
Fixes bug where the share url was sent using a different key than the server was expecting.