### PR TITLE
Make it explicit that npm start should also be run from TerriaJS directory for SpecRunner.

### DIFF
--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -110,7 +110,7 @@ We use [Jasmine](https://jasmine.github.io/) for the TerriaJS tests, called spec
 npm run gulp
 ```
 
-And start the development web server by running:
+And start the development web server by running (also from the TerriaJS and not TerriaMap! directory):
 
 ```
 npm start


### PR DESCRIPTION
I made this mistake when I did this the first time.