### PR TITLE
Fix lat/lon coordinate wrapping in IE11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * `WebMapServiceCatalogItem` now ignores [leap seconds](https://en.wikipedia.org/wiki/Leap_second) when evaluating ISO8601 periods in a time dimension.  As a result, 2 hours after `2016-06-30T23:00:00Z` is now `2016-07-01T01:00:00Z` instead of `2016-07-01T00:59:59Z` even though a leap second at the end of June 2016 makes that technically 2 hours and 1 second.  We expect that this is more likely to align with the expectations of WMS server software.
 * Added option to specify `mobileDefaultViewerMode` in the `parameters` section of `config.json` to specify the default view mode when running on a mobile platform.
 * Added support for `itemProperties` to `CswCatalogGroup`.
+* Fixed a layout problem that caused the coordinates on the location bar to be displayed below the bar itself in Internet Explorer 11.
 
 ### 5.0.1
 

--- a/lib/ReactViews/Map/Legend/legend.scss
+++ b/lib/ReactViews/Map/Legend/legend.scss
@@ -55,7 +55,7 @@ $distance-bg: rgba($dark, 0.9);
   }
 
   .section{
-    width: 110px;
+    width: 112px;
   }
 
   .section-short{


### PR DESCRIPTION
Fixes #2446 
