### PR TITLE
Use updated custom czml properties (Cesium PR#5105)

### DIFF
--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -421,11 +421,9 @@ const simpleStyleIdentifiers = ['title', 'description',
 function describeFromProperties(properties, time) {
     let html = '';
     if (typeof properties.getValue === 'function') {
-        const singleValue = properties.getValue(time);
-        if (defined(singleValue)) {
-            html = '<tr><th>' + '</th><td>' + singleValue + '</td></tr>';
-        }
-    } else {
+        properties = properties.getValue(time);
+    }
+    if (typeof properties === 'object') {
         for (const key in properties) {
             if (properties.hasOwnProperty(key)) {
                 if (simpleStyleIdentifiers.indexOf(key) !== -1) {
@@ -446,6 +444,9 @@ function describeFromProperties(properties, time) {
                 }
             }
         }
+    } else {
+        // properties is only a single value.
+        html += '<tr><th>' + '</th><td>' + properties + '</td></tr>';
     }
     if (html.length > 0) {
         html = '<table class="cesium-infoBox-defaultTable"><tbody>' + html + '</tbody></table>';


### PR DESCRIPTION
We'll need this once https://github.com/AnalyticalGraphicsInc/cesium/pull/5105 is merged into https://github.com/TerriaJS/cesium/tree/terriajs. (Though it will do no harm to merge it now.)

In my earlier way of doing this, `properties` could either be an object directly or something with a `getValue`. With the Cesium PR, CZML `properties` is a `PropertyBag`, which has `getValue` that returns an object.

So this PR handles the new additional possibility that `properties.getValue` is not a single value, but itself is an object.

Test this with http://localhost:3001/#build/terriajs/test/init/czml.json.