### PR TITLE
Improve Esri polygon to GeoJSON conversion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.2.8
+
+* Improved the conversion of Esri polygons to GeoJSON by `featureDataToGeoJson`.  It now correctly handles polygons with holes and with multiple outer rings.
+
 ### 5.2.7
 
 * Added the Latitude and Longitude to the filename for the Feature Information file download.

--- a/lib/Map/MapboxVectorTileImageryProvider.js
+++ b/lib/Map/MapboxVectorTileImageryProvider.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /*global require*/
+var computeRingWindingOrder = require('../Map/computeRingWindingOrder');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');
@@ -17,6 +18,7 @@ var Cartographic = require('terriajs-cesium/Source/Core/Cartographic');
 var Cartesian2 = require('terriajs-cesium/Source/Core/Cartesian2');
 var BoundingRectangle = require('terriajs-cesium/Source/Core/BoundingRectangle');
 var Intersect = require('terriajs-cesium/Source/Core/Intersect');
+var WindingOrder = require('terriajs-cesium/Source/Core/WindingOrder');
 
 var POLYGON_FEATURE = 3; // feature.type == 3 for polygon features
 
@@ -277,15 +279,9 @@ MapboxVectorTileImageryProvider.prototype._drawTile = function (requestedTile, n
 };
 
 function isExteriorRing(ring) {
-    // See https://github.com/mapbox/vector-tile-spec/tree/master/2.0#4344-polygon-geometry-type && https://en.wikipedia.org/wiki/Shoelace_formula
-    var n = ring.length;
-    var twiceArea = ring[n-1][0]*(ring[0][1]-ring[n-2][1]) + ring[0][0]*(ring[1][1]-ring[n-1][1]);
-    for (var i = 1; i <= n-2; i++) {
-        twiceArea += ring[i][0]*(ring[i+1][1]-ring[i-1][1]);
-    }
-    return twiceArea <= 0; // Reversed sign because vector tile y coordinates are reversed
+    const windingOrder = computeRingWindingOrder(ring);
+    return windingOrder === WindingOrder.CLOCKWISE;
 }
-
 
 // Adapted from npm package "point-in-polygon" by James Halliday
 // Licence included in LICENSE.md

--- a/lib/Map/computeRingWindingOrder.js
+++ b/lib/Map/computeRingWindingOrder.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const WindingOrder = require('terriajs-cesium/Source/Core/WindingOrder');
+
+function computeRingWindingOrder(ring) {
+    // See https://github.com/mapbox/vector-tile-spec/tree/master/2.0#4344-polygon-geometry-type && https://en.wikipedia.org/wiki/Shoelace_formula
+    const n = ring.length;
+    let twiceArea = ring[n-1][0] * (ring[0][1] - ring[n-2][1]) + ring[0][0] * (ring[1][1] - ring[n-1][1]);
+    for (let i = 1; i <= n-2; i++) {
+        twiceArea += ring[i][0] * (ring[i+1][1] - ring[i-1][1]);
+    }
+
+    return twiceArea > 0.0 ? WindingOrder.COUNTER_CLOCKWISE : WindingOrder.CLOCKWISE;
+}
+
+module.exports = computeRingWindingOrder;

--- a/lib/Map/featureDataToGeoJson.js
+++ b/lib/Map/featureDataToGeoJson.js
@@ -1,7 +1,10 @@
 'use strict';
 
 /*global require*/
+var computeRingWindingOrder = require('../Map/computeRingWindingOrder');
 var defined = require('terriajs-cesium/Source/Core/defined');
