### PR TITLE
Added `initialTimeSource` property to `CsvCatalogItem` so it is possible to specify the value of the animation timeline at start from init files.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 Change Log
 ==========
 
+
+### 5.x.x
+
+* Added `initialTimeSource` property to `CsvCatalogItem` so it is possible to specify the value of the animation timeline at start from init files.
+
 ### 5.2.12
 
 * Added the ability to use the analytics region picker with vector tile region mapping by specifiying a WMS server & layer for analytics only.

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -23,6 +23,7 @@ var DisplayVariablesConcept = require('../Map/DisplayVariablesConcept');
 var inherit = require('../Core/inherit');
 var TableColumn = require('./TableColumn');
 var VarType = require('../Map/VarType');
+var setClockCurrentTime = require('../Models/setClockCurrentTime');
 
 var defaultDisplayVariableTypes = [VarType.ENUM, VarType.SCALAR, VarType.ALT];
 var defaultFinalDurationSeconds = 3600 * 24 - 1; // one day less a second, if there is only one date.
@@ -41,6 +42,11 @@ var defaultShaveSeconds = 1;
  * @param {Object} [options] Options:
  * @param {Array} [options.displayVariableTypes] Which variable types to show in the NowViewing tab. Defaults to ENUM, SCALAR, and ALT (not LAT, LON or TIME).
  * @param {VarType[]} [options.unallowedTypes] An array of types which should not be guessed. If not present, all types are allowed. Cannot include VarType.SCALAR.
+ * @param {String} [options.initialTimeSource]  A string specifiying the value of the animation timeline at start. Valid options are:
+ *                 ("present": closest to today's date,
+ *                  "start": start of time range of animation,
+ *                  "end": end of time range of animation,
+ *                  An ISO8601 date e.g. "2015-08-08": specified date or nearest if date is outside range).
  * @param {Number} [options.displayDuration] Passed on to TableColumn, unless overridden by options.columnOptions.
  * @param {String[]} [options.replaceWithNullValues] Passed on to TableColumn, unless overridden by options.columnOptions.
  * @param {String[]} [options.replaceWithZeroValues] Passed on to TableColumn, unless overridden by options.columnOptions.
