### PR TITLE
Use unique IDs for linear gradients when generating legends.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Added `CatalogShortcut` for creating tool items for linking to a `CatalogItem`.
 * Renamed ViewState.viewCatalogItem() to ViewState.viewCatalogMember() to reflect that it can be used for all catalogMembers, not just catlogItems.
 * Fixed a bug that could crash a crash when switching to 2D when the `initialView` was just a `Rectangle` instead of a `CameraView`.
+* Fixed a bug that caused multiple layers with generated, gradient legends to all show the same legend on the Workbench.
 
 ### 5.2.11
 

--- a/lib/Map/Legend.js
+++ b/lib/Map/Legend.js
@@ -230,16 +230,18 @@ function drawVariableName(legend) {
     return y;
 }
 
+var gradientCount = 0;
 
 /* The older, non-quantised, smooth gradient. */
 function drawGradient(legend, barGroup, y) {
+    var id = 'gradient' + (++gradientCount);
     var defs = addSvgElement(legend, 'defs', {}); // apparently it's ok to have the defs anywhere in the doc
     var linearGradient = svgElement(legend, 'linearGradient', {
         x1: '0',
         x2: '0',
         y1: '1',
         y2: '0',
-        id: 'gradient'
+        id: id
     });
     legend.gradientColorMap.forEach(function(c, i) {
         linearGradient.appendChild(svgElement(legend, 'stop', {
@@ -263,7 +265,7 @@ function drawGradient(legend, barGroup, y) {
         y: y,
         width: legend.itemWidth,
         height: barHeight,
-        fill: 'url(#gradient)'
+        fill: 'url(#' + id + ')'
     }, 'gradient-bar');
 
     return barHeight;

--- a/lib/Map/Legend.js
+++ b/lib/Map/Legend.js
@@ -234,7 +234,7 @@ var gradientCount = 0;
 
 /* The older, non-quantised, smooth gradient. */
 function drawGradient(legend, barGroup, y) {
-    var id = 'gradient' + (++gradientCount);
+    var id = 'terriajs-legend-gradient' + (++gradientCount);
     var defs = addSvgElement(legend, 'defs', {}); // apparently it's ok to have the defs anywhere in the doc
     var linearGradient = svgElement(legend, 'linearGradient', {
         x1: '0',


### PR DESCRIPTION
Fixes #2639 
