### PR TITLE
Fix Travis CI failing due to mkdocs configuration option deprecation

### DIFF
--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,7 +1,9 @@
 site_name: TerriaJS
 #cosmo|cyborg|readthedocs|yeti|journal|bootstrap|readable|united|simplex|flatly|spacelab|amelia|cerulean|slate|mkdocs
 #theme: readthedocs
-theme_dir: mkdocs-material/material
+theme:
+    name: null
+    custom_dir: mkdocs-material/material
 docs_dir: 'doc'
 site_dir: '../wwwroot/doc/guide'
 markdown_extensions:


### PR DESCRIPTION
Fixes currently broken Travis CI. Merge as soon as possible to avoid more greenkeeper false positives.

See http://www.mkdocs.org/about/release-notes/ for deprecation note (version 0.17.0) and http://www.mkdocs.org/user-guide/custom-themes/ under **Creating a custom theme** for new custom theme configuration.