### PR TITLE
Changed "no value" colour of region-mapped data to fully transparent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 4.10.6
+
+* Changed "no value" colour of region-mapped data to fully transparent, not black.
+
 ### 4.10.5
 
 * Improved error message when accessing the user's location under http with Chrome.

--- a/lib/Models/LegendHelper.js
+++ b/lib/Models/LegendHelper.js
@@ -24,7 +24,8 @@ var defaultScalarColorMap = [
 
 var defaultEnumColorCodes = standardCssColors.brewer9ClassSet1;
 var defaultLargeEnumColorCodes = standardCssColors.highContrast;
-var defaultColorArray = [32, 32, 32, 128];  // Used if no selected variable.
+var defaultColorArray = [32, 32, 32, 128];  // Used if no selected variable (and no regions).
+var noColorArray = [0, 0, 0, 0];
 
 var defaultNullLabel = '(No value)';
 var defaultNoColumnColorCodes = standardCssColors.highContrast;
@@ -56,7 +57,11 @@ var LegendHelper = function(tableColumn, tableStyle, regionProvider, name) {
     this._colorGradient = undefined;
     this._binColors = undefined; // An array of objects with upperBound and colorArray properties.
     this._regionProvider = regionProvider;
-    this._nullColorArray = defined(this.tableColumnStyle.nullColor) ? getColorArrayFromCssColorString(this.tableColumnStyle.nullColor) : defaultColorArray;
+    if (defined(this.tableColumnStyle.nullColor)) {
+        this._nullColorArray = getColorArrayFromCssColorString(this.tableColumnStyle.nullColor);
+    } else {
+        this._nullColorArray = defined(regionProvider) ? noColorArray : defaultColorArray;
+    }
     this._cycleEnumValues = false;
     this._cycleColors = undefined; // Array of colors used for the cycle method
 


### PR DESCRIPTION
Fixes #2377.

Eg. try this with http://localhost:3001/#test , and look at `Region Mapping / NEXIS NSW 2012 (LGA)`.
Before
![image](https://cloud.githubusercontent.com/assets/1757858/23933532/414fb35e-0993-11e7-9001-eb96c5d45d90.png)
After
![image](https://cloud.githubusercontent.com/assets/1757858/23933537/4712aeea-0993-11e7-8219-186c37b7816f.png)

Note this has no effect on lat-lon csv points with no value, which keep their dark transparent colour.