@@ -68,6 +74,7 @@ var TableStructure = function(name, options) {
     this.shaveSeconds = defaultValue(options.shaveSeconds, defaultShaveSeconds);
     this.finalEndJulianDate = options.finalEndJulianDate;
     this.unallowedTypes = options.unallowedTypes;
+    this.initialTimeSource = options.initialTimeSource;
     this.displayDuration = options.displayDuration;
     this.replaceWithNullValues = options.replaceWithNullValues;
     this.replaceWithZeroValues = options.replaceWithZeroValues;
@@ -167,6 +174,8 @@ defineProperties(TableStructure.prototype, {
                     timeColumnToActivate.finishJulianDates = calculateFinishDates(sortedColumns, nameIdOrIndex, this);
                     timeColumnToActivate._timeIntervals = calculateTimeIntervals(timeColumnToActivate);
                     timeColumnToActivate._clock = createClock(timeColumnToActivate);
+                    timeColumnToActivate.initialTimeSource = this.initialTimeSource;
+                    setClockCurrentTime(timeColumnToActivate._clock, timeColumnToActivate.initialTimeSource);
                     this.columns = sortedColumns;
                 } else {
                     this._activeTimeColumnNameIdOrIndex = undefined;

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -174,8 +174,7 @@ defineProperties(TableStructure.prototype, {
                     timeColumnToActivate.finishJulianDates = calculateFinishDates(sortedColumns, nameIdOrIndex, this);
                     timeColumnToActivate._timeIntervals = calculateTimeIntervals(timeColumnToActivate);
                     timeColumnToActivate._clock = createClock(timeColumnToActivate);
-                    timeColumnToActivate.initialTimeSource = this.initialTimeSource;
-                    setClockCurrentTime(timeColumnToActivate._clock, timeColumnToActivate.initialTimeSource);
+                    setClockCurrentTime(timeColumnToActivate._clock, this.initialTimeSource);
                     this.columns = sortedColumns;
                 } else {
                     this._activeTimeColumnNameIdOrIndex = undefined;

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -45,6 +45,16 @@ var CsvCatalogItem = function(terria, url, options) {
      * @type {CatalogItem}
      */
     this.sourceCatalogItem = undefined;
+
+    /**
+     * Options for the value of the animation timeline at start. Valid options in config file are:
+     *     initialTimeSource: "present"                            // closest to today's date
+     *     initialTimeSource: "start"                              // start of time range of animation
+     *     initialTimeSource: "end"                                // end of time range of animation
+     *     initialTimeSource: An ISO8601 date e.g. "2015-08-08"    // specified date or nearest if date is outside range
+     * @type {String}
+     */
+    this.initialTimeSource = undefined;
 };
 
 inherit(TableCatalogItem, CsvCatalogItem);
@@ -130,6 +140,7 @@ function loadTableFromCsv(item, csvString) {
     var options = {
         idColumnNames: item.idColumns,
         isSampled: item.isSampled,
+        initialTimeSource: item.initialTimeSource,
         displayDuration: tableStyle.displayDuration,
         replaceWithNullValues: tableStyle.replaceWithNullValues,
         replaceWithZeroValues: tableStyle.replaceWithZeroValues,

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -19,6 +19,7 @@ var CompositeCatalogItem = require('./CompositeCatalogItem');
 var inherit = require('../Core/inherit');
 var TerriaError = require('../Core/TerriaError');
 var overrideProperty = require('../Core/overrideProperty');
+var setClockCurrentTime = require('./setClockCurrentTime');
 
 /**
  * A {@link CatalogItem} that is added to the map as a rasterized imagery layer.
@@ -142,7 +143,7 @@ var ImageryLayerCatalogItem = function(terria) {
                 this._clock.stopTime = stopTime;
                 this._clock.multiplier = timePerSecond;
 
-                _setClockCurrentTime(this);
+                setClockCurrentTime(this);
             }
             return this._clock;
         },
@@ -692,79 +693,5 @@ function fixNextLayerOrder(catalogItem) {
         }
     }
 }
-
-/**
- * Set time to nearest time to specified (may be start or end of time range if time is not in range).
- * @param {ImageryLayerCatalogItem} catalogItem catalog item to set timeslider current time on
- * @param {JulianDate} date to set
- * @private
- */
-function _setTimeIfInRange(catalogItem, timeToSet)
-{
-    if (JulianDate.lessThan(timeToSet, catalogItem._clock.startTime)) {
-        catalogItem._clock.currentTime = catalogItem._clock.startTime.clone(catalogItem._clock.currentTime);
-    }
-    else if (JulianDate.greaterThan(timeToSet, catalogItem._clock.stopTime)) {
-        catalogItem._clock.currentTime = catalogItem._clock.stopTime.clone(catalogItem._clock.currentTime);
-
-    } else {
-        catalogItem._clock.currentTime = timeToSet.clone(catalogItem._clock.currentTime);
-    }
-}
-
-/**
- * Sets the current time of the clock, so the animation starts at a point which can be user defined.
- * Valid options in config file are:
- *     initialTimeSource: "present"                            // closest to today's date
- *     initialTimeSource: "start"                              // start of time range of animation
- *     initialTimeSource: "end"                                // end of time range of animation
- *     initialTimeSource: An ISO8601 date e.g. "2015-08-08"    // specified date or nearest if date is outside range
- * @param {ImageryLayerCatalogItem} catalogItem catalog item to set timeslider current time on
- * @private
- */
-function _setClockCurrentTime(catalogItem)
-{
-    // This is our default. Start at the nearest instant in time.
-    var now = JulianDate.now();
-    _setTimeIfInRange(catalogItem, now);
-
-    var initialTimeSource = catalogItem.initialTimeSource;
-    if (!defined(initialTimeSource)) {
-        initialTimeSource = "present";
-    }
-    switch(initialTimeSource)
-    {
-        case "start":
-            catalogItem._clock.currentTime = catalogItem._clock.startTime.clone(catalogItem._clock.currentTime);
-            break;
-        case "end":
-            catalogItem._clock.currentTime = catalogItem._clock.stopTime.clone(catalogItem._clock.currentTime);
-            break;
-        case "present":
-            // Set to present by default.
-            break;
-        default:
-            // Note that if it's not an ISO8601 timestamp, it ends up being set to present.
-            // Find out whether it's an ISO8601 timestamp.
-            var timestamp;
-            try {
-                timestamp = JulianDate.fromIso8601(initialTimeSource);
-
-                // Cesium no longer validates dates in the release build.
-                // So convert to a JavaScript date as a cheesy means of checking if the date is valid.
-                if (isNaN(JulianDate.toDate(timestamp))) {
-                    throw new Error('Invalid Date');
-                }
-            }
-            catch (e) {
-                throw new TerriaError('Invalid initialTimeSource specified in config file: ' + initialTimeSource);
-            }
-            if (defined(timestamp))
-            {
-                _setTimeIfInRange(catalogItem, timestamp);
-            }
-    }
-}
-
 
 module.exports = ImageryLayerCatalogItem;

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -143,7 +143,7 @@ var ImageryLayerCatalogItem = function(terria) {
                 this._clock.stopTime = stopTime;
                 this._clock.multiplier = timePerSecond;
 
-                setClockCurrentTime(this);
+                setClockCurrentTime(this._clock, this.initialTimeSource);
             }
             return this._clock;
         },

--- a/lib/Models/setClockCurrentTime.js
+++ b/lib/Models/setClockCurrentTime.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/*global require*/
+var defined = require('terriajs-cesium/Source/Core/defined');
+var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
+var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
+
+/**
+ * Set time to nearest time to specified (may be start or end of time range if time is not in range).
+ * @param {ImageryLayerCatalogItem} catalogItem catalog item to set timeslider current time on
+ * @param {JulianDate} date to set
+ * @private
+ */
+function _setTimeIfInRange(catalogItem, timeToSet)
+{
+    if (JulianDate.lessThan(timeToSet, catalogItem._clock.startTime)) {
+        catalogItem._clock.currentTime = catalogItem._clock.startTime.clone(catalogItem._clock.currentTime);
+    }
+    else if (JulianDate.greaterThan(timeToSet, catalogItem._clock.stopTime)) {
+        catalogItem._clock.currentTime = catalogItem._clock.stopTime.clone(catalogItem._clock.currentTime);
+
+    } else {
+        catalogItem._clock.currentTime = timeToSet.clone(catalogItem._clock.currentTime);
+    }
+}
+
+/**
+ * Sets the current time of the clock, so the animation starts at a point which can be user defined.
+ * Valid options in config file are:
+ *     initialTimeSource: "present"                            // closest to today's date
+ *     initialTimeSource: "start"                              // start of time range of animation
+ *     initialTimeSource: "end"                                // end of time range of animation
+ *     initialTimeSource: An ISO8601 date e.g. "2015-08-08"    // specified date or nearest if date is outside range
+ * @param {ImageryLayerCatalogItem} catalogItem catalog item to set timeslider current time on
+ * @private
+ */
+function setClockCurrentTime(catalogItem)
+{
+    // This is our default. Start at the nearest instant in time.
+    var now = JulianDate.now();
+    _setTimeIfInRange(catalogItem, now);
+
+    var initialTimeSource = catalogItem.initialTimeSource;
+    if (!defined(initialTimeSource)) {
+        initialTimeSource = "present";
+    }
+    switch(initialTimeSource)
+    {
+        case "start":
+            catalogItem._clock.currentTime = catalogItem._clock.startTime.clone(catalogItem._clock.currentTime);
+            break;
+        case "end":
+            catalogItem._clock.currentTime = catalogItem._clock.stopTime.clone(catalogItem._clock.currentTime);
+            break;
+        case "present":
+            // Set to present by default.
+            break;
+        default:
+            // Note that if it's not an ISO8601 timestamp, it ends up being set to present.
+            // Find out whether it's an ISO8601 timestamp.
+            var timestamp;
+            try {
+                timestamp = JulianDate.fromIso8601(initialTimeSource);
+
+                // Cesium no longer validates dates in the release build.
+                // So convert to a JavaScript date as a cheesy means of checking if the date is valid.
+                if (isNaN(JulianDate.toDate(timestamp))) {
+                    throw new Error('Invalid Date');
+                }
+            }
+            catch (e) {
+                throw new TerriaError('Invalid initialTimeSource specified in config file: ' + initialTimeSource);
+            }
+            if (defined(timestamp))
+            {
+                _setTimeIfInRange(catalogItem, timestamp);
+            }
+    }
+}
+
+module.exports = setClockCurrentTime;

--- a/lib/Models/setClockCurrentTime.js
+++ b/lib/Models/setClockCurrentTime.js
@@ -11,16 +11,16 @@ var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
  * @param {JulianDate} date to set
  * @private
  */
-function _setTimeIfInRange(catalogItem, timeToSet)
+function _setTimeIfInRange(clock, timeToSet)
 {
-    if (JulianDate.lessThan(timeToSet, catalogItem._clock.startTime)) {
-        catalogItem._clock.currentTime = catalogItem._clock.startTime.clone(catalogItem._clock.currentTime);
+    if (JulianDate.lessThan(timeToSet, clock.startTime)) {
+        clock.currentTime = clock.startTime.clone(clock.currentTime);
     }
-    else if (JulianDate.greaterThan(timeToSet, catalogItem._clock.stopTime)) {
-        catalogItem._clock.currentTime = catalogItem._clock.stopTime.clone(catalogItem._clock.currentTime);
+    else if (JulianDate.greaterThan(timeToSet, clock.stopTime)) {
+        clock.currentTime = clock.stopTime.clone(clock.currentTime);
 
     } else {
-        catalogItem._clock.currentTime = timeToSet.clone(catalogItem._clock.currentTime);
+        clock.currentTime = timeToSet.clone(clock.currentTime);
     }
 }
 
@@ -34,23 +34,20 @@ function _setTimeIfInRange(catalogItem, timeToSet)
  * @param {ImageryLayerCatalogItem} catalogItem catalog item to set timeslider current time on
  * @private
  */
-function setClockCurrentTime(catalogItem)
+function setClockCurrentTime(clock, initialTimeSource)
 {
     // This is our default. Start at the nearest instant in time.
     var now = JulianDate.now();
-    _setTimeIfInRange(catalogItem, now);
+    _setTimeIfInRange(clock, now);
 
-    var initialTimeSource = catalogItem.initialTimeSource;
-    if (!defined(initialTimeSource)) {
-        initialTimeSource = "present";
-    }
+    initialTimeSource = defaultValue(initialTimeSource, "present");
     switch(initialTimeSource)
     {
         case "start":
-            catalogItem._clock.currentTime = catalogItem._clock.startTime.clone(catalogItem._clock.currentTime);
+            clock.currentTime = clock.startTime.clone(clock.currentTime);
             break;
         case "end":
-            catalogItem._clock.currentTime = catalogItem._clock.stopTime.clone(catalogItem._clock.currentTime);
+            clock.currentTime = clock.stopTime.clone(clock.currentTime);
             break;
         case "present":
             // Set to present by default.
@@ -73,7 +70,7 @@ function setClockCurrentTime(catalogItem)
             }
             if (defined(timestamp))
             {
-                _setTimeIfInRange(catalogItem, timestamp);
+                _setTimeIfInRange(clock, timestamp);
             }
     }
 }

--- a/lib/Models/setClockCurrentTime.js
+++ b/lib/Models/setClockCurrentTime.js
@@ -7,8 +7,8 @@ var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 
 /**
  * Set time to nearest time to specified (may be start or end of time range if time is not in range).
- * @param {ImageryLayerCatalogItem} catalogItem catalog item to set timeslider current time on
- * @param {JulianDate} date to set
+ * @param {DataSourceClock} clock clock to set current time on.
+ * @param {JulianDate} timeToSet the time to set
  * @private
  */
 function _setTimeIfInRange(clock, timeToSet)
@@ -18,21 +18,19 @@ function _setTimeIfInRange(clock, timeToSet)
     }
     else if (JulianDate.greaterThan(timeToSet, clock.stopTime)) {
         clock.currentTime = clock.stopTime.clone(clock.currentTime);
-
     } else {
         clock.currentTime = timeToSet.clone(clock.currentTime);
     }
 }
 
 /**
- * Sets the current time of the clock, so the animation starts at a point which can be user defined.
- * Valid options in config file are:
- *     initialTimeSource: "present"                            // closest to today's date
- *     initialTimeSource: "start"                              // start of time range of animation
- *     initialTimeSource: "end"                                // end of time range of animation
- *     initialTimeSource: An ISO8601 date e.g. "2015-08-08"    // specified date or nearest if date is outside range
- * @param {ImageryLayerCatalogItem} catalogItem catalog item to set timeslider current time on
- * @private
+ * Sets the current time of the clock, using a string defined specification for the time point to use.
+ * @param {DataSourceClock} clock clock to set the current time on.
+ * @param {String} initialTimeSource A string specifiying the value to use when setting the currentTime of the clock. Valid options are:
+ *                 ("present": closest to today's date,
+ *                  "start": start of time range of animation,
+ *                  "end": end of time range of animation,
+ *                  An ISO8601 date e.g. "2015-08-08": specified date or nearest if date is outside range).
  */
 function setClockCurrentTime(clock, initialTimeSource)
 {

--- a/test/Map/TableStructureSpec.js
+++ b/test/Map/TableStructureSpec.js
@@ -500,4 +500,88 @@ describe('TableStructure', function() {
         ]);
     });
 
+    describe('Time slider initial time as specified by initialTimeSource ', function() {
+        var terria;
+        var catalogItem;
+
+        beforeEach(function() {
+            terria = new Terria({
+                baseUrl: './'
+            });
+
+            catalogItem = new ImageryLayerCatalogItem(terria);
+        });
+
+        // Future developers take note: some of these tests will stop working in August 3015.
+        it('should be start if "start" set', function() {
+            catalogItem.initialTimeSource = 'start';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2013-08-07');
+        });
+
+        it('should be current time if "present" set', function() {
+            catalogItem.initialTimeSource = 'present';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('3115-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var dateNow = (new Date()).toISOString();
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            dateNow = dateNow.substr(0, 10);
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe(dateNow);
+        });
+
+        it('should be last time if "end" set', function() {
+            catalogItem.initialTimeSource = 'end';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2015-08-09');
+        });
+
+        it('should be set to date specified if date is specified', function() {
+            catalogItem.initialTimeSource = '2015-08-08T00:00:00.00Z';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-11T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2015-08-08');
+        });
+
+        it('should throw if a rubbish string is specified', function() {
+            catalogItem.initialTimeSource = '2015z08-08';
+
+            expect(function() {
+                catalogItem.intervals = new TimeIntervalCollection([
+                        new TimeInterval({
+                            start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                            stop: JulianDate.fromIso8601('2115-08-09T00:00:00.00Z')
+                        })
+                ]);
+            }).toThrow();
+        });
+    });
 });

--- a/test/Map/TableStructureSpec.js
+++ b/test/Map/TableStructureSpec.js
@@ -501,42 +501,35 @@ describe('TableStructure', function() {
     });
 
     describe('Time slider initial time as specified by initialTimeSource ', function() {
-        var terria;
-        var catalogItem;
+        var tableStructure
 
         beforeEach(function() {
-            terria = new Terria({
-                baseUrl: './'
-            });
-
-            catalogItem = new ImageryLayerCatalogItem(terria);
+            tableStructure = new TableStructure();
         });
 
-        // Future developers take note: some of these tests will stop working in August 3015.
+        // Future developers take note: some of these tests will stop working sometime after August 3015.
         it('should be start if "start" set', function() {
-            catalogItem.initialTimeSource = 'start';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            var tableStructure = new TableStructure('test', {initialTimeSource: 'start'});
+            // Note: Specifying the time in this way means that the end date will be after 2015-08-09, but since we don't care particularly about the end date this is enough precision for this test.
+            var data = [['date'], ['2013-08-07T00:00:00.00Z'], ['2015-08-09T00:00:00.00Z']];
+            TableStructure.fromJson(data, tableStructure);
+            tableStructure.setActiveTimeColumn();
+
+            var currentTime = JulianDate.toIso8601(tableStructure.clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2013-08-07');
         });
 
         it('should be current time if "present" set', function() {
-            catalogItem.initialTimeSource = 'present';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('3115-08-09T00:00:00.00Z')
-                    })
-            ]);
+            var tableStructure = new TableStructure('test', {initialTimeSource: 'present'});
+            // Note: Specifying the time in this way means that the end date will be after 2015-08-09, but since we don't care particularly about the end date this is enough precision for this test.
+            var data = [['date'], ['2013-08-07T00:00:00.00Z'], ['3115-08-09T00:00:00.00Z']];
+            TableStructure.fromJson(data, tableStructure);
+            tableStructure.setActiveTimeColumn();
+
             var dateNow = (new Date()).toISOString();
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            var currentTime = JulianDate.toIso8601(tableStructure.clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             dateNow = dateNow.substr(0, 10);
             currentTime = currentTime.substr(0, 10);
@@ -544,43 +537,37 @@ describe('TableStructure', function() {
         });
 
         it('should be last time if "end" set', function() {
-            catalogItem.initialTimeSource = 'end';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            var tableStructure = new TableStructure('test', {initialTimeSource: 'end', finalEndJulianDate: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')});
+            var data = [['date'], ['2013-08-07T00:00:00.00Z']];
+            TableStructure.fromJson(data, tableStructure);
+            tableStructure.setActiveTimeColumn();
+
+            var currentTime = JulianDate.toIso8601(tableStructure.clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2015-08-09');
         });
 
         it('should be set to date specified if date is specified', function() {
-            catalogItem.initialTimeSource = '2015-08-08T00:00:00.00Z';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-11T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            var tableStructure = new TableStructure('test', {initialTimeSource: '2015-08-08T00:00:00.00Z'});
+            // Note: Specifying the time in this way means that the end date will be after 2015-08-11, but since we don't care particularly about the end date this is enough precision for this test.
+            var data = [['date'], ['2013-08-07T00:00:00.00Z'], ['2015-08-11T00:00:00.00Z']];
+            TableStructure.fromJson(data, tableStructure);
+            tableStructure.setActiveTimeColumn();
+
+            var currentTime = JulianDate.toIso8601(tableStructure.clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2015-08-08');
         });
 
         it('should throw if a rubbish string is specified', function() {
-            catalogItem.initialTimeSource = '2015z08-08';
+            var tableStructure = new TableStructure('test', {initialTimeSource: '2015z08-08'});
+            var data = [['date'], ['2013-08-07T00:00:00.00Z'], ['2015-08-11T00:00:00.00Z']];
+            TableStructure.fromJson(data, tableStructure);
 
             expect(function() {
-                catalogItem.intervals = new TimeIntervalCollection([
-                        new TimeInterval({
-                            start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                            stop: JulianDate.fromIso8601('2115-08-09T00:00:00.00Z')
-                        })
-                ]);
+                tableStructure.setActiveTimeColumn();
             }).toThrow();
         });
     });

--- a/test/Models/ImageryLayerCatalogItemSpec.js
+++ b/test/Models/ImageryLayerCatalogItemSpec.js
@@ -22,37 +22,8 @@ describe('ImageryLayerCatalogItem', function() {
         });
 
         // Future developers take note: some of these tests will stop working in August 3015.
-        it('should be present if not provided', function() {
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2015-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('3015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var dateNow = (new Date()).toISOString();
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
-            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
-            dateNow = dateNow.substr(0, 10);
-            currentTime = currentTime.substr(0, 10);
-            expect(currentTime).toBe(dateNow);
-        });
-
         it('should be start if "start" set', function() {
             catalogItem.initialTimeSource = 'start';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
-            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
-            currentTime = currentTime.substr(0, 10);
-            expect(currentTime).toBe('2013-08-07');
-        });
-
-        it('should be start if date specified is before range', function() {
-            catalogItem.initialTimeSource = '2000-08-08';
             catalogItem.intervals = new TimeIntervalCollection([
                     new TimeInterval({
                         start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
@@ -95,20 +66,6 @@ describe('ImageryLayerCatalogItem', function() {
             expect(currentTime).toBe('2015-08-09');
         });
 
-        it('should be last time if date specified is after range', function() {
-            catalogItem.initialTimeSource = '3015-08-08';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
-            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
-            currentTime = currentTime.substr(0, 10);
-            expect(currentTime).toBe('2015-08-09');
-        });
-
         it('should be set to date specified if date is specified', function() {
             catalogItem.initialTimeSource = '2015-08-08T00:00:00.00Z';
             catalogItem.intervals = new TimeIntervalCollection([
@@ -121,34 +78,6 @@ describe('ImageryLayerCatalogItem', function() {
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2015-08-08');
-        });
-
-        it('should be set to start if date specified is before time range', function() {
-            catalogItem.initialTimeSource = '2013-01-01';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2015-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
-            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
-            currentTime = currentTime.substr(0, 10);
-            expect(currentTime).toBe('2015-08-07');
-        });
-
-        it('should be set to end if date specified is after time range', function() {
-            catalogItem.initialTimeSource = '2222-08-08';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2015-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
-            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
-            currentTime = currentTime.substr(0, 10);
-            expect(currentTime).toBe('2015-08-09');
         });
 
         it('should throw if a rubbish string is specified', function() {

--- a/test/Models/setClockCurrentTimeSpec.js
+++ b/test/Models/setClockCurrentTimeSpec.js
@@ -1,0 +1,167 @@
+'use strict';
+
+/*global require,beforeEach*/
+var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
+var Terria = require('../../lib/Models/Terria');
+
+var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
+var TimeIntervalCollection = require('terriajs-cesium/Source/Core/TimeIntervalCollection');
+var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
+
+describe('ImageryLayerCatalogItem', function() {
+    describe('Time slider initial time as specified by initialTimeSource ', function() {
+        var terria;
+        var catalogItem;
+
+        beforeEach(function() {
+            terria = new Terria({
+                baseUrl: './'
+            });
+
+            catalogItem = new ImageryLayerCatalogItem(terria);
+        });
+
+        // Future developers take note: some of these tests will stop working in August 3015.
+        it('should be present if not provided', function() {
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2015-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('3015-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var dateNow = (new Date()).toISOString();
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            dateNow = dateNow.substr(0, 10);
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe(dateNow);
+        });
+
+        it('should be start if "start" set', function() {
+            catalogItem.initialTimeSource = 'start';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2013-08-07');
+        });
+
+        it('should be start if date specified is before range', function() {
+            catalogItem.initialTimeSource = '2000-08-08';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2013-08-07');
+        });
+
+        it('should be current time if "present" set', function() {
+            catalogItem.initialTimeSource = 'present';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('3115-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var dateNow = (new Date()).toISOString();
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            dateNow = dateNow.substr(0, 10);
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe(dateNow);
+        });
+
+        it('should be last time if "end" set', function() {
+            catalogItem.initialTimeSource = 'end';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2015-08-09');
+        });
+
+        it('should be last time if date specified is after range', function() {
+            catalogItem.initialTimeSource = '3015-08-08';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2015-08-09');
+        });
+
+        it('should be set to date specified if date is specified', function() {
+            catalogItem.initialTimeSource = '2015-08-08T00:00:00.00Z';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-11T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2015-08-08');
+        });
+
+        it('should be set to start if date specified is before time range', function() {
+            catalogItem.initialTimeSource = '2013-01-01';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2015-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2015-08-07');
+        });
+
+        it('should be set to end if date specified is after time range', function() {
+            catalogItem.initialTimeSource = '2222-08-08';
+            catalogItem.intervals = new TimeIntervalCollection([
+                    new TimeInterval({
+                        start: JulianDate.fromIso8601('2015-08-07T00:00:00.00Z'),
+                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
+                    })
+            ]);
+            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+            currentTime = currentTime.substr(0, 10);
+            expect(currentTime).toBe('2015-08-09');
+        });
+
+        it('should throw if a rubbish string is specified', function() {
+            catalogItem.initialTimeSource = '2015z08-08';
+
+            expect(function() {
+                catalogItem.intervals = new TimeIntervalCollection([
+                        new TimeInterval({
+                            start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
+                            stop: JulianDate.fromIso8601('2115-08-09T00:00:00.00Z')
+                        })
+                ]);
+            }).toThrow();
+        });
+    });
+});

--- a/test/Models/setClockCurrentTimeSpec.js
+++ b/test/Models/setClockCurrentTimeSpec.js
@@ -2,35 +2,26 @@
 
 /*global require,beforeEach*/
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
-var Terria = require('../../lib/Models/Terria');
+var DataSourceClock = require('terriajs-cesium/Source/DataSources/DataSourceClock');
+var setClockCurrentTime = require('../../lib/Models/setClockCurrentTime');
 
-var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
-var TimeIntervalCollection = require('terriajs-cesium/Source/Core/TimeIntervalCollection');
-var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
-
-describe('ImageryLayerCatalogItem', function() {
+describe('setClockCurrentTime', function() {
     describe('Time slider initial time as specified by initialTimeSource ', function() {
-        var terria;
-        var catalogItem;
+        var clock;
 
         beforeEach(function() {
-            terria = new Terria({
-                baseUrl: './'
-            });
-
-            catalogItem = new ImageryLayerCatalogItem(terria);
+            clock = new DataSourceClock();
         });
 
         // Future developers take note: some of these tests will stop working in August 3015.
         it('should be present if not provided', function() {
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2015-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('3015-08-09T00:00:00.00Z')
-                    })
-            ]);
+            clock.startTime = JulianDate.fromIso8601('2015-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('3015-08-09T00:00:00.00Z');
+
+            setClockCurrentTime(clock);
+
             var dateNow = (new Date()).toISOString();
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            var currentTime = JulianDate.toIso8601(clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             dateNow = dateNow.substr(0, 10);
             currentTime = currentTime.substr(0, 10);
@@ -38,43 +29,37 @@ describe('ImageryLayerCatalogItem', function() {
         });
 
         it('should be start if "start" set', function() {
-            catalogItem.initialTimeSource = 'start';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            clock.startTime = JulianDate.fromIso8601('2013-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('2015-08-09T00:00:00.00Z');
+
+            setClockCurrentTime(clock, 'start');
+
+            var currentTime = JulianDate.toIso8601(clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2013-08-07');
         });
 
         it('should be start if date specified is before range', function() {
-            catalogItem.initialTimeSource = '2000-08-08';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            clock.startTime = JulianDate.fromIso8601('2013-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('2015-08-09T00:00:00.00Z');
+
+            setClockCurrentTime(clock, '2000-08-08');
+
+            var currentTime = JulianDate.toIso8601(clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2013-08-07');
         });
 
         it('should be current time if "present" set', function() {
-            catalogItem.initialTimeSource = 'present';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('3115-08-09T00:00:00.00Z')
-                    })
-            ]);
+            clock.startTime = JulianDate.fromIso8601('2013-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('3115-08-09T00:00:00.00Z');
+
+            setClockCurrentTime(clock, 'present');
+
             var dateNow = (new Date()).toISOString();
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            var currentTime = JulianDate.toIso8601(clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             dateNow = dateNow.substr(0, 10);
             currentTime = currentTime.substr(0, 10);
@@ -82,85 +67,71 @@ describe('ImageryLayerCatalogItem', function() {
         });
 
         it('should be last time if "end" set', function() {
-            catalogItem.initialTimeSource = 'end';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            clock.startTime = JulianDate.fromIso8601('2013-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('2015-08-09T00:00:00.00Z');
+
+            setClockCurrentTime(clock, 'end');
+
+            var currentTime = JulianDate.toIso8601(clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2015-08-09');
         });
 
         it('should be last time if date specified is after range', function() {
-            catalogItem.initialTimeSource = '3015-08-08';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            clock.startTime = JulianDate.fromIso8601('2013-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('2015-08-09T00:00:00.00Z');
+
+            setClockCurrentTime(clock, '3015-08-08');
+
+            var currentTime = JulianDate.toIso8601(clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2015-08-09');
         });
 
         it('should be set to date specified if date is specified', function() {
-            catalogItem.initialTimeSource = '2015-08-08T00:00:00.00Z';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-11T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            clock.startTime = JulianDate.fromIso8601('2013-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('2015-08-11T00:00:00.00Z');
+
+            setClockCurrentTime(clock, '2015-08-08T00:00:00.00Z');
+
+            var currentTime = JulianDate.toIso8601(clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2015-08-08');
         });
 
         it('should be set to start if date specified is before time range', function() {
-            catalogItem.initialTimeSource = '2013-01-01';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2015-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            clock.startTime = JulianDate.fromIso8601('2015-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('2015-08-09T00:00:00.00Z');
+
+            setClockCurrentTime(clock, '2013-01-01');
+
+            var currentTime = JulianDate.toIso8601(clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2015-08-07');
         });
 
         it('should be set to end if date specified is after time range', function() {
-            catalogItem.initialTimeSource = '2222-08-08';
-            catalogItem.intervals = new TimeIntervalCollection([
-                    new TimeInterval({
-                        start: JulianDate.fromIso8601('2015-08-07T00:00:00.00Z'),
-                        stop: JulianDate.fromIso8601('2015-08-09T00:00:00.00Z')
-                    })
-            ]);
-            var currentTime = JulianDate.toIso8601(catalogItem._clock.currentTime, 3);
+            clock.startTime = JulianDate.fromIso8601('2015-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('2015-08-09T00:00:00.00Z');
+
+            setClockCurrentTime(clock, '2222-08-08');
+
+            var currentTime = JulianDate.toIso8601(clock.currentTime, 3);
             // Do not compare time, because on some systems the second could have ticked over between getting the two times.
             currentTime = currentTime.substr(0, 10);
             expect(currentTime).toBe('2015-08-09');
         });
 
         it('should throw if a rubbish string is specified', function() {
-            catalogItem.initialTimeSource = '2015z08-08';
+            clock.startTime = JulianDate.fromIso8601('2013-08-07T00:00:00.00Z');
+            clock.stopTime = JulianDate.fromIso8601('2115-08-09T00:00:00.00Z');
 
             expect(function() {
-                catalogItem.intervals = new TimeIntervalCollection([
-                        new TimeInterval({
-                            start: JulianDate.fromIso8601('2013-08-07T00:00:00.00Z'),
-                            stop: JulianDate.fromIso8601('2115-08-09T00:00:00.00Z')
-                        })
-                ]);
+                setClockCurrentTime(clock, '2015z08-08');
             }).toThrow();
         });
     });


### PR DESCRIPTION
I have factored by breaking setClockCurrentTime out of ImageryLayerCatalogItem. I've put this in a file along side ImageryLayerCatalogItem but I'm not sure if this is the best location for this reused function because I don't exactly understand the distinction in the directory layout so please review this and let me know where this should belong.