### PR TITLE
Don't use isMounted in ObserveModelMixIn.

### DIFF
--- a/lib/ReactViews/ObserveModelMixin.js
+++ b/lib/ReactViews/ObserveModelMixin.js
@@ -48,9 +48,7 @@ const ObserveModelMixin = {
 
                     if (!updateForced) {
                         updateForced = true;
-                        if (that.isMounted()) {
-                            that.forceUpdate();
-                        }
+                        that.forceUpdate();
                     }
                 }
 


### PR DESCRIPTION
It's deprecated, and shouldn't be needed anyway.

This eliminates a billion React deprecation warnings.