### PR TITLE
Remember user's choice of ViewerMode.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 Change Log
 ==========
+### 5.2.6
+
+* Add `viewermode` to the users persistant local storage to remember the last `ViewerMode` used.
 
 ### 5.2.5
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -468,7 +468,7 @@ Terria.prototype.start = function(options) {
                     // This is the default viewerMode to use if the configuration parameter is not set or is not set correctly.
                     that.viewerMode = ViewerMode.Leaflet;
 
-                        if (defined(that.configParameters.mobileDefaultViewerMode) && (typeof that.configParameters.mobileDefaultViewerMode === 'string')) {
+                    if (defined(that.configParameters.mobileDefaultViewerMode) && (typeof that.configParameters.mobileDefaultViewerMode === 'string')) {
                         const mobileDefault = that.configParameters.mobileDefaultViewerMode.toLowerCase();
                         if (mobileDefault === '3dterrain') {
                             that.viewerMode = ViewerMode.CesiumTerrain;

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -386,6 +386,7 @@ var Terria = function(options) {
  *                                          supplied, is parsed for startup parameters.
  * @param {String} [options.configUrl='config.json'] The URL of the file containing configuration information, such as the list of domains to proxy.
  * @param {UrlShortener} [options.urlShortener] The URL shortener to use to expand short URLs.  If this property is undefined, short URLs will not be expanded.
+ * @param {Boolean} [options.persistViewerMode] Whether to use the ViewerMode stored in localStorage if avaliable (this takes priority over other ViewerMode options). If not specified the stored ViewerMode will be used.
  */
 Terria.prototype.start = function(options) {
     function slashify(url) {
@@ -457,28 +458,35 @@ Terria.prototype.start = function(options) {
         }).then(function() {
             return that.updateApplicationUrl(applicationUrl, that.urlShortener);
         }).then(function () {
-            // If we are running on a mobile platform set the viewerMode to the config specified default mobile viewer mode.
-            if (isCommonMobilePlatform() && !defined(that.userProperties.map)) {
-                // This is the default viewerMode to use if the configuration parameter is not set or is not set correctly.
-                that.viewerMode = ViewerMode.Leaflet;
+            var persistViewerMode = defaultValue(options.persistViewerMode, true);
 
-                if (defined(that.configParameters.mobileDefaultViewerMode) && (typeof that.configParameters.mobileDefaultViewerMode === 'string')) {
-                    const mobileDefault = that.configParameters.mobileDefaultViewerMode.toLowerCase();
-                    if (mobileDefault === '3dterrain') {
-                        that.viewerMode = ViewerMode.CesiumTerrain;
+            if (persistViewerMode && defined(that.getLocalProperty('viewermode'))) {
+                that.viewerMode = parseInt(that.getLocalProperty('viewermode'), 10);
+            } else {
+                // If we are running on a mobile platform set the viewerMode to the config specified default mobile viewer mode.
+                if (isCommonMobilePlatform() && !defined(that.userProperties.map)) {
+                    // This is the default viewerMode to use if the configuration parameter is not set or is not set correctly.
+                    that.viewerMode = ViewerMode.Leaflet;
+
+                        if (defined(that.configParameters.mobileDefaultViewerMode) && (typeof that.configParameters.mobileDefaultViewerMode === 'string')) {
+                        const mobileDefault = that.configParameters.mobileDefaultViewerMode.toLowerCase();
+                        if (mobileDefault === '3dterrain') {
+                            that.viewerMode = ViewerMode.CesiumTerrain;
+                        }
+                        else if (mobileDefault === '3dsmooth') {
+                            that.viewerMode = ViewerMode.CesiumEllipsoid;
+                        }
+                        else if (mobileDefault === '2d') {
+                            that.viewerMode = ViewerMode.Leaflet;
+                        }
                     }
-                    else if (mobileDefault === '3dsmooth') {
-                        that.viewerMode = ViewerMode.CesiumEllipsoid;
-                    }
-                    else if (mobileDefault === '2d') {
-                        that.viewerMode = ViewerMode.Leaflet;
-                    }
+                }
+
+                if (options.defaultTo2D && !defined(that.userProperties.map)) {
+                    that.viewerMode = ViewerMode.Leaflet;
                 }
             }
 
-            if (options.defaultTo2D && !defined(that.userProperties.map)) {
-                that.viewerMode = ViewerMode.Leaflet;
-            }
             that.catalog.isLoading = false;
         }).otherwise(function(e) {
             console.error('Error from updateApplicationUrl: ',  e);

--- a/lib/ReactViews/Map/Panels/SettingPanel.jsx
+++ b/lib/ReactViews/Map/Panels/SettingPanel.jsx
@@ -61,19 +61,25 @@ const SettingPanel = createReactClass({
 
     selectViewer(viewer, event) {
         event.stopPropagation();
+
+        let newViewerMode;
         switch (viewer) {
             case 0:
-                this.props.terria.viewerMode = ViewerMode.CesiumTerrain;
+                newViewerMode = ViewerMode.CesiumTerrain;
                 break;
             case 1:
-                this.props.terria.viewerMode = ViewerMode.CesiumEllipsoid;
+                newViewerMode = ViewerMode.CesiumEllipsoid;
                 break;
             case 2:
-                this.props.terria.viewerMode = ViewerMode.Leaflet;
+                newViewerMode = ViewerMode.Leaflet;
                 break;
             default:
                 return;
         }
+        this.props.terria.viewerMode = newViewerMode;
+
+        // We store the user's chosen viewer mode for future use.
+        this.props.terria.setLocalProperty('viewermode', newViewerMode);
     },
 
     render() {


### PR DESCRIPTION
As per #2127 https://github.com/TerriaJS/terriajs/issues/2127.

I tried to mimic the way that selectBaseMap() gives control to the instance in whether the persistent value is used or not (although I'm not sure whether this option would ever be needed in practice). However I used the option supplied to the start function because this seems to match the style around this option. I have made the default to use the persistent value (so all instances depending on TerriaJs which wont be supplying the option since it previously didn't exist), as I presumed that this would be the desirable behavior and be the sensible default for new instances. Please let me know if any of these assumptions are wrong and I will modify accordingly.