### PR TITLE
Fix preview leaflet link color

### DIFF
--- a/lib/Sass/global/_leaflet.scss
+++ b/lib/Sass/global/_leaflet.scss
@@ -1,3 +1,5 @@
+@import '../../Sass/common/mixins';
+
 // This makes Leaflet work in hot mode
 :global {
   .leaflet-container {
@@ -205,7 +207,7 @@
     outline: 0;
   }
   .leaflet-container a {
-    color: #0078A8;
+    @extend %link;
   }
   .leaflet-container a.leaflet-active {
     outline: 2px solid orange;


### PR DESCRIPTION
If your app has a custom primary color defined, it was not picked up in the "Leaflet" link in the Add Data preview window, where it was hardwired to a specific blue.
Useful for https://github.com/TerriaJS/neii-viewer/issues/44.