### PR TITLE
[TerriaJS/geoglam-nm#5]  Fix out by one in selected column for csv data with time column.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.#.#
+
+* Fixed a bug which caused the selected column in a csv to be the second column when a time column is present.
+
 ### 5.2.6
 
 * Added the ability to disable the conversion service so that no user data is sent outside of the client by setting `conversionServiceBaseUrl` to `false` in the `parameters` section of `config.json`.

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -750,7 +750,7 @@ function ensureActiveColumnForNonSpatial(item) {
     var tableStructure = item._tableStructure;
     if (tableStructure.activeItems.length === 0) {
         var suitableColumns = tableStructure.columnsByType[VarType.SCALAR];
-        if (suitableColumns.length > 1) {
+        if ((suitableColumns.length > 1) && (tableStructure.columnsByType[VarType.TIME].length === 0)) {
             suitableColumns[1].toggleActive();
         } else if (suitableColumns.length > 0) {
             suitableColumns[0].toggleActive();


### PR DESCRIPTION
https://github.com/TerriaJS/geoglam-nm/issues/5

TableCatalogItem: Fix a bug where the column selected is the second column when a time column is present.

Test whether there is a time column as indicated in the comment 4 lines above but not tested for in this function or in the calling function (this function is only ever called from a single location).