### PR TITLE
Proxy legend URLs when necessary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 4.10.1
+
+* Fixed a bug that prevented the proxy from being used for loading legends, even in situations where it is necessary such as an `http` legend accessed from an `https` site.
+
 ### 4.10.0
 
 * Changed defaults:

--- a/lib/ReactViews/Workbench/Controls/Legend.jsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.jsx
@@ -36,7 +36,7 @@ const Legend = React.createClass({
         const isImage = legendUrl.isImage();
         const insertDirectly = !!legendUrl.safeSvgContent; // we only insert content we generated ourselves, not arbitrary SVG from init files.
         const safeSvgContent = {__html: legendUrl.safeSvgContent};
-        const proxiedUrl = proxyCatalogItemUrl(this.catalogMember, legendUrl.url);
+        const proxiedUrl = proxyCatalogItemUrl(this.props.item, legendUrl.url);
 
         return (
             <Choose>


### PR DESCRIPTION
The catalog item was not being passed in correctly, so legends were never proxied.

Fixes #2356 
Fixes TerriaJS/nationalmap#416