### PR TITLE
Remove "click to view full image" messages on Share panel.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Added a button to automatically copy share url into clipboard in share panel.
 * Added `initFragmentPaths` property to the `parameters` section of `config.json`.  It can be used to specify an array of base paths for resolving init fragments in the URL.
 * Modified `CkanCatalogItem` to exclude files that advertise themselves as KML files but have the file extension .ZIP.
+* Removed "View full size image" link on the share panel.  Chrome 60 removed the ability to navigate to a data URI, and other browsers are expected to follow this lead.
 
 ### 5.4.0
 

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
@@ -125,7 +125,6 @@ const SharePanel = createReactClass({
       return (<div>
         <div className={Styles.clipboard}><Clipboard source={shareUrlTextBox} id='share-url'/></div>
         <div className={DropdownStyles.section}>
-              <div className={Styles.mobileHeader}>Preview <span><i>tab to view full image</i></span></div>
               <a className={Styles.link} href={this.state.imageUrl} target='_blank'><div className={Styles.imgShare} style={shareImgStyle}></div></a>
         </div>
         <If condition={this.isUrlShortenable()}>
@@ -144,9 +143,6 @@ const SharePanel = createReactClass({
         <div>
           <div className={DropdownStyles.section}>
               <a className={Styles.link} href={this.state.imageUrl} target='_blank'><div className={Styles.imgShare} style={shareImgStyle}></div></a>
-              <div className={Styles.linkWrapper}>
-                  <a className={Styles.link} href={this.state.imageUrl} target='_blank'>View full size image</a>
-              </div>
           </div>
           <div className={Styles.clipboard}><Clipboard source={shareUrlTextBox} id='share-url'/></div>
           <div className={classNames(DropdownStyles.section, Styles.shortenUrl)}>


### PR DESCRIPTION
Chrome 60 removed support for top-level navigation to a data URI, and other browsers are expected to follow this lead.
https://developers.google.com/web/updates/2017/06/chrome-60-deprecations#remove_content-initiated_top_frame_navigations_to_data_urls

Users can still right-click on the image and save it, open it in a new tab, etc., but there's no easy way to make a simple click open it in a new tab.

Some possible (but not easy) ways to make it work again:
1. Have terriajs-server (temporarily?) store the image data so the browser can load it from a real URL.  I can't think of a way to do this without requiring the image to be persisted at least temporarily on the server.
2. Open a new window on, say, share-snapshot.html, and then post the image data to it.  Receive the message in share-snapshot.html and create an image tag from it. Requires a tricky handshake between the two pages.
3. Same as 3 except store the image in session storage instead of posting cross-window messages. Session storage size limits could be an issue.