### PR TITLE
Ignore leap seconds when evaluating WMS time dimension periodicity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.0.2
+
+* `WebMapServiceCatalogItem` now ignores [leap seconds](https://en.wikipedia.org/wiki/Leap_second) when evaluating ISO8601 periods in a time dimension.  As a result, 2 hours after `2016-06-30T23:00:00Z` is now `2016-07-01T01:00:00Z` instead of `2016-07-01T00:59:59Z` even though a leap second at the end of June 2016 makes that technically 2 hours and 1 second.  We expect that this is more likely to align with the expectations of WMS server software.
+
 ### 5.0.1
 
 * Breaking changes:

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -1009,19 +1009,20 @@ function durationToSeconds(wmsItem, durationString) {
     // determine the number of seconds in the duration
     // returns undefined if the durationString is badly formed
     var matches = durationString.match(/^P(([0-9]+)D)?T?(([0-9]+)H)?(([0-9]+)M)?(([0-9]+(\.[0-9]+)?)S)?$/);
+    var seconds = 0;
     if (matches) {
         // use +matches[i] to force number addition instead of string concatenation
         if (matches[2]) {
-            return +matches[2] * 86400;
+            seconds += +matches[2] * 86400;
         }
         if (matches[4]) {
-            return +matches[4] * 3600;
+            seconds += +matches[4] * 3600;
         }
         if (matches[6]) {
-            return +matches[6] * 60;
+            seconds += +matches[6] * 60;
         }
         if (matches[8]) {
-            return +matches[8];
+            seconds += +matches[8];
         }
     } else {
         wmsItem.terria.error.raiseEvent(new TerriaError({
@@ -1031,7 +1032,7 @@ The "' + wmsItem.name + '" dataset has a badly formed periodicity, "' + duration
             '".  Click the dataset\'s Info button for more information about the dataset and the data custodian.'
         }));
     }
-    return undefined;
+    return seconds === 0 ? undefined : seconds;
 }
 
 function updateIntervalsFromIsoSegments(intervals, isoSegments, time, wmsItem) {

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -1004,26 +1004,24 @@ function getRectangleFromLayers(layers) {
     }));
 }
 
