### PR TITLE
Make MyLocation button optional

### DIFF
--- a/lib/ReactViews/Map/MapNavigation.jsx
+++ b/lib/ReactViews/Map/MapNavigation.jsx
@@ -5,7 +5,6 @@ import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import Compass from './Navigation/Compass.jsx';
-import MyLocation from './Navigation/MyLocation.jsx';
 import ZoomControl from './Navigation/ZoomControl.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import ViewerMode from '../../Models/ViewerMode';
@@ -39,9 +38,6 @@ const MapNavigation = createReactClass({
                 </If>
                 <div className={Styles.control}>
                     <ZoomControl terria={this.props.terria}/>
-                </div>
-                <div className={Styles.control}>
-                    <MyLocation terria={this.props.terria}/>
                 </div>
                 <For each="item" of={this.props.navItems} index="i">
                     <div className={Styles.control} key={i}>


### PR DESCRIPTION
Move MyLocation button from within TerriaJS to inside the UserInterface of each TerriaJS map that wants a location button, so that instances can choose not to have that button.

What do you think?

This has been requested by the Parliamentary Library, because the location is sometimes inaccurate and they would rather not have the button.