### PR TITLE
Added `terria.markdown` for markdown-support for data fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 4.10.5
+
+* Added support for the `terria.markdown` function in feature info templates, so that markdown-formatted data fields can be displayed.
+
 ### 4.10.4
 
 * Added the ability for `CkanCatalogGroup` to receive results in pages, rather than all in one request.  This will happen automatically when the server returns partial results.

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -13,6 +13,7 @@ import CustomComponents from '../Custom/CustomComponents';
 import FeatureInfoDownload from './FeatureInfoDownload';
 import formatNumberForLocale from '../../Core/formatNumberForLocale';
 import Icon from '../Icon.jsx';
+import markdownToHtml from '../../Core/markdownToHtml';
 import ObserveModelMixin from '../ObserveModelMixin';
 import propertyGetTimeValues from '../../Core/propertyGetTimeValues';
 import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
@@ -74,6 +75,7 @@ const FeatureInfoSection = React.createClass({
 
             propertyData.terria = {
                 formatNumber: mustacheFormatNumberFunction,
+                markdown: mustacheMarkdownFunction,
                 urlEncodeComponent: mustacheURLEncodeTextComponent
             };
             if (this.props.position) {
@@ -406,6 +408,21 @@ function mustacheFormatNumberFunction() {
 function mustacheURLEncodeTextComponent() {
     return function(text, render) {
         return encodeURIComponent(render(text));
+    };
+}
+
+/**
+ * Returns a function which implements markdown parsing in Mustache templates.
+ * This is useful to parse a supplied variable as markdown, eg. if it may contain URLs.
+ *
+ * Eg. if myString is 'See info at www.example.com/1 and www.example.com/2.',
+ * {{#terria.markdown}}{{mystring}}{{/terria.markdown}}
+ *   -> 'See info at <a href="www.example.com/1">www.example.com/1</a> and <a href="www.example.com/2">www.example.com/2</a>.'
+ * @private
+ */
+function mustacheMarkdownFunction() {
+    return function(text, render) {
+        return markdownToHtml(render(text));
     };
 }
 

--- a/test/ReactViews/FeatureInfoSectionSpec.jsx
+++ b/test/ReactViews/FeatureInfoSectionSpec.jsx
@@ -31,36 +31,6 @@ if (typeof Intl === 'object' && typeof Intl.NumberFormat === 'function') {
 
 const contentClass = Styles.content;
 
-// function getShallowRenderedOutput(jsx) {
-//     const renderer = ReactTestUtils.createRenderer();
-//     renderer.render(jsx);
-//     return renderer.getRenderOutput();
-// }
-
-// function findAllEqualTo(reactElement, text) {
-//     return findAll(reactElement, (element) => element && element === text);
-// }
-
-// function findAllWithPropsChildEqualTo(reactElement, text) {
-//     // Returns elements with element.props.children[i] or element.props.children[i][j] equal to text, for any i or j.
-//     return findAll(reactElement, (element) => {
-//         if (!(element && element.props && element.props.children)) {
-//             return;
-//         }
-//         return element.props.children.indexOf(text) >= 0 || (element.props.children.some && element.props.children.some(x => x && x.length && x.indexOf(text) >= 0));
-//     });
-// }
-
-// function getContentAndDescription(renderedResult) {
-//     const content = findAllWithClass(renderedResult, contentClass)[0];
-//     const descriptionElement = content.props.children.props.children[1][0]; // I have no idea why it's in this position, and don't want to test that it always is.
-//     const descriptionText = descriptionElement.props.children[1][0]; // Ditto.
-//     return {
-//         content: renderedResult.props.children[1],
-//         descriptionElement: descriptionElement,
-//         descriptionText: descriptionText
-//     };
-// }
 
 describe('FeatureInfoSection', function() {
 
@@ -85,7 +55,8 @@ describe('FeatureInfoSection', function() {
             'owner_html': 'Jay<br>Smith',
             'ampersand': 'A & B',
             'lessThan': 'A < B',
-            'unsafe': 'ok!<script>alert("gotcha")</script>'
+            'unsafe': 'ok!<script>alert("gotcha")</script>',
+            'description': 'Check out www.example.com/1 and www.example.com/2.'
         };
         feature = new Entity({
             name: 'Bar',
@@ -318,11 +289,18 @@ describe('FeatureInfoSection', function() {
             expect(findAllEqualTo(result, 'Test: text').length).toEqual(1);
         });
 
-        it('url encodes sections of text', function() {
+        it('can use terria.urlEncodeComponent to url-encode sections of text', function() {
             const template = 'Test: {{#terria.urlEncodeComponent}}W/HOE#1{{/terria.urlEncodeComponent}}';
             const section = <FeatureInfoSection feature={feature} isOpen={true} clock={terria.clock} template={template} viewState={viewState} />;
             const result = getShallowRenderedOutput(section);
             expect(findAllEqualTo(result, 'Test: W%2FHOE%231').length).toEqual(1);
+        });
+
+        it('can use terria.markdown to parse markdown on fields', function() {
+            const template = '<div>Description: {{#terria.markdown}}{{description}}{{/terria.markdown}}</div>';
+            const section = <FeatureInfoSection feature={feature} isOpen={true} clock={terria.clock} template={template} viewState={viewState}/>;
+            const result = getShallowRenderedOutput(section);
+            expect(findAllWithType(result, 'a').length).toEqual(2);  // The description has two links which markdown should turn into anchor tags.
         });
 
         it('does not escape ampersand as &amp;', function() {


### PR DESCRIPTION
Fixes #2386.  The problem is that the feature info template assumed `{{siteUrl}}` was a single tag, and wrapping it in `<a>`, but it actually contained two links in plain text. But if you just display it as `{{siteUrl}}` it comes out as text with no links.

With this PR you can do `{{#terria.markdown}}{{siteUrl}}{{/terria.markdown}}`.

Slightly worried that there is actually no problem here at all, and we don't need this ability. But I can't see how to do it otherwise, eg. this spec fails (with `'description': 'Check out www.example.com/1 and www.example.com/2.'`):
```
        it('does not render fields with markdown', function() {
            const template = '<div>Description: {{description}}</div>';
            const section = <FeatureInfoSection feature={feature} isOpen={true} clock={terria.clock} template={template} viewState={viewState}/>;
            const result = getShallowRenderedOutput(section);
            expect(findAllWithType(result, 'a').length).toEqual(2);
        });
```