### PR TITLE
Fix deprecated warnings with React 15.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Added option to specify `mobileDefaultViewerMode` in the `parameters` section of `config.json` to specify the default view mode when running on a mobile platform.
 * Added support for `itemProperties` to `CswCatalogGroup`.
 * Fixed a layout problem that caused the coordinates on the location bar to be displayed below the bar itself in Internet Explorer 11.
+* Updated syntax to remove deprecation warnings with React version 15.5.
 
 ### 5.0.1
 

--- a/lib/ReactViews/Analytics/BooleanParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/BooleanParameterEditor.jsx
@@ -70,7 +70,7 @@ const BooleanParameterEditor = createReactClass({
                 {this.props.parameter.hasNamedStates && <div>{this.renderRadio(true)}{this.renderRadio(false)}</div>}
             </div>
         );
-    },
+    }
 });
 
 module.exports = BooleanParameterEditor;

--- a/lib/ReactViews/Analytics/BooleanParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/BooleanParameterEditor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Icon from '../Icon.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 
@@ -7,8 +8,8 @@ import Styles from './parameter-editors.scss';
 const BooleanParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object
     },
 
     onClick() {

--- a/lib/ReactViews/Analytics/BooleanParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/BooleanParameterEditor.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Icon from '../Icon.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
 
-const BooleanParameterEditor = React.createClass({
+const BooleanParameterEditor = createReactClass({
+    displayName: 'BooleanParameterEditor',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         previewed: PropTypes.object,
         parameter: PropTypes.object
@@ -67,7 +70,7 @@ const BooleanParameterEditor = React.createClass({
                 {this.props.parameter.hasNamedStates && <div>{this.renderRadio(true)}{this.renderRadio(false)}</div>}
             </div>
         );
-    }
+    },
 });
 
 module.exports = BooleanParameterEditor;

--- a/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
 
-const DateTimeParameterEditor = React.createClass({
+const DateTimeParameterEditor = createReactClass({
+    displayName: 'DateTimeParameterEditor',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         previewed: PropTypes.object,
         parameter: PropTypes.object
@@ -71,7 +74,7 @@ const DateTimeParameterEditor = React.createClass({
                    onChange={this.onChangeTime}
                    value={this.state.time}/>
         </div>);
-    }
+    },
 });
 
 module.exports = DateTimeParameterEditor;

--- a/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
@@ -6,8 +7,8 @@ import Styles from './parameter-editors.scss';
 const DateTimeParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object
     },
 
     getInitialState() {

--- a/lib/ReactViews/Analytics/EnumerationParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/EnumerationParameterEditor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
@@ -6,8 +7,8 @@ import Styles from './parameter-editors.scss';
 const EnumerationParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object
     },
 
     getInitialState() {

--- a/lib/ReactViews/Analytics/EnumerationParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/EnumerationParameterEditor.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
 
-const EnumerationParameterEditor = React.createClass({
+const EnumerationParameterEditor = createReactClass({
+    displayName: 'EnumerationParameterEditor',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         previewed: PropTypes.object,
         parameter: PropTypes.object
@@ -28,7 +31,7 @@ const EnumerationParameterEditor = React.createClass({
                     {this.props.parameter.possibleValues.map((v, i)=>
                         <option value={v} key={i}>{v}</option>)}
                 </select>);
-    }
+    },
 });
 
 module.exports = EnumerationParameterEditor;

--- a/lib/ReactViews/Analytics/GenericParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/GenericParameterEditor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
@@ -6,8 +7,8 @@ import Styles from './parameter-editors.scss';
 const GenericParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object
     },
 
     onChange(e) {

--- a/lib/ReactViews/Analytics/GenericParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/GenericParameterEditor.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
 
-const GenericParameterEditor = React.createClass({
+const GenericParameterEditor = createReactClass({
+    displayName: 'GenericParameterEditor',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         previewed: PropTypes.object,
         parameter: PropTypes.object
@@ -21,7 +24,7 @@ const GenericParameterEditor = React.createClass({
                        onChange={this.onChange}
                        value={this.props.parameter.value}
                 />);
-    }
+    },
 });
 
 module.exports = GenericParameterEditor;

--- a/lib/ReactViews/Analytics/InvokeFunction.jsx
+++ b/lib/ReactViews/Analytics/InvokeFunction.jsx
@@ -3,6 +3,7 @@ import ObserveModelMixin from '../ObserveModelMixin';
 import ParameterEditor from './ParameterEditor';
 import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './invoke-function.scss';
 import TerriaError from '../../Core/TerriaError';
 import when from 'terriajs-cesium/Source/ThirdParty/when';
@@ -11,9 +12,9 @@ const InvokeFunction = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        previewed: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        terria: PropTypes.object,
+        previewed: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     submit() {

--- a/lib/ReactViews/Analytics/InvokeFunction.jsx
+++ b/lib/ReactViews/Analytics/InvokeFunction.jsx
@@ -3,12 +3,14 @@ import ObserveModelMixin from '../ObserveModelMixin';
 import ParameterEditor from './ParameterEditor';
 import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './invoke-function.scss';
 import TerriaError from '../../Core/TerriaError';
 import when from 'terriajs-cesium/Source/ThirdParty/when';
 
-const InvokeFunction = React.createClass({
+const InvokeFunction = createReactClass({
+    displayName: 'InvokeFunction',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -68,7 +70,7 @@ const InvokeFunction = React.createClass({
                         <button type='button' className={Styles.btn} onClick={this.submit}>Run Analysis</button>
                     </div>
                 </div>);
-    }
+    },
 });
 
 module.exports = InvokeFunction;

--- a/lib/ReactViews/Analytics/LineParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/LineParameterEditor.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
@@ -10,7 +12,8 @@ import UserDrawing from '../../Models/UserDrawing';
 import ObserveModelMixin from '../ObserveModelMixin';
 import Styles from './parameter-editors.scss';
 
-const LineParameterEditor = React.createClass({
+const LineParameterEditor = createReactClass({
+    displayName: 'LineParameterEditor',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -73,7 +76,7 @@ const LineParameterEditor = React.createClass({
                 </button>
             </div>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/Analytics/LineParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/LineParameterEditor.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
@@ -12,9 +14,9 @@ const LineParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     getInitialState() {

--- a/lib/ReactViews/Analytics/ParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/ParameterEditor.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -20,7 +22,8 @@ import defined from 'terriajs-cesium/Source/Core/defined';
 
 import Styles from './parameter-editors.scss';
 
-const ParameterEditor = React.createClass({
+const ParameterEditor = createReactClass({
+    displayName: 'ParameterEditor',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -56,7 +59,7 @@ const ParameterEditor = React.createClass({
                 {this.renderEditor()}
             </div>
         );
-    }
+    },
 });
 
 ParameterEditor.parameterTypeConverters = [

--- a/lib/ReactViews/Analytics/ParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/ParameterEditor.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import ObserveModelMixin from '../ObserveModelMixin';
 import PointParameterEditor from './PointParameterEditor';
 import LineParameterEditor from './LineParameterEditor';
@@ -22,9 +24,9 @@ const ParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        parameter: React.PropTypes.object,
-        viewState: React.PropTypes.object,
-        previewed: React.PropTypes.object
+        parameter: PropTypes.object,
+        viewState: PropTypes.object,
+        previewed: PropTypes.object
     },
 
     fieldId: new Date().getTime(),

--- a/lib/ReactViews/Analytics/PointParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PointParameterEditor.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Cartographic from 'terriajs-cesium/Source/Core/Cartographic';
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -17,9 +19,9 @@ const PointParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     setValueFromText(e) {

--- a/lib/ReactViews/Analytics/PointParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PointParameterEditor.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import Cartographic from 'terriajs-cesium/Source/Core/Cartographic';
@@ -15,7 +17,8 @@ import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
 
-const PointParameterEditor = React.createClass({
+const PointParameterEditor = createReactClass({
+    displayName: 'PointParameterEditor',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -44,7 +47,7 @@ const PointParameterEditor = React.createClass({
                 </button>
             </div>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
 
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -15,9 +17,9 @@ const PolygonParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     setValueFromText(e) {

--- a/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -13,7 +15,8 @@ import CesiumMath from 'terriajs-cesium/Source/Core/Math';
 import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
 import UserDrawing from '../../Models/UserDrawing';
 
-const PolygonParameterEditor = React.createClass({
+const PolygonParameterEditor = createReactClass({
+    displayName: 'PolygonParameterEditor',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -44,7 +47,7 @@ const PolygonParameterEditor = React.createClass({
                 </button>
             </div>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/Analytics/RectangleParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RectangleParameterEditor.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import Cartographic from 'terriajs-cesium/Source/Core/Cartographic';
@@ -13,7 +15,8 @@ import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
 
-const RectangleParameterEditor = React.createClass({
+const RectangleParameterEditor = createReactClass({
+    displayName: 'RectangleParameterEditor',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -104,7 +107,7 @@ const RectangleParameterEditor = React.createClass({
                 </button>
             </div>
         );
-    }
+    },
 });
 
 module.exports = RectangleParameterEditor;

--- a/lib/ReactViews/Analytics/RectangleParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RectangleParameterEditor.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Cartographic from 'terriajs-cesium/Source/Core/Cartographic';
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -15,9 +17,9 @@ const RectangleParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     getInitialState() {

--- a/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import VarType from '../../Map/VarType';
@@ -13,8 +15,8 @@ const RegionDataParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object
     },
 
     componentWillMount() {

--- a/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -11,7 +13,8 @@ import CatalogGroup from '../DataCatalog/CatalogGroup';
 
 import Styles from './parameter-editors.scss';
 
-const RegionDataParameterEditor = React.createClass({
+const RegionDataParameterEditor = createReactClass({
+    displayName: 'RegionDataParameterEditor',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -198,6 +201,6 @@ const RegionDataParameterEditor = React.createClass({
                 })}
             </ul>
         );
-    }
+    },
 });
 module.exports = RegionDataParameterEditor;

--- a/lib/ReactViews/Analytics/RegionParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionParameterEditor.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -10,7 +12,8 @@ import Styles from './parameter-editors.scss';
 import RegionPicker from './RegionPicker';
 import MapInteractionMode from '../../Models/MapInteractionMode';
 
-const RegionParameterEditor = React.createClass({
+const RegionParameterEditor = createReactClass({
+    displayName: 'RegionParameterEditor',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -33,7 +36,7 @@ const RegionParameterEditor = React.createClass({
                         Select region
                     </button>
                 </div>);
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/Analytics/RegionParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionParameterEditor.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './parameter-editors.scss';
@@ -12,9 +14,9 @@ const RegionParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        previewed: React.PropTypes.object,
-        viewState: React.PropTypes.object,
-        parameter: React.PropTypes.object
+        previewed: PropTypes.object,
+        viewState: PropTypes.object,
+        parameter: PropTypes.object
     },
 
     selectRegionOnMap() {

--- a/lib/ReactViews/Analytics/RegionPicker.jsx
+++ b/lib/ReactViews/Analytics/RegionPicker.jsx
@@ -3,6 +3,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -16,7 +18,8 @@ import WebMapServiceCatalogItem from '../../Models/WebMapServiceCatalogItem';
 import RegionTypeParameterEditor from './RegionTypeParameterEditor';
 import Styles from './parameter-editors.scss';
 
-const RegionPicker = React.createClass({
+const RegionPicker = createReactClass({
+    displayName: 'RegionPicker',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -278,7 +281,7 @@ const RegionPicker = React.createClass({
                 )}
             </ul>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/Analytics/RegionPicker.jsx
+++ b/lib/ReactViews/Analytics/RegionPicker.jsx
@@ -3,6 +3,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import when from 'terriajs-cesium/Source/ThirdParty/when';
@@ -18,8 +20,8 @@ const RegionPicker = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object
     },
 
     getInitialState() {

--- a/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
@@ -1,14 +1,17 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import Loader from '../Loader';
 import ObserveModelMixin from '../ObserveModelMixin';
 import Styles from './parameter-editors.scss';
 
-const RegionTypeParameterEditor = React.createClass({
+const RegionTypeParameterEditor = createReactClass({
+    displayName: 'RegionTypeParameterEditor',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         previewed: PropTypes.object,
         parameter: PropTypes.object
@@ -52,7 +55,7 @@ const RegionTypeParameterEditor = React.createClass({
                                  key={i}
                          >{r.regionType}</option>))}
                 </select>;
-    }
+    },
 });
 
 module.exports = RegionTypeParameterEditor;

--- a/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import Loader from '../Loader';
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -9,8 +10,8 @@ import Styles from './parameter-editors.scss';
 const RegionTypeParameterEditor = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        previewed: React.PropTypes.object,
-        parameter: React.PropTypes.object
+        previewed: PropTypes.object,
+        parameter: PropTypes.object
     },
 
     onChange(e) {

--- a/lib/ReactViews/BadgeBar.jsx
+++ b/lib/ReactViews/BadgeBar.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import Styles from './badge-bar.scss';
 
-const BadgeBar = React.createClass({
+const BadgeBar = createReactClass({
     propTypes: {
         label: PropTypes.string,
         badge: PropTypes.number,

--- a/lib/ReactViews/BadgeBar.jsx
+++ b/lib/ReactViews/BadgeBar.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './badge-bar.scss';
 
 const BadgeBar = React.createClass({
     propTypes: {
-        label: React.PropTypes.string,
-        badge: React.PropTypes.number,
-        buttonCaption: React.PropTypes.string,
-        children: React.PropTypes.node
+        label: PropTypes.string,
+        badge: PropTypes.number,
+        buttonCaption: PropTypes.string,
+        children: PropTypes.node
     },
 
     render() {

--- a/lib/ReactViews/BottomDock/BottomDock.jsx
+++ b/lib/ReactViews/BottomDock/BottomDock.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ChartPanel from '../Custom/Chart/ChartPanel.jsx';
 import Timeline from './Timeline/Timeline.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -12,9 +13,9 @@ const BottomDock = React.createClass({
     displayName: 'BottomDock',
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired,
-        domElementRef: React.PropTypes.func
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
+        domElementRef: PropTypes.func
     },
 
     render() {

--- a/lib/ReactViews/BottomDock/BottomDock.jsx
+++ b/lib/ReactViews/BottomDock/BottomDock.jsx
@@ -1,13 +1,14 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ChartPanel from '../Custom/Chart/ChartPanel.jsx';
 import Timeline from './Timeline/Timeline.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import Styles from './bottom-dock.scss';
 
-const BottomDock = React.createClass({
+const BottomDock = createReactClass({
     mixins: [ObserveModelMixin],
 
     displayName: 'BottomDock',

--- a/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 
 import WrappedTimeline from 'terriajs-cesium/Source/Widgets/Timeline/Timeline';
@@ -11,7 +12,7 @@ import Styles from '!style-loader!css-loader?modules&sourceMap!sass-loader?sourc
 import defined from 'terriajs-cesium/Source/Core/defined';
 import dateFormat from 'dateformat';
 
-const CesiumTimeline = React.createClass({
+const CesiumTimeline = createReactClass({
     propTypes: {
         terria: PropTypes.object.isRequired,
         autoPlay: PropTypes.bool

--- a/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 
 import WrappedTimeline from 'terriajs-cesium/Source/Widgets/Timeline/Timeline';
@@ -12,8 +13,8 @@ import dateFormat from 'dateformat';
 
 const CesiumTimeline = React.createClass({
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        autoPlay: React.PropTypes.bool
+        terria: PropTypes.object.isRequired,
+        autoPlay: PropTypes.bool
     },
 
     componentDidMount() {

--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import TimelineControls from './TimelineControls';
 import CesiumTimeline from './CesiumTimeline';
@@ -12,7 +13,7 @@ import Styles from './timeline.scss';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import dateFormat from 'dateformat';
 
-const Timeline = React.createClass({
+const Timeline = createReactClass({
     propTypes: {
         terria: PropTypes.object.isRequired,
         autoPlay: PropTypes.bool,

--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import TimelineControls from './TimelineControls';
 import CesiumTimeline from './CesiumTimeline';
@@ -13,9 +14,9 @@ import dateFormat from 'dateformat';
 
 const Timeline = React.createClass({
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        autoPlay: React.PropTypes.bool,
-        locale: React.PropTypes.object
+        terria: PropTypes.object.isRequired,
+        autoPlay: PropTypes.bool,
+        locale: PropTypes.object
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/BottomDock/Timeline/TimelineControls.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/TimelineControls.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import ClockRange from 'terriajs-cesium/Source/Core/ClockRange';
 import classnames from 'classnames';
 import Styles from './timeline-controls.scss';
@@ -9,10 +11,10 @@ import Icon from "../../Icon.jsx";
 
 const TimelineControls = React.createClass({
     propTypes: {
-        clock: React.PropTypes.object.isRequired,
-        analytics: React.PropTypes.object.isRequired,
-        currentViewer: React.PropTypes.object.isRequired,
-        locale: React.PropTypes.object
+        clock: PropTypes.object.isRequired,
+        analytics: PropTypes.object.isRequired,
+        currentViewer: PropTypes.object.isRequired,
+        locale: PropTypes.object
     },
 
     getInitialState() {

--- a/lib/ReactViews/BottomDock/Timeline/TimelineControls.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/TimelineControls.jsx
@@ -3,13 +3,14 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import ClockRange from 'terriajs-cesium/Source/Core/ClockRange';
 import classnames from 'classnames';
 import Styles from './timeline-controls.scss';
 import Icon from "../../Icon.jsx";
 
-const TimelineControls = React.createClass({
+const TimelineControls = createReactClass({
     propTypes: {
         clock: PropTypes.object.isRequired,
         analytics: PropTypes.object.isRequired,

--- a/lib/ReactViews/Custom/Chart/Chart.jsx
+++ b/lib/ReactViews/Custom/Chart/Chart.jsx
@@ -15,6 +15,7 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
 import defaultValue from 'terriajs-cesium/Source/Core/defaultValue';
@@ -33,7 +34,7 @@ import Styles from './chart.scss';
 const defaultHeight = 100;
 const defaultColor = undefined; // Allows the line color to be set by the css, esp. in the feature info panel.
 
-const Chart = React.createClass({
+const Chart = createReactClass({
     // this._element is updated by the ref callback attribute, https://facebook.github.io/react/docs/more-about-refs.html
     _element: undefined,
 

--- a/lib/ReactViews/Custom/Chart/Chart.jsx
+++ b/lib/ReactViews/Custom/Chart/Chart.jsx
@@ -14,6 +14,8 @@
 
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
 import defaultValue from 'terriajs-cesium/Source/Core/defaultValue';
 import DeveloperError from 'terriajs-cesium/Source/Core/DeveloperError';
@@ -40,25 +42,25 @@ const Chart = React.createClass({
     _tooltipId: undefined,
 
     propTypes: {
-        domain: React.PropTypes.object,
-        styling: React.PropTypes.string,  // nothing, 'feature-info' or 'histogram' -- TODO: improve
-        height: React.PropTypes.number,
-        axisLabel: React.PropTypes.object,
-        catalogItem: React.PropTypes.object,
-        transitionDuration: React.PropTypes.number,
-        highlightX: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-        updateCounter: React.PropTypes.any,  // Change this to trigger an update.
-        pollSeconds: React.PropTypes.any, // This is not used by Chart. It is used internally by registerCustomComponentTypes.
+        domain: PropTypes.object,
+        styling: PropTypes.string,  // nothing, 'feature-info' or 'histogram' -- TODO: improve
+        height: PropTypes.number,
+        axisLabel: PropTypes.object,
+        catalogItem: PropTypes.object,
+        transitionDuration: PropTypes.number,
+        highlightX: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        updateCounter: PropTypes.any,  // Change this to trigger an update.
+        pollSeconds: PropTypes.any, // This is not used by Chart. It is used internally by registerCustomComponentTypes.
         // You can provide the data directly via props.data (ChartData[]):
-        data: React.PropTypes.array,
+        data: PropTypes.array,
         // Or, provide a URL to the data, along with optional xColumn, yColumns, colors
-        url: React.PropTypes.string,
-        xColumn: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-        yColumns: React.PropTypes.array,
-        colors: React.PropTypes.array,
-        pollUrl: React.PropTypes.string,
+        url: PropTypes.string,
+        xColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        yColumns: PropTypes.array,
+        colors: PropTypes.array,
+        pollUrl: PropTypes.string,
         // Or, provide a tableStructure directly.
-        tableStructure: React.PropTypes.object
+        tableStructure: PropTypes.object
     },
 
     chartDataArrayFromTableStructure(table) {

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import defaultValue from 'terriajs-cesium/Source/Core/defaultValue';
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -22,7 +23,7 @@ import Styles from './chart-expand-and-download-buttons.scss';
 // This displays both an "expand" button, which enables a new catalog item based on the chart data,
 // and a "download" button, which downloads the data.
 //
-const ChartExpandAndDownloadButtons = React.createClass({
+const ChartExpandAndDownloadButtons = createReactClass({
 
     propTypes: {
         terria: PropTypes.object.isRequired,

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -3,6 +3,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defaultValue from 'terriajs-cesium/Source/Core/defaultValue';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import clone from 'terriajs-cesium/Source/Core/clone';
@@ -23,31 +25,31 @@ import Styles from './chart-expand-and-download-buttons.scss';
 const ChartExpandAndDownloadButtons = React.createClass({
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
+        terria: PropTypes.object.isRequired,
         // Either provide URLs to the expanded data.
-        sources: React.PropTypes.array,
-        sourceNames: React.PropTypes.array,
-        downloads: React.PropTypes.array,
-        downloadNames: React.PropTypes.array,
+        sources: PropTypes.array,
+        sourceNames: PropTypes.array,
+        downloads: PropTypes.array,
+        downloadNames: PropTypes.array,
         // Optional polling info that would need to be transferred to any standalone catalog item.
-        pollSources: React.PropTypes.array,
-        pollSeconds: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-        pollReplace: React.PropTypes.bool,
-        updateCounter: React.PropTypes.any,  // Change this to trigger an update.
+        pollSources: PropTypes.array,
+        pollSeconds: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        pollReplace: PropTypes.bool,
+        updateCounter: PropTypes.any,  // Change this to trigger an update.
         // Or, provide a tableStructure directly.
-        tableStructure: React.PropTypes.object,
+        tableStructure: PropTypes.object,
         //
-        catalogItem: React.PropTypes.object,
-        title: React.PropTypes.string,
-        colors: React.PropTypes.array,
-        feature: React.PropTypes.object,
-        id: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-        columnNames: React.PropTypes.array,
-        columnUnits: React.PropTypes.array,
-        xColumn: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
-        yColumns: React.PropTypes.array,
-        canDownload: React.PropTypes.bool,
-        raiseToTitle: React.PropTypes.bool
+        catalogItem: PropTypes.object,
+        title: PropTypes.string,
+        colors: PropTypes.array,
+        feature: PropTypes.object,
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        columnNames: PropTypes.array,
+        columnUnits: PropTypes.array,
+        xColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        yColumns: PropTypes.array,
+        canDownload: PropTypes.bool,
+        raiseToTitle: PropTypes.bool
     },
 
     expandButton() {

--- a/lib/ReactViews/Custom/Chart/ChartPanel.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanel.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -16,7 +18,8 @@ import Styles from './chart-panel.scss';
 
 const height = 250;
 
-const ChartPanel = React.createClass({
+const ChartPanel = createReactClass({
+    displayName: 'ChartPanel',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -99,7 +102,7 @@ const ChartPanel = React.createClass({
                 </div>
             </div>
         );
-    }
+    },
 });
 
 module.exports = ChartPanel;

--- a/lib/ReactViews/Custom/Chart/ChartPanel.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanel.jsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
 
 import Chart from './Chart.jsx';
@@ -18,10 +20,10 @@ const ChartPanel = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        onHeightChange: React.PropTypes.func,
-        viewState: React.PropTypes.object.isRequired,
-        animationDuration: React.PropTypes.number
+        terria: PropTypes.object.isRequired,
+        onHeightChange: PropTypes.func,
+        viewState: PropTypes.object.isRequired,
+        animationDuration: PropTypes.number
     },
 
     closePanel() {

--- a/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
@@ -21,8 +21,8 @@ const ChartPanelDownloadButton = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        chartableItems: React.PropTypes.array.isRequired,
-        errorEvent: React.PropTypes.object.isRequired
+        chartableItems: PropTypes.array.isRequired,
+        errorEvent: PropTypes.object.isRequired
     },
 
     _subscription: undefined,

--- a/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
@@ -2,6 +2,7 @@
 /* global Float32Array */
 /* eslint new-parens: 0 */
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import debounce from 'lodash.debounce';
 

--- a/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
@@ -2,6 +2,7 @@
 /* global Float32Array */
 /* eslint new-parens: 0 */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import debounce from 'lodash.debounce';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -17,7 +18,8 @@ import Styles from './chart-panel-download-button.scss';
 const RUN_WORKER_DEBOUNCE = 100; // Wait 100ms for initial setup changes to be completed.
 const TIME_COLUMN_DEFAULT_NAME = 'date';
 
-const ChartPanelDownloadButton = React.createClass({
+const ChartPanelDownloadButton = createReactClass({
+    displayName: 'ChartPanelDownloadButton',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -126,7 +128,7 @@ const ChartPanelDownloadButton = React.createClass({
             }
         }
         return null;
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/Custom/Collapsible/Collapsible.jsx
+++ b/lib/ReactViews/Custom/Collapsible/Collapsible.jsx
@@ -1,14 +1,15 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Icon from '../../Icon';
 import Styles from './collapsible.scss';
 
 const Collapsible = React.createClass({
     propTypes: {
-        title: React.PropTypes.string,
-        startsOpen: React.PropTypes.bool,
-        isInverse: React.PropTypes.bool,
-        children: React.PropTypes.any
+        title: PropTypes.string,
+        startsOpen: PropTypes.bool,
+        isInverse: PropTypes.bool,
+        children: PropTypes.any
     },
 
     getInitialState: function() {

--- a/lib/ReactViews/Custom/Collapsible/Collapsible.jsx
+++ b/lib/ReactViews/Custom/Collapsible/Collapsible.jsx
@@ -1,10 +1,11 @@
 import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import Icon from '../../Icon';
 import Styles from './collapsible.scss';
 
-const Collapsible = React.createClass({
+const Collapsible = createReactClass({
     propTypes: {
         title: PropTypes.string,
         startsOpen: PropTypes.bool,

--- a/lib/ReactViews/DataCatalog/CatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/CatalogGroup.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Loader from '../Loader.jsx';
@@ -54,18 +55,18 @@ function CatalogGroup(props) {
 }
 
 CatalogGroup.propTypes = {
-    text: React.PropTypes.string,
-    title: React.PropTypes.string,
-    topLevel: React.PropTypes.bool,
-    open: React.PropTypes.bool,
-    loading: React.PropTypes.bool,
-    emptyMessage: React.PropTypes.string,
-    onClick: React.PropTypes.func,
-    children: React.PropTypes.oneOfType([
-        React.PropTypes.element,
-        React.PropTypes.arrayOf(React.PropTypes.element)
+    text: PropTypes.string,
+    title: PropTypes.string,
+    topLevel: PropTypes.bool,
+    open: PropTypes.bool,
+    loading: PropTypes.bool,
+    emptyMessage: PropTypes.string,
+    onClick: PropTypes.func,
+    children: PropTypes.oneOfType([
+        PropTypes.element,
+        PropTypes.arrayOf(PropTypes.element)
     ]),
-    selected: React.PropTypes.bool
+    selected: PropTypes.bool
 };
 
 export default CatalogGroup;

--- a/lib/ReactViews/DataCatalog/CatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/CatalogItem.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Icon from "../Icon.jsx";
 
@@ -45,13 +46,13 @@ function CatalogItem(props) {
 }
 
 CatalogItem.propTypes = {
-    onTextClick: React.PropTypes.func,
-    selected: React.PropTypes.bool,
-    text: React.PropTypes.string,
-    title: React.PropTypes.string,
-    onBtnClick: React.PropTypes.func,
-    btnState: React.PropTypes.oneOf(Object.keys(STATE_TO_ICONS)),
-    titleOverrides: React.PropTypes.object
+    onTextClick: PropTypes.func,
+    selected: PropTypes.bool,
+    text: PropTypes.string,
+    title: PropTypes.string,
+    onBtnClick: PropTypes.func,
+    btnState: PropTypes.oneOf(Object.keys(STATE_TO_ICONS)),
+    titleOverrides: PropTypes.object
 };
 
 export default CatalogItem;

--- a/lib/ReactViews/DataCatalog/DataCatalog.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalog.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -11,7 +13,8 @@ import SearchHeader from '../Search/SearchHeader.jsx';
 import Styles from './data-catalog.scss';
 
 // Displays the data catalog.
-const DataCatalog = React.createClass({
+const DataCatalog = createReactClass({
+    displayName: 'DataCatalog',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -46,7 +49,7 @@ const DataCatalog = React.createClass({
                 </For>
             </ul>
         );
-    }
+    },
 });
 
 module.exports = DataCatalog;

--- a/lib/ReactViews/DataCatalog/DataCatalog.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalog.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
 
 import DataCatalogMember from './DataCatalogMember.jsx';
@@ -13,8 +15,8 @@ const DataCatalog = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        terria: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     render() {

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import addedByUser from '../../Core/addedByUser';
 import CatalogGroup from './CatalogGroup';
 import DataCatalogMember from './DataCatalogMember';
@@ -10,11 +12,11 @@ const DataCatalogGroup = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        group: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired,
+        group: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
         /** Overrides whether to get the open state of the group from the group model or manage it internally */
-        manageIsOpenLocally: React.PropTypes.bool,
-        userData: React.PropTypes.bool
+        manageIsOpenLocally: PropTypes.bool,
+        userData: PropTypes.bool
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import addedByUser from '../../Core/addedByUser';
@@ -8,7 +10,8 @@ import DataCatalogMember from './DataCatalogMember';
 import getAncestors from '../../Models/getAncestors';
 import ObserveModelMixin from '../ObserveModelMixin';
 
-const DataCatalogGroup = React.createClass({
+const DataCatalogGroup = createReactClass({
+    displayName: 'DataCatalogGroup',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -94,7 +97,7 @@ const DataCatalogGroup = React.createClass({
                 </If>
             </CatalogGroup>
         );
-    }
+    },
 });
 
 module.exports = DataCatalogGroup;

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
 
 import addedByUser from '../../Core/addedByUser';
@@ -19,8 +21,8 @@ const DataCatalogItem = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        item: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     onBtnClicked(event) {

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -17,7 +19,8 @@ const STATE_TO_TITLE = {
 };
 
 // Individual dataset
-const DataCatalogItem = React.createClass({
+const DataCatalogItem = createReactClass({
+    displayName: 'DataCatalogItem',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -89,7 +92,7 @@ const DataCatalogItem = React.createClass({
         } else {
             return 'stats';
         }
-    }
+    },
 });
 
 module.exports = DataCatalogItem;

--- a/lib/ReactViews/DataCatalog/DataCatalogMember.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogMember.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 import DataCatalogItem from './DataCatalogItem.jsx';
@@ -9,7 +10,7 @@ import DataCatalogGroup from './DataCatalogGroup.jsx';
 /**
  * Component that is either a {@link CatalogItem} or a {@link DataCatalogMember} and encapsulated this choosing logic.
  */
-export default React.createClass({
+export default createReactClass({
     mixins: [ObserveModelMixin],
     
     displayName: 'DataCatalogMember',

--- a/lib/ReactViews/DataCatalog/DataCatalogMember.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogMember.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 import DataCatalogItem from './DataCatalogItem.jsx';
 import DataCatalogGroup from './DataCatalogGroup.jsx';
@@ -14,9 +15,9 @@ export default React.createClass({
     displayName: 'DataCatalogMember',
 
     propTypes: {
-        member: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired,
-        manageIsOpenLocally: React.PropTypes.bool
+        member: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
+        manageIsOpenLocally: PropTypes.bool
     },
 
     render() {

--- a/lib/ReactViews/DragDropFile.jsx
+++ b/lib/ReactViews/DragDropFile.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import ObserveModelMixin from './ObserveModelMixin';
@@ -10,8 +11,8 @@ const DragDropFile = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object,
+        terria: PropTypes.object,
+        viewState: PropTypes.object,
     },
 
     handleDrop(e) {

--- a/lib/ReactViews/DragDropFile.jsx
+++ b/lib/ReactViews/DragDropFile.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -7,7 +8,8 @@ import addUserFiles from '../Models/addUserFiles';
 
 import Styles from './drag-drop-file.scss';
 
-const DragDropFile = React.createClass({
+const DragDropFile = createReactClass({
+    displayName: 'DragDropFile',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -66,7 +68,7 @@ const DragDropFile = React.createClass({
                 </If>
             </div>
         );
-    }
+    },
 });
 
 module.exports = DragDropFile;

--- a/lib/ReactViews/ExplorerWindow/ExplorerWindow.jsx
+++ b/lib/ReactViews/ExplorerWindow/ExplorerWindow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import ko from 'terriajs-cesium/Source/ThirdParty/knockout';
 
@@ -13,8 +14,8 @@ const ExplorerWindow = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     getInitialState() {

--- a/lib/ReactViews/ExplorerWindow/ExplorerWindow.jsx
+++ b/lib/ReactViews/ExplorerWindow/ExplorerWindow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import ko from 'terriajs-cesium/Source/ThirdParty/knockout';
@@ -10,7 +11,8 @@ import Styles from './explorer-window.scss';
 
 const SLIDE_DURATION = 300;
 
-const ExplorerWindow = React.createClass({
+const ExplorerWindow = createReactClass({
+    displayName: 'ExplorerWindow',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -116,7 +118,7 @@ const ExplorerWindow = React.createClass({
                 </div>
             </div>
         ) : null;
-    }
+    },
 });
 
 module.exports = ExplorerWindow;

--- a/lib/ReactViews/ExplorerWindow/Tabs.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -8,7 +9,8 @@ import ObserveModelMixin from '../ObserveModelMixin';
 
 import Styles from './tabs.scss';
 
-const Tabs = React.createClass({
+const Tabs = createReactClass({
+    displayName: 'Tabs',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -77,7 +79,7 @@ const Tabs = React.createClass({
                 </section>
             </div>
         );
-    }
+    },
 });
 
 module.exports = Tabs;

--- a/lib/ReactViews/ExplorerWindow/Tabs.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import DataCatalogTab from './Tabs/DataCatalogTab.jsx';
@@ -11,9 +12,9 @@ const Tabs = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired,
-        tabs: React.PropTypes.array
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
+        tabs: PropTypes.array
     },
 
     getInitialState() {

--- a/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
 import DataCatalog from '../../DataCatalog/DataCatalog.jsx';
 import DataCatalogMember from '../../DataCatalog/DataCatalogMember.jsx';
@@ -15,8 +17,8 @@ const DataCatalogTab = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        terria: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     changeSearchText(newText) {

--- a/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -13,7 +15,8 @@ import SearchBox from '../../Search/SearchBox.jsx';
 import Styles from './data-catalog-tab.scss';
 
 // The DataCatalog Tab
-const DataCatalogTab = React.createClass({
+const DataCatalogTab = createReactClass({
+    displayName: 'DataCatalogTab',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -75,7 +78,7 @@ const DataCatalogTab = React.createClass({
                 </For>
             </ul>
         );
-    }
+    },
 });
 
 module.exports = DataCatalogTab;

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -21,7 +22,8 @@ const localDataType = getDataType().localDataType;
 /**
  * Add data panel in modal window -> My data tab
  */
-const AddData = React.createClass({
+const AddData = createReactClass({
+    displayName: 'AddData',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -180,7 +182,7 @@ const AddData = React.createClass({
                 {this.renderPanels()}
             </div>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import addUserCatalogMember from '../../../../Models/addUserCatalogMember';
@@ -24,8 +25,8 @@ const AddData = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        terria: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     getInitialState() {

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/FileInput.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/FileInput.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import classNames from 'classnames';
 
 import Styles from './file-input.scss';
 
 // When uploading a file
 // use an button element to have consistent stylying
-const FileInput = React.createClass({
+const FileInput = createReactClass({
     propTypes: {
         onChange: PropTypes.func,
         accept: PropTypes.string

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/FileInput.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/FileInput.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Styles from './file-input.scss';
@@ -7,8 +8,8 @@ import Styles from './file-input.scss';
 // use an button element to have consistent stylying
 const FileInput = React.createClass({
     propTypes: {
-        onChange: React.PropTypes.func,
-        accept: React.PropTypes.string
+        onChange: PropTypes.func,
+        accept: PropTypes.string
     },
 
     getInitialState() {

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import DataCatalogGroup from '../../../DataCatalog/DataCatalogGroup.jsx';
@@ -10,7 +12,8 @@ import ObserveModelMixin from '../../../ObserveModelMixin';
 import Styles from './my-data-tab.scss';
 
 // My data tab include Add data section and preview section
-const MyDataTab = React.createClass({
+const MyDataTab = createReactClass({
+    displayName: 'MyDataTab',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -72,7 +75,7 @@ const MyDataTab = React.createClass({
                 />
             </div>
         );
-    }
+    },
 });
 
 module.exports = MyDataTab;

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import DataCatalogGroup from '../../../DataCatalog/DataCatalogGroup.jsx';
 import DataPreview from '../../../Preview/DataPreview.jsx';
 import AddData from './AddData.jsx';
@@ -12,8 +14,8 @@ const MyDataTab = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        terria: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     onBackButtonClicked() {

--- a/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.jsx
@@ -3,6 +3,8 @@ import FeatureInfoSection from './FeatureInfoSection.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Styles from './feature-info-catalog-item.scss';
 
 // Any Catalog in a feature-info-panel
@@ -10,11 +12,11 @@ const FeatureInfoCatalogItem = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        features: React.PropTypes.array,
-        catalogItem: React.PropTypes.object,
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired,
-        onToggleOpen: React.PropTypes.func.isRequired
+        features: PropTypes.array,
+        catalogItem: PropTypes.object,
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
+        onToggleOpen: PropTypes.func.isRequired
     },
 
     render() {

--- a/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.jsx
@@ -3,12 +3,15 @@ import FeatureInfoSection from './FeatureInfoSection.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import Styles from './feature-info-catalog-item.scss';
 
 // Any Catalog in a feature-info-panel
-const FeatureInfoCatalogItem = React.createClass({
+const FeatureInfoCatalogItem = createReactClass({
+    displayName: 'FeatureInfoCatalogItem',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -72,7 +75,7 @@ const FeatureInfoCatalogItem = React.createClass({
                 </ul>
             </li>
         );
-    }
+    },
 });
 
 module.exports = FeatureInfoCatalogItem;

--- a/lib/ReactViews/FeatureInfo/FeatureInfoDownload.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoDownload.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import FeatureDetection from 'terriajs-cesium/Source/Core/FeatureDetection';
 
 import DataUri from '../../Core/DataUri';
@@ -10,10 +12,10 @@ import Styles from './feature-info-download.scss';
 
 const FeatureInfoDownload = React.createClass({
     propTypes: {
-        data: React.PropTypes.object.isRequired,
-        name: React.PropTypes.string.isRequired,
-        viewState: React.PropTypes.object.isRequired,
-        canUseDataUri: React.PropTypes.bool
+        data: PropTypes.object.isRequired,
+        name: PropTypes.string.isRequired,
+        viewState: PropTypes.object.isRequired,
+        canUseDataUri: PropTypes.bool
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/FeatureInfo/FeatureInfoDownload.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoDownload.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import FeatureDetection from 'terriajs-cesium/Source/Core/FeatureDetection';
 
@@ -10,7 +11,7 @@ import Icon from '../Icon.jsx';
 
 import Styles from './feature-info-download.scss';
 
-const FeatureInfoDownload = React.createClass({
+const FeatureInfoDownload = createReactClass({
     propTypes: {
         data: PropTypes.object.isRequired,
         name: PropTypes.string.isRequired,

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -5,6 +5,7 @@ import FeatureInfoCatalogItem from './FeatureInfoCatalogItem.jsx';
 import Loader from '../Loader.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import Entity from 'terriajs-cesium/Source/DataSources/Entity';
 import Icon from "../Icon.jsx";
@@ -16,8 +17,8 @@ import classNames from 'classnames';
 const FeatureInfoPanel = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     componentDidMount() {

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -5,6 +5,7 @@ import FeatureInfoCatalogItem from './FeatureInfoCatalogItem.jsx';
 import Loader from '../Loader.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import Entity from 'terriajs-cesium/Source/DataSources/Entity';
@@ -14,8 +15,10 @@ import { SEARCH_MARKER_DATA_SOURCE_NAME } from '../Search/SearchMarkerUtils';
 import Styles from './feature-info-panel.scss';
 import classNames from 'classnames';
 
-const FeatureInfoPanel = React.createClass({
+const FeatureInfoPanel = createReactClass({
+    displayName: 'FeatureInfoPanel',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         terria: PropTypes.object.isRequired,
         viewState: PropTypes.object.isRequired
@@ -156,7 +159,7 @@ const FeatureInfoPanel = React.createClass({
                 </ul>
             </div>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -3,6 +3,8 @@
 import Mustache from 'mustache';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
 import classNames from 'classnames';
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -29,14 +31,14 @@ const FeatureInfoSection = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        viewState: React.PropTypes.object.isRequired,
-        template: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.string]),
-        feature: React.PropTypes.object,
-        position: React.PropTypes.object,
-        clock: React.PropTypes.object,
-        catalogItem: React.PropTypes.object,  // Note this may not be known (eg. WFS).
-        isOpen: React.PropTypes.bool,
-        onClickHeader: React.PropTypes.func
+        viewState: PropTypes.object.isRequired,
+        template: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+        feature: PropTypes.object,
+        position: PropTypes.object,
+        clock: PropTypes.object,
+        catalogItem: PropTypes.object,  // Note this may not be known (eg. WFS).
+        isOpen: PropTypes.bool,
+        onClickHeader: PropTypes.func
     },
 
     getInitialState() {

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -3,6 +3,8 @@
 import Mustache from 'mustache';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
@@ -27,7 +29,8 @@ Mustache.escape = function(string) {
 };
 
 // Individual feature info section
-const FeatureInfoSection = React.createClass({
+const FeatureInfoSection = createReactClass({
+    displayName: 'FeatureInfoSection',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -222,7 +225,7 @@ const FeatureInfoSection = React.createClass({
                 </If>
             </li>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/Feedback/FeedbackButton.jsx
+++ b/lib/ReactViews/Feedback/FeedbackButton.jsx
@@ -2,6 +2,7 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './feedback-button.scss';
 import Icon from "../Icon.jsx";
 
@@ -9,7 +10,7 @@ const FeedbackButton = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        viewState: React.PropTypes.object.isRequired
+        viewState: PropTypes.object.isRequired
     },
 
     onClick() {

--- a/lib/ReactViews/Feedback/FeedbackButton.jsx
+++ b/lib/ReactViews/Feedback/FeedbackButton.jsx
@@ -2,11 +2,13 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './feedback-button.scss';
 import Icon from "../Icon.jsx";
 
-const FeedbackButton = React.createClass({
+const FeedbackButton = createReactClass({
+    displayName: 'FeedbackButton',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -26,7 +28,7 @@ const FeedbackButton = React.createClass({
                 </button>
             </div>
         );
-    }
+    },
 });
 
 module.exports = FeedbackButton;

--- a/lib/ReactViews/Feedback/FeedbackForm.jsx
+++ b/lib/ReactViews/Feedback/FeedbackForm.jsx
@@ -2,13 +2,15 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import sendFeedback from '../../Models/sendFeedback.js';
 import Styles from './feedback-form.scss';
 import Icon from "../Icon.jsx";
 import classNames from "classnames";
 
-const FeedbackForm = React.createClass({
+const FeedbackForm = createReactClass({
+    displayName: 'FeedbackForm',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -111,7 +113,7 @@ const FeedbackForm = React.createClass({
                 </div>
             </div>
         );
-    }
+    },
 });
 
 module.exports = FeedbackForm;

--- a/lib/ReactViews/Feedback/FeedbackForm.jsx
+++ b/lib/ReactViews/Feedback/FeedbackForm.jsx
@@ -2,6 +2,7 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import sendFeedback from '../../Models/sendFeedback.js';
 import Styles from './feedback-form.scss';
 import Icon from "../Icon.jsx";
@@ -11,7 +12,7 @@ const FeedbackForm = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        viewState: React.PropTypes.object.isRequired
+        viewState: PropTypes.object.isRequired
     },
 
     getInitialState() {

--- a/lib/ReactViews/Generic/Dropdown.jsx
+++ b/lib/ReactViews/Generic/Dropdown.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import classNames from 'classnames';
 
@@ -10,13 +11,13 @@ import Styles from './dropdown.scss';
 // Uses the contents of the element as the name of the dropdown if none selected.
 const Dropdown = React.createClass({
     propTypes: {
-        theme: React.PropTypes.object,
-        options: React.PropTypes.array, // Must be an array of objects with name properties. Uses <a> when there is an href property, else <button type='button'>.
-        selected: React.PropTypes.object,
-        selectOption: React.PropTypes.func, // The callback function; its arguments are the chosen object and its index.
-        textProperty: React.PropTypes.string, // property to display as text
-        matchWidth: React.PropTypes.bool,
-        children: React.PropTypes.any
+        theme: PropTypes.object,
+        options: PropTypes.array, // Must be an array of objects with name properties. Uses <a> when there is an href property, else <button type='button'>.
+        selected: PropTypes.object,
+        selectOption: PropTypes.func, // The callback function; its arguments are the chosen object and its index.
+        textProperty: PropTypes.string, // property to display as text
+        matchWidth: PropTypes.bool,
+        children: PropTypes.any
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Generic/Dropdown.jsx
+++ b/lib/ReactViews/Generic/Dropdown.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import classNames from 'classnames';
 
@@ -9,7 +10,7 @@ import Styles from './dropdown.scss';
 
 // Use this as drop down rather than the html <select> tag so we have more consistent styling
 // Uses the contents of the element as the name of the dropdown if none selected.
-const Dropdown = React.createClass({
+const Dropdown = createReactClass({
     propTypes: {
         theme: PropTypes.object,
         options: PropTypes.array, // Must be an array of objects with name properties. Uses <a> when there is an href property, else <button type='button'>.

--- a/lib/ReactViews/HelpScreens/HelpMenuPanel.jsx
+++ b/lib/ReactViews/HelpScreens/HelpMenuPanel.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import classNames from 'classnames';
@@ -14,9 +15,9 @@ const HelpMenuPanel = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        helpViewState: React.PropTypes.object.isRequired,
-        helpSequences: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        helpViewState: PropTypes.object.isRequired,
+        helpSequences: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     getInitialState() {

--- a/lib/ReactViews/HelpScreens/HelpMenuPanel.jsx
+++ b/lib/ReactViews/HelpScreens/HelpMenuPanel.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -11,7 +12,8 @@ import Styles from './help-panel.scss';
 import DropdownStyles from '../Map/Panels/panel.scss';
 import helpIcon from '../../../wwwroot/images/icons/help.svg';
 
-const HelpMenuPanel = React.createClass({
+const HelpMenuPanel = createReactClass({
+    displayName: 'HelpMenuPanel',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -69,7 +71,7 @@ const HelpMenuPanel = React.createClass({
                 </If>
             </MenuPanel>
         );
-    }
+    },
 });
 
 export default HelpMenuPanel;

--- a/lib/ReactViews/HelpScreens/HelpOverlay.jsx
+++ b/lib/ReactViews/HelpScreens/HelpOverlay.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -8,7 +9,8 @@ import defined from 'terriajs-cesium/Source/Core/defined';
 import HelpScreenWindow from './HelpScreenWindow.jsx';
 import ObscureOverlay from './ObscureOverlay.jsx';
 
-const HelpOverlay = React.createClass({
+const HelpOverlay = createReactClass({
+    displayName: 'HelpOverlay',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -123,7 +125,7 @@ const HelpOverlay = React.createClass({
                 <HelpScreenWindow helpViewState={this.props.helpViewState}/>
             </div>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/HelpScreens/HelpOverlay.jsx
+++ b/lib/ReactViews/HelpScreens/HelpOverlay.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../ObserveModelMixin';
 import defined from 'terriajs-cesium/Source/Core/defined';
 
@@ -11,8 +12,8 @@ const HelpOverlay = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        helpViewState: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        helpViewState: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     getInitialState() {

--- a/lib/ReactViews/HelpScreens/HelpScreenWindow.jsx
+++ b/lib/ReactViews/HelpScreens/HelpScreenWindow.jsx
@@ -2,6 +2,7 @@
 
 import ObserverModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import parseCustomHtmlToReact from '../Custom/parseCustomHtmlToReact';
 import Styles from './help-screen-window.scss';
@@ -9,7 +10,8 @@ import classNames from 'classnames';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import HelpViewState from '../../ReactViewModels/HelpViewState';
 
-const HelpScreenWindow = React.createClass({
+const HelpScreenWindow = createReactClass({
+    displayName: 'HelpScreenWindow',
     mixins: [ObserverModelMixin],
 
     propTypes: {
@@ -47,7 +49,7 @@ const HelpScreenWindow = React.createClass({
                       className={Styles.btn}><strong>{buttonText}</strong></button>
               </div>
             </div>);
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/HelpScreens/HelpScreenWindow.jsx
+++ b/lib/ReactViews/HelpScreens/HelpScreenWindow.jsx
@@ -2,6 +2,7 @@
 
 import ObserverModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import parseCustomHtmlToReact from '../Custom/parseCustomHtmlToReact';
 import Styles from './help-screen-window.scss';
 import classNames from 'classnames';
@@ -12,7 +13,7 @@ const HelpScreenWindow = React.createClass({
     mixins: [ObserverModelMixin],
 
     propTypes: {
-        helpViewState: React.PropTypes.object
+        helpViewState: PropTypes.object
     },
 
     render() {

--- a/lib/ReactViews/HelpScreens/ObscureOverlay.jsx
+++ b/lib/ReactViews/HelpScreens/ObscureOverlay.jsx
@@ -2,6 +2,7 @@
 
 import ObserverModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './obscure-overlay.scss';
 import classNames from 'classnames';
@@ -12,7 +13,8 @@ import defined from 'terriajs-cesium/Source/Core/defined';
 * to grey out the rest of the screen. A fifth panel, which is clear, covers the whole screen to prevent the highlighted
 * element from being selectable.
 */
-const ObscureOverlay = React.createClass({
+const ObscureOverlay = createReactClass({
+    displayName: 'ObscureOverlay',
     mixins: [ObserverModelMixin],
 
     propTypes: {
@@ -68,7 +70,7 @@ const ObscureOverlay = React.createClass({
                 <div className={Styles.bottomOverlay} style={{left: bottomOverlayPositionLeft, top: bottomOverlayPositionTop, width: bottomOverlayWidth, height: bottomOverlayHeight }} onClick={this.cancel}></div>
                 <div className={Styles.clearOverlay} onClick={this.advance}></div>
             </div>);
-    }
+    },
 });
 
 module.exports = ObscureOverlay;

--- a/lib/ReactViews/HelpScreens/ObscureOverlay.jsx
+++ b/lib/ReactViews/HelpScreens/ObscureOverlay.jsx
@@ -2,6 +2,7 @@
 
 import ObserverModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './obscure-overlay.scss';
 import classNames from 'classnames';
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -15,7 +16,7 @@ const ObscureOverlay = React.createClass({
     mixins: [ObserverModelMixin],
 
     propTypes: {
-        helpViewState: React.PropTypes.object
+        helpViewState: PropTypes.object
     },
 
     cancel() {

--- a/lib/ReactViews/Icon.jsx
+++ b/lib/ReactViews/Icon.jsx
@@ -50,9 +50,9 @@ const GLYPHS = {
 
 const Icon = React.createClass({
     propTypes: {
-        glyph: React.PropTypes.string,
-        style: React.PropTypes.object,
-        className: React.PropTypes.string
+        glyph: PropTypes.string,
+        style: PropTypes.object,
+        className: PropTypes.string
     },
     render() {
         const glyph = this.props.glyph;

--- a/lib/ReactViews/Icon.jsx
+++ b/lib/ReactViews/Icon.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import classNames from 'classnames';
 import Styles from './icon.scss';
 
@@ -48,7 +50,7 @@ const GLYPHS = {
     sphere: require('../../wwwroot/images/icons/sphere.svg'),
 };
 
-const Icon = React.createClass({
+const Icon = createReactClass({
     propTypes: {
         glyph: PropTypes.string,
         style: PropTypes.object,

--- a/lib/ReactViews/Loader.jsx
+++ b/lib/ReactViews/Loader.jsx
@@ -1,12 +1,14 @@
 'use strict';
 import ObserveModelMixin from './ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Icon from "./Icon.jsx";
 
 import Styles from './loader.scss';
 
-const Loader = React.createClass({
+const Loader = createReactClass({
+    displayName: 'Loader',
     mixins: [ObserveModelMixin],
 
     getDefaultProps() {
@@ -26,6 +28,6 @@ const Loader = React.createClass({
                   <Icon glyph={Icon.GLYPHS.loader}/>
                   <span>{this.props.message || 'Loading'}</span>
                </span>;
-    }
+    },
 });
 module.exports = Loader;

--- a/lib/ReactViews/Loader.jsx
+++ b/lib/ReactViews/Loader.jsx
@@ -1,6 +1,7 @@
 'use strict';
 import ObserveModelMixin from './ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Icon from "./Icon.jsx";
 
 import Styles from './loader.scss';
@@ -16,8 +17,8 @@ const Loader = React.createClass({
     },
 
     propTypes: {
-        message: React.PropTypes.string,
-        className: React.PropTypes.string
+        message: PropTypes.string,
+        className: PropTypes.string
     },
 
     render() {

--- a/lib/ReactViews/Map/Legend/DistanceLegend.jsx
+++ b/lib/ReactViews/Map/Legend/DistanceLegend.jsx
@@ -1,5 +1,6 @@
 'use strict';
 import React from 'react';
+import PropTypes from 'prop-types';
 import L from 'leaflet';
 import Cartesian2 from 'terriajs-cesium/Source/Core/Cartesian2';
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -24,7 +25,7 @@ const DistanceLegend = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
+        terria: PropTypes.object,
     },
 
     getInitialState() {

--- a/lib/ReactViews/Map/Legend/DistanceLegend.jsx
+++ b/lib/ReactViews/Map/Legend/DistanceLegend.jsx
@@ -1,5 +1,6 @@
 'use strict';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import L from 'leaflet';
 import Cartesian2 from 'terriajs-cesium/Source/Core/Cartesian2';
@@ -21,7 +22,8 @@ const distances = [
     1000000, 2000000, 3000000, 5000000,
     10000000, 20000000, 30000000, 50000000];
 
-const DistanceLegend = React.createClass({
+const DistanceLegend = createReactClass({
+    displayName: 'DistanceLegend',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -178,6 +180,6 @@ const DistanceLegend = React.createClass({
                  </div>) : null;
 
         return distanceLabel;
-    }
+    },
 });
 module.exports = DistanceLegend;

--- a/lib/ReactViews/Map/Legend/LocationBar.jsx
+++ b/lib/ReactViews/Map/Legend/LocationBar.jsx
@@ -2,15 +2,16 @@
 import classNames from "classnames";
 import ObserveModelMixin from '../../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './legend.scss';
 
 const LocationBar = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        showUtmZone: React.PropTypes.bool,
-        mouseCoords: React.PropTypes.object.isRequired
+        terria: PropTypes.object,
+        showUtmZone: PropTypes.bool,
+        mouseCoords: PropTypes.object.isRequired
     },
 
     getDefaultProps: function() {

--- a/lib/ReactViews/Map/Legend/LocationBar.jsx
+++ b/lib/ReactViews/Map/Legend/LocationBar.jsx
@@ -2,10 +2,12 @@
 import classNames from "classnames";
 import ObserveModelMixin from '../../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './legend.scss';
 
-const LocationBar = React.createClass({
+const LocationBar = createReactClass({
+    displayName: 'LocationBar',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -44,7 +46,7 @@ const LocationBar = React.createClass({
                 </div>
             </button>
         );
-    }
+    },
 });
 
 module.exports = LocationBar;

--- a/lib/ReactViews/Map/MapNavigation.jsx
+++ b/lib/ReactViews/Map/MapNavigation.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import Compass from './Navigation/Compass.jsx';
@@ -11,7 +13,8 @@ import ViewerMode from '../../Models/ViewerMode';
 import Styles from './map-navigation.scss';
 
 // The map navigation region
-const MapNavigation = React.createClass({
+const MapNavigation = createReactClass({
+    displayName: 'MapNavigation',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -47,7 +50,7 @@ const MapNavigation = React.createClass({
                 </For>
             </div>
         );
-    }
+    },
 });
 
 export default MapNavigation;

--- a/lib/ReactViews/Map/MapNavigation.jsx
+++ b/lib/ReactViews/Map/MapNavigation.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Compass from './Navigation/Compass.jsx';
 import MyLocation from './Navigation/MyLocation.jsx';
 import ZoomControl from './Navigation/ZoomControl.jsx';
@@ -13,9 +15,9 @@ const MapNavigation = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired,
-        navItems: React.PropTypes.arrayOf(React.PropTypes.element)
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
+        navItems: PropTypes.arrayOf(PropTypes.element)
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Map/MenuBar.jsx
+++ b/lib/ReactViews/Map/MenuBar.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import SettingPanel from './Panels/SettingPanel.jsx';
 import SharePanel from './Panels/SharePanel/SharePanel.jsx';
 
@@ -12,10 +14,10 @@ import Styles from './menu-bar.scss';
 const MenuBar = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object.isRequired,
-        allBaseMaps: React.PropTypes.array,
-        menuItems: React.PropTypes.arrayOf(React.PropTypes.element)
+        terria: PropTypes.object,
+        viewState: PropTypes.object.isRequired,
+        allBaseMaps: PropTypes.array,
+        menuItems: PropTypes.arrayOf(PropTypes.element)
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Map/MenuBar.jsx
+++ b/lib/ReactViews/Map/MenuBar.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import SettingPanel from './Panels/SettingPanel.jsx';
@@ -11,8 +13,10 @@ import ObserveModelMixin from '../ObserveModelMixin';
 import Styles from './menu-bar.scss';
 
 // The map navigation region
-const MenuBar = React.createClass({
+const MenuBar = createReactClass({
+    displayName: 'MenuBar',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         terria: PropTypes.object,
         viewState: PropTypes.object.isRequired,
@@ -52,7 +56,7 @@ const MenuBar = React.createClass({
                 </ul>
             </div>
         );
-    }
+    },
 });
 
 export default MenuBar;

--- a/lib/ReactViews/Map/MenuButton.jsx
+++ b/lib/ReactViews/Map/MenuButton.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Styles from './menu-button.scss';
 
 /**
@@ -25,8 +27,8 @@ MenuButton.defaultProps = {
 };
 
 MenuButton.propTypes = {
-    href: React.PropTypes.string,
-    caption: React.PropTypes.string.isRequired
+    href: PropTypes.string,
+    caption: PropTypes.string.isRequired
 };
 
 export default MenuButton;

--- a/lib/ReactViews/Map/Navigation/Compass.jsx
+++ b/lib/ReactViews/Map/Navigation/Compass.jsx
@@ -1,6 +1,7 @@
 'use strict';
 const React = require('react');
 const PropTypes = require('prop-types');
+import createReactClass from 'create-react-class';
 const CameraFlightPath = require('terriajs-cesium/Source/Scene/CameraFlightPath');
 const Cartesian2 = require('terriajs-cesium/Source/Core/Cartesian2');
 const Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3');
@@ -14,7 +15,7 @@ const Transforms = require('terriajs-cesium/Source/Core/Transforms');
 import Styles from './compass.scss';
 
 // the compass on map
-const Compass = React.createClass({
+const Compass = createReactClass({
     propTypes: {
         terria: PropTypes.object
     },

--- a/lib/ReactViews/Map/Navigation/Compass.jsx
+++ b/lib/ReactViews/Map/Navigation/Compass.jsx
@@ -1,5 +1,6 @@
 'use strict';
 const React = require('react');
+const PropTypes = require('prop-types');
 const CameraFlightPath = require('terriajs-cesium/Source/Scene/CameraFlightPath');
 const Cartesian2 = require('terriajs-cesium/Source/Core/Cartesian2');
 const Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3');
@@ -15,7 +16,7 @@ import Styles from './compass.scss';
 // the compass on map
 const Compass = React.createClass({
     propTypes: {
-        terria: React.PropTypes.object
+        terria: PropTypes.object
     },
 
     getInitialState() {

--- a/lib/ReactViews/Map/Navigation/FullScreenButton.jsx
+++ b/lib/ReactViews/Map/Navigation/FullScreenButton.jsx
@@ -1,5 +1,6 @@
 'use strict';
 const React = require('react');
+const createReactClass = require('create-react-class');
 const PropTypes = require('prop-types');
 import ObserveModelMixin from '../../ObserveModelMixin';
 import triggerResize from '../../../Core/triggerResize';
@@ -8,7 +9,8 @@ import classNames from "classnames";
 import Icon from "../../Icon.jsx";
 
 // The button to make the map full screen and hide the workbench.
-const FullScreenButton = React.createClass({
+const FullScreenButton = createReactClass({
+    displayName: 'FullScreenButton',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -22,6 +24,7 @@ const FullScreenButton = React.createClass({
             isActive: false
         };
     },
+
     toggleFullScreen() {
         this.props.viewState.isMapFullScreen = !this.props.viewState.isMapFullScreen;
 
@@ -51,6 +54,6 @@ const FullScreenButton = React.createClass({
                         className={btnClassName}><span>{this.renderButtonText()}</span></button>
             </div>
         );
-    }
+    },
 });
 module.exports = FullScreenButton;

--- a/lib/ReactViews/Map/Navigation/FullScreenButton.jsx
+++ b/lib/ReactViews/Map/Navigation/FullScreenButton.jsx
@@ -1,5 +1,6 @@
 'use strict';
 const React = require('react');
+const PropTypes = require('prop-types');
 import ObserveModelMixin from '../../ObserveModelMixin';
 import triggerResize from '../../../Core/triggerResize';
 import Styles from './full_screen_button.scss';
@@ -11,9 +12,9 @@ const FullScreenButton = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object.isRequired,
-        animationDuration: React.PropTypes.number // Defaults to 1 millisecond.
+        terria: PropTypes.object,
+        viewState: PropTypes.object.isRequired,
+        animationDuration: PropTypes.number // Defaults to 1 millisecond.
     },
 
     getInitialState() {

--- a/lib/ReactViews/Map/Navigation/MeasureTool.jsx
+++ b/lib/ReactViews/Map/Navigation/MeasureTool.jsx
@@ -18,7 +18,7 @@ const MeasureTool = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object
+        terria: PropTypes.object
     },
 
     getInitialState() {

--- a/lib/ReactViews/Map/Navigation/MeasureTool.jsx
+++ b/lib/ReactViews/Map/Navigation/MeasureTool.jsx
@@ -1,5 +1,6 @@
 'use strict';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import Styles from './measure_tool.scss';
 import Icon from "../../Icon.jsx";
@@ -14,7 +15,8 @@ const PolygonHierarchy = require('terriajs-cesium/Source/Core/PolygonHierarchy.j
 const Cartesian3 = require('terriajs-cesium/Source/Core/Cartesian3.js');
 const VertexFormat = require('terriajs-cesium/Source/Core/VertexFormat.js');
 
-const MeasureTool = React.createClass({
+const MeasureTool = createReactClass({
+    displayName: 'MeasureTool',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -192,7 +194,7 @@ const MeasureTool = React.createClass({
                           <Icon glyph={Icon.GLYPHS.measure}/>
                   </button>
                </div>;
-    }
+    },
 });
 
 export default MeasureTool;

--- a/lib/ReactViews/Map/Navigation/MeasureTool.jsx
+++ b/lib/ReactViews/Map/Navigation/MeasureTool.jsx
@@ -1,5 +1,6 @@
 'use strict';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import Styles from './measure_tool.scss';

--- a/lib/ReactViews/Map/Navigation/MyLocation.jsx
+++ b/lib/ReactViews/Map/Navigation/MyLocation.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import URI from 'urijs';
 
 import Rectangle from 'terriajs-cesium/Source/Core/Rectangle';
@@ -15,7 +16,7 @@ const MyLocation = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired
+        terria: PropTypes.object.isRequired
     },
 
     _marker: undefined,

--- a/lib/ReactViews/Map/Navigation/MyLocation.jsx
+++ b/lib/ReactViews/Map/Navigation/MyLocation.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import URI from 'urijs';
 
@@ -12,7 +13,8 @@ import Styles from './my_location.scss';
 import TerriaError from '../../../Core/TerriaError';
 import Icon from "../../Icon.jsx";
 
-const MyLocation = React.createClass({
+const MyLocation = createReactClass({
+    displayName: 'MyLocation',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -92,6 +94,7 @@ const MyLocation = React.createClass({
     handleCick() {
         this.getLocation();
     },
+
     render() {
         return <div className={Styles.myLocation}>
                   <button type='button' className={Styles.btn}
@@ -100,7 +103,7 @@ const MyLocation = React.createClass({
                           <Icon glyph={Icon.GLYPHS.geolocation}/>
                   </button>
                </div>;
-    }
+    },
 });
 
 export default MyLocation;

--- a/lib/ReactViews/Map/Navigation/ZoomControl.jsx
+++ b/lib/ReactViews/Map/Navigation/ZoomControl.jsx
@@ -1,6 +1,7 @@
 'use strict';
 const React = require('react');
 const PropTypes = require('prop-types');
+import createReactClass from 'create-react-class';
 const defined = require('terriajs-cesium/Source/Core/defined');
 const Ray = require('terriajs-cesium/Source/Core/Ray');
 const IntersectionTests = require('terriajs-cesium/Source/Core/IntersectionTests');
@@ -12,7 +13,7 @@ import Icon from "../../Icon.jsx";
 import Styles from './zoom_control.scss';
 
 // Map zoom control
-const ZoomControl = React.createClass({
+const ZoomControl = createReactClass({
 
     propTypes: {
         terria: PropTypes.object

--- a/lib/ReactViews/Map/Navigation/ZoomControl.jsx
+++ b/lib/ReactViews/Map/Navigation/ZoomControl.jsx
@@ -1,5 +1,6 @@
 'use strict';
 const React = require('react');
+const PropTypes = require('prop-types');
 const defined = require('terriajs-cesium/Source/Core/defined');
 const Ray = require('terriajs-cesium/Source/Core/Ray');
 const IntersectionTests = require('terriajs-cesium/Source/Core/IntersectionTests');
@@ -14,7 +15,7 @@ import Styles from './zoom_control.scss';
 const ZoomControl = React.createClass({
 
     propTypes: {
-        terria: React.PropTypes.object
+        terria: PropTypes.object
     },
 
     flyToPosition(scene, position, durationMilliseconds) {

--- a/lib/ReactViews/Map/Panels/BaseOuterPanel.js
+++ b/lib/ReactViews/Map/Panels/BaseOuterPanel.js
@@ -1,13 +1,15 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 export default {
     propTypes: {
-        theme: React.PropTypes.object,
-        children: React.PropTypes.any,
-        btnTitle: React.PropTypes.string,
-        btnText: React.PropTypes.string,
-        onOpenChanged: React.PropTypes.func,
-        forceClosed: React.PropTypes.bool
+        theme: PropTypes.object,
+        children: PropTypes.any,
+        btnTitle: PropTypes.string,
+        btnText: PropTypes.string,
+        onOpenChanged: PropTypes.func,
+        forceClosed: PropTypes.bool
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Map/Panels/BaseOuterPanel.js
+++ b/lib/ReactViews/Map/Panels/BaseOuterPanel.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import PropTypes from 'prop-types';
 
 export default {

--- a/lib/ReactViews/Map/Panels/DropdownPanel.jsx
+++ b/lib/ReactViews/Map/Panels/DropdownPanel.jsx
@@ -4,6 +4,7 @@
 /* eslint react/prop-types:0*/
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import classNames from 'classnames';
 import Icon from "../../Icon.jsx";
 import InnerPanel from './InnerPanel';
@@ -13,7 +14,8 @@ import Styles from './panel.scss';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
 
-const DropdownPanel = React.createClass({
+const DropdownPanel = createReactClass({
+    displayName: 'DropdownPanel',
     mixins: [BaseOuterPanel],
 
     onInnerMounted(innerElement) {
@@ -77,7 +79,7 @@ const DropdownPanel = React.createClass({
                 </If>
             </div>
         );
-    }
+    },
 });
 
 export default DropdownPanel;

--- a/lib/ReactViews/Map/Panels/InnerPanel.jsx
+++ b/lib/ReactViews/Map/Panels/InnerPanel.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import classNames from 'classnames';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
 
 import Styles from './panel.scss';
 
-const InnerPanel = React.createClass({
+const InnerPanel = createReactClass({
     propTypes: {
         /**
          * A property that will be looked for on window click events - if it's set, the click event will not cause the

--- a/lib/ReactViews/Map/Panels/InnerPanel.jsx
+++ b/lib/ReactViews/Map/Panels/InnerPanel.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -11,19 +12,19 @@ const InnerPanel = React.createClass({
          * A property that will be looked for on window click events - if it's set, the click event will not cause the
          * panel to close.
          */
-        doNotCloseFlag: React.PropTypes.string,
+        doNotCloseFlag: PropTypes.string,
         /** Will be called when the panel has finished hiding */
-        onDismissed: React.PropTypes.func,
+        onDismissed: PropTypes.func,
         /** Theme to style components */
-        theme: React.PropTypes.object,
+        theme: PropTypes.object,
         /** How far the caret at the top of the panel should be from its left, as CSS (so #px or #% are both valid) */
-        caretOffset: React.PropTypes.string,
+        caretOffset: PropTypes.string,
         /** Will be passed as "ref" to the outermost element */
-        innerRef: React.PropTypes.oneOfType([React.PropTypes.func, React.PropTypes.string]),
+        innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
         /** How far the dropdown should be offset from the left of the container. */
-        dropdownOffset: React.PropTypes.string,
+        dropdownOffset: PropTypes.string,
 
-        children: React.PropTypes.oneOfType([React.PropTypes.arrayOf(React.PropTypes.element), React.PropTypes.element])
+        children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element])
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Map/Panels/MobilePanel.jsx
+++ b/lib/ReactViews/Map/Panels/MobilePanel.jsx
@@ -3,13 +3,16 @@
 
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import MobileMenuItem from '../../Mobile/MobileMenuItem';
 import BaseOuterPanel from './BaseOuterPanel';
 import InnerPanel from './InnerPanel';
 
 import Styles from './panel.scss';
 
-const MobilePanel = React.createClass({
+const MobilePanel = createReactClass({
+    displayName: 'MobilePanel',
     mixins: [BaseOuterPanel],
 
     render() {
@@ -29,7 +32,7 @@ const MobilePanel = React.createClass({
                 </If>
             </div>
         );
-    }
+    },
 });
 
 export default MobilePanel;

--- a/lib/ReactViews/Map/Panels/SettingPanel.jsx
+++ b/lib/ReactViews/Map/Panels/SettingPanel.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import ViewerMode from '../../../Models/ViewerMode';
@@ -16,10 +17,10 @@ const SettingPanel = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewerModes: React.PropTypes.array,
-        allBaseMaps: React.PropTypes.array.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        terria: PropTypes.object.isRequired,
+        viewerModes: PropTypes.array,
+        allBaseMaps: PropTypes.array.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Map/Panels/SettingPanel.jsx
+++ b/lib/ReactViews/Map/Panels/SettingPanel.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -13,7 +14,8 @@ import Styles from './setting-panel.scss';
 import DropdownStyles from './panel.scss';
 
 // The basemap and viewer setting panel
-const SettingPanel = React.createClass({
+const SettingPanel = createReactClass({
+    displayName: 'SettingPanel',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -123,7 +125,7 @@ const SettingPanel = React.createClass({
                 </div>
             </MenuPanel>
         );
-    }
+    },
 });
 
 module.exports = SettingPanel;

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import {buildShareLink, buildShortShareLink, canShorten} from './BuildShareLink';
 import ObserverModelMixin from '../../../ObserveModelMixin';
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -15,11 +16,11 @@ const SharePanel = React.createClass({
     mixins: [ObserverModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        userPropWhiteList: React.PropTypes.array,
-        isOpen: React.PropTypes.bool,
-        shortenUrls: React.PropTypes.bool,
-        viewState: React.PropTypes.object.isRequired
+        terria: PropTypes.object,
+        userPropWhiteList: PropTypes.array,
+        isOpen: PropTypes.bool,
+        shortenUrls: PropTypes.bool,
+        viewState: PropTypes.object.isRequired
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import {buildShareLink, buildShortShareLink, canShorten} from './BuildShareLink';
 import ObserverModelMixin from '../../../ObserveModelMixin';
@@ -12,7 +13,8 @@ import Styles from './share-panel.scss';
 import DropdownStyles from '../panel.scss';
 import Icon from "../../../Icon.jsx";
 
-const SharePanel = React.createClass({
+const SharePanel = createReactClass({
+    displayName: 'SharePanel',
     mixins: [ObserverModelMixin],
 
     propTypes: {
@@ -158,7 +160,7 @@ const SharePanel = React.createClass({
                 </If>
             </MenuPanel>
         );
-    }
+    },
 });
 
 export default SharePanel;

--- a/lib/ReactViews/Map/ProgressBar.jsx
+++ b/lib/ReactViews/Map/ProgressBar.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import EventHelper from 'terriajs-cesium/Source/Core/EventHelper';
 import classNames from 'classnames';
 
@@ -9,7 +10,7 @@ import Styles from './progress-bar.scss';
 // The map navigation region
 const ProgressBar = React.createClass({
     propTypes: {
-        terria: React.PropTypes.object.isRequired
+        terria: PropTypes.object.isRequired
     },
 
     getInitialState() {

--- a/lib/ReactViews/Map/ProgressBar.jsx
+++ b/lib/ReactViews/Map/ProgressBar.jsx
@@ -2,13 +2,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import EventHelper from 'terriajs-cesium/Source/Core/EventHelper';
 import classNames from 'classnames';
 
 import Styles from './progress-bar.scss';
 
 // The map navigation region
-const ProgressBar = React.createClass({
+const ProgressBar = createReactClass({
     propTypes: {
         terria: PropTypes.object.isRequired
     },

--- a/lib/ReactViews/Map/TerriaViewerWrapper.jsx
+++ b/lib/ReactViews/Map/TerriaViewerWrapper.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import TerriaViewer from '../../ViewModels/TerriaViewer';
 import Cartesian2 from 'terriajs-cesium/Source/Core/Cartesian2';
 import Styles from './terria-viewer-wrapper.scss';
 
-const TerriaViewerWrapper = React.createClass({
+const TerriaViewerWrapper = createReactClass({
+    displayName: 'TerriaViewerWrapper',
+
     // mixins: [ObserveModelMixin],
 
     lastMouseX: -1,
+
     lastMouseY: -1,
 
     propTypes: {
@@ -63,6 +67,6 @@ const TerriaViewerWrapper = React.createClass({
                 <div className={Styles.mapPlaceholder}>Loading the map, please wait!</div>
             </aside>
         );
-    }
+    },
 });
 module.exports = TerriaViewerWrapper;

--- a/lib/ReactViews/Map/TerriaViewerWrapper.jsx
+++ b/lib/ReactViews/Map/TerriaViewerWrapper.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import TerriaViewer from '../../ViewModels/TerriaViewer';
 import Cartesian2 from 'terriajs-cesium/Source/Core/Cartesian2';
 import Styles from './terria-viewer-wrapper.scss';
@@ -10,8 +11,8 @@ const TerriaViewerWrapper = React.createClass({
     lastMouseY: -1,
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     componentDidMount() {

--- a/lib/ReactViews/Mobile/MobileHeader.jsx
+++ b/lib/ReactViews/Mobile/MobileHeader.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import SearchBox from '../Search/SearchBox.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -10,7 +11,8 @@ import MobileMenu from './MobileMenu';
 import classNames from 'classnames';
 import { removeMarker } from '../Search/SearchMarkerUtils';
 
-const MobileHeader = React.createClass({
+const MobileHeader = createReactClass({
+    displayName: 'MobileHeader',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -185,6 +187,6 @@ const MobileHeader = React.createClass({
                 />
             </div>
         );
-    }
+    },
 });
 module.exports = MobileHeader;

--- a/lib/ReactViews/Mobile/MobileHeader.jsx
+++ b/lib/ReactViews/Mobile/MobileHeader.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import SearchBox from '../Search/SearchBox.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import MobileModalWindow from './MobileModalWindow';
@@ -13,11 +14,11 @@ const MobileHeader = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object.isRequired,
-        allBaseMaps: React.PropTypes.array.isRequired,
-        version: React.PropTypes.string,
-        menuItems: React.PropTypes.array
+        terria: PropTypes.object,
+        viewState: PropTypes.object.isRequired,
+        allBaseMaps: PropTypes.array.isRequired,
+        version: PropTypes.string,
+        menuItems: PropTypes.array
     },
 
     getInitialState() {

--- a/lib/ReactViews/Mobile/MobileMenu.jsx
+++ b/lib/ReactViews/Mobile/MobileMenu.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -13,7 +15,8 @@ import ViewState from '../../ReactViewModels/ViewState';
 
 import Styles from './mobile-menu.scss';
 
-const MobileMenu = React.createClass({
+const MobileMenu = createReactClass({
+    displayName: 'MobileMenu',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -80,7 +83,7 @@ const MobileMenu = React.createClass({
                 </div>
             </div>
         );
-    }
+    },
 });
 
 export default MobileMenu;

--- a/lib/ReactViews/Mobile/MobileMenu.jsx
+++ b/lib/ReactViews/Mobile/MobileMenu.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import ObserveModelMixin from '../ObserveModelMixin';
 import classNames from 'classnames';
 import MobileMenuItem from './MobileMenuItem';
@@ -15,11 +17,11 @@ const MobileMenu = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        menuItems: React.PropTypes.arrayOf(React.PropTypes.element),
-        viewState: React.PropTypes.instanceOf(ViewState).isRequired,
-        showFeedback: React.PropTypes.bool,
-        terria: React.PropTypes.instanceOf(Terria).isRequired,
-        allBaseMaps: React.PropTypes.array.isRequired
+        menuItems: PropTypes.arrayOf(PropTypes.element),
+        viewState: PropTypes.instanceOf(ViewState).isRequired,
+        showFeedback: PropTypes.bool,
+        terria: PropTypes.instanceOf(Terria).isRequired,
+        allBaseMaps: PropTypes.array.isRequired
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Mobile/MobileMenuItem.jsx
+++ b/lib/ReactViews/Mobile/MobileMenuItem.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Styles from './mobile-menu-item.scss';
 
 /** A simple text item in the mobile menu */
@@ -20,9 +22,9 @@ export default function MobileMenuItem(props) {
 }
 
 MobileMenuItem.propTypes = {
-    href: React.PropTypes.string,
-    onClick: React.PropTypes.func,
-    caption: React.PropTypes.string
+    href: PropTypes.string,
+    onClick: PropTypes.func,
+    caption: PropTypes.string
 };
 
 MobileMenuItem.defaultProps = {

--- a/lib/ReactViews/Mobile/MobileModalWindow.jsx
+++ b/lib/ReactViews/Mobile/MobileModalWindow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import DataCatalog from '../DataCatalog/DataCatalog.jsx';
@@ -14,8 +15,8 @@ const MobileModalWindow = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object.isRequired
+        terria: PropTypes.object,
+        viewState: PropTypes.object.isRequired
     },
 
     renderModalContent() {

--- a/lib/ReactViews/Mobile/MobileModalWindow.jsx
+++ b/lib/ReactViews/Mobile/MobileModalWindow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -11,7 +12,8 @@ import Icon from '../Icon';
 
 import Styles from './mobile-modal-window.scss';
 
-const MobileModalWindow = React.createClass({
+const MobileModalWindow = createReactClass({
+    displayName: 'MobileModalWindow',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -104,6 +106,6 @@ const MobileModalWindow = React.createClass({
                 </div>
             </div>
         );
-    }
+    },
 });
 module.exports = MobileModalWindow;

--- a/lib/ReactViews/Mobile/MobileSearch.jsx
+++ b/lib/ReactViews/Mobile/MobileSearch.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import {addMarker} from '../Search/SearchMarkerUtils';
 import ObserveModelMixin from '../ObserveModelMixin';
 import LocationSearchResults from '../Search/LocationSearchResults.jsx';
@@ -10,8 +12,8 @@ const MobileSearch = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        viewState: React.PropTypes.object,
-        terria: React.PropTypes.object
+        viewState: PropTypes.object,
+        terria: PropTypes.object
     },
 
     onLocationClick(result) {

--- a/lib/ReactViews/Mobile/MobileSearch.jsx
+++ b/lib/ReactViews/Mobile/MobileSearch.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import {addMarker} from '../Search/SearchMarkerUtils';
@@ -8,7 +10,8 @@ import LocationSearchResults from '../Search/LocationSearchResults.jsx';
 import Styles from './mobile-search.scss';
 
 // A Location item when doing Bing map searvh or Gazetter search
-const MobileSearch = React.createClass({
+const MobileSearch = createReactClass({
+    displayName: 'MobileSearch',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -52,7 +55,7 @@ const MobileSearch = React.createClass({
 
                 />
             );
-    }
+    },
 });
 
 module.exports = MobileSearch;

--- a/lib/ReactViews/Notification/MapInteractionWindow.jsx
+++ b/lib/ReactViews/Notification/MapInteractionWindow.jsx
@@ -2,13 +2,15 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import parseCustomHtmlToReact from '../Custom/parseCustomHtmlToReact';
 import Styles from './map-interaction-window.scss';
 import classNames from 'classnames';
 import defined from 'terriajs-cesium/Source/Core/defined';
 
-const MapInteractionWindow = React.createClass({
+const MapInteractionWindow = createReactClass({
+    displayName: 'MapInteractionWindow',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -58,7 +60,7 @@ const MapInteractionWindow = React.createClass({
               <button type='button' onClick={interactionMode && interactionMode.onCancel}
                   className={Styles.btn}>{interactionMode && interactionMode.buttonText}</button>
             </div>);
-    }
+    },
 });
 
 module.exports = MapInteractionWindow;

--- a/lib/ReactViews/Notification/MapInteractionWindow.jsx
+++ b/lib/ReactViews/Notification/MapInteractionWindow.jsx
@@ -2,6 +2,7 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import parseCustomHtmlToReact from '../Custom/parseCustomHtmlToReact';
 import Styles from './map-interaction-window.scss';
 import classNames from 'classnames';
@@ -11,8 +12,8 @@ const MapInteractionWindow = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object,
-        viewState: React.PropTypes.object
+        terria: PropTypes.object,
+        viewState: PropTypes.object
     },
 
     componentWillUnmount() {

--- a/lib/ReactViews/Notification/Notification.jsx
+++ b/lib/ReactViews/Notification/Notification.jsx
@@ -2,13 +2,14 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import NotificationWindow from './NotificationWindow';
 
 const Notification = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        viewState: React.PropTypes.object
+        viewState: PropTypes.object
     },
 
     confirm() {

--- a/lib/ReactViews/Notification/Notification.jsx
+++ b/lib/ReactViews/Notification/Notification.jsx
@@ -2,10 +2,12 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import NotificationWindow from './NotificationWindow';
 
-const Notification = React.createClass({
+const Notification = createReactClass({
+    displayName: 'Notification',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -41,7 +43,7 @@ const Notification = React.createClass({
                 onConfirm={this.confirm}
                 onDeny={this.deny}
             />);
-    }
+    },
 });
 
 module.exports = Notification;

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -2,6 +2,7 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
 import Styles from './notification-window.scss';
 
@@ -9,12 +10,12 @@ const NotificationWindow = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        title: React.PropTypes.string.isRequired,
-        message: React.PropTypes.string.isRequired,
-        confirmText: React.PropTypes.string,
-        denyText: React.PropTypes.string,
-        onConfirm: React.PropTypes.func.isRequired,
-        onDeny: React.PropTypes.func.isRequired
+        title: PropTypes.string.isRequired,
+        message: PropTypes.string.isRequired,
+        confirmText: PropTypes.string,
+        denyText: PropTypes.string,
+        onConfirm: PropTypes.func.isRequired,
+        onDeny: PropTypes.func.isRequired
     },
 
     confirm(e) {

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -2,11 +2,13 @@
 
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
 import Styles from './notification-window.scss';
 
-const NotificationWindow = React.createClass({
+const NotificationWindow = createReactClass({
+    displayName: 'NotificationWindow',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -57,7 +59,7 @@ const NotificationWindow = React.createClass({
                 </div>
             </div>
         );
-    }
+    },
 });
 
 module.exports = NotificationWindow;

--- a/lib/ReactViews/Preview/DataPreview.jsx
+++ b/lib/ReactViews/Preview/DataPreview.jsx
@@ -7,6 +7,7 @@ import InvokeFunction from '../Analytics/InvokeFunction';
 import MappablePreview from './MappablePreview';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './data-preview.scss';
 
 /**
@@ -16,9 +17,9 @@ const DataPreview = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object,
-        previewed: React.PropTypes.object
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object,
+        previewed: PropTypes.object
     },
 
     backToMap() {

--- a/lib/ReactViews/Preview/DataPreview.jsx
+++ b/lib/ReactViews/Preview/DataPreview.jsx
@@ -7,13 +7,15 @@ import InvokeFunction from '../Analytics/InvokeFunction';
 import MappablePreview from './MappablePreview';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './data-preview.scss';
 
 /**
  * Data preview section, for the preview map see DataPreviewMap
  */
-const DataPreview = React.createClass({
+const DataPreview = createReactClass({
+    displayName: 'DataPreview',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -73,7 +75,7 @@ const DataPreview = React.createClass({
                 </Choose>
             </div>
         );
-    }
+    },
 });
 
 module.exports = DataPreview;

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -7,6 +7,7 @@ const GeoJsonCatalogItem = require('../../Models/GeoJsonCatalogItem');
 const ObserveModelMixin = require('../ObserveModelMixin');
 const OpenStreetMapCatalogItem = require('../../Models/OpenStreetMapCatalogItem');
 const React = require('react');
+const PropTypes = require('prop-types');
 const Terria = require('../../Models/Terria');
 const TerriaViewer = require('../../ViewModels/TerriaViewer.js');
 const ViewerMode = require('../../Models/ViewerMode');
@@ -22,9 +23,9 @@ const DataPreviewMap = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        previewedCatalogItem: React.PropTypes.object,
-        showMap: React.PropTypes.bool
+        terria: PropTypes.object.isRequired,
+        previewedCatalogItem: PropTypes.object,
+        showMap: PropTypes.bool
     },
 
     getInitialState() {

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -7,6 +7,7 @@ const GeoJsonCatalogItem = require('../../Models/GeoJsonCatalogItem');
 const ObserveModelMixin = require('../ObserveModelMixin');
 const OpenStreetMapCatalogItem = require('../../Models/OpenStreetMapCatalogItem');
 const React = require('react');
+const createReactClass = require('create-react-class');
 const PropTypes = require('prop-types');
 const Terria = require('../../Models/Terria');
 const TerriaViewer = require('../../ViewModels/TerriaViewer.js');
@@ -19,7 +20,8 @@ import Styles from './data-preview-map.scss';
 /**
  * Leaflet-based preview map that sits within the preview.
  */
-const DataPreviewMap = React.createClass({
+const DataPreviewMap = createReactClass({
+    displayName: 'DataPreviewMap',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -317,6 +319,6 @@ const DataPreviewMap = React.createClass({
                 <label className={Styles.badge}>{this.state.previewBadgeText}</label>
             </div>
         );
-    }
+    },
 });
 module.exports = DataPreviewMap;

--- a/lib/ReactViews/Preview/DataPreviewSections.jsx
+++ b/lib/ReactViews/Preview/DataPreviewSections.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import naturalSort from 'javascript-natural-sort';
@@ -26,7 +28,8 @@ const DEFAULT_SECTION_ORDER = [
  * CatalogItem-defined sections that sit within the preview description. These are ordered according to the catalog item's
  * order if available.
  */
-const DataPreviewSections = React.createClass({
+const DataPreviewSections = createReactClass({
+    displayName: 'DataPreviewSections',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -68,7 +71,7 @@ const DataPreviewSections = React.createClass({
                 </For>
             </div>
         );
-    }
+    },
 });
 
 export default DataPreviewSections;

--- a/lib/ReactViews/Preview/DataPreviewSections.jsx
+++ b/lib/ReactViews/Preview/DataPreviewSections.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import naturalSort from 'javascript-natural-sort';
 import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -28,7 +30,7 @@ const DataPreviewSections = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        metadataItem: React.PropTypes.object.isRequired
+        metadataItem: PropTypes.object.isRequired
     },
 
     sortInfoSections(items) {

--- a/lib/ReactViews/Preview/DataPreviewUrl.jsx
+++ b/lib/ReactViews/Preview/DataPreviewUrl.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import ObserveModelMixin from '../ObserveModelMixin';
 import Styles from './data-preview.scss';
 /**
@@ -9,7 +11,7 @@ const DataPreviewUrl = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        metadataItem: React.PropTypes.object.isRequired
+        metadataItem: PropTypes.object.isRequired
     },
 
     selectUrl(e) {

--- a/lib/ReactViews/Preview/DataPreviewUrl.jsx
+++ b/lib/ReactViews/Preview/DataPreviewUrl.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -7,7 +9,8 @@ import Styles from './data-preview.scss';
 /**
  * URL section of the preview.
  */
-const DataPreviewUrl = React.createClass({
+const DataPreviewUrl = createReactClass({
+    displayName: 'DataPreviewUrl',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -48,7 +51,7 @@ const DataPreviewUrl = React.createClass({
                 </If>
             </div>
         );
-    }
+    },
 });
 
 export default DataPreviewUrl;

--- a/lib/ReactViews/Preview/Description.js
+++ b/lib/ReactViews/Preview/Description.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import defined from 'terriajs-cesium/Source/Core/defined';
 
 import Collapsible from '../Custom/Collapsible/Collapsible';
@@ -17,7 +19,7 @@ const Description = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        item: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired
     },
 
     render() {
@@ -216,9 +218,9 @@ const Link = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        url: React.PropTypes.string.isRequired,
-        text: React.PropTypes.string.isRequired,
-        download: React.PropTypes.string
+        url: PropTypes.string.isRequired,
+        text: PropTypes.string.isRequired,
+        download: PropTypes.string
     },
 
     render() {

--- a/lib/ReactViews/Preview/Description.js
+++ b/lib/ReactViews/Preview/Description.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -15,7 +17,8 @@ import Styles from './mappable-preview.scss';
 /**
  * CatalogItem description.
  */
-const Description = React.createClass({
+const Description = createReactClass({
+    displayName: 'Description',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -177,7 +180,7 @@ const Description = React.createClass({
                 </If>
             </div>
         );
-    }
+    },
 });
 
 /**
@@ -214,7 +217,8 @@ function getBetterFileName(dataUrlType, itemName, format) {
     return name;
 }
 
-const Link = React.createClass({
+const Link = createReactClass({
+    displayName: 'Link',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -227,7 +231,7 @@ const Link = React.createClass({
         return (
             <a href={this.props.url} className={Styles.link} download={this.props.download} target="_blank">{this.props.text}</a>
         );
-    }
+    },
 });
 
 export default Description;

--- a/lib/ReactViews/Preview/GroupPreview.jsx
+++ b/lib/ReactViews/Preview/GroupPreview.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import DataPreviewSections from './DataPreviewSections';
@@ -11,7 +13,8 @@ import parseCustomMarkdownToReact from '../Custom/parseCustomMarkdownToReact';
 /**
  * A "preview" for CatalogGroup.
  */
-const GroupPreview = React.createClass({
+const GroupPreview = createReactClass({
+    displayName: 'GroupPreview',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -58,7 +61,7 @@ const GroupPreview = React.createClass({
                 </div>
             </div>
         );
-    }
+    },
 });
 
 export default GroupPreview;

--- a/lib/ReactViews/Preview/GroupPreview.jsx
+++ b/lib/ReactViews/Preview/GroupPreview.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import DataPreviewSections from './DataPreviewSections';
 import DataPreviewUrl from './DataPreviewUrl.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -13,9 +15,9 @@ const GroupPreview = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        previewed: React.PropTypes.object.isRequired,
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired,
+        previewed: PropTypes.object.isRequired,
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
     },
 
     backToMap() {

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import DataPreviewMap from './DataPreviewMap';
@@ -11,7 +13,8 @@ import Styles from './mappable-preview.scss';
  * CatalogItem preview that is mappable (as opposed to say, an analytics item that can't be displayed on a map without
  * configuration of other parameters.
  */
-const MappablePreview = React.createClass({
+const MappablePreview = createReactClass({
+    displayName: 'MappablePreview',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -51,7 +54,7 @@ const MappablePreview = React.createClass({
                 </div>
             </div>
         );
-    }
+    },
 });
 
 export default MappablePreview;

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import DataPreviewMap from './DataPreviewMap';
 import Description from './Description';
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -13,9 +15,9 @@ const MappablePreview = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        previewed: React.PropTypes.object.isRequired,
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        previewed: PropTypes.object.isRequired,
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     toggleOnMap(event) {

--- a/lib/ReactViews/Preview/MetadataTable.jsx
+++ b/lib/ReactViews/Preview/MetadataTable.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import ObserveModelMixin from '../ObserveModelMixin';
 import Styles from './metadata-table.scss';
 
@@ -10,7 +12,7 @@ const MetadataTable = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        metadataItem: React.PropTypes.object.isRequired  // A MetadataItem instance.
+        metadataItem: PropTypes.object.isRequired  // A MetadataItem instance.
     },
 
     render() {

--- a/lib/ReactViews/Preview/MetadataTable.jsx
+++ b/lib/ReactViews/Preview/MetadataTable.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -8,7 +10,8 @@ import Styles from './metadata-table.scss';
 /**
  * Displays a table showing the name and values of items in a MetadataItem.
  */
-const MetadataTable = React.createClass({
+const MetadataTable = createReactClass({
+    displayName: 'MetadataTable',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -49,7 +52,7 @@ const MetadataTable = React.createClass({
                 </If>
             </div>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/Search/LocationSearchResults.jsx
+++ b/lib/ReactViews/Search/LocationSearchResults.jsx
@@ -1,5 +1,6 @@
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import SearchHeader from './SearchHeader.jsx';
 import SearchResult from './SearchResult.jsx';
@@ -7,8 +8,10 @@ import classNames from 'classnames';
 import Icon from "../Icon.jsx";
 import Styles from './location-search-result.scss';
 
-const LocationSearchResults = React.createClass({
+const LocationSearchResults = createReactClass({
+    displayName: 'LocationSearchResults',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         viewState: PropTypes.object.isRequired,
         isWaitingForSearchToStart: PropTypes.bool,
@@ -55,7 +58,7 @@ const LocationSearchResults = React.createClass({
                         ))}
                     </ul>
                 </div>);
-    }
+    },
 });
 
 module.exports = LocationSearchResults;

--- a/lib/ReactViews/Search/LocationSearchResults.jsx
+++ b/lib/ReactViews/Search/LocationSearchResults.jsx
@@ -1,5 +1,6 @@
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import SearchHeader from './SearchHeader.jsx';
 import SearchResult from './SearchResult.jsx';
 import classNames from 'classnames';
@@ -9,12 +10,12 @@ import Styles from './location-search-result.scss';
 const LocationSearchResults = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        viewState: React.PropTypes.object.isRequired,
-        isWaitingForSearchToStart: React.PropTypes.bool,
-        terria: React.PropTypes.object.isRequired,
-        search: React.PropTypes.object.isRequired,
-        onLocationClick: React.PropTypes.func.isRequired,
-        theme: React.PropTypes.string
+        viewState: PropTypes.object.isRequired,
+        isWaitingForSearchToStart: PropTypes.bool,
+        terria: PropTypes.object.isRequired,
+        search: PropTypes.object.isRequired,
+        onLocationClick: PropTypes.func.isRequired,
+        theme: PropTypes.string
     },
 
     getInitialState() {

--- a/lib/ReactViews/Search/SearchBox.jsx
+++ b/lib/ReactViews/Search/SearchBox.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import debounce from 'lodash.debounce';
 import Icon from "../Icon.jsx";
 
@@ -12,7 +13,7 @@ const DEBOUNCE_INTERVAL = 2000;
  * that just like an input, this calls onSearchTextChanged when the value is changed, and expects that its parent
  * component will listen for this and update searchText with the new value.
  */
-export default React.createClass({
+export default createReactClass({
     displayName: 'SearchBox',
     propTypes: {
         /** Called when the search changes, after a debounce of {@link DEBOUNCE_INTERVAL} ms */

--- a/lib/ReactViews/Search/SearchBox.jsx
+++ b/lib/ReactViews/Search/SearchBox.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import Icon from "../Icon.jsx";
 
@@ -15,18 +16,18 @@ export default React.createClass({
     displayName: 'SearchBox',
     propTypes: {
         /** Called when the search changes, after a debounce of {@link DEBOUNCE_INTERVAL} ms */
-        onSearchTextChanged: React.PropTypes.func.isRequired,
+        onSearchTextChanged: PropTypes.func.isRequired,
         /** Called when an actual search is triggered, either by clicking the button or pressing Enter */
-        onDoSearch: React.PropTypes.func.isRequired,
+        onDoSearch: PropTypes.func.isRequired,
         /** The search text to display in the search box */
-        searchText: React.PropTypes.string.isRequired,
+        searchText: PropTypes.string.isRequired,
         /** Called when the search box receives focus */
-        onFocus: React.PropTypes.func,
+        onFocus: PropTypes.func,
 
-        placeholder: React.PropTypes.string,
-        onClear: React.PropTypes.func,
-        alwaysShowClear: React.PropTypes.bool,
-        autoFocus: React.PropTypes.bool
+        placeholder: PropTypes.string,
+        onClear: PropTypes.func,
+        alwaysShowClear: PropTypes.bool,
+        autoFocus: PropTypes.bool
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Search/SearchHeader.jsx
+++ b/lib/ReactViews/Search/SearchHeader.jsx
@@ -1,11 +1,12 @@
 import Loader from '../Loader.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './search-header.scss';
 
 /** Renders either a loader or a message based off search state. */
-export default React.createClass({
+export default createReactClass({
     mixins: [ObserveModelMixin],
 
     displayName: 'SearchHeader',

--- a/lib/ReactViews/Search/SearchHeader.jsx
+++ b/lib/ReactViews/Search/SearchHeader.jsx
@@ -1,6 +1,7 @@
 import Loader from '../Loader.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './search-header.scss';
 
 /** Renders either a loader or a message based off search state. */
@@ -10,8 +11,8 @@ export default React.createClass({
     displayName: 'SearchHeader',
 
     propTypes: {
-        searchProvider: React.PropTypes.object.isRequired,
-        isWaitingForSearchToStart: React.PropTypes.bool
+        searchProvider: PropTypes.object.isRequired,
+        isWaitingForSearchToStart: PropTypes.bool
     },
 
     render() {

--- a/lib/ReactViews/Search/SearchResult.jsx
+++ b/lib/ReactViews/Search/SearchResult.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Icon from "../Icon.jsx";
 import Styles from './search-result.scss';
 import classNames from 'classnames';
@@ -6,10 +7,10 @@ import classNames from 'classnames';
 // A Location item when doing Bing map searvh or Gazetter search
 const SearchResult = React.createClass({
     propTypes: {
-        name: React.PropTypes.string.isRequired,
-        clickAction: React.PropTypes.func.isRequired,
-        showPin: React.PropTypes.bool,
-        theme: React.PropTypes.string
+        name: PropTypes.string.isRequired,
+        clickAction: PropTypes.func.isRequired,
+        showPin: PropTypes.bool,
+        theme: PropTypes.string
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/Search/SearchResult.jsx
+++ b/lib/ReactViews/Search/SearchResult.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import Icon from "../Icon.jsx";
 import Styles from './search-result.scss';
 import classNames from 'classnames';
 
 // A Location item when doing Bing map searvh or Gazetter search
-const SearchResult = React.createClass({
+const SearchResult = createReactClass({
     propTypes: {
         name: PropTypes.string.isRequired,
         clickAction: PropTypes.func.isRequired,

--- a/lib/ReactViews/Search/SidebarSearch.jsx
+++ b/lib/ReactViews/Search/SidebarSearch.jsx
@@ -1,5 +1,6 @@
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import SearchResult from './SearchResult.jsx';
 import BadgeBar from '../BadgeBar.jsx';
 import Styles from './sidebar-search.scss';
@@ -12,9 +13,9 @@ const SidebarSearch = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        viewState: React.PropTypes.object.isRequired,
-        isWaitingForSearchToStart: React.PropTypes.bool,
-        terria: React.PropTypes.object.isRequired
+        viewState: PropTypes.object.isRequired,
+        isWaitingForSearchToStart: PropTypes.bool,
+        terria: PropTypes.object.isRequired
     },
 
     searchInDataCatalog() {

--- a/lib/ReactViews/Search/SidebarSearch.jsx
+++ b/lib/ReactViews/Search/SidebarSearch.jsx
@@ -1,5 +1,6 @@
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import SearchResult from './SearchResult.jsx';
 import BadgeBar from '../BadgeBar.jsx';
@@ -9,7 +10,8 @@ import LocationSearchResults from './LocationSearchResults.jsx';
 import {addMarker} from './SearchMarkerUtils';
 
 // Handle any of the three kinds of search based on the props
-const SidebarSearch = React.createClass({
+const SidebarSearch = createReactClass({
+    displayName: 'SidebarSearch',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -66,7 +68,7 @@ const SidebarSearch = React.createClass({
                 </div>
             </div>
         );
-    }
+    },
 });
 
 module.exports = SidebarSearch;

--- a/lib/ReactViews/SidePanel/Branding.jsx
+++ b/lib/ReactViews/SidePanel/Branding.jsx
@@ -2,13 +2,14 @@
 import defined from 'terriajs-cesium/Source/Core/defined';
 import parseCustomHtmlToReact from '../Custom/parseCustomHtmlToReact';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './branding.scss';
 
 const Branding = React.createClass({
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        version: React.PropTypes.string,
-        onClick: React.PropTypes.func
+        terria: PropTypes.object.isRequired,
+        version: PropTypes.string,
+        onClick: PropTypes.func
     },
 
     render() {

--- a/lib/ReactViews/SidePanel/Branding.jsx
+++ b/lib/ReactViews/SidePanel/Branding.jsx
@@ -3,9 +3,10 @@ import defined from 'terriajs-cesium/Source/Core/defined';
 import parseCustomHtmlToReact from '../Custom/parseCustomHtmlToReact';
 import React from 'react';
 import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 import Styles from './branding.scss';
 
-const Branding = React.createClass({
+const Branding = createReactClass({
     propTypes: {
         terria: PropTypes.object.isRequired,
         version: PropTypes.string,

--- a/lib/ReactViews/SidePanel/SidePanel.jsx
+++ b/lib/ReactViews/SidePanel/SidePanel.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import PropTypes from 'prop-types';
 
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
@@ -13,7 +15,8 @@ import { removeMarker } from '../Search/SearchMarkerUtils';
 
 import Styles from './side-panel.scss';
 
-const SidePanel = React.createClass({
+const SidePanel = createReactClass({
+    displayName: 'SidePanel',
     mixins: [ObserveModelMixin],
 
     propTypes: {

--- a/lib/ReactViews/SidePanel/SidePanel.jsx
+++ b/lib/ReactViews/SidePanel/SidePanel.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 
 import ObserveModelMixin from '../ObserveModelMixin';
@@ -15,8 +17,8 @@ const SidePanel = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     componentDidMount() {

--- a/lib/ReactViews/StandardUserInterface/MapColumn.jsx
+++ b/lib/ReactViews/StandardUserInterface/MapColumn.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import 'mutationobserver-shim';
 
 import TerriaViewerWrapper from '../Map/TerriaViewerWrapper.jsx';
@@ -25,8 +26,8 @@ const MapColumn = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired,
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
     },
 
     getInitialState() {

--- a/lib/ReactViews/StandardUserInterface/MapColumn.jsx
+++ b/lib/ReactViews/StandardUserInterface/MapColumn.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import 'mutationobserver-shim';
 
@@ -22,7 +23,8 @@ const isIE = FeatureDetection.isInternetExplorer();
  * Note that because IE9-11 is terrible the pure-CSS layout that is used in nice browsers doesn't work, so for IE only
  * we use a (usually polyfilled) MutationObserver to watch the bottom dock and resize when it changes.
  */
-const MapColumn = React.createClass({
+const MapColumn = createReactClass({
+    displayName: 'MapColumn',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -114,7 +116,7 @@ const MapColumn = React.createClass({
                 </If>
             </div>
         );
-    }
+    },
 });
 
 export default MapColumn;

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import arrayContains from '../../Core/arrayContains';
 import Branding from './../SidePanel/Branding.jsx';
@@ -23,7 +24,8 @@ import 'inobounce';
 import Styles from './standard-user-interface.scss';
 
 /** blah */
-const StandardUserInterface = React.createClass({
+const StandardUserInterface = createReactClass({
+    displayName: 'StandardUserInterface',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -162,7 +164,7 @@ const StandardUserInterface = React.createClass({
                 />
             </div>
         );
-    }
+    },
 });
 
 module.exports = StandardUserInterface;

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import arrayContains from '../../Core/arrayContains';
 import Branding from './../SidePanel/Branding.jsx';
 import DisclaimerHandler from '../../ReactViewModels/DisclaimerHandler';
@@ -29,15 +30,15 @@ const StandardUserInterface = React.createClass({
         /**
          * Terria instance
          */
-        terria: React.PropTypes.object.isRequired,
+        terria: PropTypes.object.isRequired,
         /**
          * All the base maps.
          */
-        allBaseMaps: React.PropTypes.array,
-        viewState: React.PropTypes.object.isRequired,
-        minimumLargeScreenWidth: React.PropTypes.number,
-        version: React.PropTypes.string,
-        children: React.PropTypes.oneOfType([React.PropTypes.arrayOf(React.PropTypes.element), React.PropTypes.element])
+        allBaseMaps: PropTypes.array,
+        viewState: PropTypes.object.isRequired,
+        minimumLargeScreenWidth: PropTypes.number,
+        version: PropTypes.string,
+        children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element])
     },
 
     getDefaultProps() {

--- a/lib/ReactViews/StandardUserInterface/customizable/ResponsiveSwitch.jsx
+++ b/lib/ReactViews/StandardUserInterface/customizable/ResponsiveSwitch.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 /**
  * Higher-order component that either shows a one element or the other, depending on whether the "smallScreen" prop
  * passed to it is true or false.
@@ -20,7 +22,7 @@ export default (LargeScreenComponent, SmallScreenComponent) => {
     }
 
     ResponsiveSwitch.propTypes = {
-        smallScreen: React.PropTypes.bool
+        smallScreen: PropTypes.bool
     };
 
     return ResponsiveSwitch;

--- a/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
@@ -1,12 +1,14 @@
 'use strict';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import Styles from './colorscalerange-section.scss';
 
-const ColorScaleRangeSection = React.createClass({
+const ColorScaleRangeSection = createReactClass({
+    displayName: 'ColorScaleRangeSection',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -80,6 +82,6 @@ const ColorScaleRangeSection = React.createClass({
                 <button type='submit' title="Update Range" className={Styles.btn}>Update Range</button>
             </form>
         );
-    }
+    },
 });
 module.exports = ColorScaleRangeSection;

--- a/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import Styles from './colorscalerange-section.scss';
@@ -9,7 +10,7 @@ const ColorScaleRangeSection = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        item: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired
     },
 
     minRange: -50,

--- a/lib/ReactViews/Workbench/Controls/Concept.jsx
+++ b/lib/ReactViews/Workbench/Controls/Concept.jsx
@@ -4,10 +4,12 @@ import classNames from 'classnames';
 import Icon from '../../Icon';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './concept-viewer.scss';
 
-const Concept = React.createClass({
+const Concept = createReactClass({
+    displayName: 'Concept',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -87,7 +89,7 @@ const Concept = React.createClass({
                 </If>
             </li>
         );
-    }
+    },
 });
 
 /**

--- a/lib/ReactViews/Workbench/Controls/Concept.jsx
+++ b/lib/ReactViews/Workbench/Controls/Concept.jsx
@@ -4,15 +4,16 @@ import classNames from 'classnames';
 import Icon from '../../Icon';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './concept-viewer.scss';
 
 const Concept = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        concept: React.PropTypes.object.isRequired,
-        hideName: React.PropTypes.bool,
-        isLoading: React.PropTypes.bool
+        concept: PropTypes.object.isRequired,
+        hideName: PropTypes.bool,
+        isLoading: PropTypes.bool
     },
 
     toggleOpen() {

--- a/lib/ReactViews/Workbench/Controls/ConceptViewer.jsx
+++ b/lib/ReactViews/Workbench/Controls/ConceptViewer.jsx
@@ -6,10 +6,12 @@ import ObserveModelMixin from '../../ObserveModelMixin';
 import SummaryConceptModel from '../../../Map/SummaryConcept';
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './concept-viewer.scss';
 
-const ConceptViewer = React.createClass({
+const ConceptViewer = createReactClass({
+    displayName: 'ConceptViewer',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -43,7 +45,7 @@ const ConceptViewer = React.createClass({
                 </For>
             </div>
         );
-    }
+    },
 });
 
 module.exports = ConceptViewer;

--- a/lib/ReactViews/Workbench/Controls/ConceptViewer.jsx
+++ b/lib/ReactViews/Workbench/Controls/ConceptViewer.jsx
@@ -6,13 +6,14 @@ import ObserveModelMixin from '../../ObserveModelMixin';
 import SummaryConceptModel from '../../../Map/SummaryConcept';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './concept-viewer.scss';
 
 const ConceptViewer = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        item: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired
     },
 
     render() {

--- a/lib/ReactViews/Workbench/Controls/DimensionSelectorSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/DimensionSelectorSection.jsx
@@ -2,6 +2,7 @@
 
 import defined from 'terriajs-cesium/Source/Core/defined';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../../ObserveModelMixin';
 
 import Styles from './dimension-selector-section.scss';
@@ -10,7 +11,7 @@ const DimensionSelectorSection = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        item: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired
     },
 
     changeDimension(dimension, event) {

--- a/lib/ReactViews/Workbench/Controls/DimensionSelectorSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/DimensionSelectorSection.jsx
@@ -2,12 +2,14 @@
 
 import defined from 'terriajs-cesium/Source/Core/defined';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../../ObserveModelMixin';
 
 import Styles from './dimension-selector-section.scss';
 
-const DimensionSelectorSection = React.createClass({
+const DimensionSelectorSection = createReactClass({
+    displayName: 'DimensionSelectorSection',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -77,7 +79,7 @@ const DimensionSelectorSection = React.createClass({
                 </select>
             </div>
         );
-    }
+    },
 });
 
 module.exports = DimensionSelectorSection;

--- a/lib/ReactViews/Workbench/Controls/DisplayAsPercentSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/DisplayAsPercentSection.jsx
@@ -3,12 +3,15 @@
 import classNames from 'classnames';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Icon from "../../Icon.jsx";
 import Styles from './display-as-percent.scss';
 
-const DisplayAsPercentSection = React.createClass({
+const DisplayAsPercentSection = createReactClass({
+    displayName: 'DisplayAsPercentSection',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         item: PropTypes.object
     },
@@ -39,6 +42,6 @@ const DisplayAsPercentSection = React.createClass({
                 </button>
             </label>
         );
-    }
+    },
 });
 module.exports = DisplayAsPercentSection;

--- a/lib/ReactViews/Workbench/Controls/DisplayAsPercentSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/DisplayAsPercentSection.jsx
@@ -3,13 +3,14 @@
 import classNames from 'classnames';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Icon from "../../Icon.jsx";
 import Styles from './display-as-percent.scss';
 
 const DisplayAsPercentSection = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        item: React.PropTypes.object
+        item: PropTypes.object
     },
 
     togglePercentage() {

--- a/lib/ReactViews/Workbench/Controls/Legend.jsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.jsx
@@ -7,11 +7,14 @@ import Loader from '../../Loader.jsx';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import proxyCatalogItemUrl from '../../../Models/proxyCatalogItemUrl';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './legend.scss';
 
-const Legend = React.createClass({
+const Legend = createReactClass({
+    displayName: 'Legend',
     mixins: [ObserveModelMixin],
+
     propTypes: {
         item: PropTypes.object
     },
@@ -85,6 +88,6 @@ const Legend = React.createClass({
                 </div>
             </ul>
         );
-    }
+    },
 });
 module.exports = Legend;

--- a/lib/ReactViews/Workbench/Controls/Legend.jsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.jsx
@@ -7,12 +7,13 @@ import Loader from '../../Loader.jsx';
 import ObserveModelMixin from '../../ObserveModelMixin';
 import proxyCatalogItemUrl from '../../../Models/proxyCatalogItemUrl';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './legend.scss';
 
 const Legend = React.createClass({
     mixins: [ObserveModelMixin],
     propTypes: {
-        item: React.PropTypes.object
+        item: PropTypes.object
     },
 
     componentWillMount() {

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
@@ -2,12 +2,14 @@
 
 import RangeSlider from 'react-rangeslider';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../../ObserveModelMixin';
 
 import Styles from './opacity-section.scss';
 
-const OpacitySection = React.createClass({
+const OpacitySection = createReactClass({
+    displayName: 'OpacitySection',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -29,6 +31,6 @@ const OpacitySection = React.createClass({
                 <RangeSlider className={Styles.rangeSlider} name='opacity' min={0} max={100} step={1} value={item.opacity * 100 | 0} onChange={this.changeOpacity}/>
             </div>
         );
-    }
+    },
 });
 module.exports = OpacitySection;

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
@@ -2,6 +2,7 @@
 
 import RangeSlider from 'react-rangeslider';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../../ObserveModelMixin';
 
 import Styles from './opacity-section.scss';
@@ -10,7 +11,7 @@ const OpacitySection = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        item: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired
     },
 
     changeOpacity(value) {

--- a/lib/ReactViews/Workbench/Controls/ShortReport.jsx
+++ b/lib/ReactViews/Workbench/Controls/ShortReport.jsx
@@ -2,11 +2,13 @@
 
 import ObserveModelMixin from '../../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import parseCustomMarkdownToReact from '../../Custom/parseCustomMarkdownToReact';
 import Styles from './short-report.scss';
 
-const ShortReport = React.createClass({
+const ShortReport = createReactClass({
+    displayName: 'ShortReport',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -29,7 +31,7 @@ const ShortReport = React.createClass({
                 </If>
             </div>
         );
-    }
+    },
 });
 
 module.exports = ShortReport;

--- a/lib/ReactViews/Workbench/Controls/ShortReport.jsx
+++ b/lib/ReactViews/Workbench/Controls/ShortReport.jsx
@@ -2,6 +2,7 @@
 
 import ObserveModelMixin from '../../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import parseCustomMarkdownToReact from '../../Custom/parseCustomMarkdownToReact';
 import Styles from './short-report.scss';
 
@@ -9,7 +10,7 @@ const ShortReport = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        item: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired
     },
 
     render() {

--- a/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
@@ -2,12 +2,14 @@
 
 import defined from 'terriajs-cesium/Source/Core/defined';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ObserveModelMixin from '../../ObserveModelMixin';
 
 import Styles from './style-selector-section.scss';
 
-const StyleSelectorSection = React.createClass({
+const StyleSelectorSection = createReactClass({
+    displayName: 'StyleSelectorSection',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -70,6 +72,6 @@ const StyleSelectorSection = React.createClass({
                 </select>
             </div>
         );
-    }
+    },
 });
 module.exports = StyleSelectorSection;

--- a/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
@@ -2,6 +2,7 @@
 
 import defined from 'terriajs-cesium/Source/Core/defined';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ObserveModelMixin from '../../ObserveModelMixin';
 
 import Styles from './style-selector-section.scss';
@@ -10,7 +11,7 @@ const StyleSelectorSection = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        item: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired
     },
 
     changeStyle(layer, event) {

--- a/lib/ReactViews/Workbench/Controls/SummaryConcept/ActiveConcept.jsx
+++ b/lib/ReactViews/Workbench/Controls/SummaryConcept/ActiveConcept.jsx
@@ -5,6 +5,7 @@ import Concept from '../Concept';
 import Icon from '../../../Icon.jsx';
 import ObserveModelMixin from '../../../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './summary-concept.scss';
 
@@ -17,7 +18,8 @@ import Styles from './summary-concept.scss';
  * When it is clicked, parent.isOpen is set to True.
  * (The condition can only be "removed" if rootConcept.allowMultiple is true.)
  */
-const ActiveConcept = React.createClass({
+const ActiveConcept = createReactClass({
+    displayName: 'ActiveConcept',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -87,7 +89,7 @@ const ActiveConcept = React.createClass({
                 </div>
             </div>
         );
-    }
+    },
 });
 
 module.exports = ActiveConcept;

--- a/lib/ReactViews/Workbench/Controls/SummaryConcept/ActiveConcept.jsx
+++ b/lib/ReactViews/Workbench/Controls/SummaryConcept/ActiveConcept.jsx
@@ -5,6 +5,7 @@ import Concept from '../Concept';
 import Icon from '../../../Icon.jsx';
 import ObserveModelMixin from '../../../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './summary-concept.scss';
 
 /*
@@ -20,9 +21,9 @@ const ActiveConcept = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        activeLeafNodesWithParent: React.PropTypes.object.isRequired,
-        rootConcept: React.PropTypes.object.isRequired,
-        isLoading: React.PropTypes.bool
+        activeLeafNodesWithParent: PropTypes.object.isRequired,
+        rootConcept: PropTypes.object.isRequired,
+        isLoading: PropTypes.bool
     },
 
     open() {

--- a/lib/ReactViews/Workbench/Controls/SummaryConcept/OpenInactiveConcept.jsx
+++ b/lib/ReactViews/Workbench/Controls/SummaryConcept/OpenInactiveConcept.jsx
@@ -5,6 +5,7 @@ import Concept from '../Concept';
 import Icon from '../../../Icon.jsx';
 import ObserveModelMixin from '../../../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './summary-concept.scss';
 
 const NEW_TEXT = 'New condition';
@@ -13,8 +14,8 @@ const OpenInactiveConcept = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        rootConcept: React.PropTypes.object.isRequired,
-        openInactiveConcept: React.PropTypes.object.isRequired
+        rootConcept: PropTypes.object.isRequired,
+        openInactiveConcept: PropTypes.object.isRequired
     },
 
     cancel() {
@@ -75,7 +76,7 @@ const ConceptParent = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        concept: React.PropTypes.object.isRequired
+        concept: PropTypes.object.isRequired
     },
 
     open() {

--- a/lib/ReactViews/Workbench/Controls/SummaryConcept/OpenInactiveConcept.jsx
+++ b/lib/ReactViews/Workbench/Controls/SummaryConcept/OpenInactiveConcept.jsx
@@ -5,12 +5,14 @@ import Concept from '../Concept';
 import Icon from '../../../Icon.jsx';
 import ObserveModelMixin from '../../../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './summary-concept.scss';
 
 const NEW_TEXT = 'New condition';
 
-const OpenInactiveConcept = React.createClass({
+const OpenInactiveConcept = createReactClass({
+    displayName: 'OpenInactiveConcept',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -69,10 +71,11 @@ const OpenInactiveConcept = React.createClass({
                 </ul>
             </div>
         );
-    }
+    },
 });
 
-const ConceptParent = React.createClass({
+const ConceptParent = createReactClass({
+    displayName: 'ConceptParent',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -97,7 +100,7 @@ const ConceptParent = React.createClass({
                 </div>
             </li>
         );
-    }
+    },
 });
 
 module.exports = OpenInactiveConcept;

--- a/lib/ReactViews/Workbench/Controls/SummaryConcept/SummaryConcept.jsx
+++ b/lib/ReactViews/Workbench/Controls/SummaryConcept/SummaryConcept.jsx
@@ -6,6 +6,7 @@ import OpenInactiveConcept from './OpenInactiveConcept';
 import Icon from '../../../Icon.jsx';
 import ObserveModelMixin from '../../../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Styles from './summary-concept.scss';
 
@@ -34,7 +35,8 @@ const ADD_MORE_TEXT = 'Add new condition';
  * This design would need revision to handle concepts whose direct children are a mix of
  * both leaf nodes and parent nodes.
  */
-const SummaryConcept = React.createClass({
+const SummaryConcept = createReactClass({
+    displayName: 'SummaryConcept',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -69,7 +71,7 @@ const SummaryConcept = React.createClass({
                 </If>
             </div>
         );
-    }
+    },
 });
 
 /**
@@ -135,7 +137,8 @@ function groupByParentId(nodes, idFunction) {
 * @return {String} The parent id.
 */
 
-const AddButton = React.createClass({
+const AddButton = createReactClass({
+    displayName: 'AddButton',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -158,7 +161,7 @@ const AddButton = React.createClass({
                 </button>
             </div>
         );
-    }
+    },
 });
 
 module.exports = SummaryConcept;

--- a/lib/ReactViews/Workbench/Controls/SummaryConcept/SummaryConcept.jsx
+++ b/lib/ReactViews/Workbench/Controls/SummaryConcept/SummaryConcept.jsx
@@ -6,6 +6,7 @@ import OpenInactiveConcept from './OpenInactiveConcept';
 import Icon from '../../../Icon.jsx';
 import ObserveModelMixin from '../../../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Styles from './summary-concept.scss';
 
 const ADD_FIRST_TEXT = 'Add a condition';
@@ -37,8 +38,8 @@ const SummaryConcept = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        concept: React.PropTypes.object.isRequired,  // Must be a SummaryConcept.
-        isLoading: React.PropTypes.bool
+        concept: PropTypes.object.isRequired,  // Must be a SummaryConcept.
+        isLoading: PropTypes.bool
     },
 
     render() {
@@ -138,8 +139,8 @@ const AddButton = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        rootConcept: React.PropTypes.object.isRequired,
-        numberOfExisting: React.PropTypes.number
+        rootConcept: PropTypes.object.isRequired,
+        numberOfExisting: PropTypes.number
     },
 
     addNew() {

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
@@ -6,13 +6,15 @@ import Icon from "../../Icon.jsx";
 import ObserveModelMixin from '../../ObserveModelMixin';
 import PickedFeatures from '../../../Map/PickedFeatures';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Rectangle from 'terriajs-cesium/Source/Core/Rectangle';
 import when from 'terriajs-cesium/Source/ThirdParty/when';
 import classNames from 'classnames';
 import Styles from './viewing-controls.scss';
 
-const ViewingControls = React.createClass({
+const ViewingControls = createReactClass({
+    displayName: 'ViewingControls',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -23,6 +25,7 @@ const ViewingControls = React.createClass({
     removeFromMap() {
         this.props.item.isEnabled = false;
     },
+
     zoomTo() {
         this.props.item.zoomToAndUseClock();
     },
@@ -84,6 +87,6 @@ const ViewingControls = React.createClass({
                 </li>
             </ul>
         );
-    }
+    },
 });
 module.exports = ViewingControls;

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
@@ -6,6 +6,7 @@ import Icon from "../../Icon.jsx";
 import ObserveModelMixin from '../../ObserveModelMixin';
 import PickedFeatures from '../../../Map/PickedFeatures';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Rectangle from 'terriajs-cesium/Source/Core/Rectangle';
 import when from 'terriajs-cesium/Source/ThirdParty/when';
 import classNames from 'classnames';
@@ -15,8 +16,8 @@ const ViewingControls = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        item: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        item: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     removeFromMap() {

--- a/lib/ReactViews/Workbench/Workbench.jsx
+++ b/lib/ReactViews/Workbench/Workbench.jsx
@@ -2,12 +2,14 @@ import BadgeBar from '../BadgeBar.jsx';
 import Icon from "../Icon.jsx";
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import WorkbenchList from './WorkbenchList.jsx';
 
 import Styles from './workbench.scss';
 
-const Workbench = React.createClass({
+const Workbench = createReactClass({
+    displayName: 'Workbench',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -30,7 +32,7 @@ const Workbench = React.createClass({
                 <WorkbenchList viewState={this.props.viewState} terria={this.props.terria}/>
             </div>
         );
-    }
+    },
 });
 
 export default Workbench;

--- a/lib/ReactViews/Workbench/Workbench.jsx
+++ b/lib/ReactViews/Workbench/Workbench.jsx
@@ -2,6 +2,7 @@ import BadgeBar from '../BadgeBar.jsx';
 import Icon from "../Icon.jsx";
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
+import PropTypes from 'prop-types';
 import WorkbenchList from './WorkbenchList.jsx';
 
 import Styles from './workbench.scss';
@@ -10,8 +11,8 @@ const Workbench = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     removeAll() {

--- a/lib/ReactViews/Workbench/WorkbenchItem.jsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.jsx
@@ -2,6 +2,7 @@
 
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import {sortable} from 'react-anything-sortable';
 
 import defined from 'terriajs-cesium/Source/Core/defined';
@@ -25,13 +26,13 @@ const WorkbenchItem = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        style: React.PropTypes.object,
-        className: React.PropTypes.string,
-        onMouseDown: React.PropTypes.func.isRequired,
-        onTouchStart: React.PropTypes.func.isRequired,
-        item: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired,
-        setWrapperState: React.PropTypes.func
+        style: PropTypes.object,
+        className: PropTypes.string,
+        onMouseDown: PropTypes.func.isRequired,
+        onTouchStart: PropTypes.func.isRequired,
+        item: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
+        setWrapperState: PropTypes.func
     },
 
     toggleDisplay() {

--- a/lib/ReactViews/Workbench/WorkbenchItem.jsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.jsx
@@ -2,6 +2,7 @@
 
 import classNames from 'classnames';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import {sortable} from 'react-anything-sortable';
 
@@ -22,7 +23,8 @@ import ViewingControls from './Controls/ViewingControls';
 import Styles from './workbench-item.scss';
 import Icon from '../Icon.jsx';
 
-const WorkbenchItem = React.createClass({
+const WorkbenchItem = createReactClass({
+    displayName: 'WorkbenchItem',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -112,7 +114,7 @@ const WorkbenchItem = React.createClass({
                 </If>
             </li>
         );
-    }
+    },
 });
 
 module.exports = sortable(WorkbenchItem);

--- a/lib/ReactViews/Workbench/WorkbenchList.jsx
+++ b/lib/ReactViews/Workbench/WorkbenchList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Sortable from 'react-anything-sortable';
 
@@ -9,7 +10,8 @@ import Styles from './workbench-list.scss';
 import '!!style-loader!css-loader?sourceMap!react-anything-sortable/sortable.css';
 import '!!style-loader!css-loader?sourceMap!./sortable.css';
 
-const WorkbenchList = React.createClass({
+const WorkbenchList = createReactClass({
+    displayName: 'WorkbenchList',
     mixins: [ObserveModelMixin],
 
     propTypes: {
@@ -46,7 +48,7 @@ const WorkbenchList = React.createClass({
                 </Sortable>
             </ul>
         );
-    }
+    },
 });
 
 module.exports = WorkbenchList;

--- a/lib/ReactViews/Workbench/WorkbenchList.jsx
+++ b/lib/ReactViews/Workbench/WorkbenchList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Sortable from 'react-anything-sortable';
 
 import WorkbenchItem from './WorkbenchItem.jsx';
@@ -12,8 +13,8 @@ const WorkbenchList = React.createClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        terria: React.PropTypes.object.isRequired,
-        viewState: React.PropTypes.object.isRequired
+        terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired
     },
 
     onSort(sortedArray, currentDraggingSortData, currentDraggingIndex) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-preset-react": "^6.5.0",
     "class-list": "^0.1.1",
     "classnames": "^2.2.3",
+    "create-react-class": "^15.5.2",
     "d3-array": "^1.0.0",
     "d3-axis": "^1.0.0",
     "d3-collection": "^1.0.0",


### PR DESCRIPTION
There remains one dependency (that I'm aware of) that means we still get the deprecation warnings, unfortunately: https://github.com/jasonslyvia/react-anything-sortable - and it is not under active development.
Also, needs an update to the latest version of redbox in TerriaMap / NationalMap etc.