### PR TITLE
Improve Google Analytics events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 Change Log
 ==========
 
+### 5.1.1
+
+* Fixed a bug that caused an 'added' and a 'shown' event for "Unnamed Item" to be logged to Google Analytics when previewing an item in the catalog.
+* Added a 'preview' Google Analytics event when a catalog item is shown on the preview map in the catalog.
+
 ### 5.1.0
 
 * Fixed a bug that prevented `WebMapServiceCatalogItem` from acting as a time-dynamic layer when the time dimension was inherited from a parent layer.

--- a/lib/Core/GoogleAnalytics.js
+++ b/lib/Core/GoogleAnalytics.js
@@ -41,7 +41,7 @@ function initializeGoogleAnalytics(that) {
         a.async=1;
         a.src=g;
         m.parentNode.insertBefore(a,m);
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
     ga('create', that.key, defaultValue(that.options, 'auto'));
     ga('send', 'pageview');
 }

--- a/lib/ReactViews/ObserveModelMixin.js
+++ b/lib/ReactViews/ObserveModelMixin.js
@@ -48,9 +48,7 @@ const ObserveModelMixin = {
 
                     if (!updateForced) {
                         updateForced = true;
-                        if (that.isMounted()) {
-                            that.forceUpdate();
-                        }
+                        that.forceUpdate();
                     }
                 }
 

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 const CesiumMath = require('terriajs-cesium/Source/Core/Math');
+const ConsoleAnalytics = require('../../Core/ConsoleAnalytics');
 const defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 const defined = require('terriajs-cesium/Source/Core/defined');
 const GeoJsonCatalogItem = require('../../Models/GeoJsonCatalogItem');
@@ -43,7 +44,8 @@ const DataPreviewMap = createReactClass({
             appName: terria.appName + ' preview',
             supportEmail: terria.supportEmail,
             baseUrl: terria.baseUrl,
-            cesiumBaseUrl: terria.cesiumBaseUrl
+            cesiumBaseUrl: terria.cesiumBaseUrl,
+            analytics: new ConsoleAnalytics()
         });
 
         this.terriaPreview.viewerMode = ViewerMode.Leaflet;
@@ -94,6 +96,10 @@ const DataPreviewMap = createReactClass({
     updatePreview(previewedCatalogItem) {
         if (this.lastPreviewedCatalogItem === previewedCatalogItem) {
             return;
+        }
+
+        if (previewedCatalogItem) {
+            this.props.terria.analytics.logEvent('dataSource', 'preview', previewedCatalogItem.name);
         }
 
         this.lastPreviewedCatalogItem = previewedCatalogItem;


### PR DESCRIPTION
* Don't generate an "Unnamed Item" event on the preview map.
* Do generate a "preview" event when previewing a dataset.

This incorporates #2488, so merge that first.