### PR TITLE
2588 Request tokens from terriajs-server and plumb them into ArcGisMapServerImageryProvider.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,10 @@
 Change Log
 ==========
 
-### 5.#.#
+### 5.4.0
 
-* Added the ability to use tokens from terriajs-server for layers requiring ESRI tokens.
-### 5.3.1
 * Catalog group items are now sorted by their in-catalog name
+* Added the ability to use tokens from terriajs-server for layers requiring ESRI tokens.
 
 ### 5.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.#.#
+
+* Added the ability to use tokens from terriajs-server for layers requiring ESRI tokens.
+
 ### 5.3.0
 
 * Added the ability to use the analytics region picker with vector tile region mapping by specifiying a WMS server & layer for analytics only.

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -206,29 +206,34 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
             layers = uri.segment(-1);
             this.layers = layers; // ## is this ok to do?
         }
-        var serviceUri = getBaseURI(this);
-        var layersUri = getBaseURI(this).segment(layers); // either 'layers' or a number
-        var legendUri = getBaseURI(this).segment('legend');
 
-        var serviceMetadata = this._mapServerData || getJson(this, serviceUri);
-        var layersMetadata = this._layersData || getJson(this, layersUri);
-        var legendMetadata = this._legendData || getJson(this, legendUri);
+        function requestMetadata() {
+            var serviceUri = getBaseURI(that);
+            var layersUri = getBaseURI(that).segment(layers); // either 'layers' or a number
+            var legendUri = getBaseURI(that).segment('legend');
 
-        return when.all([serviceMetadata, layersMetadata, legendMetadata]).then(function(results) {
-            if (defined(results[1].layers)) {
-                that.updateFromMetadata(results[0], results[1], results[2], false);
-            } else if (defined(results[1].id)) {
-                // Results of a single layer query. Make it look like a multi layer query result.
-                that.updateFromMetadata(results[0], {"layers": [results[1]]}, results[2], false, results[1]);
-            } else {
-                var message = defined(results[0].error) ? results[0].error.message : 'This dataset returned unusable metadata.';
-                throw new TerriaError({
-                    title: 'ArcGIS Mapserver Error',
-                    message: '<p>' + message + '</p><p>Please report it by \
+            var serviceMetadata = that._mapServerData || getJson(that, serviceUri);
+            var layersMetadata = that._layersData || getJson(that, layersUri);
+            var legendMetadata = that._legendData || getJson(that, legendUri);
+
+            return when.all([serviceMetadata, layersMetadata, legendMetadata]).then(function(results) {
+                if (defined(results[1].layers)) {
+                    that.updateFromMetadata(results[0], results[1], results[2], false);
+                } else if (defined(results[1].id)) {
+                    // Results of a single layer query. Make it look like a multi layer query result.
+                    that.updateFromMetadata(results[0], {"layers": [results[1]]}, results[2], false, results[1]);
+                } else {
+                    var message = defined(results[0].error) ? results[0].error.message : 'This dataset returned unusable metadata.';
+                    throw new TerriaError({
+                        title: 'ArcGIS Mapserver Error',
+                        message: '<p>' + message + '</p><p>Please report it by \
 sending an email to <a href="mailto:' + that.terria.supportEmail + '">' + that.terria.supportEmail + '</a>.</p>'
-                });
-            }
-        });
+                    });
+                }
+            });
+        }
+
+        return requestMetadata();
     }
 };
 

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -217,10 +217,10 @@ function getToken(item) {
         if (defined(token.token)) {
             item._lastToken = token.token;
             return token.token;
-        } else {
-            item._lastToken = undefined;
-            throw new RuntimeError('The token server responded with an invalid token.');
         }
+
+        item._lastToken = undefined;
+        throw new RuntimeError('The token server responded with an invalid token.');
     }).otherwise(() => {
         item._lastToken = undefined;
         throw new RuntimeError('Unable to request a token from the token server.');

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -288,7 +288,7 @@ sending an email to <a href="mailto:' + that.terria.supportEmail + '">' + that.t
 
         if (this.tokenSource) {
             return getToken(this).then(function (token) {
-                requestMetadata (token);
+                return requestMetadata (token);
             });
         } else {
             return requestMetadata();

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -244,14 +244,15 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
     // Strip trailing forward slash if exists
     baseUrl = baseUrl.replace(/\/$/g, '');
 
-    var imageryProvider = new ArcGisMapServerImageryProvider({
+    let imageryOptions = {
         url: cleanAndProxyUrl(this, baseUrl),
         layers: getLayerList(this),
         tilingScheme: new WebMercatorTilingScheme(),
         maximumLevel: maximumLevel,
         mapServerData: this._mapServerData,
         enablePickFeatures: defaultValue(this.allowFeaturePicking, true)
-    });
+    };
+    var imageryProvider = new ArcGisMapServerImageryProvider(imageryOptions);
 
     var maximumLevelBeforeMessage = maximumScaleToLevel(this.maximumScaleBeforeMessage);
     if (defined(maximumLevelBeforeMessage)) {

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -306,7 +306,7 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
         imageryOptions.requestNewToken = () => getToken(this);
 
         if (defined(this._lastToken)) {
-            // Using the last token is an optomisation; if its still valid it will speed up
+            // Using the last token is an optimization; if its still valid it will speed up
             // the operation and if its not then it will just be requested when its needed.
             imageryOptions.token = this._lastToken;
         }

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -252,7 +252,12 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
             this.layers = layers; // ## is this ok to do?
         }
 
-        function requestMetadata(token) {
+        var promise = when();
+        if (this.tokenSource) {
+            promise = getToken(this);
+        }
+
+        return promise.then(function (token) {
             var serviceUri = getBaseURI(that);
             var layersUri = getBaseURI(that).segment(layers); // either 'layers' or a number
             var legendUri = getBaseURI(that).segment('legend');
@@ -283,15 +288,7 @@ sending an email to <a href="mailto:' + that.terria.supportEmail + '">' + that.t
                     });
                 }
             });
-        }
-
-        if (this.tokenSource) {
-            return getToken(this).then(function (token) {
-                return requestMetadata (token);
-            });
-        } else {
-            return requestMetadata();
-        }
+        });
     }
 };
 

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -227,19 +227,6 @@ function getToken(item) {
     });
 }
 
