### PR TITLE
Move "Done" button text into css for easier overriding

### DIFF
--- a/lib/ReactViews/ExplorerWindow/ExplorerWindow.jsx
+++ b/lib/ReactViews/ExplorerWindow/ExplorerWindow.jsx
@@ -109,7 +109,6 @@ const ExplorerWindow = React.createClass({
                             className={Styles.btnCloseModal}
                             title="Close data panel"
                             data-target="close-modal">
-                        Done
                     </button>
                     <Tabs terria={this.props.terria} viewState={this.props.viewState}/>
                 </div>

--- a/lib/ReactViews/ExplorerWindow/explorer-window.scss
+++ b/lib/ReactViews/ExplorerWindow/explorer-window.scss
@@ -68,6 +68,6 @@
   top: 0;
   right: 0;
   &:before {
-    content: '';
+    content: 'Done';
   }
 }


### PR DESCRIPTION
Makes it easier to address #2090.
Addresses https://github.com/TerriaJS/neii-viewer/issues/44.

Eg. after this PR is merged, you could replace the "Done" button with an "✕" in the client's `globals.scss` via:

    .tjs-explorer-window__btn--close-modal {
      &:before {
        content: '✕' !important;
      }
      color: #EDEDED;
      font-size: $font-size-large !important;
      border: none;
      &:focus, &:hover {
        border: none;
      }
    }

@chloeleichen - is this good practice?