### PR TITLE
Only show "zoom to extent" if rectangle is available

### DIFF
--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -764,6 +764,17 @@ var scratchRectangle = new Rectangle();
 };
 
 /**
+ * Returns true if this item currently has a rectangle to zoom to. Depends on observable properties, and so updates once loaded.
+ * @returns {Boolean} A flag for whether this catalog item supports "zoom to".
+ */
+CatalogItem.prototype.canZoomTo = function() {
+    if (defined(this.nowViewingCatalogItem)) {
+        return defined(this.nowViewingCatalogItem.rectangle);
+    }
+    return defined(this.rectangle);
+};
+
+/**
  * Uses the {@link CatalogItem#clock} settings from this data item.  If this data item
  * has no clock settings, or has the useOwnClock property true, this method does nothing.
  * Because the clock update may happen asynchronously (for example, if the item's clock parameters are not yet known),

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -141,7 +141,7 @@ var CatalogItem = function(terria) {
     this.isEnableable = true;
 
     /**
-     * Gets or sets a value indicating whether this data source is mappable and should therefore include a Zoom To button.
+     * Gets or sets a value indicating whether this data source is mappable.
      * This property is observable.
      * @type {Boolean}
      */

--- a/lib/Models/TableDataSource.js
+++ b/lib/Models/TableDataSource.js
@@ -80,7 +80,7 @@ var TableDataSource = function(tableStructure, tableStyle, name, isUpdating) {
 
     // Track _tableStructure so that csvCatalogItem's concepts are maintained.
     // Track _legendUrl so that csvCatalogItem can update the legend if it changes.
-    knockout.track(this, ['_tableStructure', '_legendUrl']);
+    knockout.track(this, ['_tableStructure', '_legendUrl', '_extent']);
 
     // Whenever the active item is changed, recalculate the legend and the display of all the entities.
     // This is triggered both on deactivation and on reactivation, ie. twice per change; it would be nicer to trigger once.

--- a/lib/Models/TableDataSource.js
+++ b/lib/Models/TableDataSource.js
@@ -80,6 +80,7 @@ var TableDataSource = function(tableStructure, tableStyle, name, isUpdating) {
 
     // Track _tableStructure so that csvCatalogItem's concepts are maintained.
     // Track _legendUrl so that csvCatalogItem can update the legend if it changes.
+    // Track _extent so that the TableCatalogItem's rectangle updates properly, which also feeds into catalog item's canZoomTo function.
     knockout.track(this, ['_tableStructure', '_legendUrl', '_extent']);
 
     // Whenever the active item is changed, recalculate the legend and the display of all the entities.

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
@@ -93,13 +93,13 @@ const ViewingControls = createReactClass({
 
     render() {
         const item = this.props.item;
-        const canZoom = item.isMappable || (item.tableStructure && item.tableStructure.sourceFeature);
+        const canZoom = item.canZoomTo() || (item.tableStructure && item.tableStructure.sourceFeature);
         const canSplit = item.supportsSplitting && defined(item.splitDirection) && item.terria.currentViewer.canShowSplitter;
         const classList = {[Styles.noZoom]: !canZoom, [Styles.noSplit]: !canSplit, [Styles.noInfo]: !item.showsInfo};
         return (
             <ul className={Styles.control}>
-                <If condition={item.isMappable}>
-                    <li className={classNames(Styles.zoom, classList)}><button type='button' onClick={this.zoomTo} title="Zoom to data" className={Styles.btn}>Zoom To Extent</button></li>
+                <If condition={item.canZoomTo()}>
+                    <li className={classNames(Styles.zoom, classList)}><button type='button' onClick={this.zoomTo} title="Zoom to extent" className={Styles.btn}>Zoom To Extent</button></li>
                 </If>
                 <If condition={item.tableStructure && item.tableStructure.sourceFeature}>
                     <li className={classNames(Styles.zoom, classList)}><button type='button' onClick={this.openFeature} title="Zoom to data" className={Styles.btn}>Zoom To</button></li>

--- a/test/Models/CatalogItemSpec.js
+++ b/test/Models/CatalogItemSpec.js
@@ -1,6 +1,8 @@
 'use strict';
 
 /*global require*/
+var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
+
 var CatalogItem = require('../../lib/Models/CatalogItem');
 var CatalogGroup = require('../../lib/Models/CatalogGroup');
 var Catalog = require('../../lib/Models/Catalog');
@@ -42,6 +44,13 @@ describe('CatalogItem', function () {
         item.url = 'http://hello.there';
         expect(item.dataUrl).toBe('http://something.else');
         expect(item.dataUrlType).toBe('wfs');
+    });
+
+    it('can zoom to only if rectangle is defined', function () {
+        expect(item.canZoomTo).toBe(false);
+        // When a rectangle is defined, it can be zoomed-to.
+        item.rectangle = Rectangle.fromDegrees(1, 2, 3, 4);
+        expect(item.canZoomTo).toBe(true);
     });
 
     describe('time series data: ', function() {

--- a/test/Models/CatalogItemSpec.js
+++ b/test/Models/CatalogItemSpec.js
@@ -47,10 +47,10 @@ describe('CatalogItem', function () {
     });
 
     it('can zoom to only if rectangle is defined', function () {
-        expect(item.canZoomTo).toBe(false);
+        expect(item.canZoomTo()).toBe(false);
         // When a rectangle is defined, it can be zoomed-to.
         item.rectangle = Rectangle.fromDegrees(1, 2, 3, 4);
-        expect(item.canZoomTo).toBe(true);
+        expect(item.canZoomTo()).toBe(true);
     });
 
     describe('time series data: ', function() {


### PR DESCRIPTION
Fixes #2579.
Unfortunately I think this makes use of some of the changes introduced to make "split" show nicely, so may be hard to retrofit.