### PR TITLE
Add nameInCatalog property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 4.10.4
+
+* Added support for a new `nameInCatalog` property on all catalog members which overrides `name` when displayed in the catalog, if present.
+
 ### 4.10.3
 
 * Locked third-party dependency proj4 to v2.3.x because v2.4.0 breaks our build.

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -182,6 +182,13 @@ var CatalogMember = function(terria) {
      */
     this._sourceInfoItemNames = [];
 
+    /**
+     * The name of the item to show in the catalog, if different from `name`. Default undefined.
+     * This property is observed.
+     * @type {String}
+     * @private
+     */
+    this._nameInCatalog = undefined;
 
     this._loadingPromise = undefined;
 
@@ -190,7 +197,7 @@ var CatalogMember = function(terria) {
 
     knockout.track(this, ['name', 'info', 'infoSectionOrder', 'description', 'isUserSupplied', 'isPromoted',
         'initialMessage', 'isHidden', 'cacheDuration', 'customProperties', 'shortReport', 'shortReportSections',
-        'isLoading', 'isWaitingForDisclaimer']);
+        'isLoading', 'isWaitingForDisclaimer', '_nameInCatalog']);
 
     knockout.defineProperty(this, 'nameSortKey', {
         get: function() {
@@ -203,6 +210,20 @@ var CatalogMember = function(terria) {
                     return part.trim().toLowerCase();
                 }
             });
+        }
+    });
+
+    /**
+     * Gets or sets the name of this catalog member in the catalog. By default this is just `name`, but can be overridden.
+     * @member {String} nameInCatalog
+     * @memberOf CatalogMember.prototype
+     */
+    knockout.defineProperty(this, 'nameInCatalog', {
+        get : function() {
+            return defaultValue(this._nameInCatalog, this.name);
+        },
+        set : function(value) {
+            this._nameInCatalog = value;
         }
     });
 };

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
@@ -71,8 +71,8 @@ const DataCatalogGroup = React.createClass({
         const group = this.props.group;
         return (
             <CatalogGroup
-                text={group.name}
-                title={getAncestors(group).map(member => member.name).join(' → ')}
+                text={group.nameInCatalog}
+                title={getAncestors(group).map(member => member.nameInCatalog).join(' → ')}
                 topLevel={this.isTopLevel()}
                 open={this.isOpen()}
                 loading={group.isLoading}

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -66,8 +66,8 @@ const DataCatalogItem = React.createClass({
             <CatalogItem
                 onTextClick={this.setPreviewedItem}
                 selected={this.isSelected()}
-                text={item.name}
-                title={getAncestors(item).map(member => member.name).join(' → ')}
+                text={item.nameInCatalog}
+                title={getAncestors(item).map(member => member.nameInCatalog).join(' → ')}
                 btnState={this.getState()}
                 onBtnClick={this.onBtnClicked}
                 titleOverrides={STATE_TO_TITLE}

--- a/lib/ReactViews/Workbench/WorkbenchItem.jsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.jsx
@@ -1,21 +1,25 @@
 'use strict';
 
-import DisplayAsPercentSection from './Controls/DisplayAsPercentSection';
 import classNames from 'classnames';
-import ConceptViewer from './Controls/ConceptViewer';
+import React from 'react';
+import {sortable} from 'react-anything-sortable';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
+
+import DisplayAsPercentSection from './Controls/DisplayAsPercentSection';
+import ConceptViewer from './Controls/ConceptViewer';
 import DimensionSelectorSection from './Controls/DimensionSelectorSection';
+import getAncestors from '../../Models/getAncestors';
 import Legend from './Controls/Legend';
 import ObserveModelMixin from './../ObserveModelMixin';
 import OpacitySection from './Controls/OpacitySection';
 import ColorScaleRangeSection from './Controls/ColorScaleRangeSection';
-import React from 'react';
 import ShortReport from './Controls/ShortReport';
-import Styles from './workbench-item.scss';
 import StyleSelectorSection from './Controls/StyleSelectorSection';
 import ViewingControls from './Controls/ViewingControls';
-import Icon from "../Icon.jsx";
-import {sortable} from 'react-anything-sortable';
+
+import Styles from './workbench-item.scss';
+import Icon from '../Icon.jsx';
 
 const WorkbenchItem = React.createClass({
     mixins: [ObserveModelMixin],
@@ -67,7 +71,8 @@ const WorkbenchItem = React.createClass({
                         <div
                             onMouseDown={this.props.onMouseDown}
                             onTouchStart={this.props.onTouchStart}
-                            className={Styles.draggable}>
+                            className={Styles.draggable}
+                            title={getAncestors(workbenchItem).map(member => member.nameInCatalog).concat(workbenchItem.nameInCatalog).join(' → ')}>
                             <If condition={!workbenchItem.isMappable}>
                                 <span className={Styles.iconLineChart}><Icon glyph={Icon.GLYPHS.lineChart}/></span>
                             </If>

--- a/wwwroot/test/init/csv.json
+++ b/wwwroot/test/init/csv.json
@@ -5,291 +5,346 @@
         "isOpen": true,
         "items": [
             {
-                "name": "Moving features (sampled)",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
-                "idColumns": ["id"],
-                "tableStyle": {
-                    "dataVariable": "value",
-                    "scaleByValue": true
-                }
-            },
-            {
-                "name": "Moving features turned off with []",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
-                "idColumns": [],
-                "tableStyle": {
-                    "dataVariable": "value",
-                    "scaleByValue": true
-                }
-            },
-            {
-                "name": "Moving features turned off with null",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
-                "idColumns": null,
-                "tableStyle": {
-                    "dataVariable": "value",
-                    "scaleByValue": true
-                }
-            },
-            {
-                "name": "Moving features (sampled, with info template)",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
-                "idColumns": ["id"],
-                "tableStyle": {
-                    "dataVariable": "value",
-                    "scaleByValue": true
-                },
-                "featureInfoTemplate": "<p>Name: {{id}}</p><h2>Time series</h2>{{terria.timeSeries.chart}}"
-            },
-            {
-                "name": "Moving features (sampled, with manual info template)",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
-                "idColumns": ["id"],
-                "tableStyle": {
-                    "dataVariable": "value",
-                    "scaleByValue": true,
-                    "columns": {
-                        "value": {
-                            "name": "speed",
-                            "units": "km/hr"
+                "name": "CSVs with moving features",
+                "nameInCatalog": "Moving features",
+                "type": "group",
+                "isOpen": false,
+                "items": [
+                    {
+                        "name": "Moving features (sampled)",
+                        "nameInCatalog": "Sampled",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
+                        "idColumns": ["id"],
+                        "tableStyle": {
+                            "dataVariable": "value",
+                            "scaleByValue": true
+                        }
+                    },
+                    {
+                        "name": "Moving features turned off with []",
+                        "nameInCatalog": "Turned off with []",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
+                        "idColumns": [],
+                        "tableStyle": {
+                            "dataVariable": "value",
+                            "scaleByValue": true
+                        }
+                    },
+                    {
+                        "name": "Moving features turned off with null",
+                        "nameInCatalog": "Turned off with null",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
+                        "idColumns": null,
+                        "tableStyle": {
+                            "dataVariable": "value",
+                            "scaleByValue": true
+                        }
+                    },
+                    {
+                        "name": "Moving features (sampled, with info template)",
+                        "nameInCatalog": "Sampled, with info template",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
+                        "idColumns": ["id"],
+                        "tableStyle": {
+                            "dataVariable": "value",
+                            "scaleByValue": true
+                        },
+                        "featureInfoTemplate": "<p>Name: {{id}}</p><h2>Time series</h2>{{terria.timeSeries.chart}}"
+                    },
+                    {
+                        "name": "Moving features (sampled, with manual info template)",
+                        "nameInCatalog": "Sampled, with manual info template",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
+                        "idColumns": ["id"],
+                        "tableStyle": {
+                            "dataVariable": "value",
+                            "scaleByValue": true,
+                            "columns": {
+                                "value": {
+                                    "name": "speed",
+                                    "units": "km/hr"
+                                }
+                            }
+                        },
+                        "featureInfoTemplate": "<p>Name: {{id}}</p><h2>Time series</h2><p><chart x-column='{{terria.timeSeries.xName}}' y-column='{{terria.timeSeries.yName}}' column-units='{{terria.timeSeries.units}}' id='{{terria.timeSeries.id}}'>{{terria.timeSeries.data}}</chart></p>"
+                    },
+                    {
+                        "name": "Moving features (not sampled)",
+                        "nameInCatalog": "Not sampled",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
+                        "idColumns": ["id"],
+                        "isSampled": false,
+                        "tableStyle": {
+                            "dataVariable": "value",
+                            "scaleByValue": true
                         }
                     }
-                },
-                "featureInfoTemplate": "<p>Name: {{id}}</p><h2>Time series</h2><p><chart x-column='{{terria.timeSeries.xName}}' y-column='{{terria.timeSeries.yName}}' column-units='{{terria.timeSeries.units}}' id='{{terria.timeSeries.id}}'>{{terria.timeSeries.data}}</chart></p>"
+                ]
             },
             {
-                "name": "Moving features (not sampled)",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon_enum_date_id.csv",
-                "idColumns": ["id"],
-                "isSampled": false,
-                "tableStyle": {
-                    "dataVariable": "value",
-                    "scaleByValue": true
-                }
+                "name": "CSVs from the init file",
+                "nameInCatalog": "From the init file",
+                "type": "group",
+                "isOpen": false,
+                "items": [
+                    {
+                        "name": "Lat/lon CSV from init file",
+                        "nameInCatalog": "Lat/lon CSV",
+                        "type": "csv",
+                        "data": "longitude,latitude,value\n134.384,-26.716,5\n121.659,-33.592,10"
+                    },
+                    {
+                        "name": "Region-mapped CSV from init file",
+                        "nameInCatalog": "Region-mapped CSV",
+                        "type": "csv",
+                        "data": "POA,value\n2880,5\n5710,10"
+                    }
+                ]
             },
             {
-                "name": "Lat/lon CSV from init file",
-                "type": "csv",
-                "data": "longitude,latitude,value\n134.384,-26.716,5\n121.659,-33.592,10"
+                "name": "CSVs with a time column",
+                "nameInCatalog": "Time column",
+                "type": "group",
+                "isOpen": false,
+                "items": [
+                    {
+                        "name": "Melbourne postcodes with time column",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/postcode_val_enum_time.csv"
+                    },
+                    {
+                        "name": "WA postcodes with start and end dates",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/postcode_val_enum_start_end.csv",
+                        "isSampled": false // Suppresses the chart over time in feature info, which looks bad.
+                    },
+                    {
+                        "name": "Melbourne postcodes with time column and template",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/postcode_val_enum_time.csv",
+                        "featureInfoTemplate": "<p>Postcode: {{postcode}}</p><p>Time: {{time}}</p><p>Val1: {{val1}}</p><p>Enum: {{enum}}</enum>"
+                    },
+                    {
+                        "name": "Lat/lon CSV with duration of 1 hour",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon_date_value.csv",
+                        "tableStyle": {
+                            "displayDuration": 60
+                        }
+                    },
+                ]
             },
             {
-                "name": "Melbourne postcodes with time column",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/postcode_val_enum_time.csv"
+                "name": "CSVs with blank values",
+                "nameInCatalog": "Blank values",
+                "type": "group",
+                "isOpen": false,
+                "items": [
+                    {
+                        "name": "CSV (with 0) with blank values as zero",
+                        "type": "csv",
+                        "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,0",
+                        "tableStyle": {
+                            "replaceWithZeroValues": [null]
+                        }
+                    },
+                    {
+                        "name": "CSV (with 0) with blank values separated",
+                        "type": "csv",
+                        "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,0",
+                        "tableStyle": {
+                            "replaceWithZeroValues": [],
+                            "nullColor": "green",
+                            "nullLabel": "blank"
+                        }
+                    },
+                    {
+                        "name": "CSV (no 0) with blank values as zero",
+                        "type": "csv",
+                        "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
+                        "tableStyle": {
+                            "replaceWithZeroValues": [null]
+                        }
+                    },
+                    {
+                        "name": "CSV (no 0) with blank values separated",
+                        "type": "csv",
+                        "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
+                        "tableStyle": {
+                            "replaceWithZeroValues": [],
+                            "nullColor": "green",
+                            "nullLabel": "blank"
+                        }
+                    },
+                    {
+                        "name": "CSV with blank string values",
+                        "type": "csv",
+                        "data": "longitude,latitude,enum\n134,-26,dog\n121,-33,\n124,-32,cat\n130,-30,frog\n132,-28,dog",
+                        "tableStyle": {
+                            "nullLabel": "blank"
+                        }
+                    },
+                    {
+                        "name": "CSV with all values replaced with null",
+                        "type": "csv",
+                        "data": "longitude,latitude,val\n134,-26,0\n121,-33,\n124,-32,",
+                        "tableStyle": {
+                            "replaceWithNullValues": [0],
+                            "nullLabel": "blank"
+                        }
+                    },
+                ]
             },
             {
-                "name": "WA postcodes with start and end dates",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/postcode_val_enum_start_end.csv",
-                "isSampled": false // Suppresses the chart over time in feature info, which looks bad.
-            },
-            {
-                "name": "Melbourne postcodes with time column and template",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/postcode_val_enum_time.csv",
-                "featureInfoTemplate": "<p>Postcode: {{postcode}}</p><p>Time: {{time}}</p><p>Val1: {{val1}}</p><p>Enum: {{enum}}</enum>"
-            },
-            {
-                "name": "Region-mapped CSV from init file",
-                "type": "csv",
-                "data": "POA,value\n2880,5\n5710,10"
-            },
-            {
-                "name": "CSV (with 0) with blank values as zero",
-                "type": "csv",
-                "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,0",
-                "tableStyle": {
-                    "replaceWithZeroValues": [null]
-                }
-            },
-            {
-                "name": "CSV (with 0) with blank values separated",
-                "type": "csv",
-                "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,0",
-                "tableStyle": {
-                    "replaceWithZeroValues": [],
-                    "nullColor": "green",
-                    "nullLabel": "blank"
-                }
-            },
-            {
-                "name": "CSV (no 0) with blank values as zero",
-                "type": "csv",
-                "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
-                "tableStyle": {
-                    "replaceWithZeroValues": [null]
-                }
-            },
-            {
-                "name": "CSV (no 0) with blank values separated",
-                "type": "csv",
-                "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
-                "tableStyle": {
-                    "replaceWithZeroValues": [],
-                    "nullColor": "green",
-                    "nullLabel": "blank"
-                }
-            },
-            {
-                "name": "CSV with colorBins=0 (gradient)",
-                "type": "csv",
-                "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
-                "tableStyle": {
-                    "replaceWithZeroValues": [null],
-                    "colorBins": 0
-                }
-            },
-            {
-                "name": "CSV with colorBins=0 (gradient) and blank values separated",
-                "type": "csv",
-                "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
-                "tableStyle": {
-                    "replaceWithZeroValues": [],
-                    "nullColor": "green",
-                    "nullLabel": "blank",
-                    "colorBins": 0
-                }
-            },
-            {
-                "name": "CSV with no data variable selected",
-                "type": "csv",
-                "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
-                "tableStyle": {
-                    "dataVariable": null
-                }
-            },
-            {
-                "name": "CSV with blank string values",
-                "type": "csv",
-                "data": "longitude,latitude,enum\n134,-26,dog\n121,-33,\n124,-32,cat\n130,-30,frog\n132,-28,dog",
-                "tableStyle": {
-                    "nullLabel": "blank"
-                }
-            },
-             {
-                "name": "CSV with all values replaced with null",
-                "type": "csv",
-                "data": "longitude,latitude,val\n134,-26,0\n121,-33,\n124,-32,",
-                "tableStyle": {
-                    "replaceWithNullValues": [0],
-                    "nullLabel": "blank"
-                }
-            },
-            {
-                "name": "CSV with explicit enum colors",
-                "type": "csv",
-                "data": "longitude,latitude,enum\n134,-26,dog\n121,-33,\n124,-32,cat\n130,-30,frog\n132,-28,dog",
-                "tableStyle": {
-                    "nullLabel": "blank",
-                    "colorBins": [
-                        {"value": "dog", "color": "lightblue"},
-                        {"value": "cat", "color": "pink"},
-                        {"value": "frog", "color": "green"}
-                    ]
-                }
-            },
-            {
-                 "name":"CSV with explicit per column color",
-                 "type": "csv",
-                 "data": "Date,PV,NPV,BS\n2000-01-01T00:00:00.000Z,80,2,45\n2000-01-09T00:00:00.000Z,59,14,43\n2000-01-17T00:00:00.000Z,97,39,49\n2000-01-25T00:00:00.000Z,40,75,91\n",
-                 "tableStyle": {
-                     "columns" : {
-                         "PV": {
-                             "chartLineColor": "#00b050"
-                         },
-                         "NPV": {
-                             "chartLineColor": "#0070c0"
+                "name": "CSVs with colors",
+                "nameInCatalog": "Colors",
+                "type": "group",
+                "isOpen": false,
+                "items": [
+                    {
+                        "name": "CSV with colorBins=0 (gradient)",
+                        "type": "csv",
+                        "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
+                        "tableStyle": {
+                            "replaceWithZeroValues": [null],
+                            "colorBins": 0
+                        }
+                    },
+                    {
+                        "name": "CSV with colorBins=0 (gradient) and blank values separated",
+                        "type": "csv",
+                        "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
+                        "tableStyle": {
+                            "replaceWithZeroValues": [],
+                            "nullColor": "green",
+                            "nullLabel": "blank",
+                            "colorBins": 0
+                        }
+                    },
+                    {
+                        "name": "CSV with explicit enum colors",
+                        "type": "csv",
+                        "data": "longitude,latitude,enum\n134,-26,dog\n121,-33,\n124,-32,cat\n130,-30,frog\n132,-28,dog",
+                        "tableStyle": {
+                            "nullLabel": "blank",
+                            "colorBins": [
+                                {"value": "dog", "color": "lightblue"},
+                                {"value": "cat", "color": "pink"},
+                                {"value": "frog", "color": "green"}
+                            ]
+                        }
+                    },
+                    {
+                         "name":"CSV with explicit per column color",
+                         "type": "csv",
+                         "data": "Date,PV,NPV,BS\n2000-01-01T00:00:00.000Z,80,2,45\n2000-01-09T00:00:00.000Z,59,14,43\n2000-01-17T00:00:00.000Z,97,39,49\n2000-01-25T00:00:00.000Z,40,75,91\n",
+                         "tableStyle": {
+                             "columns" : {
+                                 "PV": {
+                                     "chartLineColor": "#00b050"
+                                 },
+                                 "NPV": {
+                                     "chartLineColor": "#0070c0"
+                                 }
+                             }
                          }
-                     }
-                 }
-            },
-            {
-                 "name":"CSV with explicit per column y axis extents",
-                 "type": "csv",
-                 "data": "Date,PV,NPV,BS\n2000-01-01T00:00:00.000Z,80,2,45\n2000-01-09T00:00:00.000Z,59,14,43\n2000-01-17T00:00:00.000Z,97,39,49\n2000-01-25T00:00:00.000Z,40,75,91\n",
-                 "tableStyle": {
-                     "columns" : {
-                         "PV": {
-                             "units": "%",
-                             "yAxisMin": 30,
-                             "yAxisMax": 100
-                         },
-                         "NPV": {
-                             "units": "mm",
-                             "yAxisMin": 0,
-                             "yAxisMax": 200
+                    },
+                    {
+                         "name":"CSV with explicit per column y axis extents",
+                         "type": "csv",
+                         "data": "Date,PV,NPV,BS\n2000-01-01T00:00:00.000Z,80,2,45\n2000-01-09T00:00:00.000Z,59,14,43\n2000-01-17T00:00:00.000Z,97,39,49\n2000-01-25T00:00:00.000Z,40,75,91\n",
+                         "tableStyle": {
+                             "columns" : {
+                                 "PV": {
+                                     "units": "%",
+                                     "yAxisMin": 30,
+                                     "yAxisMax": 100
+                                 },
+                                 "NPV": {
+                                     "units": "mm",
+                                     "yAxisMin": 0,
+                                     "yAxisMax": 200
+                                 }
+                             }
                          }
-                     }
-                 }
+                    },
+                    {
+                        "name": "Lat/lon with too many enum values",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon_enum_lots.csv",
+                        "tableStyle": {
+                            "colorBins": 9
+                        }
+                    },
+                    {
+                        "name": "Lat/lon with 9 enum values and 9 bins",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon_enum_lots2.csv",
+                        "tableStyle": {
+                            "colorBins": 9
+                        }
+                    },
+                    {
+                        "name": "Postcodes with 9 enum values and 9 bins",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/postcode_enum_lots2.csv",
+                        "tableStyle": {
+                            "colorBins": 9
+                        }
+                    },
+                    {
+                        "name": "Postcodes with too many enum values",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/postcode_enum_lots.csv",
+                        "tableStyle": {
+                            "colorBins": 9
+                        }
+                    },
+                    {
+                        "name": "RDA LGA 2015 (Top)",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/RDA_LGA_2015_16.csv",
+                        "tableStyle": {
+                            "dataVariable": "RDA_NAME",
+                            "colorBinMethod": "top"
+                        }
+                    },
+                    {
+                        "name": "RDA LGA 2015 (Color cycling)",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/RDA_LGA_2015_16.csv",
+                        "tableStyle": {
+                            "dataVariable": "RDA_NAME",
+                            "colorBinMethod": "cycle"
+                        }
+                    }
+                ]
             },
             {
-                "name": "Lat/lon CSV with duration of 1 hour",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon_date_value.csv",
-                "tableStyle": {
-                    "displayDuration": 60
-                }
-            },
-            {
-                "name": "Lat/lon CSV with no other columns",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon.csv"
-            },
-            {
-                "name": "Lat/lon with too many enum values",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon_enum_lots.csv",
-                "tableStyle": {
-                    "colorBins": 9
-                }
-            },
-            {
-                "name": "Lat/lon with 9 enum values and 9 bins",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/lat_lon_enum_lots2.csv",
-                "tableStyle": {
-                    "colorBins": 9
-                }
-            },
-            {
-                "name": "Postcodes with 9 enum values and 9 bins",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/postcode_enum_lots2.csv",
-                "tableStyle": {
-                    "colorBins": 9
-                }
-            },
-            {
-                "name": "Postcodes with too many enum values",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/postcode_enum_lots.csv",
-                "tableStyle": {
-                    "colorBins": 9
-                }
-            },
-            {
-                "name": "RDA LGA 2015 (Top)",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/RDA_LGA_2015_16.csv",
-                "tableStyle": {
-                    "dataVariable": "RDA_NAME",
-                    "colorBinMethod": "top"
-                }
-            },
-            {
-                "name": "RDA LGA 2015 (Color cycling)",
-                "type": "csv",
-                "url": "build/TerriaJS/test/csv/RDA_LGA_2015_16.csv",
-                "tableStyle": {
-                    "dataVariable": "RDA_NAME",
-                    "colorBinMethod": "cycle"
-                }
+                "name": "Other test CSVs",
+                "type": "group",
+                "isOpen": false,
+                "items": [
+                    {
+                        "name": "CSV with no data variable selected",
+                        "type": "csv",
+                        "data": "longitude,latitude,value\n134,-26,5\n121,-33,\n124,-32,3\n130,-30,4\n132,-28,1",
+                        "tableStyle": {
+                            "dataVariable": null
+                        }
+                    },
+                    {
+                        "name": "Lat/lon CSV with no other columns",
+                        "type": "csv",
+                        "url": "build/TerriaJS/test/csv/lat_lon.csv"
+                    }
+                ]
             }
         ]
     }]


### PR DESCRIPTION
Fixes #2378. This PR is useful in the case when it would be redundant to use the full name in the catalog given the group names above it.

You can try this out using the updated `csv.json`, ie. http://localhost:3001/#build/terriajs/test/init/csv.json

![image](https://cloud.githubusercontent.com/assets/1757858/23733906/a0a5c6b8-04cf-11e7-8733-5b5fcd4b5a3c.png)

In the screenshot note the name on the left is the same catalog item as selected on the right, but the naming is different. 