+var pointInPolygon = require('point-in-polygon');
+var WindingOrder = require('terriajs-cesium/Source/Core/WindingOrder');
 
 /**
  * Converts feature data, such as from a WMS GetFeatureInfo or an Esri Identify, to
@@ -81,10 +84,45 @@ function getEsriGeometry(featureData, geometryType, spatialReference) {
         //    (exterior) ring is expected to be counter-clockwise, though lots of implementations probably don't
         //    enforce this.  The spec says, "For backwards compatibility, parsers SHOULD NOT reject
         //    Polygons that do not follow the right-hand rule."
-        geoJsonFeature.geometry = {
-            type: 'Polygon',
-            coordinates: featureData.geometry.rings
-        };
+
+        // Group rings into outer rings and holes/
+        const outerRings = [];
+        const holes = [];
+        featureData.geometry.rings.forEach(function(ring) {
+            if (computeRingWindingOrder(ring) === WindingOrder.CLOCKWISE) {
+                outerRings.push(ring);
+            } else {
+                holes.push(ring);
+            }
+
+            // Reverse the coordinate order along the way due to #3 above.
+            ring.reverse();
+        });
+
+        // If there's only one outer ring, we can use a `Polygon` and things are simple.
+        if (outerRings.length === 1) {
+            geoJsonFeature.geometry = {
+                type: 'Polygon',
+                coordinates: [outerRings[0], ...holes]
+            };
+        } else if (outerRings.length === 0 && holes.length > 0) {
+            // Well this is pretty weird.  We have holes but not outer ring?
+            // Most likely scenario is that someone messed up the winding order.
+            // So let's treat all the holes as outer rings instead.
+            holes.forEach(hole => { hole.reverse(); });
+            geoJsonFeature.geometry = {
+                type: 'Polygon',
+                coordinates: holes
+            };
+        } else {
+            // Multiple outer rings, so we need to use a multipolygon, and we need
+            // to figure out which outer ring contains each hole.
+            geoJsonFeature.geometry = {
+                type: 'MultiPolygon',
+                coordinates: outerRings.map(ring => [ring, ...findHolesInRing(ring, holes)])
+            };
+        }
+
     } else if (geometryType === 'esriGeometryPoint') {
         geoJsonFeature.geometry = {
             type: 'Point',
@@ -99,6 +137,11 @@ function getEsriGeometry(featureData, geometryType, spatialReference) {
         return undefined;
     }
     return geoJsonFeature;
+}
+
+function findHolesInRing(ring, holes) {
+    // Return all holes where every vertex in the hole ring is inside the outer ring.
+    return holes.filter(hole => hole.every(coordinates => pointInPolygon(coordinates, ring)));
 }
 
 function esriSpatialReferenceToCrs(spatialReference) {

--- a/lib/Map/featureDataToGeoJson.js
+++ b/lib/Map/featureDataToGeoJson.js
@@ -69,6 +69,18 @@ function getEsriGeometry(featureData, geometryType, spatialReference) {
         geoJsonFeature.crs = esriSpatialReferenceToCrs(spatialReference);
     }
     if (geometryType === 'esriGeometryPolygon') {
+        // There are a bunch of differences between Esri polygons and GeoJSON polygons.
+        // For GeoJSON, see https://tools.ietf.org/html/rfc7946#section-3.1.6.
+        // For Esri, see http://resources.arcgis.com/en/help/arcgis-rest-api/#/Geometry_objects/02r3000000n1000000/
+        // In particular:
+        // 1. Esri polygons can actually be multiple polygons by using multiple outer rings.  GeoJSON polygons
+        //    can only have one outer ring and we need to use a MultiPolygon to represent multiple outer rings.
+        // 2. In Esri which rings are outer rings and which are holes is determined by the winding order of the
+        //    rings.  In GeoJSON, the first ring is the outer ring and subsequent rings are holes.
+        // 3. In Esri polygons, clockwise rings are exterior, counter-clockwise are interior.  In GeoJSON, the first
+        //    (exterior) ring is expected to be counter-clockwise, though lots of implementations probably don't
+        //    enforce this.  The spec says, "For backwards compatibility, parsers SHOULD NOT reject
+        //    Polygons that do not follow the right-hand rule."
         geoJsonFeature.geometry = {
             type: 'Polygon',
             coordinates: featureData.geometry.rings
@@ -98,7 +110,7 @@ function esriSpatialReferenceToCrs(spatialReference) {
         return {
             type: 'name',
             properties: {
-                name: 'EPSG:3857'
+                name: 'urn:ogc:def:crs:EPSG::3857'
             }
         };
     } else if (defined(spatialReference.wkid)) {

--- a/lib/Map/featureDataToGeoJson.js
+++ b/lib/Map/featureDataToGeoJson.js
@@ -99,23 +99,23 @@ function getEsriGeometry(featureData, geometryType, spatialReference) {
             ring.reverse();
         });
 
+        if (outerRings.length === 0 && holes.length > 0) {
+            // Well, this is pretty weird.  We have holes but not outer ring?
+            // Most likely scenario is that someone messed up the winding order.
+            // So let's treat all the holes as outer rings instead.
+            holes.forEach(hole => { hole.reverse(); });
+            outerRings.push(...holes);
+            holes.length = 0;
+        }
+
         // If there's only one outer ring, we can use a `Polygon` and things are simple.
         if (outerRings.length === 1) {
             geoJsonFeature.geometry = {
                 type: 'Polygon',
                 coordinates: [outerRings[0], ...holes]
             };
-        } else if (outerRings.length === 0 && holes.length > 0) {
-            // Well this is pretty weird.  We have holes but not outer ring?
-            // Most likely scenario is that someone messed up the winding order.
-            // So let's treat all the holes as outer rings instead.
-            holes.forEach(hole => { hole.reverse(); });
-            geoJsonFeature.geometry = {
-                type: 'Polygon',
-                coordinates: holes
-            };
         } else {
-            // Multiple outer rings, so we need to use a multipolygon, and we need
+            // Multiple (or zero!) outer rings, so we need to use a multipolygon, and we need
             // to figure out which outer ring contains each hole.
             geoJsonFeature.geometry = {
                 type: 'MultiPolygon',
@@ -160,7 +160,7 @@ function esriSpatialReferenceToCrs(spatialReference) {
         return {
             type: 'name',
             properties: {
-                name: 'EPSG:' + spatialReference.wkid
+                name: 'urn:ogc:def:crs:EPSG::' + spatialReference.wkid
             }
         };
     }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mutationobserver-shim": "^0.3.1",
     "pbf": "^3.0.1",
     "point-geometry": "^0.1.0",
+    "point-in-polygon": "^1.0.1",
     "proj4": "~2.3.16",
     "raw-loader": "^0.5.1",
     "react": "^15.5.4",

--- a/test/Map/featureDataToGeoJsonSpec.js
+++ b/test/Map/featureDataToGeoJsonSpec.js
@@ -1,0 +1,149 @@
+'use strict';
+
+/*global require,describe,it,expect*/
+const featureDataToGeoJson = require('../../lib/Map/featureDataToGeoJson');
+
+describe('featureDataToGeoJson', function() {
+    describe('Esri polygon', function() {
+        it('with a single outer ring', function() {
+            const esri = {
+                geometryType: 'esriGeometryPolygon',
+                geometry: {
+                    rings: [
+                       [[5.0, 5.0], [5.0, 10.0], [10.0, 10.0], [10.0, 5.0], [5.0, 5.0]]
+                    ]
+                },
+                attributes: {}
+            };
+            const geoJson = featureDataToGeoJson(esri);
+            expect(geoJson).toEqual({
+                type: 'Feature',
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [
+                        [[5.0, 5.0], [10.0, 5.0], [10.0, 10.0], [5.0, 10.0], [5.0, 5.0]]
+                    ]
+                },
+                properties: {}
+            });
+        });
+
+        it('with one outer ring and two holes', function() {
+            const esri = {
+                geometryType: 'esriGeometryPolygon',
+                geometry: {
+                    rings: [
+                       [[5.0, 5.0], [5.0, 10.0], [10.0, 10.0], [10.0, 5.0], [5.0, 5.0]],
+                       [[7.0, 7.0], [8.0, 7.0], [8.0, 8.0], [7.0, 8.0], [7.0, 7.0]],
+                       [[8.5, 8.5], [9.5, 8.5], [9.5, 9.5], [8.5, 9.5], [8.5, 8.5]]
+                    ]
+                },
+                attributes: {}
+            };
+            const geoJson = featureDataToGeoJson(esri);
+            expect(geoJson).toEqual({
+                type: 'Feature',
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [
+                        [[5.0, 5.0], [10.0, 5.0], [10.0, 10.0], [5.0, 10.0], [5.0, 5.0]],
+                        [[7.0, 7.0], [7.0, 8.0], [8.0, 8.0], [8.0, 7.0], [7.0, 7.0]],
+                        [[8.5, 8.5], [8.5, 9.5], [9.5, 9.5], [9.5, 8.5], [8.5, 8.5]]
+                    ]
+                },
+                properties: {}
+            });
+        });
+
+        it('with two outer rings', function() {
+            const esri = {
+                geometryType: 'esriGeometryPolygon',
+                geometry: {
+                    rings: [
+                       [[5.0, 5.0], [5.0, 10.0], [10.0, 10.0], [10.0, 5.0], [5.0, 5.0]],
+                       [[11.0, 11.0], [11.0, 12.0], [12.0, 12.0], [12.0, 11.0], [11.0, 11.0]]
+                    ]
+                },
+                attributes: {}
+            };
+            const geoJson = featureDataToGeoJson(esri);
+            expect(geoJson).toEqual({
+                type: 'Feature',
+                geometry: {
+                    type: 'MultiPolygon',
+                    coordinates: [
+                        [
+                            [[5.0, 5.0], [10.0, 5.0], [10.0, 10.0], [5.0, 10.0], [5.0, 5.0]]
+                        ],
+                        [
+                            [[11.0, 11.0], [12.0, 11.0], [12.0, 12.0], [11.0, 12.0], [11.0, 11.0]]
+                        ]
+                    ]
+                },
+                properties: {}
+            });
+        });
+
+        it('with two outer rings and a hole in each', function() {
+            const esri = {
+                geometryType: 'esriGeometryPolygon',
+                geometry: {
+                    rings: [
+                       [[5.0, 5.0], [5.0, 10.0], [10.0, 10.0], [10.0, 5.0], [5.0, 5.0]],
+                       [[11.25, 11.25], [11.75, 11.25], [11.75, 11.75], [11.25, 11.75], [11.25, 11.25]],
+                       [[11.0, 11.0], [11.0, 12.0], [12.0, 12.0], [12.0, 11.0], [11.0, 11.0]],
+                       [[7.0, 7.0], [8.0, 7.0], [8.0, 8.0], [7.0, 8.0], [7.0, 7.0]]
+                    ]
+                },
+                attributes: {}
+            };
+            const geoJson = featureDataToGeoJson(esri);
+            expect(geoJson).toEqual({
+                type: 'Feature',
+                geometry: {
+                    type: 'MultiPolygon',
+                    coordinates: [
+                        [
+                            [[5.0, 5.0], [10.0, 5.0], [10.0, 10.0], [5.0, 10.0], [5.0, 5.0]],
+                            [[7.0, 7.0], [7.0, 8.0], [8.0, 8.0], [8.0, 7.0], [7.0, 7.0]]
+                        ],
+                        [
+                            [[11.0, 11.0], [12.0, 11.0], [12.0, 12.0], [11.0, 12.0], [11.0, 11.0]],
+                            [[11.25, 11.25], [11.25, 11.75], [11.75, 11.75], [11.75, 11.25], [11.25, 11.25]]
+                        ]
+                    ]
+                },
+                properties: {}
+            });
+        });
+
+        it('with no outer rings, assumes winding order is reversed and uses holes as outer rings', function() {
+            const esri = {
+                geometryType: 'esriGeometryPolygon',
+                geometry: {
+                    rings: [
+                       [[5.0, 5.0], [10.0, 5.0], [10.0, 10.0], [5.0, 10.0], [5.0, 5.0]],
+                       [[11.0, 11.0], [12.0, 11.0], [12.0, 12.0], [11.0, 12.0], [11.0, 11.0]]
+                    ]
+                },
+                attributes: {}
+            };
+            const geoJson = featureDataToGeoJson(esri);
+            expect(geoJson).toEqual({
+                type: 'Feature',
+                geometry: {
+                    type: 'MultiPolygon',
+                    coordinates: [
+                        [
+                            [[5.0, 5.0], [10.0, 5.0], [10.0, 10.0], [5.0, 10.0], [5.0, 5.0]]
+                        ],
+                        [
+                            [[11.0, 11.0], [12.0, 11.0], [12.0, 12.0], [11.0, 12.0], [11.0, 11.0]]
+                        ]
+                    ]
+                },
+                properties: {}
+            });
+        });
+    });
+});


### PR DESCRIPTION
It now handles polygons with holes and with multiple outer rings.

This is for TerriaJS/geoglam-nm#16.