### PR TITLE
Refresh Cesium data source when load recreates it.

### DIFF
--- a/lib/Models/CzmlCatalogItem.js
+++ b/lib/Models/CzmlCatalogItem.js
@@ -114,8 +114,18 @@ CzmlCatalogItem.prototype._load = function() {
         var CzmlDataSource = require('terriajs-cesium/Source/DataSources/CzmlDataSource');
 
         promiseFunctionToExplicitDeferred(codeSplitDeferred, function() {
+            // If there is an existing data source, remove it first.
+            var reAdd = false;
+            if (defined(that._dataSource)) {
+                reAdd = that.terria.dataSources.remove(that._dataSource, true);
+            }
+
             var dataSource = new CzmlDataSource();
             that._dataSource = dataSource;
+
+            if (reAdd) {
+                that.terria.dataSources.add(that._dataSource);
+            }
 
             if (defined(that.data)) {
                 return when(that.data, function(data) {

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -167,6 +167,7 @@ function describeWithoutUnderscores(properties, nameProperty) {
 }
 
 GeoJsonCatalogItem.prototype._load = function() {
+    console.log('Loading');
     var codeSplitDeferred = when.defer();
 
     var that = this;
@@ -174,7 +175,17 @@ GeoJsonCatalogItem.prototype._load = function() {
         var GeoJsonDataSource = require('terriajs-cesium/Source/DataSources/GeoJsonDataSource');
 
         promiseFunctionToExplicitDeferred(codeSplitDeferred, function() {
+            // If there is an existing data source, remove it first.
+            var reAdd = false;
+            if (defined(that._dataSource)) {
+                reAdd = that.terria.dataSources.remove(that._dataSource, true);
+            }
+
             that._dataSource = new GeoJsonDataSource(that.name);
+
+            if (reAdd) {
+                that.terria.dataSources.add(that._dataSource);
+            }
 
             if (defined(that.data)) {
                 return when(that.data, function(data) {

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -167,7 +167,6 @@ function describeWithoutUnderscores(properties, nameProperty) {
 }
 
 GeoJsonCatalogItem.prototype._load = function() {
-    console.log('Loading');
     var codeSplitDeferred = when.defer();
 
     var that = this;

--- a/lib/Models/KmlCatalogItem.js
+++ b/lib/Models/KmlCatalogItem.js
@@ -119,6 +119,12 @@ KmlCatalogItem.prototype._load = function() {
         var KmlDataSource = require('terriajs-cesium/Source/DataSources/KmlDataSource');
 
         promiseFunctionToExplicitDeferred(codeSplittingDeferred, function() {
+            // If there is an existing data source, remove it first.
+            var reAdd = false;
+            if (defined(that._dataSource)) {
+                reAdd = that.terria.dataSources.remove(that._dataSource, true);
+            }
+
             var dataSource = new KmlDataSource({
                 // Currently we don't pass camera and canvas, which are technically required as of Cesium v1.23.
                 // We get away with it because A) the code to check that they're supplied is removed
@@ -133,6 +139,10 @@ KmlCatalogItem.prototype._load = function() {
                 }
             });
             that._dataSource = dataSource;
+
+            if (reAdd) {
+                that.terria.dataSources.add(that._dataSource);
+            }
 
             if (defined(that.data)) {
                 return when(that.data, function(data) {

--- a/lib/ReactViews/Map/Navigation/MyLocation.jsx
+++ b/lib/ReactViews/Map/Navigation/MyLocation.jsx
@@ -88,6 +88,7 @@ const MyLocation = createReactClass({
             'stroke': '#ffffff',
             'stroke-width': 3
         };
+        this._marker.load();
         this._marker.isEnabled = true;
     },
 


### PR DESCRIPTION
This fixes some dodgy behavior when a `DataSourceCatalogItem` is loaded again (because one of its "values that influence load" changed) after it is enabled and possibly shown.

1. Use the Chome developer tools, Sensors tool to set a custom Geolocation.  Something like latitude -25, longitude 135.
2. Click "go to my location" in the TerriaJS user interface and allow the site to use your location if necessary.
3. Click the checkbox on the workbench next to "My Location" to hide the point.
4. Change your location in the Chrome dev tools to something nearby, like -25 latitude, 135.01 longitude.
5. Click "go to my location" again.  The map should pan to center on the new location but the point should still not be shown (so far so good).
6. Click the checkbox on the workbench again to re-show the point.

Two points will appear appear on the map after step 6.  This PR fixes that.

Another problem fixed in this PR:

1. Complete steps 1 and 2 as above.
2. With the point still shown, change your location in the Chrome dev tools.
3. Click "go to my location".

The location will not update.  This PR fixes that.