### PR TITLE
Add `charSet` parameter on CSV catalog items, to override mime-type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * Changed "go to full screen mode" tooltip to "Hide workbench", and "Exit Full Screen" button to "Show Workbench".  The term "full screen" was misleading.
 * Fixed a bug where a chartable (non-geo-spatial) CSV file with a column including the text "height" would not let the user choose the "height" column as the y-axis of a chart.
 * Added support for non-default x-axes for charts via `<chart x-column="x">` and the new `tableStyle.xAxis` parameter.
+* Added support for a `charSet` parameter on CSV catalog items, which overrides the server's mime-type if present.
 
 ### 4.10.4
 

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -6,7 +6,7 @@ var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
-var loadText = require('terriajs-cesium/Source/Core/loadText');
+var loadWithXhr = require('terriajs-cesium/Source/Core/loadWithXhr');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var inherit = require('../Core/inherit');
@@ -31,6 +31,13 @@ var TableStructure = require('../Map/TableStructure');
  */
 var CsvCatalogItem = function(terria, url, options) {
     TableCatalogItem.call(this, terria, url, options);
+
+    /**
+     * Gets or sets the character set of the data, which overrides the file information if present. Default is undefined.
+     * This property is observable.
+     * @type {String}
+     */
+    this.charSet = undefined;
 
     /**
      * Some catalog items are created from other catalog items.
@@ -213,7 +220,11 @@ CsvCatalogItem.prototype._load = function() {
             }
         });
     } else if (defined(that.url)) {
-        return loadText(proxyCatalogItemUrl(that, that.url, '1d')).then(function(text) {
+        var overrideMimeType;
+        if (defined(that.charSet)) {
+            overrideMimeType = 'text/csv; charset=' + that.charSet;
+        }
+        return loadText(proxyCatalogItemUrl(that, that.url, '1d'), undefined, overrideMimeType).then(function(text) {
             return loadTableFromCsv(that, text);
         }).otherwise(function(e) {
             throw new TerriaError({
@@ -224,5 +235,18 @@ CsvCatalogItem.prototype._load = function() {
         });
     }
 };
+
+/**
+ * The same as terriajs-cesium/Source/Core/loadText, but with the ability to pass overrideMimeType through to loadWithXhr.
+ * @private
+ */
+function loadText(url, headers, overrideMimeType) {
+    return loadWithXhr({
+            url : url,
+            headers : headers,
+            overrideMimeType: overrideMimeType,
+            preferText : true
+        });
+}
 
 module.exports = CsvCatalogItem;

--- a/wwwroot/test/init/csv.json
+++ b/wwwroot/test/init/csv.json
@@ -343,6 +343,19 @@
                         "name": "Lat/lon CSV with no other columns",
                         "type": "csv",
                         "url": "build/TerriaJS/test/csv/lat_lon.csv"
+                    },
+                    {
+                        "name": "Csv with LATIN-1 encoding not specified by server",
+                        "type": "csv",
+                        "url": "http://data.gov.au/dataset/3fd356c6-0ad4-453e-82e9-03af582024c3/resource/d73f2a2a-c271-4edd-ac45-25fd7ad2241f/download/localphotostories20092014csv.csv",
+                        "charSet": "iso-8859-1",
+                        "featureInfoTemplate": {
+                            "template": "<div class='abc'><small>{{Date}}</small>{{#Primary image}}<figure><img src='{{Primary image}}'/><figcaption>{{Primary image caption}}</figcaption></figure>{{/Primary image}}<p><a target='_blank' href={{URL}}>Read More</a></div>"
+                        },
+                        "tableStyle": {
+                            "dataVariable": "State",
+                            "timeColumn": null
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
Provides a way to fix https://github.com/TerriaJS/nationalmap/issues/436#issuecomment-286304897.

Try it out with the new csv test file at http://localhost:3001/#build/terriajs/test/init/csv.json .