### PR TITLE
Don't access config.json's shareUrl before config.json is loaded.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 4.8.2
+
+* Fixed a bug that prevented a `shareUrl` specified in `config.json` from actually being used by the `ShareDataService`.
+
 ### 4.8.1
 
 * `CkanCatalogGroup` now automatically adds the type of the resource (e.g. `(WMS)`) after the name when a dataset contains multiple resources that can be turned into catalog items and `useResourceName` is false.

--- a/lib/Models/ShareDataService.js
+++ b/lib/Models/ShareDataService.js
@@ -16,7 +16,7 @@ var ShareDataService = function(options) {
     }
 
     this.terria = options.terria;
-    this.url = defaultValue(options.url, defaultValue(this.terria.configParameters.shareUrl, 'share'));
+    this.url = options.url;
 
     this._isUsable = undefined;
 };
@@ -34,6 +34,8 @@ defineProperties(ShareDataService.prototype, {
  * @param  {Object} serverConfig Options retrieved from ServerConfig.config.
  */
 ShareDataService.prototype.init = function(serverConfig) {
+    this.url = defaultValue(this.url, defaultValue(this.terria.configParameters.shareUrl, 'share'));
+
     if (typeof serverConfig === 'object' && typeof serverConfig.newShareUrlPrefix === 'string') {
         this._isUsable = true;
     } else {


### PR DESCRIPTION
Fixes #2323 
