### PR TITLE
	Make zoomOnEnable work on initial load

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 
 * Added the ability to use the analytics region picker with vector tile region mapping by specifiying a WMS server & layer for analytics only.
 * Updated the client side validation to use the server provided file size limit when drag/dropping a file requiring the conversion service.
+* `zoomOnEnable` now works even for a catalog item that is initially enabled in the catalog.  Previously, it only worked for catalog items enabled via the user interface or otherwise outside of the load process.
 
 ### 5.2.11
 

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -175,6 +175,14 @@ var CatalogItem = function(terria) {
 
     /**
      * Gets or sets a value indicating whether the map will automatically zoom to this catalog item when it is enabled.
+     *
+     * Note that within a single init source:
+     *
+     * * Catalog items with both `isEnabled` and `zoomOnEnable` set to true will override the top-level `initialCamera` property.
+     * * If multiple catalog items have both `isEnabled` and `zoomOnEnable` set to true, it is undefined which one will affect the camera.
+     *
+     * In the case of multiple init sources, however, the camera will reflect whatever happens in the _last_ init source, whether
+     * it is a result of a `zoomOnEnable` or an `initialCamera`,
      * @type {Boolean}
      * @default false
      */
@@ -980,10 +988,9 @@ function isEnabledChanged(catalogItem) {
                       catalogItem.imageryLayer.featureInfoTemplate = catalogItem.featureInfoTemplate;
                     }
 
-                    // Zoom to this catalog item if requested, unless the catalog is in the process of
-                    // loading (e.g. if we're enabling this item as a result of visiting a share URL)
-                    if (catalogItem.zoomOnEnable && !catalogItem.terria.catalog.isLoading) {
-                        catalogItem.zoomTo();
+                    // Zoom to this catalog item if requested.
+                    if (catalogItem.zoomOnEnable) {
+                        return catalogItem.zoomTo();
                     }
                 }
             });

--- a/lib/Models/NoViewer.js
+++ b/lib/Models/NoViewer.js
@@ -51,6 +51,7 @@ NoViewer.prototype.getContainer = function() {
  * @param {Number} [flightDurationSeconds=3.0] The length of the flight animation in seconds.
  */
 NoViewer.prototype.zoomTo = function(viewOrExtent, flightDurationSeconds) {
+    this.terria.initialView = viewOrExtent;
 };
 
 /**

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -612,8 +612,9 @@ Terria.prototype.addInitSource = function(initSource) {
         promise = promise.then(this.catalog.updateByShareKeys.bind(this.catalog, initSource.sharedCatalogMembers));
     }
 
+    var that = this;
+
     if (defined(initSource.pickedFeatures)) {
-        var that = this;
         promise.then(function() {
             var removeViewLoadedListener;
 


### PR DESCRIPTION
Previously, it only worked for catalog items enabled via the user interface or otherwise outside of the load process.

Fixes TerriaJS/TerriaMap#204
Makes TerriaJS/magda#159 possible

Some scenarios to test:
* An init file specified in the URL and loaded at app startup.  Should start zoomed in to the dataset.  E.g.:
```
{
    "catalog": [
        {
            "name": "Ballarat Bus Shelters",
            "type": "wms",
            "url": "http://data.gov.au/geoserver/ballaratbusshelters/wms",
            "layers": "bea6519d_2785_4435_9d1e_a7ca070d675d",
            "isEnabled": true,
            "zoomOnEnable": true
        }
    ]
}
```
* The same as above, except with a CKAN catalog item (there's some extra indirection here worth testing):
```
{
    "catalog": [
        {
            "name": "Ballarat Bus Shelters",
            "type": "ckan-resource",
            "url": "http://www.data.gov.au",
            "datasetId": "bea6519d-2785-4435-9d1e-a7ca070d675d",
            "resourceId": "97bbf0cf-9d75-44b0-b37a-b360c35f48c7",
            "isEnabled": true,
            "zoomOnEnable": true
        }
    ]
}
```
* Start with the init files above loaded at app startup, and then move the camera and create a share link. Visiting the share should recreate the new camera view.  It should _not_ be zoomed in to the dataset anymore.
* Add an `initialCamera` to the two init files above and verify that it is ignored (within a single init source, `zoomOnEnable` takes precedence).  E.g.:
```
    "catalog": [ ... ],
    "initialCamera": {
        "north": 5,
        "east": 10,
        "south": 4,
        "west": 5
    }
```
