### PR TITLE
Fix ArcGisCatalogItem for proj4 v2.3.16

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,12 @@
 
+
 Change Log
 ==========
 
 ### 4.8.3
 
 * Add HelpScreens. If used, this adds a button to the top right titled help, which drops down a list of available help sequences, such as how to add data or how to change map settings. When a dropdown item is clicked, a sequence of help screens appears leading the user through a task. Help sequences must be defined by instance using TerriaJS.
+* Fixed a bug with calculating bounding rectangles in `ArcGisCatalogItem` caused by changes to `proj4` package.
 
 ### 4.8.2
 

--- a/lib/Map/Reproject.js
+++ b/lib/Map/Reproject.js
@@ -59,9 +59,7 @@ var Reproject = {
     reprojectPoint: function(coordinates, sourceCode, destCode) {
         var source = new proj4.Proj(Proj4Definitions[sourceCode]);
         var dest = new proj4.Proj(Proj4Definitions[destCode]);
-        var p = proj4.toPoint(coordinates);
-        var reprojected = proj4(source, dest, p);
-        return [reprojected.x, reprojected.y];
+        return proj4(source, dest, coordinates);
     },
 
     /**

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -395,17 +395,15 @@ function getRectangleFromLayer(thisLayerJson) {
         var source = new proj4.Proj(proj4definitions[wkid]);
         var dest = new proj4.Proj('EPSG:4326');
 
-        var p = proj4.toPoint([extent.xmin, extent.ymin]);
-        proj4(source, dest, p);
+        var p = proj4(source, dest, [extent.xmin, extent.ymin]);
 
-        var west = p.x;
-        var south = p.y;
+        var west = p[0];
+        var south = p[1];
 
-        p = proj4.toPoint([extent.xmax, extent.ymax]);
-        proj4(source, dest, p);
+        p = proj4(source, dest, [extent.xmax, extent.ymax]);
 
-        var east = p.x;
-        var north = p.y;
+        var east = p[0];
+        var north = p[1];
 
         return Rectangle.fromDegrees(west, south, east, north);
     }


### PR DESCRIPTION
Fix ArcGisCatalogItem relying on `proj4` correctly mutating a point, and change usage of `proj4` function across terriajs to the form `proj4(CRS, CRS, [lon, lat]) -> [lon, lat]`, which is the documented form on [`proj4` Github page](https://github.com/proj4js/proj4js) to avoid future issues.