### PR TITLE
Add Terria.filterStartDataCallback.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Updated `TableCatalogItem`s to show a download URL in About This Dataset, which downloads the entire dataset as csv, even if the original data was more complex (eg. from an API).
 * The icon specified to the `MenuPanel` / `DropdownPanel` theme can now be either the identifier of an icon from `Icon.GLYPHS` or an actual SVG `require`'d via the `svg-sprite-loader`.
 * Fixed a bug that caused time-varying points from a CSV file to leave a trail on the 2D map.
+* Add `Terria.filterStartDataCallback`.  This callback gives an application the opportunity to modify start (share) data supplied in a URL before TerriaJS loads it.
 
 ### 4.7.4
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -344,6 +344,13 @@ var Terria = function(options) {
      */
     this.selectBox = false;
 
+    /**
+     * Gets or sets a callback function that can modify any "start data" (e.g. a share URL) before it is loaded.
+     * The function is passed the start data and may modify it in place or return a new instance.
+     * @type {Function}
+     */
+    this.filterStartDataCallback = undefined;
+
     // TODO: Why track showTimeline, which doesn't appear anywhere in the code (in this file or any other)?
     knockout.track(this, ['viewerMode', 'baseMap', 'baseMapName', 'fogSettings', '_initialView', 'homeView', 'pickedFeatures', 'selectedFeature', 'mapInteractionModeStack', 'configParameters', 'showTimeline', 'catalog', 'selectBox']);
 
@@ -489,7 +496,7 @@ Terria.prototype.updateApplicationUrl = function(newUrl) {
 
 Terria.prototype.updateFromStartData = function(startData) {
     var initSources = this.initSources.slice();
-    interpretStartData(startData, this.initSources, initSources);
+    interpretStartData(this, startData, this.initSources, initSources);
     return loadInitSources(this, initSources);
 };
 
@@ -687,7 +694,7 @@ function interpretHash(terria, hashProperties, userProperties, persistentInitSou
             } else if (property === 'start') {
                 // a share link that hasn't been shortened: JSON embedded in URL (only works for small quantities of JSON)
                 var startData = JSON.parse(propertyValue);
-                interpretStartData(startData, persistentInitSources, temporaryInitSources);
+                interpretStartData(terria, startData, persistentInitSources, temporaryInitSources);
             } else if (defined(propertyValue) && propertyValue.length > 0) {
                 userProperties[property] = propertyValue;
                 knockout.track(userProperties, [property]);
@@ -698,14 +705,18 @@ function interpretHash(terria, hashProperties, userProperties, persistentInitSou
             }
         });
         if (shareProps) {
-            interpretStartData(shareProps, persistentInitSources, temporaryInitSources);
+            interpretStartData(terria, shareProps, persistentInitSources, temporaryInitSources);
         }
     });
 }
 
-function interpretStartData(startData, persistentInitSources, temporaryInitSources) {
+function interpretStartData(terria, startData, persistentInitSources, temporaryInitSources) {
     if (defined(startData.version) && startData.version !== latestStartVersion) {
         adjustForBackwardCompatibility(startData);
+    }
+
+    if (defined(terria.filterStartDataCallback)) {
+        startData = terria.filterStartDataCallback(startData) || startData;
     }
 
     // Include any initSources specified in the URL.


### PR DESCRIPTION
This allows an application using TerriaJS to modify start (share) data before it is loaded by TerriaJS.  We'll use this in NationalMap to make sure we don't load old versions of the catalog even if the share data tells us to.