### PR TITLE
CKAN Improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+### 4.8.1
+
+* `CkanCatalogGroup` now automatically adds the type of the resource (e.g. `(WMS)`) after the name when a dataset contains multiple resources that can be turned into catalog items and `useResourceName` is false.
+* Added support for ArcGIS FeatureServers to `CkanCatalogGroup` and `CkanCatalogItem`.  In order for `CkanCatalogGroup` to include FeatureServers, `includeEsriFeatureServer` must be set to true.
+
 ### 4.8.0
 
 * Fixed a bug that prevented downloading data from the chart panel if the map was started in 2D mode.

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -651,9 +651,7 @@ function populateGroupFromResults(ckanGroup, json) {
         if (resourceItems.length > 1 && !ckanGroup.useResourceName) {
             resourceItems.forEach(function(item) {
                 var typeName = CkanCatalogItem.shortHumanReadableTypeNames[item.type] || 'Other';
-                if (defined(typeName)) {
-                    item.name += ' (' + typeName + ')';
-                }
+                item.name += ' (' + typeName + ')';
             });
         }
     }

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -567,6 +567,8 @@ function populateGroupFromResults(ckanGroup, json) {
             }
         }
 
+        var resourceItems = [];
+
         var resources = item.resources;
         for (var resourceIndex = 0; resourceIndex < resources.length; ++resourceIndex) {
             var resource = resources[resourceIndex];
@@ -576,7 +578,11 @@ function populateGroupFromResults(ckanGroup, json) {
                 groups = item.groups;
             } else if (ckanGroup.groupBy === 'organization' && item.organization) { // item.organization is sometimes null
                 groups = [item.organization];
+            } else {
+                groups = undefined;
             }
+
+            var addedItem;
 
             if (defined(groups) && groups.length > 0) {
                 for (var groupIndex = 0; groupIndex < groups.length; ++groupIndex) {
@@ -597,7 +603,7 @@ function populateGroupFromResults(ckanGroup, json) {
                         groupToAdd.id = groupId;
                     }
 
-                    addItem(resource, ckanGroup, item, extras, groupToAdd);
+                    addedItem = addItem(resource, ckanGroup, item, extras, groupToAdd);
 
                     if (!updating && groupToAdd.items.length) {
                         ckanGroup.add(groupToAdd);
@@ -605,7 +611,7 @@ function populateGroupFromResults(ckanGroup, json) {
                 }
             } else {
                 if (!ckanGroup.ungroupedTitle) {
-                    addItem(resource, ckanGroup, item, extras, ckanGroup);
+                    addedItem = addItem(resource, ckanGroup, item, extras, ckanGroup);
                 } else {
                     if (!defined(ungrouped)) {
                         ungrouped = new CatalogGroup(ckanGroup.terria);
@@ -613,9 +619,25 @@ function populateGroupFromResults(ckanGroup, json) {
                         ungrouped.id = ckanGroup.uniqueId + '/_ungrouped';
                         ckanGroup.add(ungrouped);
                     }
-                    addItem(resource, ckanGroup, item, extras, ungrouped);
+                    addedItem = addItem(resource, ckanGroup, item, extras, ungrouped);
                 }
             }
+
+            if (defined(addedItem)) {
+                resourceItems.push(addedItem);
+            }
+        }
+
+        // If there's more than one resource item, and we're not using the resource name to name
+        // our items, then they'll all have the same name.  Add the type to the name to help
+        // distinguish them.
+        if (resourceItems.length > 1 && !ckanGroup.useResourceName) {
+            resourceItems.forEach(function(item) {
+                var typeName = CkanCatalogItem.shortHumanReadableTypeNames[item.type] || 'Other';
+                if (defined(typeName)) {
+                    item.name += ' (' + typeName + ')';
+                }
+            });
         }
     }
 
@@ -648,6 +670,7 @@ function populateGroupFromResults(ckanGroup, json) {
  * @param itemData The data of the item to build the catalog item from
  * @param extras
  * @param parent The parent group to add the item to once it's constructed - set this to rootCkanGroup for flat hierarchies.
+ * @returns {CatalogItem} The catalog item added, or undefined if no catalog item was added.
  */
 function addItem(resource, rootCkanGroup, itemData, extras, parent) {
     var item = rootCkanGroup.terria.catalog.shareKeyIndex[parent.uniqueId + '/' + resource.id];
@@ -660,6 +683,8 @@ function addItem(resource, rootCkanGroup, itemData, extras, parent) {
             parent.add(item);
         }
     }
+
+    return item;
 }
 
 module.exports = CkanCatalogGroup;

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -188,17 +188,31 @@ var CkanCatalogGroup = function(terria) {
     this.csvResourceFormat = /^csv-geo-/i;
 
     /**
-     * True to allow ESRI Map resources to be added to the catalog; otherwise, false.
+     * True to allow ESRI MapServer resources to be added to the catalog; otherwise, false.
      * @type {Boolean}
      * @default false
      */
     this.includeEsriMapServer = false;
 
     /**
+     * True to allow ESRI FeatureServer resources to be added to the catalog; otherwise, false.
+     * @type {Boolean}
+     * @default false
+     */
+    this.includeEsriFeatureServer = false;
+
+    /**
      * Gets or sets a regular expression that, when it matches a resource's format, indicates that the resource is an Esri MapServer resource.
      * @type {RegExp}
      */
     this.esriMapServerResourceFormat = /^esri rest$/i;
+
+    /**
+     * Gets or sets a regular expression that, when it matches a resource's format, indicates that the resource is an Esri
+     * MapServer or FeatureServer resource.  A valid FeatureServer resource must also have `FeatureServer` in its URL.
+     * @type {RegExp}
+     */
+    this.esriFeatureServerResourceFormat = /^esri rest$/i;
 
     /**
      * True to allow GeoJSON resources to be added to the catalog; otherwise, false.
@@ -321,6 +335,7 @@ CkanCatalogGroup.defaultUpdaters.wfsResourceFormat = createRegexDeserializer('wf
 CkanCatalogGroup.defaultUpdaters.kmlResourceFormat = createRegexDeserializer('kmlResourceFormat');
 CkanCatalogGroup.defaultUpdaters.csvResourceFormat = createRegexDeserializer('csvResourceFormat');
 CkanCatalogGroup.defaultUpdaters.esriMapServerResourceFormat = createRegexDeserializer('esriMapServerResourceFormat');
+CkanCatalogGroup.defaultUpdaters.esriFeatureServerResourceFormat = createRegexDeserializer('esriFeatureServerResourceFormat');
 CkanCatalogGroup.defaultUpdaters.geoJsonResourceFormat = createRegexDeserializer('geoJsonResourceFormat');
 CkanCatalogGroup.defaultUpdaters.czmlResourceFormat = createRegexDeserializer('czmlResourceFormat');
 
@@ -340,6 +355,7 @@ CkanCatalogGroup.defaultSerializers.wfsResourceFormat = createRegexSerializer('w
 CkanCatalogGroup.defaultSerializers.kmlResourceFormat = createRegexSerializer('kmlResourceFormat');
 CkanCatalogGroup.defaultSerializers.csvResourceFormat = createRegexSerializer('csvResourceFormat');
 CkanCatalogGroup.defaultSerializers.esriMapServerResourceFormat = createRegexSerializer('esriMapServerResourceFormat');
+CkanCatalogGroup.defaultSerializers.esriFeatureServerResourceFormat = createRegexSerializer('esriFeatureServerResourceFormat');
 CkanCatalogGroup.defaultSerializers.geoJsonResourceFormat = createRegexSerializer('geoJsonResourceFormat');
 CkanCatalogGroup.defaultSerializers.czmlResourceFormat = createRegexSerializer('czmlResourceFormat');
 
@@ -538,6 +554,7 @@ function createItemFromResource(resource, ckanGroup, itemData, extras, parent) {
         kmlResourceFormat: ckanGroup.includeKml ? ckanGroup.kmlResourceFormat : undefined,
         csvResourceFormat: ckanGroup.includeCsv ? ckanGroup.csvResourceFormat : undefined,
         esriMapServerResourceFormat: ckanGroup.includeEsriMapServer ? ckanGroup.esriMapServerResourceFormat : undefined,
+        esriFeatureServerResourceFormat: ckanGroup.includeEsriFeatureServer ? ckanGroup.esriFeatureServerResourceFormat : undefined,
         geoJsonResourceFormat: ckanGroup.includeGeoJson ? ckanGroup.geoJsonResourceFormat : undefined,
         czmlResourceFormat: ckanGroup.includeCzml ? ckanGroup.czmlResourceFormat : undefined,
         allowWmsGroups: ckanGroup.allowEntireWmsServers,

--- a/lib/Models/CkanCatalogItem.js
+++ b/lib/Models/CkanCatalogItem.js
@@ -451,6 +451,24 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
     return newItem;
 };
 
+/**
+ * Maps catalog item `type` to a short, human-readable identifier of the
+ * type of resource accessed (e.g. `wms` maps to `WMS` and `esri-mapServer`
+ * maps to `MapServer`).
+ * @type {Object}
+ */
+CkanCatalogItem.shortHumanReadableTypeNames = {
+    wms: 'WMS',
+    'wms-getCapabilities': 'WMS',
+    wfs: 'WFS',
+    'wfs-getCapabilities': 'WFS',
+    'esri-mapServer': 'MapServer',
+    kml: 'KML',
+    geojson: 'GeoJSON',
+    czml: 'CZML',
+    csv: 'CSV'
+};
+
 CkanCatalogItem.prototype._load = function() {
     var baseUri = new URI(this.url).segment('api/3/action');
 

--- a/lib/Models/CkanCatalogItem.js
+++ b/lib/Models/CkanCatalogItem.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /*global require*/
+var ArcGisFeatureServerCatalogItem = require('./ArcGisFeatureServerCatalogItem');
 var ArcGisMapServerCatalogItem = require('./ArcGisMapServerCatalogItem');
 var CatalogItem = require('./CatalogItem');
 var clone = require('terriajs-cesium/Source/Core/clone');
@@ -343,6 +344,7 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
 
     var isWms = matchingFormats[0][1] === WebMapServiceCatalogItem;
     var isWfs = matchingFormats[0][1] === WebFeatureServiceCatalogItem;
+    var isEsriRest = matchingFormats[0][1] === ArcGisMapServerCatalogItem;
 
     var baseUrl = resource.wms_url;
     if (!defined(baseUrl)) {
@@ -376,11 +378,18 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
         }
         uri.search('');
         url = uri.toString();
+    } else if (isEsriRest) {
+        // Determine if this is really a FeatureServer by looking at the URL.
+        if (url.match(/FeatureServer/)) {
+            newItem = new ArcGisFeatureServerCatalogItem(options.terria);
+        } else {
+            newItem = new matchingFormats[0][1](options.terria);
+        }
     } else {
         newItem = new matchingFormats[0][1](options.terria);
     }
     if (!newItem) {
-        return;
+        return undefined;
     }
 
     if (options.useResourceName) {
@@ -463,6 +472,7 @@ CkanCatalogItem.shortHumanReadableTypeNames = {
     wfs: 'WFS',
     'wfs-getCapabilities': 'WFS',
     'esri-mapServer': 'MapServer',
+    'esri-featureServer': 'FeatureServer',
     kml: 'KML',
     geojson: 'GeoJSON',
     czml: 'CZML',

--- a/lib/Models/CkanCatalogItem.js
+++ b/lib/Models/CkanCatalogItem.js
@@ -126,10 +126,25 @@ function CkanCatalogItem(terria) {
     this.allowEsriMapServer = true;
 
     /**
+     * Gets or sets a value indicating whether this may be an Esri FeatureServer resource.
+     * @type {Boolean}
+     * @default true
+     */
+    this.allowEsriFeatureServer = true;
+
+    /**
      * Gets or sets a regular expression that, when it matches a resource's format, indicates that the resource is an Esri MapServer resource.
+     * A valid MapServer resource must also have `MapServer` in its URL.
      * @type {RegExp}
      */
     this.esriMapServerResourceFormat = /^esri rest$/i;
+
+    /**
+     * Gets or sets a regular expression that, when it matches a resource's format, indicates that the resource is an Esri
+     * MapServer or FeatureServer resource.  A valid FeatureServer resource must also have `FeatureServer` in its URL.
+     * @type {RegExp}
+     */
+    this.esriFeatureServerResourceFormat = /^esri rest$/i;
 
     /**
      * Gets or sets a value indicating whether this may be a GeoJSON resource.
@@ -246,6 +261,7 @@ CkanCatalogItem.defaultUpdaters.wfsResourceFormat = createRegexDeserializer('wfs
 CkanCatalogItem.defaultUpdaters.kmlResourceFormat = createRegexDeserializer('kmlResourceFormat');
 CkanCatalogItem.defaultUpdaters.csvResourceFormat = createRegexDeserializer('csvResourceFormat');
 CkanCatalogItem.defaultUpdaters.esriMapServerResourceFormat = createRegexDeserializer('esriMapServerResourceFormat');
+CkanCatalogItem.defaultUpdaters.esriFeatureServerResourceFormat = createRegexDeserializer('esriFeatureServerResourceFormat');
 CkanCatalogItem.defaultUpdaters.geoJsonResourceFormat = createRegexDeserializer('geoJsonResourceFormat');
 CkanCatalogItem.defaultUpdaters.czmlResourceFormat = createRegexDeserializer('czmlResourceFormat');
 
@@ -263,6 +279,7 @@ CkanCatalogItem.defaultSerializers.wfsResourceFormat = createRegexSerializer('wf
 CkanCatalogItem.defaultSerializers.kmlResourceFormat = createRegexSerializer('kmlResourceFormat');
 CkanCatalogItem.defaultSerializers.csvResourceFormat = createRegexSerializer('csvResourceFormat');
 CkanCatalogItem.defaultSerializers.esriMapServerResourceFormat = createRegexSerializer('esriMapServerResourceFormat');
+CkanCatalogItem.defaultSerializers.esriFeatureServerResourceFormat = createRegexSerializer('esriFeatureServerResourceFormat');
 CkanCatalogItem.defaultSerializers.geoJsonResourceFormat = createRegexSerializer('geoJsonResourceFormat');
 CkanCatalogItem.defaultSerializers.czmlResourceFormat = createRegexSerializer('czmlResourceFormat');
 
@@ -283,6 +300,8 @@ freezeObject(CkanCatalogItem.defaultSerializers);
  *                                             is a WFS resource.  If undefined, WFS resources will not be returned.
  * @param {RegExp} [options.esriMapServerResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
  *                                                       is an Esri MapServer resource.  If undefined, Esri MapServer resources will not be returned.
+ * @param {RegExp} [options.esriFeatureServerResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
+ *                                                           is an Esri FeatureServer resource.  If undefined, Esri FeatureServer resources will not be returned.
  * @param {RegExp} [options.kmlResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
  *                                             is a KML resource.  If undefined, KML resources will not be returned.
  * @param {RegExp} [options.geoJsonResourceFormat] A regular expression that, when it matches a resource's format, indicates that the resource
@@ -326,9 +345,11 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
     }
 
     var formats = [
+        // Format Regex, Catalog Item, (optional) URL regex
         [options.wmsResourceFormat, WebMapServiceCatalogItem],
         [options.wfsResourceFormat, WebFeatureServiceCatalogItem],
-        [options.esriMapServerResourceFormat, ArcGisMapServerCatalogItem],
+        [options.esriMapServerResourceFormat, ArcGisMapServerCatalogItem, /MapServer/],
+        [options.esriFeatureServerResourceFormat, ArcGisFeatureServerCatalogItem, /FeatureServer/],
         [options.kmlResourceFormat, KmlCatalogItem],
         [options.geoJsonResourceFormat, GeoJsonCatalogItem],
         [options.czmlResourceFormat, CzmlCatalogItem],
@@ -337,15 +358,6 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
         return defined(format[0]);
     });
 
-    var matchingFormats = formats.filter(function(format) { return resource.format.match(format[0]); });
-    if (matchingFormats.length === 0) {
-        return undefined;
-    }
-
-    var isWms = matchingFormats[0][1] === WebMapServiceCatalogItem;
-    var isWfs = matchingFormats[0][1] === WebFeatureServiceCatalogItem;
-    var isEsriRest = matchingFormats[0][1] === ArcGisMapServerCatalogItem;
-
     var baseUrl = resource.wms_url;
     if (!defined(baseUrl)) {
         baseUrl = resource.url;
@@ -353,6 +365,19 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
             return undefined;
         }
     }
+
+    var matchingFormats = formats.filter(function(format) {
+        // Matching formats must match the format regex,
+        // and also the URL regex if it exists.
+        return resource.format.match(format[0]) &&
+               (!defined(format[2]) || baseUrl.match(format[2]));
+    });
+    if (matchingFormats.length === 0) {
+        return undefined;
+    }
+
+    var isWms = matchingFormats[0][1] === WebMapServiceCatalogItem;
+    var isWfs = matchingFormats[0][1] === WebFeatureServiceCatalogItem;
 
     // Extract the layer name from the URL.
     var uri = new URI(baseUrl);
@@ -378,13 +403,6 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
         }
         uri.search('');
         url = uri.toString();
-    } else if (isEsriRest) {
-        // Determine if this is really a FeatureServer by looking at the URL.
-        if (url.match(/FeatureServer/)) {
-            newItem = new ArcGisFeatureServerCatalogItem(options.terria);
-        } else {
-            newItem = new matchingFormats[0][1](options.terria);
-        }
     } else {
         newItem = new matchingFormats[0][1](options.terria);
     }


### PR DESCRIPTION
From CHANGES.md:
* `CkanCatalogGroup` now automatically adds the type of the resource (e.g. `(WMS)`) after the name when a dataset contains multiple resources that can be turned into catalog items and `useResourceName` is false.
* Added support for ArcGIS FeatureServers to `CkanCatalogGroup` and `CkanCatalogItem`.  In order for `CkanCatalogGroup` to include FeatureServers, `includeEsriFeatureServer` must be set to true.

To try this out, use http://localhost:3001/#clean&https://raw.githubusercontent.com/TerriaJS/NationalMap-Catalog/esri/build/nm.json and look for FeatureServers under `Data.gov.au -> Moreton Bay Regional Council` and multiple resources of different types under `Local Government -> Victoria -> Ballarat`.  To verify that MapServers still work, check out `Data.gov.au -> Geoscience Australia -> GA_SBAGD_Framework (MapServer)`.

Fixes #2318
Fixes #2319 