-function addDurationFromString(start, durationString, wmsItem) {
+function durationToSeconds(wmsItem, durationString) {
     // given an ISO8601 duration string such as PT1H or PT30M or P1D
-    // add this duration to the start date
-    // NOTE start is a javascript date, as is the result
-    // returns false if the durationString is badly formed
+    // determine the number of seconds in the duration
+    // returns undefined if the durationString is badly formed
     var matches = durationString.match(/^P(([0-9]+)D)?T?(([0-9]+)H)?(([0-9]+)M)?(([0-9]+(\.[0-9]+)?)S)?$/);
-    var stop = JulianDate.clone(start);
     if (matches) {
         // use +matches[i] to force number addition instead of string concatenation
         if (matches[2]) {
-            JulianDate.addDays(start, +matches[2], stop);
+            return +matches[2] * 86400;
         }
         if (matches[4]) {
-            JulianDate.addHours(start, +matches[4], stop);
+            return +matches[4] * 3600;
         }
         if (matches[6]) {
-            JulianDate.addMinutes(start, +matches[6], stop);
+            return +matches[6] * 60;
         }
         if (matches[8]) {
-            JulianDate.addSeconds(start, +matches[8], stop);
+            return +matches[8];
         }
     } else {
         wmsItem.terria.error.raiseEvent(new TerriaError({
@@ -1032,9 +1030,8 @@ function addDurationFromString(start, durationString, wmsItem) {
 The "' + wmsItem.name + '" dataset has a badly formed periodicity, "' + durationString +
             '".  Click the dataset\'s Info button for more information about the dataset and the data custodian.'
         }));
-        return false;
     }
-    return stop;
+    return undefined;
 }
 
 function updateIntervalsFromIsoSegments(intervals, isoSegments, time, wmsItem) {
@@ -1051,24 +1048,29 @@ function updateIntervalsFromIsoSegments(intervals, isoSegments, time, wmsItem) {
         // and does not use the "R[n]/" prefix for repeated intervals
         // eg. Data refreshed every 30 min: 2000-06-18T14:30Z/2000-06-18T14:30Z/PT30M
         // See 06-042_OpenGIS_Web_Map_Service_WMS_Implementation_Specification.pdf section D.4
-        var thisStop = start,
-            prevStop = start,
-            stopDate = stop,
-            count = 0;
+        var seconds = durationToSeconds(wmsItem, isoSegments[2]);
+        if (defined(seconds)) {
+            var millis = seconds * 1000;
 
-        // Add intervals starting at start until:
-        //    we detect a bad periodicity (which sets thisStop to false), or
-        //    we go past the stop date, or
-        //    we go past the max limit
-        while (thisStop && prevStop <= stopDate && count < wmsItem.maxRefreshIntervals) {
-            thisStop = addDurationFromString(prevStop, isoSegments[2], wmsItem);
-            intervals.addInterval(new TimeInterval({
-                start: prevStop,
-                stop: thisStop || prevStop, // if there was a bad periodicity, use prevStop
-                data: JulianDate.toIso8601(prevStop) // used to form the web request
-            }));
-            prevStop = thisStop;
-            count++;
+            var thisStop = JulianDate.toDate(start);
+            var prevStop = JulianDate.fromDate(thisStop);
+            var stopDate = stop;
+            var count = 0;
+
+            // Add intervals starting at start until:
+            //    we go past the stop date, or
+            //    we go past the max limit
+            while (thisStop && prevStop <= stopDate && count < wmsItem.maxRefreshIntervals) {
+                thisStop = new Date(+thisStop + millis);
+                var endOfInterval = JulianDate.fromDate(thisStop);
+                intervals.addInterval(new TimeInterval({
+                    start: prevStop,
+                    stop: endOfInterval,
+                    data: JulianDate.toIso8601(prevStop) // used to form the web request
+                }));
+                prevStop = endOfInterval;
+                ++count;
+            }
         }
     }
 }

--- a/test/Models/WebMapServiceCatalogItemSpec.js
+++ b/test/Models/WebMapServiceCatalogItemSpec.js
@@ -384,6 +384,19 @@ describe('WebMapServiceCatalogItem', function() {
         }).then(done).otherwise(done.fail);
     });
 
+    it('supports multiple units in a single period', function(done) {
+        // <Dimension name="time" units="ISO8601" />
+        //   <Extent name="time">2015-04-27T16:00:00/2015-04-27T16:15:00/PT1M57S</Extent>
+        wmsItem.updateFromJson({
+            url: 'http://example.com',
+            metadataUrl: 'test/WMS/period_datetimes_multiple_units.xml',
+            layers: 'single_period'
+        });
+        wmsItem.load().then(function() {
+            expect(wmsItem.intervals.length).toEqual(8);
+        }).then(done).otherwise(done.fail);
+    });
+
     it('ignores leap seconds when evaluating period', function(done) {
         // <Dimension name="time" units="ISO8601" />
         //   <Extent name="time">2015-06-30T20:00:00Z/2015-07-01T01:00:00Z/PT15M</Extent>

--- a/test/Models/WebMapServiceCatalogItemSpec.js
+++ b/test/Models/WebMapServiceCatalogItemSpec.js
@@ -2,15 +2,15 @@
 
 /*global require,describe,it,expect,beforeEach,fail*/
 
-var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
-var Terria = require('../../lib/Models/Terria');
-var LegendUrl = require('../../lib/Map/LegendUrl');
+var Credit = require('terriajs-cesium/Source/Core/Credit');
 var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
+var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
+var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
+var LegendUrl = require('../../lib/Map/LegendUrl');
+var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
+var Terria = require('../../lib/Models/Terria');
 var WebMapServiceCatalogItem = require('../../lib/Models/WebMapServiceCatalogItem');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
-
-var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
-var Credit = require('terriajs-cesium/Source/Core/Credit');
 
 var terria;
 var wmsItem;
@@ -57,11 +57,7 @@ describe('WebMapServiceCatalogItem', function() {
             });
             wmsItem.load().then(function() {
                 expect(wmsItem.legendUrl.url.indexOf('http://foo.com/bar')).toBe(0);
-                done();
-            }).otherwise(function(e) {
-                fail(e);
-                done();
-            });
+            }).then(done).otherwise(done.fail);
         });
 
         it('incorporates parameters if legendUrl comes from style', function(done) {
@@ -74,12 +70,7 @@ describe('WebMapServiceCatalogItem', function() {
             });
             wmsItem.load().then(function() {
                 expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/foo?request=GetLegendGraphic&secondUrl&styles=jet2&foo=bar&srs=EPSG%3A3857', 'image/gif'));
-                done();
-            }).otherwise(function(e) {
-                fail(e);
-                done();
-            });
-
+            }).then(done).otherwise(done.fail);
         });
 
         it('incorporates parameters if legendUrl is created from scratch', function(done) {
@@ -92,11 +83,7 @@ describe('WebMapServiceCatalogItem', function() {
             });
             wmsItem.load().then(function() {
                 expect(wmsItem.legendUrl.url.indexOf('http://foo.com/bar?service=WMS&version=1.1.0&request=GetLegendGraphic&format=image%2Fpng&transparent=True&layer=single_period&alpha=beta&foo=bar&srs=EPSG%3A3857')).toBe(0);
-                done();
-            }).otherwise(function(e) {
-                fail(e);
-                done();
-            });
+            }).then(done).otherwise(done.fail);
 
         });
 
