### PR TITLE
Make the share URL configurable and relative by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 
 * `CkanCatalogGroup` now automatically adds the type of the resource (e.g. `(WMS)`) after the name when a dataset contains multiple resources that can be turned into catalog items and `useResourceName` is false.
 * Added support for ArcGIS FeatureServers to `CkanCatalogGroup` and `CkanCatalogItem`.  In order for `CkanCatalogGroup` to include FeatureServers, `includeEsriFeatureServer` must be set to true.
+* Changed default URL for the share service from `/share` to `share` and made it configurable by specifying `shareUrl` in config.json.  This helps with deployments in subdirectories.
 
 ### 4.8.0
 

--- a/lib/Models/ShareDataService.js
+++ b/lib/Models/ShareDataService.js
@@ -16,7 +16,7 @@ var ShareDataService = function(options) {
     }
 
     this.terria = options.terria;
-    this.url = defaultValue(options.url, 'share');
+    this.url = defaultValue(options.url, defaultValue(this.terria.configParameters.shareUrl, 'share'));
 
     this._isUsable = undefined;
 };

--- a/lib/Models/ShareDataService.js
+++ b/lib/Models/ShareDataService.js
@@ -16,7 +16,7 @@ var ShareDataService = function(options) {
     }
 
     this.terria = options.terria;
-    this.url = defaultValue(options.url, '/share');
+    this.url = defaultValue(options.url, 'share');
 
     this._isUsable = undefined;
 };

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -40,6 +40,7 @@ var defaultConfigParameters = {
     proj4ServiceBaseUrl: 'proj4/',
     corsProxyBaseUrl: 'proxy/',
     proxyableDomainsUrl: 'proxyabledomains/',
+    shareUrl: 'share',
     feedbackUrl: undefined
 };
 


### PR DESCRIPTION
This makes is consistent with other services provided by terriajs-server (such as `proxy` rather than `/proxy`) and is correct for all of our applications except Northern Australia.  I'll open a PR in NA to override it there.