### PR TITLE
fix workbench image oversize

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 
 * Fixed a bug where providing feedback did not properly share the map view.
 * Updated to terriajs-server 2.6.2.
+* Fixed a bug leading to oversized graphics being displayed from WPS calls.
 
 ### 4.7.0
 

--- a/lib/ReactViews/Workbench/workbench-item.scss
+++ b/lib/ReactViews/Workbench/workbench-item.scss
@@ -32,6 +32,10 @@ $workbench-margin: $padding-small;
   composes: clearfix from '../../Sass/common/_base.scss';
   padding: $padding;
   border-top: 1px solid $border-color;
+  img{
+    max-width: 100%;
+    height: auto;
+  }
 }
 
 .header {


### PR DESCRIPTION
Fixes: https://github.com/TerriaJS/terriajs/issues/2203