### PR TITLE
Update eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,6 @@
 {
     "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:jsx-control-statements/recommended"],
     "parser": "babel-eslint",
-    "parserOptions": {
-        "sourceType": "module"
-    },
     "env": {
         "browser": true,
         "commonjs": true

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "css-loader": "^0.28.0",
     "electron": "^1.4.10",
     "enzyme": "^2.4.1",
-    "eslint": "^4.4.1",
+    "eslint": "^4.9.0",
     "eslint-plugin-jsx-control-statements": "^2.2.0",
     "eslint-plugin-react": "^7.2.1",
     "fs-extra": "^4.0.0",


### PR DESCRIPTION
Fixes 
> ImportDeclaration should appear when the mode is ES6 and in the module context.

by upgrading to eslint v4.9.0 and reverts previous fix that fixed for eslint v4.5.0.