@@ -108,11 +95,7 @@ describe('WebMapServiceCatalogItem', function() {
             });
             wmsItem.load().then(function() {
                 expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/foo?request=GetLegendGraphic&firstUrl&srs=EPSG%3A3857', 'image/gif'));
-                done();
-            }).otherwise(function(e) {
-                fail(e);
-                done();
-            });
+            }).then(done).otherwise(done.fail);
         });
 
         it('is read from the first style tag when XML specifies multiple styles for a layer, provided style is unspecified', function(done) {
@@ -123,11 +106,7 @@ describe('WebMapServiceCatalogItem', function() {
             });
             wmsItem.load().then(function() {
                 expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/foo?request=GetLegendGraphic&firstUrl&srs=EPSG%3A3857', 'image/gif'));
-                done();
-            }).otherwise(function(e) {
-                fail(e);
-                done();
-            });
+            }).then(done).otherwise(done.fail);
         });
 
         it('is read from the first LegendURL tag when XML specifies multiple LegendURL tags for a style', function(done) {
@@ -138,11 +117,7 @@ describe('WebMapServiceCatalogItem', function() {
             });
             wmsItem.load().then(function() {
                 expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/foo?request=GetLegendGraphic&firstUrl&srs=EPSG%3A3857', 'image/gif'));
-                done();
-            }).otherwise(function(e) {
-                fail(e);
-                done();
-            });
+            }).then(done).otherwise(done.fail);
         });
 
 
@@ -157,11 +132,7 @@ describe('WebMapServiceCatalogItem', function() {
 
             wmsItem.load().then(function() {
                 expect(wmsItem.legendUrl).toEqual(new LegendUrl('http://www.example.com/blahFace'));
-                done();
-            }).otherwise(function(e) {
-                fail(e);
-                done();
-            });
+            }).then(done).otherwise(done.fail);
         });
     });
 
@@ -382,11 +353,7 @@ describe('WebMapServiceCatalogItem', function() {
         });
         wmsItem.load().then(function() {
             expect(wmsItem.intervals.length).toEqual(13);
-            done();
-        }).otherwise(function() {
-            fail();
-            done();
-        });
+        }).then(done).otherwise(done.fail);
     });
 
 
