### PR TITLE
Fix Leaflet visualisation point removal for lat-lon time csvs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,10 @@
 Change Log
 ==========
 
-### 4.7.5
+### 4.8.0
 
 * The icon specified to the `MenuPanel` / `DropdownPanel` theme can now be either the identifier of an icon from `Icon.GLYPHS` or an actual SVG `require`'d via the `svg-sprite-loader`.
+* Fixed a bug that caused time-varying points from a CSV file to leave a trail on the 2D map.
 
 ### 4.7.4
 

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -198,7 +198,7 @@ LeafletGeomVisualizer.prototype._updatePoint = function(entity, time, entityHash
 
     var show = entity.isAvailable(time) && Property.getValueOrDefault(pointGraphics._show, time, true);
     if (!show) {
-        delete entityDetails.point;
+        cleanPoint(entity, featureGroup, entityDetails);
         return;
     }
 


### PR DESCRIPTION
Fixes #2299.

Points still stay on a little longer than they do in 3D mode, but it's the same behaviour as in the old UI (when time varying csvs last worked).