### PR TITLE
Fix a race condition in Leaflet layer initialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ### 5.2.10
 
 * Improved the conversion of Esri polygons to GeoJSON by `featureDataToGeoJson`.  It now correctly handles polygons with holes and with multiple outer rings.
+* Fixed a bug that could cause some layers, especially the Bing Maps basemap, to occasionally be missing from the 2D map.
 
 ### 5.2.9
 

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -69,41 +69,45 @@ var CesiumTileLayer = L.TileLayer.extend({
         if (!this.initialized) {
             this.initialized = true;
 
-            if (!this._delayedUpdate) {
-                this._delayedUpdate = setTimeout(function() {
-                    that._delayedUpdate = undefined;
-
-                    // If we're no longer attached to a map, do nothing.
-                    if (!that._map) {
-                        return;
-                    }
-
-                    var tilingScheme = that.imageryProvider.tilingScheme;
-                    if (!(tilingScheme instanceof WebMercatorTilingScheme)) {
-                        that.errorEvent.raiseEvent(that, 'This dataset cannot be displayed on the 2D map because it does not support the Web Mercator (EPSG:3857) projection.');
-                        return;
-                    }
-
-                    if (tilingScheme.getNumberOfXTilesAtLevel(0) === 2 && tilingScheme.getNumberOfYTilesAtLevel(0) === 2) {
-                        that._zSubtract = 1;
-                    } else if (tilingScheme.getNumberOfXTilesAtLevel(0) !== 1 || tilingScheme.getNumberOfYTilesAtLevel(0) !== 1) {
-                        that.errorEvent.raiseEvent(that, 'This dataset cannot be displayed on the 2D map because it uses an unusual tiling scheme that is not supported.');
-                        return;
-                    }
-
-                    if (defined(that.imageryProvider.maximumLevel)) {
-                        that.options.maxNativeZoom = that.imageryProvider.maximumLevel;
-                    }
-
-                    if (defined(that.imageryProvider.credit)) {
-                        that._map.attributionControl.addAttribution(getCreditHtml(that.imageryProvider.credit));
-                    }
-
-                    that._usable = true;
-
-                    that._update();
-                }, 100);
+            // Cancel the existing delayed update, if any.
+            if (this._delayedUpdate) {
+                clearTimeout(this._delayedUpdate);
+                this._delayedUpdate = undefined;
             }
+
+            this._delayedUpdate = setTimeout(function() {
+                that._delayedUpdate = undefined;
+
+                // If we're no longer attached to a map, do nothing.
+                if (!that._map) {
+                    return;
+                }
+
+                var tilingScheme = that.imageryProvider.tilingScheme;
+                if (!(tilingScheme instanceof WebMercatorTilingScheme)) {
+                    that.errorEvent.raiseEvent(that, 'This dataset cannot be displayed on the 2D map because it does not support the Web Mercator (EPSG:3857) projection.');
+                    return;
+                }
+
+                if (tilingScheme.getNumberOfXTilesAtLevel(0) === 2 && tilingScheme.getNumberOfYTilesAtLevel(0) === 2) {
+                    that._zSubtract = 1;
+                } else if (tilingScheme.getNumberOfXTilesAtLevel(0) !== 1 || tilingScheme.getNumberOfYTilesAtLevel(0) !== 1) {
+                    that.errorEvent.raiseEvent(that, 'This dataset cannot be displayed on the 2D map because it uses an unusual tiling scheme that is not supported.');
+                    return;
+                }
+
+                if (defined(that.imageryProvider.maximumLevel)) {
+                    that.options.maxNativeZoom = that.imageryProvider.maximumLevel;
+                }
+
+                if (defined(that.imageryProvider.credit)) {
+                    that._map.attributionControl.addAttribution(getCreditHtml(that.imageryProvider.credit));
+                }
+
+                that._usable = true;
+
+                that._update();
+            }, 100);
         }
 
         if (this._usable) {


### PR DESCRIPTION
A user at [Intech Solutions](http://www.intechiq.com) reported a problem where the base map would sometimes be missing from a NationalMap instance embedded in an iframe when the map was launched in 2D mode (e.g. because it was running in a VM without WebGL support).  The cause turned out to be a race condition in Leaflet layer intialization with layers that are not immediately ready upon construction (such as Bing Maps layers).  Here's the sequence of events leading to the bug:

1. CesiumTileLayer._update is called, but the imagery provider is not yet `ready`, so it sets a timeout to call `_update` again in 100ms.
2. Before the timeout expires, `_update` is called again, and this time the imagery provider _is_ `ready`.
3. Because the imagery provider is now ready and the CesiumTileLayer is not yet `initialized`, initialization begins.
4. Initialization entails first setting up some processing to happen 100ms later.  But it first checks to see if a delayed update is already installed.  If it is, it doesn't install another one.
5. When the original timeout installed in step 1 expires, the CesiumTileLayer thinks that initialization has already happened (even though it hasn't), and the layer never ends up getting properly initialized.

This PR rearranges the initialization sequence to avoid this problem.