### PR TITLE
Bug fixes for time-varying tables

### DIFF
--- a/lib/Map/RegionProvider.js
+++ b/lib/Map/RegionProvider.js
@@ -4,8 +4,10 @@
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
+var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var loadText = require('terriajs-cesium/Source/Core/loadText');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
+var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var TerriaError = require('../Core/TerriaError');
@@ -339,21 +341,47 @@ RegionProvider.prototype.loadRegionNames = function() {
  * @param {Array} [failedMatches] An optional empty array. If provided, indices of failed matches are appended to the array.
  * @param {Array} [ambiguousMatches] An optional empty array. If provided, indices of matches which duplicate prior matches are appended to the array.
  *                (Eg. these are not relevant if at different times.)
+ * @param {TimeInterval[]} [timeIntervals] The time intervals during which each value in `regionArray` applies.  If undefined, the data is not
+ *                         time-varying.
+ * @param {JulianDate} [time] The time at which to do the mapping.  If undefined, the data is not time-varying.
  * @return {Array} Indices into this.region.
  */
-RegionProvider.prototype.mapRegionsToIndicesInto = function(regionArray, disambigValues, failedMatches, ambiguousMatches) {
+RegionProvider.prototype.mapRegionsToIndicesInto = function(
+    regionArray,
+    disambigValues,
+    failedMatches,
+    ambiguousMatches,
+    timeIntervals,
+    time) {
     if (this.regions.length < 1) {
         throw new DeveloperError('Region provider is not ready to match regions.');
     }
     if (!defined(disambigValues)) {
         disambigValues = [];  // so that disambigValues[i] is undefined, not an error.
     }
+
+    var isTimeVarying = defined(timeIntervals) && defined(time);
+
     var result = new Array(this.regions.length);
     for (var i = 0; i < regionArray.length; i++) {
         if (!defined(regionArray[i])) {
             // Skip over undefined or null values
             continue;
         }
+
+        // Is this row applicable at this time?
+        if (isTimeVarying) {
+            var interval = timeIntervals[i];
+            if (!defined(interval)) {
+                // Row is not applicable at any time.
+                continue;
+            }
+            if (!TimeInterval.contains(interval, time)) {
+                // Row is not applicable at this time.
+                continue;
+            }
+        }
+
         var index = findRegionIndex(this, regionArray[i], disambigValues[i]);
         if (index < 0) {
             if (defined(failedMatches)) {
@@ -362,11 +390,30 @@ RegionProvider.prototype.mapRegionsToIndicesInto = function(regionArray, disambi
             continue;
         }
         if (defined(result[index])) {
+            // This region already has a value. In a time-varying dataset, intervals may
+            // overlap at their endpoints (i.e. the end of one interval is the start of the next).
+            // In that case, we want to the later interval to apply.
+            if (isTimeVarying) {
+                var existingInterval = timeIntervals[result[index]];
+                var newInterval = timeIntervals[i];
+                if (JulianDate.greaterThan(newInterval.start, existingInterval.start)) {
+                    // Use the current row as the value.
+                    result[index] = i;
+                    continue;
+                } else if (JulianDate.lessThan(newInterval.start, existingInterval.start)) {
+                    // Use the existing row as the value.
+                    continue;
+                } else {
+                    // The two rows have the same start date, so treat this as an ambiguous match.
+                }
+            }
+
             if (defined(ambiguousMatches)) {
                 ambiguousMatches.push(i);
             }
             continue;
         }
+
         result[index] = i;
     }
     return result;

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -522,7 +522,6 @@ function calculateAvailability(timeColumn, index) {
         return new TimeInterval({
             start: timeColumn.julianDates[index],
             stop: finishJulianDate,
-            isStopIncluded: false,
             data: timeColumn.julianDates[index] // Stop overlapping intervals being collapsed into one interval unless they start at the same time
         });
     }

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -174,7 +174,10 @@ defineProperties(TableStructure.prototype, {
                     timeColumnToActivate.finishJulianDates = calculateFinishDates(sortedColumns, nameIdOrIndex, this);
                     timeColumnToActivate._timeIntervals = calculateTimeIntervals(timeColumnToActivate);
                     timeColumnToActivate._clock = createClock(timeColumnToActivate);
-                    setClockCurrentTime(timeColumnToActivate._clock, this.initialTimeSource);
+
+                    var lastInterval = timeColumnToActivate._timeIntervals.length > 0 ? timeColumnToActivate._timeIntervals[timeColumnToActivate._timeIntervals.length - 1] : undefined;
+                    var stopTime = lastInterval ? lastInterval.start : undefined;
+                    setClockCurrentTime(timeColumnToActivate._clock, this.initialTimeSource, stopTime);
                     this.columns = sortedColumns;
                 } else {
                     this._activeTimeColumnNameIdOrIndex = undefined;

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -522,6 +522,7 @@ function calculateAvailability(timeColumn, index) {
         return new TimeInterval({
             start: timeColumn.julianDates[index],
             stop: finishJulianDate,
+            isStopIncluded: false,
             data: timeColumn.julianDates[index] // Stop overlapping intervals being collapsed into one interval unless they start at the same time
         });
     }

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -71,7 +71,6 @@ var RegionMapping = function(catalogItem, tableStructure, tableStyle) {
     this._nextImageryLayerInterval = undefined;
     this._hadImageryAtLayerIndex = undefined;
     this._clockTickSubscription = undefined; // For time-varying region-mapped tables only.
-    this._previousRegionIndices = undefined; // For time-varying region-mapped tables only. Only redraws regions if they've changed.
     this._hasDisplayedFeedback = false; // So that we only show the feedback once.
 
     this._constantRegionRowObjects = undefined;
@@ -357,13 +356,7 @@ RegionMapping.prototype.updateOpacity = function(opacity) {
 
 RegionMapping.prototype.showDataForTime = function(currentTime) {
     // Check if record data has changed.
-    var regionIndices = calculateRegionIndices(this, currentTime);
-    if (arraysAreEqual(this._previousRegionIndices, regionIndices)) {
-        return;
-    }
-    this._previousRegionIndices = regionIndices;
-
-    redisplayRegions(this, regionIndices);
+    redisplayRegions(this);
 };
 
 /**
@@ -694,40 +687,89 @@ function calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards
  *                  If not provided, it is calculated, and failed/ambiguous warnings are displayed to the user.
  */
 function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
-    var catalogItem = regionMapping._catalogItem;
-    var currentTime = catalogItem.terria.clock.currentTime;
-    if (regionMapping._nextImageryLayerInterval && TimeInterval.contains(regionMapping._nextImageryLayerInterval, currentTime)) {
-        // Potential race condition. If someone changes variables after the last clock tick of the current imagery,
-        //  the old nextImageryLayer will be shown. Could store _nextILRegionIndices and compare before using that IL
-        setOpacity(catalogItem, regionMapping._nextImageryLayer, catalogItem.opacity);
-        fixNextLayerOrder(catalogItem, regionMapping._imageryLayer, regionMapping._nextImageryLayer);
-        ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._imageryLayer);
-        regionMapping._imageryLayer = regionMapping._nextImageryLayer;
-        regionMapping._nextImageryLayer = undefined;
-        regionMapping._nextImageryLayerInterval = undefined;
-    } else {
-        // For random scrubbing on a timeseries layer or for non-timeseries layers
-        if (defined(regionMapping._nextImageryLayer)) {
-            ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._nextImageryLayer);
-        }
-        regionMapping._nextImageryLayer = undefined;
-        regionMapping._nextImageryLayerInterval = undefined;
+    if (!defined(regionMapping._tableStructure.activeTimeColumn)) {
         regionMapping._imageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices);
-    }
-    if (defined(regionMapping._tableStructure.activeTimeColumn)) {
+    } else {
+        var catalogItem = regionMapping._catalogItem;
+        var currentTime = catalogItem.terria.clock.currentTime;
+
         // Calulate the interval of time that the next imagery layer is valid for
         var { nextInterval, currentInterval } = calculateImageryLayerIntervals(regionMapping._tableStructure.activeTimeColumn, currentTime, catalogItem.terria.clock.multiplier >= 0.0);
-        if (currentInterval !== null) {
-            regionMapping._imageryLayerInterval = currentInterval;
+        if (currentInterval === regionMapping._imageryLayerInterval && nextInterval === regionMapping._nextImageryLayerInterval) {
+            // No change in intervals, so nothing to do.
+            return;
         }
-        if (nextInterval !== null) {
-            var nextILTime = nextInterval.stop; //JulianDate.addSeconds(nextInterval.start, JulianDate.secondsDifference(nextInterval.start, nextInterval.stop)/2, new JulianDate()); // Get a point that lies within the interval (not the start or stop)
-            regionMapping._nextImageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, undefined, undefined, nextILTime, 0.0);
-            ImageryLayerCatalogItem.showLayer(catalogItem, regionMapping._nextImageryLayer);
+
+        if (currentInterval !== regionMapping._imageryLayerInterval) {
+            // Current layer is incorrect.  Can we use the next one?
+            if (regionMapping._nextImageryLayerInterval && TimeInterval.contains(regionMapping._nextImageryLayerInterval, currentTime)) {
+                setOpacity(catalogItem, regionMapping._nextImageryLayer, catalogItem.opacity);
+                fixNextLayerOrder(catalogItem, regionMapping._imageryLayer, regionMapping._nextImageryLayer);
+                ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._imageryLayer);
+                regionMapping._imageryLayer = regionMapping._nextImageryLayer;
+                regionMapping._imageryLayerInterval = regionMapping._nextImageryLayerInterval;
+                regionMapping._nextImageryLayer = undefined;
+                regionMapping._nextImageryLayerInterval = undefined;
+            } else {
+                // Next is not right, either, possibly because the user is randomly scrubbing
+                // on the timeline.  So create a new layer.
+                ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._imageryLayer);
+
+                if (currentInterval) {
+                    regionMapping._imageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices);
+                } else {
+                    regionMapping._imageryLayer = undefined;
+                }
+                regionMapping._imageryLayerInterval = currentInterval;
+            }
+        }
+
+        if (nextInterval !== regionMapping._nextImageryLayerInterval) {
+            // Next layer is incorrect, so recreate it.
+            ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._nextImageryLayer);
+
+            if (nextInterval) {
+                regionMapping._nextImageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, undefined, undefined, nextInterval.start, 0.0);
+            } else {
+                regionMapping._nextImageryLayer = undefined;
+            }
             regionMapping._nextImageryLayerInterval = nextInterval;
-            regionMapping._nextILTime = nextILTime;
         }
     }
+
+    // if (regionMapping._nextImageryLayerInterval && TimeInterval.contains(regionMapping._nextImageryLayerInterval, currentTime)) {
+    //     // Potential race condition. If someone changes variables after the last clock tick of the current imagery,
+    //     //  the old nextImageryLayer will be shown. Could store _nextILRegionIndices and compare before using that IL
+    //     setOpacity(catalogItem, regionMapping._nextImageryLayer, catalogItem.opacity);
+    //     fixNextLayerOrder(catalogItem, regionMapping._imageryLayer, regionMapping._nextImageryLayer);
+    //     ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._imageryLayer);
+    //     regionMapping._imageryLayer = regionMapping._nextImageryLayer;
+    //     regionMapping._imageryLayerInterval = regionMapping._nextImageryLayerInterval;
+    //     regionMapping._nextImageryLayer = undefined;
+    //     regionMapping._nextImageryLayerInterval = undefined;
+    // } else {
+    //     // For random scrubbing on a timeseries layer or for non-timeseries layers
+    //     if (defined(regionMapping._nextImageryLayer)) {
+    //         ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._nextImageryLayer);
+    //     }
+    //     regionMapping._nextImageryLayer = undefined;
+    //     regionMapping._nextImageryLayerInterval = undefined;
+    //     regionMapping._imageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices);
+    // }
+    // if (defined(regionMapping._tableStructure.activeTimeColumn)) {
+    //     // Calulate the interval of time that the next imagery layer is valid for
+    //     var { nextInterval, currentInterval } = calculateImageryLayerIntervals(regionMapping._tableStructure.activeTimeColumn, currentTime, catalogItem.terria.clock.multiplier >= 0.0);
+    //     if (currentInterval !== null) {
+    //         regionMapping._imageryLayerInterval = currentInterval;
+    //     }
+    //     if (nextInterval !== null) {
+    //         var nextILTime = nextInterval.stop; //JulianDate.addSeconds(nextInterval.start, JulianDate.secondsDifference(nextInterval.start, nextInterval.stop)/2, new JulianDate()); // Get a point that lies within the interval (not the start or stop)
+    //         regionMapping._nextImageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, undefined, undefined, nextILTime, 0.0);
+    //         ImageryLayerCatalogItem.showLayer(catalogItem, regionMapping._nextImageryLayer);
+    //         regionMapping._nextImageryLayerInterval = nextInterval;
+    //         regionMapping._nextILTime = nextILTime;
+    //     }
+    // }
 }
 
 function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, globeOrMap, time, overrideOpacity) {
@@ -894,13 +936,7 @@ function onClockTick(regionMapping, clock) {
     if (regionMapping._imageryLayerInterval && TimeInterval.contains(regionMapping._imageryLayerInterval, clock.currentTime)) {
         return;
     }
-    var regionIndices = calculateRegionIndices(regionMapping, clock.currentTime);
-    if (arraysAreEqual(regionMapping._previousRegionIndices, regionIndices)) {
-        return;
-    }
-    regionMapping._previousRegionIndices = regionIndices;
-
-    redisplayRegions(regionMapping, clock.currentTime, regionIndices);
+    redisplayRegions(regionMapping, clock.currentTime);
 }
 
 function updateClockSubscription(regionMapping) {

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -672,8 +672,8 @@ function calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards
     }
     var intervalFromDatePair = (date1, date2) => JulianDate.lessThan(date1, date2) ? new TimeInterval({start: date1, stop: date2}) : new TimeInterval({start: date2, stop: date1});
     return {
-        currentInterval: (past && future1) ? intervalFromDatePair(past, future1) : null,
-        nextInterval: (future1 && future2) ? intervalFromDatePair(future1, future2) : null,
+        currentInterval: (past && future1) ? intervalFromDatePair(past, future1) : undefined,
+        nextInterval: (future1 && future2) ? intervalFromDatePair(future1, future2) : undefined,
     };
 }
 
@@ -730,6 +730,7 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
 
             if (nextInterval) {
                 regionMapping._nextImageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, undefined, undefined, nextInterval.start, 0.0);
+                ImageryLayerCatalogItem.showLayer(catalogItem, regionMapping._nextImageryLayer);
             } else {
                 regionMapping._nextImageryLayer = undefined;
             }

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -448,21 +448,23 @@ function calculateRegionIndices(regionMapping, time, failedMatches, ambiguousMat
     var regionColumnValues = regionColumn.values;
     // Wipe out the region names from the rows that do not apply at this time, if there is a time column.
     var timeColumn = tableStructure.activeTimeColumn;
-    if (defined(time) && defined(timeColumn) && timeColumn.timeIntervals) {
-        regionColumnValues = regionColumnValues.map(function(value, index) {
-            // If there's a missing time value, ignore it.
-            if (defined(timeColumn.timeIntervals[index])) {
-                return (TimeInterval.contains(timeColumn.timeIntervals[index], time) ? value : undefined);
-            }
-        });
-    }
+    // if (defined(time) && defined(timeColumn) && timeColumn.timeIntervals) {
+    //     regionColumnValues = regionColumnValues.map(function(value, index) {
+    //         // If there's a missing time value, ignore it.
+    //         if (defined(timeColumn.timeIntervals[index])) {
+    //             return (TimeInterval.contains(timeColumn.timeIntervals[index], time) ? value : undefined);
+    //         }
+    //     });
+    // }
     var disambigColumn = defined(regionDetail.disambigColumnName) ? tableStructure.getColumnWithNameIdOrIndex(regionDetail.disambigColumnName) : undefined;
     // regionIndices will be an array the same length as regionProvider.regions, giving the index of each region into the table.
     var regionIndices = regionDetail.regionProvider.mapRegionsToIndicesInto(
         regionColumnValues,
         disambigColumn && disambigColumn.values,
         failedMatches,
-        ambiguousMatches
+        ambiguousMatches,
+        defined(timeColumn) ? timeColumn.timeIntervals : undefined,
+        time
     );
     return regionIndices;
 }

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -657,6 +657,10 @@ function calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards
     var future2 = null;
 
     for (const interval of timeColumn.timeIntervals) {
+        if (!defined(interval)) {
+            continue;
+        }
+
         for (const time of [interval.start, interval.stop]) {
             if (isAfter(time, currentTime)) {
                 if (future1 === null || isBefore(time, future1)) {
@@ -670,10 +674,10 @@ function calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards
             }
         }
     }
-    var intervalFromDatePair = (date1, date2) => JulianDate.lessThan(date1, date2) ? new TimeInterval({start: date1, stop: date2}) : new TimeInterval({start: date2, stop: date1});
+    var intervalFromDatePair = (date1, date2) => JulianDate.lessThan(date1, date2) ? new TimeInterval({start: date1, stop: date2, isStopIncluded: false}) : new TimeInterval({start: date2, stop: date1, isStopIncluded: false});
     return {
-        currentInterval: (past && future1) ? intervalFromDatePair(past, future1) : undefined,
-        nextInterval: (future1 && future2) ? intervalFromDatePair(future1, future2) : undefined,
+        currentInterval: (past && future1) ? intervalFromDatePair(past, future1) : null,
+        nextInterval: (future1 && future2) ? intervalFromDatePair(future1, future2) : null,
     };
 }
 