-function appendQuery(query, addition) {
-    if (addition) {
-        if (query) {
-            query += '&' + addition;
-        }
-        else {
-            query = addition;
-        }
-    }
-
-    return query;
-}
-
 ArcGisMapServerCatalogItem.prototype._load = function() {
     var that = this;
 
@@ -264,9 +251,9 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
 
             if (token)
             {
-                serviceUri._parts.query = appendQuery(serviceUri._parts.query, 'token=' + token);
-                layersUri._parts.query = appendQuery(layersUri._parts.query,  'token=' + token);
-                legendUri._parts.query = appendQuery(legendUri._parts.query,  'token=' + token);
+                serviceUri.addQuery('token', token);
+                layersUri.addQuery('token', token);
+                legendUri.addQuery('token', token);
             }
 
             var serviceMetadata = that._mapServerData || getJson(that, serviceUri);

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -244,7 +244,7 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
     // Strip trailing forward slash if exists
     baseUrl = baseUrl.replace(/\/$/g, '');
 
-    let imageryOptions = {
+    const imagryOptions = {
         url: cleanAndProxyUrl(this, baseUrl),
         layers: getLayerList(this),
         tilingScheme: new WebMercatorTilingScheme(),
@@ -252,7 +252,7 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
         mapServerData: this._mapServerData,
         enablePickFeatures: defaultValue(this.allowFeaturePicking, true)
     };
-    var imageryProvider = new ArcGisMapServerImageryProvider(imageryOptions);
+    var imageryProvider = new ArcGisMapServerImageryProvider(imagryOptions);
 
     var maximumLevelBeforeMessage = maximumScaleToLevel(this.maximumScaleBeforeMessage);
     if (defined(maximumLevelBeforeMessage)) {

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -14,6 +14,7 @@ var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var Legend = require('../Map/Legend');
 var LegendUrl = require('../Map/LegendUrl');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
+var loadWithXhr = require('terriajs-cesium/Source/Core/loadWithXhr');
 var Metadata = require('./Metadata');
 var MetadataItem = require('./MetadataItem');
 var overrideProperty = require('../Core/overrideProperty');
@@ -201,6 +202,45 @@ function getJson(item, uri) {
     return loadJson(proxyCatalogItemUrl(item, uri.addQuery('f', 'json').toString(), '1d'));
 }
 
+function getToken(item) {
+    const options = {
+        url: item.tokenSource,
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        data: JSON.stringify({'url': item.url})
+    };
+
+    return loadWithXhr(options).then(function (result) {
+        const token = JSON.parse(result);
+
+        if (defined(token.token)) {
+            item._lastToken = token.token;
+            return token.token;
+        } else {
+            delete item._lastToken;
+            // todo: how should I really be dealing with failure here...both this current implmentation and developer error don't really feel right....check this with kring
+            return undefined;
+        }
+    }).otherwise(() => {
+        delete item._lastToken;
+        // todo: how should I really be dealing with failure here...both this current implmentation and developer error don't really feel right....check this with kring
+        return undefined;
+    });
+}
+
+function appendQuery(query, addition) {
+    if (addition) {
+        if (query) {
+            query += '&' + addition;
+        }
+        else {
+            query = addition;
+        }
+    }
+
+    return query;
+}
+
 ArcGisMapServerCatalogItem.prototype._load = function() {
     var that = this;
 
@@ -213,10 +253,17 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
             this.layers = layers; // ## is this ok to do?
         }
 
-        function requestMetadata() {
+        function requestMetadata(token) {
             var serviceUri = getBaseURI(that);
             var layersUri = getBaseURI(that).segment(layers); // either 'layers' or a number
             var legendUri = getBaseURI(that).segment('legend');
+
+            if (token)
+            {
+                serviceUri._parts.query = appendQuery(serviceUri._parts.query, 'token=' + token);
+                layersUri._parts.query = appendQuery(layersUri._parts.query,  'token=' + token);
+                legendUri._parts.query = appendQuery(legendUri._parts.query,  'token=' + token);
+            }
 
             var serviceMetadata = that._mapServerData || getJson(that, serviceUri);
             var layersMetadata = that._layersData || getJson(that, layersUri);
@@ -239,7 +286,13 @@ sending an email to <a href="mailto:' + that.terria.supportEmail + '">' + that.t
             });
         }
 
-        return requestMetadata();
+        if (this.tokenSource) {
+            return getToken(this).then(function (token) {
+                requestMetadata (token);
+            });
+        } else {
+            return requestMetadata();
+        }
     }
 };
 