@@ -400,11 +367,7 @@ describe('WebMapServiceCatalogItem', function() {
         });
         wmsItem.load().then(function() {
             expect(wmsItem.intervals.length).toEqual(1);
-            done();
-        }).otherwise(function(e) {
-            fail(e);
-            done();
-        });
+        }).then(done).otherwise(done.fail);
 
     });
 
@@ -418,11 +381,22 @@ describe('WebMapServiceCatalogItem', function() {
         });
         wmsItem.load().then(function() {
             expect(wmsItem.intervals.length).toEqual(11);
-            done();
-        }).otherwise(function(e) {
-            fail(e);
-            done();
+        }).then(done).otherwise(done.fail);
+    });
+
+    it('ignores leap seconds when evaluating period', function(done) {
+        // <Dimension name="time" units="ISO8601" />
+        //   <Extent name="time">2015-06-30T20:00:00Z/2015-07-01T01:00:00Z/PT15M</Extent>
+        wmsItem.updateFromJson({
+            url: 'http://example.com',
+            metadataUrl: 'test/WMS/period_datetimes_crossing_leap_second.xml',
+            layers: 'single_period'
         });
+        wmsItem.load().then(function() {
+            expect(wmsItem.intervals.length).toEqual(9);
+            expect(wmsItem.intervals.get(8).start).toEqual(JulianDate.fromIso8601('2015-07-01T01:00:00Z'));
+            expect(wmsItem.intervals.get(8).stop).toEqual(JulianDate.fromIso8601('2015-07-01T01:15:00Z'));
+        }).then(done).otherwise(done.fail);
     });
 
     it('warns on bad periodicity in datetimes', function(done) {

--- a/wwwroot/test/WMS/period_datetimes_crossing_leap_second.xml
+++ b/wwwroot/test/WMS/period_datetimes_crossing_leap_second.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WMT_MS_Capabilities version="1.1.1">
+    <Service>
+        <Name>OGC:WMS</Name>
+        <Title>wms Server</Title>
+        <Abstract></Abstract>
+        <KeywordList>
+
+            <Keyword></Keyword>
+
+        </KeywordList>
+        <OnlineResource href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <ContactInformation>
+            <ContactPersonPrimary>
+                <ContactPerson></ContactPerson>
+                <ContactOrganization></ContactOrganization>
+            </ContactPersonPrimary>
+            <ContactPosition></ContactPosition>
+            <ContactAddress>
+                <AddressType>postal</AddressType>
+                <Address></Address>
+                <City></City>
+                <StateOrProvince></StateOrProvince>
+                <PostCode></PostCode>
+                <Country></Country>
+            </ContactAddress>
+            <ContactVoiceTelephone></ContactVoiceTelephone>
+            <ContactElectronicMailAddress></ContactElectronicMailAddress>
+        </ContactInformation>
+    </Service>
+    <Capability>
+        <Request>
+            <GetCapabilities>
+                <Format>application/vnd.ogc.wms_xml</Format>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetCapabilities>
+            <GetMap>
+                <Format>image/png</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetMap>
+            <GetFeatureInfo>
+                <Format>image/png</Format>
+                <Format>text/csv</Format>
+                <Format>text/javascript</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetFeatureInfo>
+            <GetLegendGraphic>
+                <Format>image/png</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetLegendGraphic>
+        </Request>
+        <Exception>
+            <Format>text/html</Format>
+        </Exception>
+        <Layer>
+            <Title>Test dataset</Title>
+            <Abstract>Test data set</Abstract>
+            <SRS>EPSG:3857</SRS>
+            <SRS>MERCATOR</SRS>
+
+            <Layer opaque="0" queryable="1">
+                <Name>single_period</Name>
+                <Title>average_data</Title>
+                <Abstract></Abstract>
+                <SRS>EPSG:3857</SRS>
+                <LatLonBoundingBox maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
+                <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
+                <Dimension name="time" units="ISO8601" />
+
+                    <Extent name="time">2015-06-30T23:00:00Z/2015-07-01T01:00:00Z/PT15M</Extent>
+
+                <Style>
+                    <Name>jet</Name>
+                    <Title>jet</Title>
+                    <Abstract></Abstract>
+                    <LegendURL width="72" height="72">
+                        <Format>image/gif</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        xlink:type="simple"
+                                        xlink:href="http://www.example.com"/>
+                    </LegendURL>
+                </Style>
+            </Layer>
+
+        </Layer>
+    </Capability>
+</WMT_MS_Capabilities>

--- a/wwwroot/test/WMS/period_datetimes_multiple_units.xml
+++ b/wwwroot/test/WMS/period_datetimes_multiple_units.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WMT_MS_Capabilities version="1.1.1">
+    <Service>
+        <Name>OGC:WMS</Name>
+        <Title>wms Server</Title>
+        <Abstract></Abstract>
+        <KeywordList>
+
+            <Keyword></Keyword>
+
+        </KeywordList>
+        <OnlineResource href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <ContactInformation>
+            <ContactPersonPrimary>
+                <ContactPerson></ContactPerson>
+                <ContactOrganization></ContactOrganization>
+            </ContactPersonPrimary>
+            <ContactPosition></ContactPosition>
+            <ContactAddress>
+                <AddressType>postal</AddressType>
+                <Address></Address>
+                <City></City>
+                <StateOrProvince></StateOrProvince>
+                <PostCode></PostCode>
+                <Country></Country>
+            </ContactAddress>
+            <ContactVoiceTelephone></ContactVoiceTelephone>
+            <ContactElectronicMailAddress></ContactElectronicMailAddress>
+        </ContactInformation>
+    </Service>
+    <Capability>
+        <Request>
+            <GetCapabilities>
+                <Format>application/vnd.ogc.wms_xml</Format>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetCapabilities>
+            <GetMap>
+                <Format>image/png</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetMap>
+            <GetFeatureInfo>
+                <Format>image/png</Format>
+                <Format>text/csv</Format>
+                <Format>text/javascript</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetFeatureInfo>
+            <GetLegendGraphic>
+                <Format>image/png</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetLegendGraphic>
+        </Request>
+        <Exception>
+            <Format>text/html</Format>
+        </Exception>
+        <Layer>
+            <Title>Test dataset</Title>
+            <Abstract>Test data set</Abstract>
+            <SRS>EPSG:3857</SRS>
+            <SRS>MERCATOR</SRS>
+
+            <Layer opaque="0" queryable="1">
+                <Name>single_period</Name>
+                <Title>average_data</Title>
+                <Abstract></Abstract>
+                <SRS>EPSG:3857</SRS>
+                <LatLonBoundingBox maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
+                <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
+                <Dimension name="time" units="ISO8601" />
+
+                    <Extent name="time">2015-04-27T16:00:00/2015-04-27T16:15:00/PT1M57S</Extent>
+
+                <Style>
+                    <Name>jet</Name>
+                    <Title>jet</Title>
+                    <Abstract></Abstract>
+                    <LegendURL width="72" height="72">
+                        <Format>image/gif</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        xlink:type="simple"
+                                        xlink:href="http://www.example.com"/>
+                    </LegendURL>
+                </Style>
+            </Layer>
+
+        </Layer>
+    </Capability>
+</WMT_MS_Capabilities>


### PR DESCRIPTION
`WebMapServiceCatalogItem` now ignores [leap seconds](https://en.wikipedia.org/wiki/Leap_second) when evaluating ISO8601 periods in a time dimension.  As a result, 2 hours after `2016-06-30T23:00:00Z` is now `2016-07-01T01:00:00Z` instead of `2016-07-01T00:59:59Z` even though a leap second at the end of June 2016 makes that technically 2 hours and 1 second.  We expect that this is more likely to align with the expectations of WMS server software.

Fixes #2452 
