### PR TITLE
Fix IE11 bug with colouring vector tiled regions

### DIFF
--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -687,7 +687,7 @@ function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, g
                 var terria = catalogItem.terria;
                 var color = colorFunction(id);
                 return color ? {
-                    fillStyle: 'rgba(' + color.join(',') + ')',
+                    fillStyle: 'rgba(' + Array.prototype.join.call(color, ',') + ')',
                     strokeStyle: terria.baseMapContrastColor,
                     lineWidth: 1
                 } : undefined;

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -687,6 +687,7 @@ function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, g
                 var terria = catalogItem.terria;
                 var color = colorFunction(id);
                 return color ? {
+                    // color is an Array-like object (note: typed arrays don't have a 'join' method in IE10 & IE11)
                     fillStyle: 'rgba(' + Array.prototype.join.call(color, ',') + ')',
                     strokeStyle: terria.baseMapContrastColor,
                     lineWidth: 1


### PR DESCRIPTION
In certain cases, `color` can be a typed array which in IE11 don't have the `join` method.

Fixes #2575