### PR TITLE
Add initFragmentPaths property.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Improved display of "Add Data" panel on small screens when Feedback and Feature Info panels are open.
 * Added "search in data catalog" link to mobile search.
 * Added a button to automatically copy share url into clipboard in share panel.
+* Added `initFragmentPaths` property to the `parameters` section of `config.json`.  It can be used to specify an array of base paths for resolving init fragments in the URL.
 
 ### 5.4.0
 

--- a/doc/customizing/client-side-config.md
+++ b/doc/customizing/client-side-config.md
@@ -41,6 +41,7 @@ Option                      | Meaning
 `"printDisclaimer": {`<span><br/>&nbsp;&nbsp;`"text": "",`<br/>&nbsp;&nbsp;`"url": ""`<br/>`}`</span> | Same as `disclaimer`, except only shown in printed views.
 `"supportEmail"`            | The email address shown when things go wrong.
 `"mobileDefaultViewerMode"` | A string specifying the default view mode to load when running on a mobile platform. Options are: `"3DTerrain"`, `"3DSmooth"`, `"2D"`. (Default: `"2D"`)
+`"initFragmentPaths"`       | An array of base paths to use to try to use to resolve init fragments in the URL.  For example, if this property is `[ "init/", "http://example.com/init/"]`, then a URL with `#test` will first try to load `init/test.json` and, if that fails, next try to load `http://example.com/init/test.json`.  If not specified, this property defaults to `[ "init/" ]`.
 
 ## Advanced options
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -43,7 +43,10 @@ var defaultConfigParameters = {
     corsProxyBaseUrl: 'proxy/',
     proxyableDomainsUrl: 'proxyabledomains/',
     shareUrl: 'share',
-    feedbackUrl: undefined
+    feedbackUrl: undefined,
+    initFragmentPaths: [
+        'init/'
+    ]
 };
 
 // These properties can be directly passed in as properties of an init source.
@@ -814,7 +817,9 @@ function interpretStartData(terria, startData, persistentInitSources, temporaryI
 
 function generateInitializationUrl(url) {
     if (url.toLowerCase().substring(url.length - 5) !== '.json') {
-        return 'init/' + url + '.json';
+        return {
+            initFragment: url
+        };
     }
     return url;
 }
@@ -832,22 +837,52 @@ function loadInitSources(terria, initSources) {
 }
 
 function loadInitSource(terria, source) {
+    let loadSource;
+    let loadPromise;
     if (typeof source === 'string') {
-        return loadJson5(terria.corsProxy.getURLProxyIfNecessary(source))
-            .then(function (initSource) {
-                initSource.isFromExternalFile = true;
-                return initSource;
-            })
-            .otherwise(function () {
-                terria.error.raiseEvent({
-                    title: 'Error loading initialization source',
-                    message: 'An error occurred while loading initialization information from ' + source + '.  This may indicate that you followed an invalid link or that there is a problem with your Internet connection.'
-                });
-                return undefined;
+        loadSource = source;
+        loadPromise = loadJson5(terria.corsProxy.getURLProxyIfNecessary(source));
+    } else if (typeof source === 'object' && typeof source.initFragment === 'string') {
+        const fragment = source.initFragment;
+        const fragmentPaths = terria.configParameters.initFragmentPaths;
+        if (fragmentPaths.length === 0) {
+            terria.error.raiseEvent({
+                title: 'Error loading initialization source',
+                message: 'Could not load initialization information from ' + fragment + ' because no initFragmentPaths are defined.'
             });
+            return undefined;
+        }
+
+        loadSource = fragmentPaths.map(path => buildInitUrlFromFragment(path, fragment)).join(', ');
+
+        loadPromise = loadJson5(terria.corsProxy.getURLProxyIfNecessary(buildInitUrlFromFragment(fragmentPaths[0], fragment)));
+
+        for (let i = 1; i < fragmentPaths.length; ++i) {
+            loadPromise = loadPromise.otherwise(function() {
+                return loadJson5(terria.corsProxy.getURLProxyIfNecessary(buildInitUrlFromFragment(fragmentPaths[i], fragment)));
+            });
+        }
+    }
+
+    if (loadPromise) {
+        return loadPromise.then(function (initSource) {
+            initSource.isFromExternalFile = true;
+            return initSource;
+        })
+        .otherwise(function () {
+            terria.error.raiseEvent({
+                title: 'Error loading initialization source',
+                message: 'An error occurred while loading initialization information from ' + loadSource + '.  This may indicate that you followed an invalid link or that there is a problem with your Internet connection.'
+            });
+            return undefined;
+        });
     } else {
         return source;
     }
+}
+
+function buildInitUrlFromFragment(path, fragment) {
+    return path + fragment + '.json';
 }
 
 function adjustForBackwardCompatibility(startData) {


### PR DESCRIPTION
Add an optional `initFragmentPaths` property in `config.json`.  It specifies a list of base URLs to use to resolve fragments in the hash portion of the URL, instead of the default of `init/`.

This is :shipit: related.
