### PR TITLE
Fix crash when starting in 2D and switching to 3D Smooth.

### DIFF
--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -203,9 +203,9 @@ upgrade your computer\'s video driver or operating system in order to get the 3D
 
                 if (defined(terria.leaflet)) {
                     viewer.selectViewer(true);
+                } else {
+                    terria.cesium.scene.globe.terrainProvider = new EllipsoidTerrainProvider();
                 }
-
-                terria.cesium.scene.globe.terrainProvider = new EllipsoidTerrainProvider();
             }
         }
     }


### PR DESCRIPTION
I introduced this bug when I changed TerriaJS to defer load of 3D code when starting in 2D.  It made `terria.cesium` set asynchronously, so attempting to immediately set the globe's terrain provider would crash.  Since it's unnecessary to do this anyway when the viewer was just created, I adjusted the logic accordingly.