### PR TITLE
[TerriaJS/geoglam-nm#36] ImageryLayerCatalogItem: Fix a bug that means that the stopTime and currentTime become the same instance.

### DIFF
--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -735,10 +735,10 @@ function _setClockCurrentTime(catalogItem)
     switch(initialTimeSource)
     {
         case "start":
-            catalogItem._clock.currentTime = catalogItem._clock.startTime;
+            catalogItem._clock.currentTime = catalogItem._clock.startTime.clone(catalogItem._clock.currentTime);
             break;
         case "end":
-            catalogItem._clock.currentTime = catalogItem._clock.stopTime;
+            catalogItem._clock.currentTime = catalogItem._clock.stopTime.clone(catalogItem._clock.currentTime);
             break;
         case "present":
             // Set to present by default.


### PR DESCRIPTION
Have also updated for the startTime since via inspection it appears that this will suffer from the same issue.