### PR TITLE
Allow TerriaError to be constructed without parameters.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.2.4
+
+* Fixed a bug that prevented error messages, such as when a dataset fails to load, from being shown to the user. Instead, the errors were silently ignored.
+
 ### 5.2.3
 
 * Fixed a bug that gave expanded Sensor Observation Service charts poor names.

--- a/lib/Core/TerriaError.js
+++ b/lib/Core/TerriaError.js
@@ -17,6 +17,8 @@ var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
  * @param {String} options.message A detailed message describing the error.  This message may be HTML and it should be sanitized before display to the user.
  */
 var TerriaError = function(options) {
+    options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
     /**
      * Gets or sets the object that raised the error.
      * @type {Object}


### PR DESCRIPTION
`TerriaError`'s inability to be default constructed was breaking popup dataset error messages.  They were silently ignored instead of being shown to the user.  I broke this in #2507.