### PR TITLE
Add a configuration parameter which specifies which view mode to use as default when running on a mobile platform.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Change Log
 ==========
 
 ### 5.0.2
-* Added configuration option to specify default view mode when running on a mobile platform.
+
+* Added option to specify `mobileDefaultViewerMode` in the `parameters` section of `config.json` to specify the default view mode when running on a mobile platform.
 
 ### 5.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 Change Log
 ==========
 
+### 5.0.2
+* Added configuration option to specify default view mode when running on a mobile platform.
+
 ### 5.0.1
 
 * Breaking changes:

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -17,6 +17,7 @@ var loadJson5 = require('../Core/loadJson5');
 var queryToObject = require('terriajs-cesium/Source/Core/queryToObject');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
+var isCommonMobilePlatform = require('terriajs/lib/Core/isCommonMobilePlatform');
 
 var CameraView = require('./CameraView');
 var Catalog = require('./Catalog');
@@ -456,6 +457,25 @@ Terria.prototype.start = function(options) {
         }).then(function() {
             return that.updateApplicationUrl(applicationUrl, that.urlShortener);
         }).then(function () {
+            // If we are running on a mobile platform set the viewerMode to the config specified default mobile viewer mode.
+            if (isCommonMobilePlatform() && !defined(that.userProperties.map)) {
+                // This is the default viewerMode to use if the configuration parameter is not set or is not set correctly.
+                that.viewerMode = ViewerMode.Leaflet;
+
+                if (defined(that.configParameters.mobileDefaultViewerMode) && (typeof that.configParameters.mobileDefaultViewerMode === 'string')) {
+                    let mobileDefault = that.configParameters.mobileDefaultViewerMode.toLowerCase();
+                    if (mobileDefault === '3dterrain') {
+                        that.viewerMode = ViewerMode.CesiumTerrain;
+                    }
+                    else if (mobileDefault === '3dsmooth') {
+                        that.viewerMode = ViewerMode.CesiumEllipsoid;
+                    }
+                    else if (mobileDefault === '2d') {
+                        that.viewerMode = ViewerMode.Leaflet;
+                    }
+                }
+            }
+
             if (options.defaultTo2D && !defined(that.userProperties.map)) {
                 that.viewerMode = ViewerMode.Leaflet;
             }


### PR DESCRIPTION
Now that I have added Augmented Virtuality mode it has been requested that there is an option to specify using 3DSmooth as the default on mobile platforms to make this feature more accessible from some instances.

This patch is somewhat conservative in that it preserves the previous functionality and yields to that specification if it is provided (that being if options.defaultTo2D is set). The reason for this is simply that I didn't know whether other implementations made use of this option for purposes other then mobile configuration. If this functionality is not needed beyond this then the following lines should also be removed:
             if (options.defaultTo2D && !defined(that.userProperties.map)) {
                 that.viewerMode = ViewerMode.Leaflet;
             }

I have not added test cases for this commit as I couldn't find test cases for the configuration file, if I have overlooked this please let me know. 

I have submitted a corresponding PR for TerriaMap which changes the default behavior for configuration of 2D mode from 

