### PR TITLE
Enable the splitter by default.

### DIFF
--- a/doc/customizing/client-side-config.md
+++ b/doc/customizing/client-side-config.md
@@ -42,6 +42,8 @@ Option                      | Meaning
 `"supportEmail"`            | The email address shown when things go wrong.
 `"mobileDefaultViewerMode"` | A string specifying the default view mode to load when running on a mobile platform. Options are: `"3DTerrain"`, `"3DSmooth"`, `"2D"`. (Default: `"2D"`)
 `"initFragmentPaths"`       | An array of base paths to use to try to use to resolve init fragments in the URL.  For example, if this property is `[ "init/", "http://example.com/init/"]`, then a URL with `#test` will first try to load `init/test.json` and, if that fails, next try to load `http://example.com/init/test.json`.  If not specified, this property defaults to `[ "init/" ]`.
+`"disableMyLocation"`       | True to disable the "go to my location" button.
+`"disableSplitter"`         | True to disable the use of the splitter control.
 
 ## Advanced options
 

--- a/lib/ReactViews/Map/MapNavigation.jsx
+++ b/lib/ReactViews/Map/MapNavigation.jsx
@@ -1,16 +1,13 @@
-import React from 'react';
-
-import createReactClass from 'create-react-class';
-
-import PropTypes from 'prop-types';
-
 import Compass from './Navigation/Compass.jsx';
+import createReactClass from 'create-react-class';
 import MyLocation from './Navigation/MyLocation.jsx';
-import ZoomControl from './Navigation/ZoomControl.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
-import ViewerMode from '../../Models/ViewerMode';
-
+import PropTypes from 'prop-types';
+import React from 'react';
 import Styles from './map-navigation.scss';
+import ToggleSplitterTool from './Navigation/ToggleSplitterTool';
+import ViewerMode from '../../Models/ViewerMode';
+import ZoomControl from './Navigation/ZoomControl.jsx';
 
 // The map navigation region
 const MapNavigation = createReactClass({
@@ -43,6 +40,11 @@ const MapNavigation = createReactClass({
                 <If condition={!this.props.terria.configParameters.disableMyLocation}>
                     <div className={Styles.control}>
                         <MyLocation terria={this.props.terria}/>
+                    </div>
+                </If>
+                <If condition={!this.props.terria.configParameters.disableSplitter}>
+                    <div className={Styles.control}>
+                        <ToggleSplitterTool terria={this.props.viewState.terria}/>
                     </div>
                 </If>
                 <For each="item" of={this.props.navItems} index="i">

--- a/lib/ReactViews/Map/Navigation/ToggleSplitterTool.jsx
+++ b/lib/ReactViews/Map/Navigation/ToggleSplitterTool.jsx
@@ -26,7 +26,7 @@ const ToggleSplitterTool = createReactClass({
         }
         return <div className={Styles.toggle_splitter_tool}>
                   <button type='button' className={Styles.btn}
-                          title='Toggle splitter control'
+                          title='toggle splitter control'
                           onClick={this.handleClick}>
                           <Icon glyph={this.props.terria.showSplitter ? Icon.GLYPHS.splitterOn : Icon.GLYPHS.splitterOff}/>
                   </button>

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
@@ -94,7 +94,7 @@ const ViewingControls = createReactClass({
     render() {
         const item = this.props.item;
         const canZoom = item.canZoomTo || (item.tableStructure && item.tableStructure.sourceFeature);
-        const canSplit = item.supportsSplitting && defined(item.splitDirection) && item.terria.currentViewer.canShowSplitter;
+        const canSplit = !item.terria.configParameters.disableSplitter && item.supportsSplitting && defined(item.splitDirection) && item.terria.currentViewer.canShowSplitter;
         const classList = {[Styles.noZoom]: !canZoom, [Styles.noSplit]: !canSplit, [Styles.noInfo]: !item.showsInfo};
         return (
             <ul className={Styles.control}>


### PR DESCRIPTION
Disable it by setting `disableSplitter` in config.json.

@meh9 and @steve9164 you guys will want to remove the code in your maps that explicitly added the splitter control after this is merged.