@@ -258,6 +311,17 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
         mapServerData: this._mapServerData,
         enablePickFeatures: defaultValue(this.allowFeaturePicking, true)
     };
+
+    if (this.tokenSource) {
+        imagryOptions.requestNewToken = () => {return getToken(this);};
+
+        if (defined(this._lastToken)) {
+            // Using the last token is an optomisation; if its still valid it will speed up
+            // the operation and if its not then it will just be requested when its needed.
+            imagryOptions.token = this._lastToken;
+        }
+    }
+
     var imageryProvider = new ArcGisMapServerImageryProvider(imagryOptions);
 
     var maximumLevelBeforeMessage = maximumScaleToLevel(this.maximumScaleBeforeMessage);

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -21,6 +21,7 @@ var overrideProperty = require('../Core/overrideProperty');
 var proj4 = require('proj4/lib/index.js');
 var proj4definitions = require ('../Map/Proj4Definitions');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
+var RuntimeError = require('terriajs-cesium/Source/Core/RuntimeError');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var replaceUnderscores = require('../Core/replaceUnderscores');
 var TerriaError = require('../Core/TerriaError');
@@ -217,14 +218,12 @@ function getToken(item) {
             item._lastToken = token.token;
             return token.token;
         } else {
-            delete item._lastToken;
-            // todo: how should I really be dealing with failure here...both this current implmentation and developer error don't really feel right....check this with kring
-            return undefined;
+            item._lastToken = undefined;
+            throw new RuntimeError('The token server responded with an invalid token.');
         }
     }).otherwise(() => {
-        delete item._lastToken;
-        // todo: how should I really be dealing with failure here...both this current implmentation and developer error don't really feel right....check this with kring
-        return undefined;
+        item._lastToken = undefined;
+        throw new RuntimeError('Unable to request a token from the token server.');
     });
 }
 

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -21,7 +21,6 @@ var overrideProperty = require('../Core/overrideProperty');
 var proj4 = require('proj4/lib/index.js');
 var proj4definitions = require ('../Map/Proj4Definitions');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
-var RuntimeError = require('terriajs-cesium/Source/Core/RuntimeError');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var replaceUnderscores = require('../Core/replaceUnderscores');
 var TerriaError = require('../Core/TerriaError');
@@ -220,10 +219,18 @@ function getToken(item) {
         }
 
         item._lastToken = undefined;
