### PR TITLE
Fix expanded Sensor Observation Service chart naming

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.2.3
+
+* Fixed a bug which gave expanded Sensor Observation Service charts poor names.
+
 ### 5.2.2
 
 * Fixed download of selected dataset (as csv) so that quotes are handled in accordance with https://tools.ietf.org/html/rfc4180. As a result, more such downloads can be directly re-loaded in Terria by dragging and dropping them.

--- a/lib/Models/SensorObservationServiceCatalogItem.js
+++ b/lib/Models/SensorObservationServiceCatalogItem.js
@@ -792,17 +792,17 @@ function buildConcepts(item) {
     return concepts;
 }
 
-function getChartTagFromFeatureIdentifier(identifier, chartName) {
-    // Including the chart name looks cosmetic, but it serves an important purpose: it means that something about the chart has changed,
+function getChartTagFromFeatureIdentifier(identifier, chartId) {
+    // Including a chart id which depends on the frequency serves an important purpose: it means that something about the chart has changed,
     // which tells the FeatureInfoSection React component to re-render.
     // The feature's definitionChanged event triggers when the feature's properties change, but if this chart tag doesn't change,
     // React does not know to re-render the chart.
-    if (defined(chartName)) {
-        chartName = ' title="' + encodeURIComponent(chartName) + '"';
+    if (defined(chartId)) {
+        chartId = ' id="' + encodeURIComponent(chartId) + '"';
     } else {
-        chartName = '';
+        chartId = '';
     }
-    return '<chart src="' + identifier + '" can-download="false"' + chartName + '></chart>';
+    return '<chart src="' + identifier + '" can-download="false"' + chartId + '></chart>';
 }
 
 /**
@@ -867,8 +867,9 @@ function createColumnsFromMapping(item, tableStructure, identifiers) {
     if (addChartColumn) {
         var procedure = getObjectCorrespondingToSelectedConcept(item, 'procedures');
         var observableProperty = getObjectCorrespondingToSelectedConcept(item, 'observableProperties');
-        var chartName = procedure.title || observableProperty || 'chart';
-        var charts = rows.map(row => getChartTagFromFeatureIdentifier(row.identifier, chartName));
+        var chartName = procedure.title || observableProperty.title || 'chart';
+        var chartId = procedure.title + '_' + observableProperty.title;
+        var charts = rows.map(row => getChartTagFromFeatureIdentifier(row.identifier, chartId));
         result.push(
             new TableColumn('identifier', rows.map(row => row.identifier), columnOptions),
             new TableColumn(chartName, charts, chartColumnOptions)

--- a/lib/ReactViews/Custom/registerCustomComponentTypes.js
+++ b/lib/ReactViews/Custom/registerCustomComponentTypes.js
@@ -73,8 +73,7 @@ function splitStringIfDefined(string) {
  * It can have the following attributes. Currently URLs must point to csv (not json) data; but inline json data is supported.
  * Note if you change any of these, also update the chartAttributes array above, or they won't make it here.
  *
- * - [title]:        The title of the chart.  If supplied, it overrides an automatic title derived from the context-supplied feature.
- *                   If this property is not specified, there is no feature, or it has no name, the title will be simply "Chart".
+ * - [title]:        The title of the chart.  If not supplied, defaults to the name of the context-supplied feature, if available, or else simply "Chart".
  * - [x-column]:     The x column name or number to show in the preview, if not the first appropriate column. NOT FULLY IMPLEMENTED YET.
  * - [y-column]:     The y column name or number to show in the preview, if not the first scalar column.
  * - [y-columns]:    Comma-separated list of y column names or numbers to show in the preview. Overrides "y-column" if provided.
@@ -84,7 +83,8 @@ function splitStringIfDefined(string) {
  * - [column-units]: Comma-separated list of the units for each column. Empty strings are ok.
  *                   Eg. column-units=",m,km/h"
  * - [preview-x-label]: The preview chart x-axis label. Defaults to empty string. Eg. long-names="Last 24 hours,Last 5 days,Time".
- * - [id]:           An id for the chart; give different charts from the same feature different ids.
+ * - [id]:           An id for the chart; give different charts from the same feature different ids. The actual catalogItem.id used for the expanded chart will
+ *                   also incorporate the chart title and the catalog item name it came from.
  * - [styling]:      Defaults to 'feature-info'. Can also be 'histogram'. TODO: improve.
  * - [highlight-x]:  An x-coordinate to highlight.
  * - [poll-seconds]: If present, the chart is updated from [poll-sources] every [poll-seconds] seconds.


### PR DESCRIPTION
Unfortunately my fix to update SOS feature info charts when you change their frequency messed up the expanded chart names, eg:
![image](https://cloud.githubusercontent.com/assets/1757858/25985437/d9d27c16-372d-11e7-9ba1-29dccc6ad061.png)
This fixes the naming.