### PR TITLE
Exclude KML files with file extension ZIP from CKAN.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Improved display of "Add Data" panel on small screens when Feedback and Feature Info panels are open.
 * Added "search in data catalog" link to mobile search.
 * Added a button to automatically copy share url into clipboard in share panel.
+* Modified `CkanCatalogItem` to exclude files that advertise themselves as KML files but have the file extension .ZIP.
 
 ### 5.4.0
 

--- a/lib/Models/CkanCatalogItem.js
+++ b/lib/Models/CkanCatalogItem.js
@@ -346,7 +346,7 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
         [options.wfsResourceFormat, WebFeatureServiceCatalogItem],
         [options.esriMapServerResourceFormat, ArcGisMapServerCatalogItem, /MapServer/],
         [options.esriFeatureServerResourceFormat, ArcGisFeatureServerCatalogItem, /FeatureServer/],
-        [options.kmlResourceFormat, KmlCatalogItem],
+        [options.kmlResourceFormat, KmlCatalogItem, undefined, /\.zip$/],
         [options.geoJsonResourceFormat, GeoJsonCatalogItem],
         [options.czmlResourceFormat, CzmlCatalogItem],
         [options.csvResourceFormat, CsvCatalogItem]
@@ -364,9 +364,10 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
 
     var matchingFormats = formats.filter(function(format) {
         // Matching formats must match the format regex,
-        // and also the URL regex if it exists.
+        // and also the URL regex if it exists and not the URL exclusion regex if it exists.
         return resource.format.match(format[0]) &&
-               (!defined(format[2]) || baseUrl.match(format[2]));
+               (!defined(format[2]) || baseUrl.match(format[2])) &&
+               (!defined(format[3]) || !baseUrl.match(format[3]));
     });
     if (matchingFormats.length === 0) {
         return undefined;


### PR DESCRIPTION
A bit hacky here.  GA has a whole bunch of ZIP files that contain KML documents on their CSW server.  data.gov.au tags the format as "kml" when it harvests these from the CSW. But these don't work in TerriaJS because they're not really KML.  This is going to be challenging to fix in data.gov.au, and much easier with Magda. So this PR excludes them for now just by ignoring any supposedly-KML files with a .ZIP extension.

Fixes TerriaJS/nationalmap#500
Fixes TerriaJS/nationalmap#526
Fixes TerriaJS/nationalmap#527
Fixes TerriaJS/nationalmap#602
