### PR TITLE
Don't crash when searching for a location in 2D.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+### 4.8.3
+
+* Fix a bug that prevented drawing the marker and zooming to the point when searching for a location in 2D.
+
 ### 4.8.2
 
 * Adding a JSON init file by dropping it on the map or selecting it from the My Data tab no longer adds an entry to the Workbench and User-Added Data catalog.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,10 @@
 Change Log
 ==========
 
-### 4.8.3
-
-* Fix a bug that prevented drawing the marker and zooming to the point when searching for a location in 2D.
-
 ### 4.8.2
 
 * Adding a JSON init file by dropping it on the map or selecting it from the My Data tab no longer adds an entry to the Workbench and User-Added Data catalog.
+* Fix a bug that prevented drawing the marker and zooming to the point when searching for a location in 2D.
 
 ### 4.8.1
 

--- a/lib/ReactViews/Search/SearchMarkerUtils.js
+++ b/lib/ReactViews/Search/SearchMarkerUtils.js
@@ -40,7 +40,9 @@ export function addMarker(terria, viewState, result) {
         }
     });
 
-    correctEntityHeight(firstPointEntity, cartographicPosition, terria.cesium.scene.globe.terrainProvider, 15);
+    if (terria.cesium && terria.cesium.scene && terria.cesium.scene.globe && terria.cesium.scene.globe.terrainProvider) {
+        correctEntityHeight(firstPointEntity, cartographicPosition, terria.cesium.scene.globe.terrainProvider, 15);
+    }
 
     viewState.searchState.mapPointerDataSource.entities.add(firstPointEntity);
 }


### PR DESCRIPTION
It was trying to set the height of the marker by querying Cesium terrain, which isn't available in 2D.

Fixes #2321 

Even after this PR, if you search in 2D, and then switch to 3D, the marker won't be at the right height so you'll get a parallax effect.  This is difficult to fix and IMO not too critical.