### PR TITLE
Don't let GetCapabilities override share properties.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 ### 4.8.2
 
 * Adding a JSON init file by dropping it on the map or selecting it from the My Data tab no longer adds an entry to the Workbench and User-Added Data catalog.
+* Fixed a bug that caused a `WebMapServiceCatalogItem` inside a `WebMapServiceCatalogGroup` to revert to defaults from GetCapabilities instead of using shared properties.
 
 ### 4.8.1
 

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -287,7 +287,7 @@ function createWmsDataSource(wmsGroup, capabilities, layer, infoDerivedFromCapab
     result.layers = layer.Name;
     result.url = wmsGroup.url;
 
-    result.updateFromCapabilities(capabilities, true, layer, infoDerivedFromCapabilities);
+    result.updateFromCapabilities(capabilities, false, layer, infoDerivedFromCapabilities);
 
     if (typeof(wmsGroup.itemProperties) === 'object') {
         result.updateFromJson(wmsGroup.itemProperties);


### PR DESCRIPTION
Fixes #2183 

In the share link in #2183, the shared WMS catalog item is inside a WMS group.  For WMS items inside WMS groups, we were previously setting the GetCapabilities data to override all existing property of the catalog item.  I guess my thinking at the time was that GetCapabilities is the authority for these auto-generated catalog items.

That was mostly ok, until I fixed #1778.  I refactored things slightly so that the GetCapabilities data, even though it was loaded with the group, wasn't actually applied to the catalog item until the catalog item itself was loaded.  So before the fix for #1778, the sequence was:

1. Create a new catalog item.
2. Load properties from GetCapabilities, clobbering anything that's already there.
3. Apply the group's `itemProperties` to the item.
4. Apply properties from the share data.

But after the fix for #1778, it was more like:

1. Create a new catalog item.
2. Apply the group's `itemProperties` to the item.
3. Apply properties from the share data.
4. Load properties from GetCapabilities, clobbering anything that's already there.

Which is pretty clearly a problem.

So this PR keeps the same post-1778 order, but changes step 4 to only set properties from GetCapabilities if the properties don't already have a value.  Since this is what we do anyway for WMS items specified directly (rather than created inside a WMS group), I don't think it should cause any problems.