### PR TITLE
Add the time to the timeline labels when zoomed in

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.2.6
+
+* Added the time to the timeline labels, when zoomed in to a single day (previously the label sometimes only showed the date).
+
 ### 5.2.5
 
 * Fixed a bug with `forceProxy: true` which meant that vector tiles would try, and fail, to load over the proxy.

--- a/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
@@ -28,8 +28,11 @@ const CesiumTimeline = createReactClass({
                     return dateFormat(JulianDate.toDate(time), layer.dateFormat.timelineTic);
                 }
             }
-
-            const totalDays = JulianDate.daysDifference(this.props.terria.clock.stopTime, this.props.terria.clock.startTime);
+            // Adjust the label format as you zoom by using the visible timeline's start and end
+            // (not the fixed this.props.terria.clock.startTime and stopTime).
+            const startJulian = this.cesiumTimeline._startJulian;
+            const endJulian = this.cesiumTimeline._endJulian;
+            const totalDays = JulianDate.daysDifference(endJulian, startJulian);
             if (totalDays > 14) {
                 return formatDate(JulianDate.toDate(time), this.locale);
             } else if (totalDays < 1) {


### PR DESCRIPTION
Fixes one big problem behind #2557.  Try this with any time-varying dataset that covers >14 days. 