### PR TITLE
Fix the cache duration value so that it uses the value from the dataset.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.2.9
+
+* Fixed a bug that caused the default cache duration to be used always rather then the catalogItem's cacheDuration if it was specified.
+
 ### 5.2.8
 
 * Added option to expand the HTML embed code and toggle URL shorting for the share link.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Change Log
 
 ### 5.2.9
 
-* Fixed a bug that caused the default cache duration to be used always rather then the catalogItem's cacheDuration if it was specified.
+* A catalog item's `cacheDuration` property now takes precedence over the default cache duration specified by the code.  Previously, the `cacheDuration` would only override the default duration (2 weeks).
 
 ### 5.2.8
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Change Log
 
 ### 5.2.9
 
-* A catalog item's `cacheDuration` property now takes precedence over the default cache duration specified by the code.  Previously, the `cacheDuration` would only override the default duration (2 weeks).
+* A catalog item's `cacheDuration` property now takes precedence over the cache duration specified by the code.  Previously, the `cacheDuration` would only override the default duration (2 weeks).
 
 ### 5.2.8
 

--- a/lib/Models/proxyCatalogItemUrl.js
+++ b/lib/Models/proxyCatalogItemUrl.js
@@ -23,7 +23,7 @@ var proxyCatalogItemUrl = function(catalogItem, url, cacheDuration) {
         return url;
     }
 
-    return corsProxy.getURL(url, defaultValue(cacheDuration, catalogItem.cacheDuration));
+    return corsProxy.getURL(url, defaultValue(catalogItem.cacheDuration, cacheDuration));
 };
 
 module.exports = proxyCatalogItemUrl;


### PR DESCRIPTION
TerriaJS/aremi-natmap#137 proxyCatalogItemUrl: Change the cache duration used to be the value from the dataset rather then mistakenly using the default always.