### PR TITLE
Make loader icon visible in feature info panel

### DIFF
--- a/lib/ReactViews/FeatureInfo/feature-info-panel.scss
+++ b/lib/ReactViews/FeatureInfo/feature-info-panel.scss
@@ -16,7 +16,7 @@
   font-family: $font-base;
 
   svg{
-    fill: $feature-info-btn-color;
+    fill: $feature-info-color;
   }
 
   a{


### PR DESCRIPTION
Just a tiny one - I was using the wrong css variable to show the "loading" spinner, so while it works on NatMap, it was white-on-white on NEII. This fixes it.