### PR TITLE
Fix a bug with vector tiles and proxy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.2.5
+
+* Fixed a bug with `forceProxy: true` which meant that vector tiles would try, and fail, to load over the proxy.
+
 ### 5.2.4
 
 * Fixed a bug that prevented error messages, such as when a dataset fails to load, from being shown to the user. Instead, the errors were silently ignored.

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -681,7 +681,7 @@ function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, g
         }
 
         regionImageryProvider = new MapboxVectorTileImageryProvider({
-            url: proxyCatalogItemUrl(catalogItem, regionDetail.regionProvider.server),
+            url: regionDetail.regionProvider.server,
             layerName: regionDetail.regionProvider.layerName,
             styleFunc: function(id) {
                 var terria = catalogItem.terria;


### PR DESCRIPTION
If you add `forceProxy: true` to a region-mapped catalog item, it will try to hit URLs like

```http://localhost:3001/proxy/_0d/https://vector-tiles.terria.io/FID_POA_2011_AUST```

which fail.  Vector tiles should never be proxied.

Question though: another function of the proxy server is to serve http over https - is that an issue here?
