### PR TITLE
DropdownPanel allow custom icon

### DIFF
--- a/lib/ReactViews/Map/Panels/DropdownPanel.jsx
+++ b/lib/ReactViews/Map/Panels/DropdownPanel.jsx
@@ -9,6 +9,8 @@ import BaseOuterPanel from './BaseOuterPanel';
 
 import Styles from './panel.scss';
 
+import defined from 'terriajs-cesium/Source/Core/defined';
+
 const DropdownPanel = React.createClass({
     mixins: [BaseOuterPanel],
 
@@ -35,6 +37,13 @@ const DropdownPanel = React.createClass({
     },
 
     render() {
+        let iconGlyph;
+        if (defined(Icon.GLYPHS[this.props.theme.icon])) {
+            iconGlyph = Icon.GLYPHS[this.props.theme.icon];
+        } else {
+            iconGlyph = this.props.theme.icon;
+        }
+
         return (
             <div className={classNames(Styles.panel, this.props.theme.outer)}>
                 <button onClick={this.openPanel}
@@ -43,7 +52,7 @@ const DropdownPanel = React.createClass({
                         title={this.props.btnTitle}
                         ref={element => this.buttonElement = element}>
                     <If condition={this.props.theme.icon}>
-                        <Icon glyph={Icon.GLYPHS[this.props.theme.icon]}/>
+                        <Icon glyph={iconGlyph}/>
                     </If>
                     <span>{this.props.btnText}</span>
                 </button>


### PR DESCRIPTION
No longer assumes that icon passed through is necessarily in Icon.GLYPHS. This allows user to specify icon. I'm using this for the help icon in SOE help screens.