@@ -691,7 +695,7 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
         regionMapping._imageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices);
     } else {
         var catalogItem = regionMapping._catalogItem;
-        var currentTime = catalogItem.terria.clock.currentTime;
+        var currentTime = catalogItem.clockForDisplay.currentTime;
 
         // Calulate the interval of time that the next imagery layer is valid for
         var { nextInterval, currentInterval } = calculateImageryLayerIntervals(regionMapping._tableStructure.activeTimeColumn, currentTime, catalogItem.terria.clock.multiplier >= 0.0);
@@ -709,17 +713,12 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
                 regionMapping._imageryLayer = regionMapping._nextImageryLayer;
                 regionMapping._imageryLayerInterval = regionMapping._nextImageryLayerInterval;
                 regionMapping._nextImageryLayer = undefined;
-                regionMapping._nextImageryLayerInterval = undefined;
+                regionMapping._nextImageryLayerInterval = null;
             } else {
                 // Next is not right, either, possibly because the user is randomly scrubbing
                 // on the timeline.  So create a new layer.
                 ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._imageryLayer);
-
-                if (currentInterval) {
-                    regionMapping._imageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices);
-                } else {
-                    regionMapping._imageryLayer = undefined;
-                }
+                regionMapping._imageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices);
                 regionMapping._imageryLayerInterval = currentInterval;
             }
         }
