### PR TITLE
Interpret dates of the form 2016-Q2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 4.7.5
+
+* Added the ability to read dates in the format "2017-Q2".
+
 ### 4.7.4
 
 * Renamed `SpatialDetailingFunction`, `WhyAmISpecialFunction`, and `PlacesLikeMeFunction` to `SpatialDetailingCatalogFunction`, `WhyAmISpecialCatalogFunction`, and `PlacesLikeMeCatalogFunction`, respectively.  The old names will be removed in a future release.

--- a/lib/Map/TableColumn.js
+++ b/lib/Map/TableColumn.js
@@ -459,15 +459,6 @@ function isInteger(value) {
     return (!isNaN(value)) && (parseInt(Number(value), 10) === +value) && (!isNaN(parseInt(value, 10)));
 }
 
-function areAllIntegers(array) {
-    for (var i = array.length - 1; i >= 0; i--) {
-        if (!isInteger(array[i])) {
-            return false;
-        }
-    }
-    return true;
-}
-
 /**
  * Returns the options you would pass to recreate this column.
  * @return {Object} An options parameter suitable for passing to new TableColumn().
@@ -516,10 +507,24 @@ TableColumn.convertToDates = function(goodValues, subtype) {
 
     var dateParsers;  // returns [jsDate, julianDate].
     // First, could it be a simple integer year format? Assume if all integers less than 9999, then years.
-    if (subtype === VarSubType.YEAR || ((firstPositionMaximum < 9999) && areAllIntegers(goodValues))) {
+    if (subtype === VarSubType.YEAR || ((firstPositionMaximum < 9999) && goodValues.every(isInteger))) {
         subtype = VarSubType.YEAR;
         dateParsers = function(v) {
             var jsDate = new Date(v + '/01/01');
+            return [jsDate, JulianDate.fromDate(jsDate)];
+        };
+    } else if ((firstPositionMaximum < 9999) && (goodValues.every(value => value.indexOf('-Q') === 4))) {
+        // Is it quarterly data in the format yyyy-Qx ?
+        dateParsers = function(v) {
+            var year = v.slice(0, 4);
+            var quarter = v.slice(6);
+            var monthString;
+            if (quarter === '1') { monthString = '01-01'; }
+            else if (quarter === '2') { monthString = '04-01'; }
+            else if (quarter === '3') { monthString = '07-01'; }
+            else if (quarter === '4') { monthString = '10-01'; }
+            else { return [undefined, undefined]; }
+            var jsDate = new Date(year + '-' + monthString);
             return [jsDate, JulianDate.fromDate(jsDate)];
         };
     } else if (firstPositionMaximum > 31) {

--- a/lib/Map/TableColumn.js
+++ b/lib/Map/TableColumn.js
@@ -519,12 +519,12 @@ TableColumn.convertToDates = function(goodValues, subtype) {
             var year = v.slice(0, 4);
             var quarter = v.slice(6);
             var monthString;
-            if (quarter === '1') { monthString = '01-01'; }
-            else if (quarter === '2') { monthString = '04-01'; }
-            else if (quarter === '3') { monthString = '07-01'; }
-            else if (quarter === '4') { monthString = '10-01'; }
+            if (quarter === '1') { monthString = '01/01'; }
+            else if (quarter === '2') { monthString = '04/01'; }
+            else if (quarter === '3') { monthString = '07/01'; }
+            else if (quarter === '4') { monthString = '10/01'; }
             else { return [undefined, undefined]; }
-            var jsDate = new Date(year + '-' + monthString);
+            var jsDate = new Date(year + '/' + monthString);
             return [jsDate, JulianDate.fromDate(jsDate)];
         };
     } else if (firstPositionMaximum > 31) {

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -353,7 +353,9 @@ defineProperties(TableCatalogItem.prototype, {
         get: function() {
             if (defined(this.tableStructure.activeTimeColumn)) {
                 return this.tableStructure.activeTimeColumn.timeIntervals.reduce(function(intervals, interval) {
-                    intervals.addInterval(interval);
+                    if (defined(interval)) {
+                        intervals.addInterval(interval);
+                    }
                     return intervals;
                 }, new TimeIntervalCollection());
             }

--- a/test/Map/TableColumnSpec.js
+++ b/test/Map/TableColumnSpec.js
@@ -182,6 +182,16 @@ describe('TableColumn', function() {
         expect(tableColumn.dates[1].getSeconds()).toEqual(45);
     });
 
+    it('can detect time type from yyyy-Qx', function() {
+        var data = ['2010-Q1', '2010-Q2', '2010-Q3', '2010-Q4'];
+        var tableColumn = new TableColumn('date', data.slice());
+        expect(tableColumn.type).toEqual(VarType.TIME);
+        expect(tableColumn.values.slice()).toEqual(data);
+        expect(tableColumn.dates[1].getDate()).toEqual(1);
+        expect(tableColumn.dates[1].getMonth()).toEqual(3); // January is month 0
+        expect(tableColumn.dates[1].getFullYear()).toEqual(2010);
+    });
+
     it('can detect year subtype using year title', function() {
         var data = ['1066', '1776', '1788', '1901', '2220'];
         var tableColumn = new TableColumn('year', data.slice());


### PR DESCRIPTION
This format is often used by the ABS in its SDMX-JSON datasets, eg. http://localhost:3001/proxy/http://stat.data.abs.gov.au/sdmx-json/data/RES_PROP_INDEX/1.3..Q/all/ . 

This increases how many ABS datasets we can display.