### PR TITLE
Allow instance to disable conversion service so no data is sent outside client

### DIFF
--- a/lib/Models/OgrCatalogItem.js
+++ b/lib/Models/OgrCatalogItem.js
@@ -118,6 +118,14 @@ We recommend you upgrade to the latest version of <a href="http://www.google.com
 <a href="http://www.microsoft.com/ie" target="_blank">Microsoft Internet Explorer</a>.'
         });
     }
+    if (this.terria.configParameters.conversionServiceBaseUrl === false) {
+        // Don't allow conversion service. Duplicated in createCatalogItemFromFileOrUrl.js
+        throw new TerriaError({
+            title: 'Unsupported file type',
+            message: 'This file format is not supported by ' + this.terria.appName + '. Supported file formats include: ' +
+            '<ul><li>.geojson</li><li>.kml, .kmz</li><li>.csv (in <a href="https://github.com/NICTA/nationalmap/wiki/csv-geo-au">csv-geo-au format</a>)</li></ul>'
+        });
+    }
 
     this._geoJsonItem = new GeoJsonCatalogItem( this.terria);
 

--- a/lib/Models/createCatalogItemFromFileOrUrl.js
+++ b/lib/Models/createCatalogItemFromFileOrUrl.js
@@ -29,7 +29,15 @@ var OgrCatalogItem = require('../Models/OgrCatalogItem');
  */
 var createCatalogItemFromFileOrUrl = function(terria, viewState, fileOrUrl, dataType, confirmConversion) {
     function tryConversionService(newItem) {
-       if (name.match(/\.(shp|jpg|jpeg|pdf|xlsx|xls|tif|tiff|png|txt|doc|docx|xml|json)$/)) {
+        if (terria.configParameters.conversionServiceBaseUrl === false) {
+            // Don't allow conversion service. Duplicated in OgrCatalogItem.js
+            terria.error.raiseEvent(new TerriaError({
+                title: 'Unsupported file type',
+                message: 'This file format is not supported by ' + terria.appName + '. Supported file formats include: ' +
+                '<ul><li>.geojson</li><li>.kml, .kmz</li><li>.csv (in <a href="https://github.com/NICTA/nationalmap/wiki/csv-geo-au">csv-geo-au format</a>)</li></ul>'
+            }));
+            return undefined;
+        } else if (name.match(/\.(shp|jpg|jpeg|pdf|xlsx|xls|tif|tiff|png|txt|doc|docx|xml|json)$/)) {
             terria.error.raiseEvent(new TerriaError({
                 title: 'Unsupported file type',
                 message: 'This file format is not supported by ' + terria.appName + '. Directly supported file formats include: ' +


### PR DESCRIPTION
Conversion service can be disabled by setting the `conversionServiceBaseUrl` to `false` instead of `"convert/"`.

The message (at least at first glance) needs to be duplicated since it is possible to create an `OgrCatalogItem` without `createCatalogItemFromFileOrUrl` and the new error should be shown instead of the other file incompatible error when using `createCatalogItemFromFileOrUrl`.