### PR TITLE
Convert String objects to string primitives before passing to markdown-it

### DIFF
--- a/lib/Core/markdownToHtml.js
+++ b/lib/Core/markdownToHtml.js
@@ -25,11 +25,19 @@ function markdownToHtml(markdownString, allowUnsafeHtml, options) {
     }
     // If the text looks like html, don't try to interpret it as Markdown because
     // we'll probably break it in the process.
+    // It would wrap non-standard tags such as <collapsible>hi</collapsible> in a <p></p>, which is bad.
     var unsafeHtml;
     if (htmlRegex.test(markdownString)) {
         unsafeHtml = markdownString;
     } else {
-        // Note this would wrap non-standard tags such as <collapsible>hi</collapsible> in a <p></p>, which is bad.
+        // MarkdownIt can't handle something that is not a string primitve.  It can't even handle
+        // something that is a string object (instanceof String) rather a string primitive
+        // (typeof string === 'string').  So if this isn't a string primitive, call toString
+        // on it in order to make it one.
+        if (markdownString && typeof markdownString !== 'string') {
+            markdownString = markdownString.toString();
+        }
+
         unsafeHtml = md.render(markdownString);
     }
     if (allowUnsafeHtml) {

--- a/lib/ReactViews/Custom/parseCustomMarkdownToReact.js
+++ b/lib/ReactViews/Custom/parseCustomMarkdownToReact.js
@@ -9,6 +9,14 @@ import parseCustomHtmlToReact from './parseCustomHtmlToReact';
  * @return {ReactElement}
  */
 function parseCustomMarkdownToReact(raw, context) {
+    // MarkdownIt can't handle something that is not a string primitve.  It can't even handle
+    // something that is a string object (instanceof String) rather a string primitive
+    // (typeof string === 'string').  So if this isn't a string primitive, call toString
+    // on it in order to make it one.
+    if (raw && typeof raw !== 'string') {
+        raw = raw.toString();
+    }
+
     const html = markdownToHtml(raw, false, {
         ADD_TAGS: CustomComponents.names(),
         ADD_ATTR: CustomComponents.attributes()

--- a/lib/ReactViews/Custom/parseCustomMarkdownToReact.js
+++ b/lib/ReactViews/Custom/parseCustomMarkdownToReact.js
@@ -9,14 +9,6 @@ import parseCustomHtmlToReact from './parseCustomHtmlToReact';
  * @return {ReactElement}
  */
 function parseCustomMarkdownToReact(raw, context) {
-    // MarkdownIt can't handle something that is not a string primitve.  It can't even handle
-    // something that is a string object (instanceof String) rather a string primitive
-    // (typeof string === 'string').  So if this isn't a string primitive, call toString
-    // on it in order to make it one.
-    if (raw && typeof raw !== 'string') {
-        raw = raw.toString();
-    }
-
     const html = markdownToHtml(raw, false, {
         ADD_TAGS: CustomComponents.names(),
         ADD_ATTR: CustomComponents.attributes()


### PR DESCRIPTION
Fixes #2721 

See that issue for an explanation of how we end up with String objects in the first place.