### PR TITLE
Fix bug where tables with numeric data couldn't load

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.2.3
+
+* Fixed bug in 5.2.2 which prevented some table-based datasets from loading.
+
 ### 5.2.2
 
 * Fixed download of selected dataset (as csv) so that quotes are handled in accordance with https://tools.ietf.org/html/rfc4180. As a result, more such downloads can be directly re-loaded in Terria by dragging and dropping them.

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -614,7 +614,7 @@ TableStructure.prototype.toArrayOfRows = function(dateFormatString, rowNumbers, 
             var formattedValue = column._formattedValues[rowNumber];
             if (quoteStringsIfNeeded) {
                 // Put quotes around any value that contains commas or quotes, so csv format doesn't go nuts.
-                return formattedValue && updatedForQuotes(formattedValue);
+                return formattedValue && updatedForQuotes(formattedValue.toString());
             } else {
                 return formattedValue;
             }


### PR DESCRIPTION
I introduced this bug in 5.2.2. I'm amazed it passed the tests. Stand by for a new test.