### PR TITLE
Fix pale background of feature info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Change Log
 ### 4.7.3
 
 * Canceled pending tile requests when removing a layer from the 2D map.  This should drastically improve the responsiveness when dragging the time slider of a time-dynamic layer in 2D mode.
+* Added the data source and data service details to the "About this dataset" (preview) panel.
+* Fixed a bug introduced in 4.7.2 which made the Feature Info panel background too pale.
 
 ### 4.7.2
 
@@ -14,7 +16,6 @@ Change Log
 * Improved consistency of "Search" and "Add Data" font sizes.
 * Improved flexibility of Feature Info Panel styling.
 * Fixed a bug that could cause an extra `/` to be added to end of URLs by `ArcGisMapServerCatalogItem`, causing some servers to reject the request.
-* Added the data source and data service details to the "About this dataset" (preview) panel.
 * Added a workaround for a bug in Internet Explorer 11 on Windows 7 that could cause the user interface to hang.
 
 ### 4.7.1

--- a/lib/ReactViews/FeatureInfo/feature-info-section.scss
+++ b/lib/ReactViews/FeatureInfo/feature-info-section.scss
@@ -4,7 +4,7 @@
 
 .section {
   composes: clearfix from '../../Sass/common/_base.scss';
-  background: $feature-info-bg;
+  background: $feature-info-section-bg;
   border-top: 1px solid $dark-lighter;
 }
 

--- a/lib/ReactViews/Preview/metadata-table.scss
+++ b/lib/ReactViews/Preview/metadata-table.scss
@@ -5,10 +5,10 @@
   overflow-x: auto;
 }
 
-table tr:nth-child(odd) {
+.root table tr:nth-child(odd) {
     background-color: darken($faint-bg, 8%);
 }
-table tr:nth-child(even) {
+.root table tr:nth-child(even) {
     background-color: $faint-bg;
 }
 

--- a/lib/Sass/common/_variables.scss
+++ b/lib/Sass/common/_variables.scss
@@ -58,7 +58,8 @@ $dropdown-hover-color: orange;
 
 $data-catalog-color: $text-black;
 
-$feature-info-bg: $overlay;
+$feature-info-bg: rgba($dark, 0.95);
+$feature-info-section-bg: $overlay;
 $feature-info-color: $text-light;
 $feature-info-header-bg: $dark;
 $feature-info-btn-color: $text-light;


### PR DESCRIPTION
Fixes #2289.
Also fixes a css problem introduced in #2214, where the metadata table rules were applied to the normal Feature Info table.
I've tested this both with NationalMap and NEII-viewer.