@@ -779,7 +778,7 @@ function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, g
     var opacity = defaultValue(overrideOpacity, catalogItem.opacity);
 
     globeOrMap = defaultValue(globeOrMap, catalogItem.terria.currentViewer);
-    time = defaultValue(time, globeOrMap.terria.clock.currentTime);
+    time = defaultValue(time, catalogItem.clockForDisplay.currentTime);
 
     var regionDetail = regionMapping._regionDetails[0];
     var legendHelper = regionMapping._legendHelper;

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -443,14 +443,6 @@ function calculateRegionIndices(regionMapping, time, failedMatches, ambiguousMat
     var regionColumnValues = regionColumn.values;
     // Wipe out the region names from the rows that do not apply at this time, if there is a time column.
     var timeColumn = tableStructure.activeTimeColumn;
-    // if (defined(time) && defined(timeColumn) && timeColumn.timeIntervals) {
-    //     regionColumnValues = regionColumnValues.map(function(value, index) {
-    //         // If there's a missing time value, ignore it.
-    //         if (defined(timeColumn.timeIntervals[index])) {
-    //             return (TimeInterval.contains(timeColumn.timeIntervals[index], time) ? value : undefined);
-    //         }
-    //     });
-    // }
     var disambigColumn = defined(regionDetail.disambigColumnName) ? tableStructure.getColumnWithNameIdOrIndex(regionDetail.disambigColumnName) : undefined;
     // regionIndices will be an array the same length as regionProvider.regions, giving the index of each region into the table.
     var regionIndices = regionDetail.regionProvider.mapRegionsToIndicesInto(
@@ -736,40 +728,6 @@ function setNewRegionImageryLayer(regionMapping, layerIndex, regionIndices) {
             regionMapping._nextImageryLayerInterval = nextInterval;
         }
     }
-
-    // if (regionMapping._nextImageryLayerInterval && TimeInterval.contains(regionMapping._nextImageryLayerInterval, currentTime)) {
-    //     // Potential race condition. If someone changes variables after the last clock tick of the current imagery,
-    //     //  the old nextImageryLayer will be shown. Could store _nextILRegionIndices and compare before using that IL
-    //     setOpacity(catalogItem, regionMapping._nextImageryLayer, catalogItem.opacity);
-    //     fixNextLayerOrder(catalogItem, regionMapping._imageryLayer, regionMapping._nextImageryLayer);
-    //     ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._imageryLayer);
-    //     regionMapping._imageryLayer = regionMapping._nextImageryLayer;
-    //     regionMapping._imageryLayerInterval = regionMapping._nextImageryLayerInterval;
-    //     regionMapping._nextImageryLayer = undefined;
-    //     regionMapping._nextImageryLayerInterval = undefined;
-    // } else {
-    //     // For random scrubbing on a timeseries layer or for non-timeseries layers
-    //     if (defined(regionMapping._nextImageryLayer)) {
-    //         ImageryLayerCatalogItem.disableLayer(catalogItem, regionMapping._nextImageryLayer);
-    //     }
-    //     regionMapping._nextImageryLayer = undefined;
-    //     regionMapping._nextImageryLayerInterval = undefined;
-    //     regionMapping._imageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices);
-    // }
-    // if (defined(regionMapping._tableStructure.activeTimeColumn)) {
-    //     // Calulate the interval of time that the next imagery layer is valid for
-    //     var { nextInterval, currentInterval } = calculateImageryLayerIntervals(regionMapping._tableStructure.activeTimeColumn, currentTime, catalogItem.terria.clock.multiplier >= 0.0);
-    //     if (currentInterval !== null) {
-    //         regionMapping._imageryLayerInterval = currentInterval;
-    //     }
-    //     if (nextInterval !== null) {
-    //         var nextILTime = nextInterval.stop; //JulianDate.addSeconds(nextInterval.start, JulianDate.secondsDifference(nextInterval.start, nextInterval.stop)/2, new JulianDate()); // Get a point that lies within the interval (not the start or stop)
-    //         regionMapping._nextImageryLayer = createNewRegionImageryLayer(regionMapping, layerIndex, undefined, undefined, nextILTime, 0.0);
-    //         ImageryLayerCatalogItem.showLayer(catalogItem, regionMapping._nextImageryLayer);
-    //         regionMapping._nextImageryLayerInterval = nextInterval;
-    //         regionMapping._nextILTime = nextILTime;
-    //     }
-    // }
 }
 
 function createNewRegionImageryLayer(regionMapping, layerIndex, regionIndices, globeOrMap, time, overrideOpacity) {

--- a/lib/Models/setClockCurrentTime.js
+++ b/lib/Models/setClockCurrentTime.js
@@ -11,15 +11,19 @@ var TerriaError = require('../Core/TerriaError');
  * Set time to nearest time to specified (may be start or end of time range if time is not in range).
  * @param {DataSourceClock} clock clock to set current time on.
  * @param {JulianDate} timeToSet the time to set
+ * @param {JulianDate} [stopTime=clock.stopTime] The stop time to use instead of `clock.stopTime`. This is useful to
+ *                     position the clock at the start of the final interval instead of at its end.
  * @private
  */
-function _setTimeIfInRange(clock, timeToSet)
+function _setTimeIfInRange(clock, timeToSet, stopTime)
 {
+    stopTime = defaultValue(stopTime, clock.stopTime);
+
     if (JulianDate.lessThan(timeToSet, clock.startTime)) {
         clock.currentTime = clock.startTime.clone(clock.currentTime);
     }
-    else if (JulianDate.greaterThan(timeToSet, clock.stopTime)) {
-        clock.currentTime = clock.stopTime.clone(clock.currentTime);
+    else if (JulianDate.greaterThan(timeToSet, stopTime)) {
+        clock.currentTime = stopTime.clone(clock.currentTime);
     } else {
         clock.currentTime = timeToSet.clone(clock.currentTime);
     }
@@ -34,11 +38,11 @@ function _setTimeIfInRange(clock, timeToSet)
  *                  "end": end of time range of animation,
  *                  An ISO8601 date e.g. "2015-08-08": specified date or nearest if date is outside range).
  */
-function setClockCurrentTime(clock, initialTimeSource)
+function setClockCurrentTime(clock, initialTimeSource, stopTime)
 {
     // This is our default. Start at the nearest instant in time.
     var now = JulianDate.now();
-    _setTimeIfInRange(clock, now);
+    _setTimeIfInRange(clock, now, stopTime);
 
     initialTimeSource = defaultValue(initialTimeSource, "present");
     switch(initialTimeSource)

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -982,7 +982,7 @@ describe('CsvCatalogItem with region mapping', function() {
             expect(csvItem.tableStructure.columnsByType[VarType.TIME].length).toEqual(1);
             expect(csvItem.tableStructure.columnsByType[VarType.TIME][0].julianDates[0]).toEqual(j('2015-08-07'));
             // Test that the right regions have been colored (since the datasource doesn't expose the entities).
-            // On 2015-08-07, only postcodes 3121 and 3122 have values. On neighboring dates, so do 3123 and 3124.
+            // On 2015-08-08, only postcodes 3121 and 3122 have values. On neighboring dates, so do 3123 and 3124.
             var recolorFunction = ImageryProviderHooks.addRecolorFunc.calls.argsFor(0)[1];
             var regionNames = regionDetail.regionProvider.regions.map(getId);
 

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -954,7 +954,7 @@ describe('CsvCatalogItem with region mapping', function() {
             expect(csvItem.tableStructure.columnsByType[VarType.TIME].length).toEqual(1);
             expect(csvItem.tableStructure.columnsByType[VarType.TIME][0].julianDates[0]).toEqual(j('2015-08-07'));
             // Test that the right regions have been colored (since the datasource doesn't expose the entities).
-            // On 2015-08-07, only postcodes 3121 and 3122 have values. On neighboring dates, so do 3123 and 3124.
+            // On 2015-08-08, only postcodes 3121 and 3122 have values. On neighboring dates, so do 3123 and 3124.
             var recolorFunction = ImageryProviderHooks.addRecolorFunc.calls.argsFor(0)[1];
             var regionNames = regionDetail.regionProvider.regions.map(getId);
 


### PR DESCRIPTION
* Makes the initial time the start of the last interval, instead of the stop of the last interval (the interval is open at the stop, so setting the initial time to the stop will result in showing no data.  Also addresses @meh9's comment here https://github.com/TerriaJS/terriajs/pull/2645#issuecomment-338062325)
* Fixes a whole bunch of bugs.
