### PR TITLE
Use MVT for region mapping and WMS for analytics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### next release (5.2.11)
+
+* Added the ability to use the analytics region picker with vector tile region mapping by specifiying a WMS server & layer for analytics only.
+
 ### 5.2.10
 
 * Improved the conversion of Esri polygons to GeoJSON by `featureDataToGeoJson`.  It now correctly handles polygons with holes and with multiple outer rings.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 Change Log
 ==========
 
-### next release (5.2.11)
+### 5.2.12
 
 * Added the ability to use the analytics region picker with vector tile region mapping by specifiying a WMS server & layer for analytics only.
 

--- a/lib/Map/RegionProvider.js
+++ b/lib/Map/RegionProvider.js
@@ -77,6 +77,18 @@ var RegionProvider = function(regionType, properties, corsProxy) {
     this.serverType = defaultValue(properties.serverType, 'WMS');
 
     /**
+     * URL of WMS server. Needed if the layer is a MVT layer, but the layer is also used for analytics region picker (analytics section uses WMS/WFS)
+     * @type {String}
+    */
+    this.analyticsWmsServer = defaultValue(properties.analyticsWmsServer, this.serverType === 'WMS' ? this.server : undefined);
+
+    /**
+     * Name of the layer on the WMS server. Needed if the layer is a MVT layer, but the layer is also used for analytics region picker (analytics section uses WMS/WFS)
+     * @type {String}
+    */
+    this.analyticsWmsLayerName = defaultValue(properties.analyticsWmsLayerName, this.serverType === 'WMS' ? this.layerName : undefined);
+
+    /**
     * List of subdomains for requests to be sent to (only defined for MVT providers)
     * @type {String[]|undefined}
     */

--- a/lib/Map/RegionProvider.js
+++ b/lib/Map/RegionProvider.js
@@ -272,6 +272,11 @@ RegionProvider.prototype.loadRegionIDs = function() {
     return when.all(this._loadRegionIDsPromises);
 };
 
+/**
+ * Load names of regions. Used for analytics region picker.
+ *
+ * @return {Promise} Promise resolving to region names
+ */
 RegionProvider.prototype.loadRegionNames = function() {
     if (defined(this._loadRegionNamesPromise)) {
         return this._loadRegionNamesPromise;
@@ -279,11 +284,11 @@ RegionProvider.prototype.loadRegionNames = function() {
 
     var nameProp = this.nameProp || this.regionProp;
 
-    var baseuri = URI(this.server).addQuery({
+    var baseuri = URI(this.analyticsWmsServer).addQuery({
         service: 'wfs',
         version: '2.0',
         request: 'getPropertyValue',
-        typenames: this.layerName
+        typenames: this.analyticsWmsLayerName
     });
 
     // get the list of IDs that we will attempt to match against for this column

--- a/lib/Models/RegionTypeParameter.js
+++ b/lib/Models/RegionTypeParameter.js
@@ -134,6 +134,10 @@ RegionTypeParameter.prototype.getAllRegionTypes = function() {
                 return that.validRegionTypes.indexOf(regionProvider.regionType) >= 0;
             });
         }
+        // Filter out region types that don't have a WMS server associated (e.g. those that are purely vector tile)
+        result = result.filter(function(regionProvider) {
+            return defined(regionProvider.analyticsWmsServer);
+        });
         that._regionProviderList = result;
         return result;
     });

--- a/lib/ReactViews/Analytics/RegionPicker.jsx
+++ b/lib/ReactViews/Analytics/RegionPicker.jsx
@@ -141,8 +141,8 @@ const RegionPicker = createReactClass({
 
             that._regionsCatalogItem = new WebMapServiceCatalogItem(that.props.previewed.terria);
             that._regionsCatalogItem.name = "Available Regions";
-            that._regionsCatalogItem.url = that.regionProvider.server;
-            that._regionsCatalogItem.layers = that.regionProvider.layerName;
+            that._regionsCatalogItem.url = that.regionProvider.analyticsWmsServer;
+            that._regionsCatalogItem.layers = that.regionProvider.analyticsWmsLayerName;
             that._regionsCatalogItem.parameters = {
                 styles: 'border_black_fill_aqua'
             };


### PR DESCRIPTION
This will facilitate finally rolling vector tiles out for region mapping across all instances, yet still have region picking analytics functionality available (and more clearly indicate the dependency of analytics on region mapping definitions).

The better solution would be to completely replace WMS/WFS usage in analytics, but that would require serving regions as GeoJSON somehow from the vector tile server.