### PR TITLE
Fix up user guide generation process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ terriajs.pid
 
 # added by GitSavvy
 /wwwroot/schema/
+/wwwroot/user-guide/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '5'
 script:
-- pip install mkdocs
+- pip install --user mkdocs
 - gulp lint docs release
 - gulp test-travis
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
 - '5'
 script:
+- pip install mkdocs
 - gulp lint docs release
 - gulp test-travis
 env:

--- a/Documentation/Contributors/Development-environment.md
+++ b/Documentation/Contributors/Development-environment.md
@@ -1,6 +1,6 @@
 # Setting up a TerriaJS development environment
 
-First, [deploy and build your instance](/Documentation/Deployment/Deploying-Terria-Map.md).
+First, [deploy and build your instance](../Deployment/Deploying-Terria-Map.md).
 
 ## Updating Build
 

--- a/Documentation/Contributors/README.md
+++ b/Documentation/Contributors/README.md
@@ -2,7 +2,7 @@
 
 For all contributors:
 
-* [CONTRIBUTING.md](/CONTRIBUTING.md): how to submit a pull request. Please read! :)
+* [CONTRIBUTING.md](https://github.com/TerriaJS/terriajs/blob/master/CONTRIBUTING.md): how to submit a pull request. Please read! :)
 * [Setting up a development environment](Development-environment.md)
 * [Working with TerriaJS and Cesium](Contributing-to-TerriaJS.md)
 

--- a/Documentation/Customizing/Config-JSON.md
+++ b/Documentation/Customizing/Config-JSON.md
@@ -20,7 +20,7 @@ It has this structure:
 
 Option                      | Meaning
 ----------------------------|--------
-`"initializationUrls"`      | Each string `"foo"` refers to a catalog (init) file found at `/wwwroot/init/foo.json`. These define all the datasets that will be loaded into the catalog. See [Initialization File](/Documentation/CatalogManagement/Initialization-File.md). 
+`"initializationUrls"`      | Each string `"foo"` refers to a catalog (init) file found at `/wwwroot/init/foo.json`. These define all the datasets that will be loaded into the catalog. See [Initialization File](../CatalogManagement/Initialization-File.md). 
 `"parameters": {`           | Key value pairs that configure Terria, as follows.
 `"bingMapsKey"`             | A [Bing Maps API key](https://msdn.microsoft.com/en-us/library/ff428642.aspx) used for requesting Bing Maps base maps and using the Bing Maps geocoder for searching. It is your responsibility to request a key and comply with all terms and conditions.
 `"googleUrlShortenerKey"`   | A Google API key for accessing the [Google URL Shortener service](https://developers.google.com/url-shortener/v1/getting_started#intro). This is required in order to generate short URLs on the "Share" page.

--- a/Documentation/Customizing/README.md
+++ b/Documentation/Customizing/README.md
@@ -2,14 +2,14 @@
 
 These guides cover configuring, skinning and tweaking Terria. You'll need some basic sysadmin or development skills for most tasks. Some of these tricks you can use on any public Terria site.
 
-First, read [Deployment](/Documentation/Deployment) to get up and running.
+First, read [Deployment](../Deployment/README.md) to get up and running.
 
 # Configuring
 
 Location | Purpose
 ---------|---------
-`wwwroot/config.json` | [Config.json](/Documentation/Customizing/Config-JSON.md): Client-side configuration. Configures catalog (init) files to load, attribution, keys for Bing Maps and Google Analytics, the name of your application.
-`wwwroot/terria.json` | A sample [catalog (init) file](/Documentation/CatalogManagement/Initialization-File.md). You can add new datasets here.
+`wwwroot/config.json` | [Config.json](Config-JSON.md): Client-side configuration. Configures catalog (init) files to load, attribution, keys for Bing Maps and Google Analytics, the name of your application.
+`wwwroot/terria.json` | A sample [catalog (init) file](../CatalogManagement/Initialization-File.md). You can add new datasets here.
 `devserverconfig.json` | Server-side configuration for [Terria Server](https://github.com/TerriaJS/TerriaJS-Server). Configures which domains the server will proxy for, and special locations of init files.
 `index.js`| The [index.js](https://github.com/TerriaJS/TerriaMap/blob/master/index.js) is an entry point for Terria Map. Some "configuration-like" aspects are controlled through JavaScript in this file, such as the choices of base map. We try to progressively move these into the above files.
 

--- a/Documentation/Deployment/Deploying-Terria-Map.md
+++ b/Documentation/Deployment/Deploying-Terria-Map.md
@@ -32,4 +32,4 @@ npm start
 
 ## Making changes
 
-Want to start tweaking? Proceed to [Customizing Terria](/Documentation/Customizing/README.md).
+Want to start tweaking? Proceed to [Customizing Terria](../Customizing/README.md).

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,5 +1,3 @@
-## TerriaJS Documentation
-
 * [Getting Started](GettingStarted): quick start guide to building your first TerriaJS application.
 * [Deployment](Deployment): getting started with deploying Terria and optional support services. For developers, sysadmins and hackers.
 * [Customizing](Customizing): How to configure and tweak Terria, including skinning, URL parameters and advanced uses.

--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -5,10 +5,10 @@ docs_dir: 'Documentation'
 site_dir: '../wwwroot/user-guide'
 strict: true
 pages:
-- Home: 'index.md'
-- Getting Started: 'GettingStarted/index.md'
+- Home: 'README.md'
+- Getting Started: 'GettingStarted/README.md'
 - Catalog Management:
-    - Overview: 'CatalogManagement/index.md'
+    - Overview: 'CatalogManagement/README.md'
     - CKAN: 'CatalogManagement/CKAN.md'
     - GeoJSON: 'CatalogManagement/GeoJSON.md'
     - Web Map Service (WMS): 'CatalogManagement/Web-Map-Service.md'
@@ -17,7 +17,7 @@ pages:
     - Initialization File: 'CatalogManagement/Initialization-File.md'
     - Format Conversion Service: 'CatalogManagement/Format-Conversion-Service.md'
 - Customizing:
-    - Overview: 'Customizing/index.md'
+    - Overview: 'Customizing/README.md'
     - Config JSON: 'Customizing/Config-JSON.md'
     - Skinning: 'Customizing/How-to-skin-a-Terria-Map.md'
     - URL Parameters: 'Customizing/TerriaJS-URL-parameters.md'
@@ -26,7 +26,7 @@ pages:
     - CKAN Previewer: 'Customizing/CKAN-previewer.md'
     - WPS Parameters: 'Customizing/WPS-parameters-guide.md'
 - Deployment:
-    - Overview: 'Deployment/index.md'
+    - Overview: 'Deployment/README.md'
     - Deploying TerriaMap: 'Deployment/Deploying-Terria-Map.md'
     - Deploying and Building: 'Deployment/Deploying-and-building-TerriaJS.md'
     - Overall System Architecture: 'Deployment/Overall-system-architecture.md'
@@ -35,7 +35,7 @@ pages:
     - Using a Vector Tile Source: 'Deployment/Using-a-vector-tile-source-for-region-mapping.md'
     - WMS Services: 'Deployment/WMS-Services.md'
 - Contributors:
-    - Overview: 'Contributors/index.md'
+    - Overview: 'Contributors/README.md'
     - Development Environment: 'Contributors/Development-environment.md'
     - Working with TerriaJS and Cesium: 'Contributors/Contributing-to-TerriaJS.md'
     - Setting up Saucelabs: 'Contributors/Setting-up-Saucelabs-Locally.md'

--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -3,14 +3,40 @@ site_name: TerriaJS
 theme: readthedocs
 docs_dir: 'Documentation'
 site_dir: '../wwwroot/user-guide'
+strict: true
 pages:
 - Home: 'index.md'
 - Getting Started: 'GettingStarted/index.md'
-- Deployment:
-    - Overview: 'Deployment/index.md'
-    - Deploying TerriaMap: 'Deployment/Deploying-Terria-Map.md'
+- Catalog Management:
+    - Overview: 'CatalogManagement/index.md'
+    - CKAN: 'CatalogManagement/CKAN.md'
+    - GeoJSON: 'CatalogManagement/GeoJSON.md'
+    - Web Map Service (WMS): 'CatalogManagement/Web-Map-Service.md'
+    - Performance Testing: 'CatalogManagement/Performance-testing.md'
+    - Issues with CORS: 'CatalogManagement/Handling-CORS.md'
+    - Initialization File: 'CatalogManagement/Initialization-File.md'
+    - Format Conversion Service: 'CatalogManagement/Format-Conversion-Service.md'
 - Customizing:
     - Overview: 'Customizing/index.md'
     - Config JSON: 'Customizing/Config-JSON.md'
+    - Skinning: 'Customizing/How-to-skin-a-Terria-Map.md'
+    - URL Parameters: 'Customizing/TerriaJS-URL-parameters.md'
+    - Controlling in an iframe: 'Customizing/TerriaJS-in-iframe.md'
+    - Extending TerriaJS: 'Customizing/Extending-TerriaJS.md'
+    - CKAN Previewer: 'Customizing/CKAN-previewer.md'
+    - WPS Parameters: 'Customizing/WPS-parameters-guide.md'
+- Deployment:
+    - Overview: 'Deployment/index.md'
+    - Deploying TerriaMap: 'Deployment/Deploying-Terria-Map.md'
+    - Deploying and Building: 'Deployment/Deploying-and-building-TerriaJS.md'
+    - Overall System Architecture: 'Deployment/Overall-system-architecture.md'
+    - Problems and Solutions: 'Deployment/Problems-and-Solutions.md'
+    - Setting up a Region Mapping Server: 'Deployment/Setting-up-a-region-mapping-server.md'
+    - Using a Vector Tile Source: 'Deployment/Using-a-vector-tile-source-for-region-mapping.md'
+    - WMS Services: 'Deployment/WMS-Services.md'
 - Contributors:
+    - Overview: 'Contributors/index.md'
     - Development Environment: 'Contributors/Development-environment.md'
+    - Working with TerriaJS and Cesium: 'Contributors/Contributing-to-TerriaJS.md'
+    - Setting up Saucelabs: 'Contributors/Setting-up-Saucelabs-Locally.md'
+    - Using Docker: 'Contributors/Using-Docker.md'

--- a/Documentation/mkdocs.yml
+++ b/Documentation/mkdocs.yml
@@ -1,0 +1,16 @@
+site_name: TerriaJS
+#cosmo|cyborg|readthedocs|yeti|journal|bootstrap|readable|united|simplex|flatly|spacelab|amelia|cerulean|slate|mkdocs
+theme: readthedocs
+docs_dir: 'Documentation'
+site_dir: '../wwwroot/user-guide'
+pages:
+- Home: 'index.md'
+- Getting Started: 'GettingStarted/index.md'
+- Deployment:
+    - Overview: 'Deployment/index.md'
+    - Deploying TerriaMap: 'Deployment/Deploying-Terria-Map.md'
+- Customizing:
+    - Overview: 'Customizing/index.md'
+    - Config JSON: 'Customizing/Config-JSON.md'
+- Contributors:
+    - Development Environment: 'Contributors/Development-environment.md'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -204,6 +204,10 @@ gulp.task('user-guide', function() {
         }
     });
 
+    // Replace README.md with index.md in mkdocs.yml
+    var mkdocsyml = fse.readFileSync('build/mkdocs.yml', 'UTF-8');
+    fse.writeFileSync('build/mkdocs.yml', mkdocsyml.replace(/README.md/g, 'index.md'), 'UTF-8');
+
     var result = spawnSync('mkdocs', ['build', '--clean', '--config-file', 'mkdocs.yml'], {
         cwd: 'build',
         stdio: 'inherit',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,7 +119,9 @@ gulp.task('build-libs', function(done) {
     runWebpack(webpack, webpackConfig, done);
 });
 
-gulp.task('docs', function() {
+gulp.task('docs', ['user-guide', 'reference-guide']);
+
+gulp.task('reference-guide', function() {
     var runExternalModule = require('./buildprocess/runExternalModule');
 
     runExternalModule('jsdoc/jsdoc.js', [
@@ -127,7 +129,6 @@ gulp.task('docs', function() {
         '-c', './buildprocess/jsdoc.json'
     ]);
 });
-
 
 gulp.task('copy-cesium-assets', function() {
     var path = require('path');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -204,7 +204,7 @@ gulp.task('user-doc', function() {
         }
     });
 
-    var result = spawnSync('mkdocs', ['build', '--clean', /*'--strict',*/ '--config-file', 'mkdocs.yml'], {
+    var result = spawnSync('mkdocs', ['build', '--clean', '--config-file', 'mkdocs.yml'], {
         cwd: 'build',
         stdio: 'inherit',
         shell: false

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -198,7 +198,8 @@ gulp.task('user-guide', function() {
 
     // Replace links to README.md with links to index.md
     markdown.forEach(function(name) {
-        var content = fse.readFileSync(name.replace(/README.md/, 'index.md'), 'UTF-8');
+        name = name.replace(/README\.md/, 'index.md');
+        var content = fse.readFileSync(name, 'UTF-8');
         var replaced = content.replace(/README\.md/g, 'index.md');
         if (content !== replaced) {
             fse.writeFileSync(name, replaced, 'UTF-8');
@@ -207,7 +208,7 @@ gulp.task('user-guide', function() {
 
     // Replace README.md with index.md in mkdocs.yml
     var mkdocsyml = fse.readFileSync('build/mkdocs.yml', 'UTF-8');
-    fse.writeFileSync('build/mkdocs.yml', mkdocsyml.replace(/README.md/g, 'index.md'), 'UTF-8');
+    fse.writeFileSync('build/mkdocs.yml', mkdocsyml.replace(/README\.md/g, 'index.md'), 'UTF-8');
 
     var result = spawnSync('mkdocs', ['build', '--clean', '--config-file', 'mkdocs.yml'], {
         cwd: 'build',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -179,7 +179,7 @@ function runKarma(configFile, done) {
     });
 }
 
-gulp.task('user-doc', function() {
+gulp.task('user-guide', function() {
     var fse = require('fs-extra');
     var gutil = require('gulp-util');
     var path = require('path');

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "http://github.com/TerriaJS/terriajs"
   },
+  "config": {
+    "docRepo": "git@github.com:TerriaJS/Documentation.git"
+  },
   "dependencies": {
     "babel-core": "^6.7.4",
     "babel-loader": "^6.2.4",
@@ -118,6 +121,7 @@
     "make-schema": "gulp make-schema",
     "start": "bash ./node_modules/terriajs-server/run_server.sh --port 3002",
     "dev": "webpack-dev-server --inline --config buildprocess/webpack.config.dev.js --host 0.0.0.0",
-    "hot": "webpack-dev-server --inline --config buildprocess/webpack.config.hot.js --hot --host 0.0.0.0"
+    "hot": "webpack-dev-server --inline --config buildprocess/webpack.config.hot.js --hot --host 0.0.0.0",
+    "publish-doc": "bash -c \"rm -rf wwwroot/user-guide && gulp user-guide && cd wwwroot/user-guide && git init && git remote add origin $npm_package_config_docRepo && git add . && git commit -m 'Generate Documentation' && git push -f origin HEAD:gh-pages\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "eslint": "^3.10.0",
     "eslint-plugin-jsx-control-statements": "2.1.1",
     "eslint-plugin-react": "^6.5.0",
+    "fs-extra": "^1.0.0",
     "generate-terriajs-schema": "^1.3.0",
     "glob-all": "^3.0.1",
     "gulp-ruby-sass": "^2.0.5",


### PR DESCRIPTION
Previously the doc generation process was in https://github.com/TerriaJS/MakeDocs and used bash, perl, and python.  Now everything needed is in this repo and it only needs node and python (for mkdocs).  It also uses a new and less buggy template.