-        throw new RuntimeError('The token server responded with an invalid token.');
+        throw new TerriaError({
+            title: 'ArcGIS Mapserver Error',
+            message: '<p>The token server responded with an invalid token.</p><p>Please report it by \
+sending an email to <a href="mailto:' + item.terria.supportEmail + '">' + item.terria.supportEmail + '</a>.</p>'
+        });
     }).otherwise(() => {
         item._lastToken = undefined;
-        throw new RuntimeError('Unable to request a token from the token server.');
+        throw new TerriaError({
+            title: 'ArcGIS Mapserver Error',
+            message: '<p>Unable to request a token from the token server.</p><p>Please report it by \
+sending an email to <a href="mailto:' + item.terria.supportEmail + '">' + item.terria.supportEmail + '</a>.</p>'
+        });
     });
 }
 

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -90,9 +90,9 @@ var ArcGisMapServerCatalogItem = function(terria) {
      * Gets or sets the URL to use for requesting tokens.
      * @type {String}
      */
-    this.tokenSource = undefined;
+    this.tokenUrl = undefined;
 
-    knockout.track(this, ['layers', 'maximumScale', '_legendUrl', '_generatedLegendUrl', 'maximumScaleBeforeMessage', 'showTilesAfterMessage', 'allowFeaturePicking', 'tokenSource']);
+    knockout.track(this, ['layers', 'maximumScale', '_legendUrl', '_generatedLegendUrl', 'maximumScaleBeforeMessage', 'showTilesAfterMessage', 'allowFeaturePicking', 'tokenUrl']);
 
     // metadataUrl and legendUrl are derived from url if not explicitly specified.
     overrideProperty(this, 'metadataUrl', {
@@ -205,7 +205,7 @@ function getJson(item, uri) {
 
 function getToken(item) {
     const options = {
-        url: item.tokenSource,
+        url: item.tokenUrl,
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         data: JSON.stringify({'url': item.url})
@@ -253,7 +253,7 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
         }
 
         var promise = when();
-        if (this.tokenSource) {
+        if (this.tokenUrl) {
             promise = getToken(this);
         }
 
@@ -308,7 +308,7 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
         enablePickFeatures: defaultValue(this.allowFeaturePicking, true)
     };
 
-    if (this.tokenSource) {
+    if (this.tokenUrl) {
         imageryOptions.requestNewToken = () => getToken(this);
 
         if (defined(this._lastToken)) {

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -84,7 +84,13 @@ var ArcGisMapServerCatalogItem = function(terria) {
      */
     this.allowFeaturePicking = true;
 
-    knockout.track(this, ['layers', 'maximumScale', '_legendUrl', '_generatedLegendUrl', 'maximumScaleBeforeMessage', 'showTilesAfterMessage', 'allowFeaturePicking']);
+    /**
+     * Gets or sets the URL to use for requesting tokens.
+     * @type {String}
+     */
+    this.tokenSource = undefined;
+
+    knockout.track(this, ['layers', 'maximumScale', '_legendUrl', '_generatedLegendUrl', 'maximumScaleBeforeMessage', 'showTilesAfterMessage', 'allowFeaturePicking', 'tokenSource']);
 
     // metadataUrl and legendUrl are derived from url if not explicitly specified.
     overrideProperty(this, 'metadataUrl', {

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -313,7 +313,7 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
     };
 
     if (this.tokenSource) {
-        imagryOptions.requestNewToken = () => {return getToken(this);};
+        imagryOptions.requestNewToken = () => getToken(this);
 
         if (defined(this._lastToken)) {
             // Using the last token is an optomisation; if its still valid it will speed up

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -303,7 +303,7 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
     // Strip trailing forward slash if exists
     baseUrl = baseUrl.replace(/\/$/g, '');
 
-    const imagryOptions = {
+    const imageryOptions = {
         url: cleanAndProxyUrl(this, baseUrl),
         layers: getLayerList(this),
         tilingScheme: new WebMercatorTilingScheme(),
@@ -313,16 +313,16 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
     };
 
     if (this.tokenSource) {
-        imagryOptions.requestNewToken = () => getToken(this);
+        imageryOptions.requestNewToken = () => getToken(this);
 
         if (defined(this._lastToken)) {
             // Using the last token is an optomisation; if its still valid it will speed up
             // the operation and if its not then it will just be requested when its needed.
-            imagryOptions.token = this._lastToken;
+            imageryOptions.token = this._lastToken;
         }
     }
 
-    var imageryProvider = new ArcGisMapServerImageryProvider(imagryOptions);
+    var imageryProvider = new ArcGisMapServerImageryProvider(imageryOptions);
 
     var maximumLevelBeforeMessage = maximumScaleToLevel(this.maximumScaleBeforeMessage);
     if (defined(maximumLevelBeforeMessage)) {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "simple-statistics": "^4.1.0",
     "string-replace-webpack-plugin": "^0.1.3",
     "style-loader": "^0.18.0",
-    "terriajs-cesium": "1.33.2",
+    "terriajs-cesium": "1.33.3",
     "togeojson": "^0.16.0",
     "urijs": "1.18.10",
     "url-loader": "^0.5.7",


### PR DESCRIPTION
There is one outstanding piece of lint associated with this code. `function requestMetadata(token) {` is inline. I have left this as is for now as I wonder whether there is a better solution to this problem then to use an intermediate function. The problem that this inline function solves is to prepend the token request in the initalisation process, and so I wonder whether there is a better solution to this problem then using the if -> inline function call.

The inline function presents particular nastiness in that to comply with the lint checks this code needs to be made top level function, however this in its currently implementation is not particularly clean in that doing in as a straight copy-paste means that the checks are separated from the implementation. To clean this up the checks can be moved into the separate function, but then the token request may happen when we know the other checks will fail. So this is not particularity nice overall and so I'm hoping that there is a cleaner higher level solution so that all of this complexity can be avoided.