### PR TITLE
[#2700] Fix the splitter on share links

### DIFF
--- a/lib/ReactViews/Map/Splitter.jsx
+++ b/lib/ReactViews/Map/Splitter.jsx
@@ -118,7 +118,7 @@ const Splitter = createReactClass({
     },
 
     render() {
-        if (!this.props.terria.showSplitter) {
+        if (!this.props.terria.showSplitter || !this.props.terria.currentViewer.canShowSplitter) {
             return null;
         }
 

--- a/lib/ReactViews/Map/Splitter.jsx
+++ b/lib/ReactViews/Map/Splitter.jsx
@@ -28,6 +28,7 @@ const Splitter = createReactClass({
 
     propTypes: {
         terria: PropTypes.object.isRequired,
+        viewState: PropTypes.object.isRequired,
         thumbSize: PropTypes.number,
         padding: PropTypes.number
     },
@@ -113,6 +114,10 @@ const Splitter = createReactClass({
     },
 
     getPosition() {
+        // Use the viewState properties from here (dummy call - as changes in these values will effect .clientWidth)
+        // the so that it will cause the component to be refreshed if these values are updated.
+        const viewState = !this.props.viewState.isMapFullScreen && !this.props.viewState.hideMapUi();
+
         const canvasWidth = this.props.terria.currentViewer.getContainer().clientWidth;
         return this.props.terria.splitPosition * canvasWidth;
     },

--- a/lib/ReactViews/Map/Splitter.jsx
+++ b/lib/ReactViews/Map/Splitter.jsx
@@ -118,7 +118,7 @@ const Splitter = createReactClass({
     },
 
     render() {
-        if (!this.props.terria.showSplitter || !this.props.terria.currentViewer.canShowSplitter) {
+        if (!this.props.terria.showSplitter || !this.props.terria.currentViewer.canShowSplitter || !this.props.terria.currentViewer.getContainer()) {
             return null;
         }
 

--- a/lib/ReactViews/Map/Splitter.jsx
+++ b/lib/ReactViews/Map/Splitter.jsx
@@ -42,14 +42,14 @@ const Splitter = createReactClass({
 
     componentDidMount() {
         const that = this;
-        window.addEventListener('resize', function() {that.resize();});
+        window.addEventListener('resize', function() {that.forceRefresh();});
     },
 
     componentWillUnmount() {
         this.unsubscribe();
     },
 
-    resize() {
+    forceRefresh() {
         const smallChange = (this.props.terria.splitPosition < 0.5) ? 0.0001 : -0.0001; // Make sure never <0 or >1.
         this.props.terria.splitPosition += smallChange;
     },
@@ -110,7 +110,7 @@ const Splitter = createReactClass({
         document.removeEventListener('touchmove', this.drag, notPassive);
         document.removeEventListener('mouseup', this.stopDrag, notPassive);
         document.removeEventListener('touchend', this.stopDrag, notPassive);
-        window.removeEventListener('resize', this.resize);
+        window.removeEventListener('resize', this.forceRefresh);
     },
 
     getPosition() {

--- a/lib/ReactViews/Map/Splitter.jsx
+++ b/lib/ReactViews/Map/Splitter.jsx
@@ -28,7 +28,6 @@ const Splitter = createReactClass({
 
     propTypes: {
         terria: PropTypes.object.isRequired,
-        viewState: PropTypes.object.isRequired,
         thumbSize: PropTypes.number,
         padding: PropTypes.number
     },
@@ -114,10 +113,6 @@ const Splitter = createReactClass({
     },
 
     getPosition() {
-        // Use the viewState properties from here (dummy call - as changes in these values will effect .clientWidth)
-        // the so that it will cause the component to be refreshed if these values are updated.
-        const viewState = !this.props.viewState.isMapFullScreen && !this.props.viewState.hideMapUi();
-
         const canvasWidth = this.props.terria.currentViewer.getContainer().clientWidth;
         return this.props.terria.splitPosition * canvasWidth;
     },

--- a/lib/ReactViews/Map/TerriaViewerWrapper.jsx
+++ b/lib/ReactViews/Map/TerriaViewerWrapper.jsx
@@ -63,7 +63,7 @@ const TerriaViewerWrapper = createReactClass({
                    ref={element => {this.mapElement = element;}}
                    onMouseMove={this.onMouseMove}>
                 <div className={Styles.mapPlaceholder}>Loading the map, please wait!</div>
-                <Splitter terria={this.props.terria} viewState={this.props.viewState}/>
+                <Splitter terria={this.props.terria} />
             </aside>
         );
     },

--- a/lib/ReactViews/Map/TerriaViewerWrapper.jsx
+++ b/lib/ReactViews/Map/TerriaViewerWrapper.jsx
@@ -63,7 +63,7 @@ const TerriaViewerWrapper = createReactClass({
                    ref={element => {this.mapElement = element;}}
                    onMouseMove={this.onMouseMove}>
                 <div className={Styles.mapPlaceholder}>Loading the map, please wait!</div>
-                <Splitter terria={this.props.terria} />
+                <Splitter terria={this.props.terria} viewState={this.props.viewState}/>
             </aside>
         );
     },

--- a/lib/ReactViews/Notification/Notification.jsx
+++ b/lib/ReactViews/Notification/Notification.jsx
@@ -21,7 +21,7 @@ const Notification = createReactClass({
             notification.confirmAction();
         }
 
-        this.close();
+        this.close(notification);
     },
 
     deny() {

--- a/lib/ReactViews/Notification/Notification.jsx
+++ b/lib/ReactViews/Notification/Notification.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import NotificationWindow from './NotificationWindow';
+import triggerResize from '../../Core/triggerResize';
 
 const Notification = createReactClass({
     displayName: 'Notification',
@@ -20,7 +21,7 @@ const Notification = createReactClass({
             notification.confirmAction();
         }
 
-        this.props.viewState.notifications.splice(0, 1);
+        this.close();
     },
 
     deny() {
@@ -29,7 +30,17 @@ const Notification = createReactClass({
             notification.denyAction();
         }
 
+        this.close(notification);
+    },
+
+    close (notification) {
         this.props.viewState.notifications.splice(0, 1);
+
+        // Force refresh once the notification is dispached if .hideUi is set since once all the .hideUi's
+        // have been dispatched the UI will no longer be suppressed causing a change in the view state.
+        if (notification && notification.hideUi) {
+            triggerResize();
+        }
     },
 
     render() {


### PR DESCRIPTION
This seems to fix the issue. I'm not sure if this is the cleanest way of achieving this or whether there is a cleaner way to do this with knockout rather then using the dummy variable. Also not sure if there is a nice location to put the call to the two state variables (i.e. refactor and make it a direct function in viewState or elsewhere) which can be used from StandardUserInterface and stop the duplication of dependence logic, but its not exactly clear to me where to put this function and what to call it so that this would be clean and make sense.

Also renamed the refresh function to help clarify the logic there, but you can pop that if you don't like it before merging.

Now should be ready to merge.

Fixes #2700 