### PR TITLE
Fix compass rotation

### DIFF
--- a/lib/ReactViews/.eslintrc
+++ b/lib/ReactViews/.eslintrc
@@ -9,7 +9,7 @@
     "react/no-danger": 0,
     "no-return-assign": 0,
     "valid-jsdoc": 0,
-    "require-jsdoc": 1,
+    "require-jsdoc": 0,
     "consistent-return": 0,
     "no-else-return": 0,
     "no-multi-spaces": 1,

--- a/lib/ReactViews/Map/Navigation/Compass.jsx
+++ b/lib/ReactViews/Map/Navigation/Compass.jsx
@@ -27,6 +27,7 @@ const Compass = React.createClass({
     },
 
     componentDidMount() {
+        this._unsubscribeFromViewerChange = this.props.terria.afterViewerChanged.addEventListener(() => viewerChange(this));
         viewerChange(this);
     },
 
@@ -35,6 +36,7 @@ const Compass = React.createClass({
         document.removeEventListener('mouseup', this.orbitMouseUpFunction, false);
         this._unsubscribeFromClockTick && this._unsubscribeFromClockTick();
         this._unsubscribeFromPostRender && this._unsubscribeFromPostRender();
+        this._unsubscribeFromViewerChange && this._unsubscribeFromViewerChange();
     },
 
     handleMouseDown(e) {
@@ -132,9 +134,6 @@ const centerScratch = new Cartesian3();
 const windowPositionScratch = new Cartesian2();
 const pickRayScratch = new Ray();
 
-/**
- * TODO: What does this do?
- */
 function rotate(viewModel, compassElement, cursorVector) {
     // Remove existing event handlers, if any.
     document.removeEventListener('mousemove', viewModel.rotateMouseMoveFunction, false);
@@ -202,9 +201,6 @@ function rotate(viewModel, compassElement, cursorVector) {
     document.addEventListener('mouseup', viewModel.rotateMouseUpFunction, false);
 }
 
-/**
- * TODO: What does this do?
- */
 function orbit(viewModel, compassElement, cursorVector) {
     // Remove existing event handlers, if any.
     document.removeEventListener('mousemove', viewModel.orbitMouseMoveFunction, false);
@@ -270,9 +266,6 @@ function orbit(viewModel, compassElement, cursorVector) {
         viewModel.orbitLastTimestamp = timestamp;
     };
 
-    /**
-     * TODO: What does this do?
-     */
     function updateAngleAndOpacity(vector, compassWidth) {
         const angle = Math.atan2(-vector.y, vector.x);
         viewModel.setState({
@@ -321,9 +314,6 @@ function orbit(viewModel, compassElement, cursorVector) {
     updateAngleAndOpacity(cursorVector, compassElement.getBoundingClientRect().width);
 }
 
-/**
- * TODO: What does this do?
- */
 function viewerChange(viewModel) {
     if (defined(viewModel.props.terria.cesium)) {
         if (viewModel._unsubscribeFromPostRender) {


### PR DESCRIPTION
Fixes #2441 

Also disabled useless eslint rule that was enforcing the opposite of what we want (jsdoc on private, non-exported functions, no need for jsdoc on the exported React components).