### PR TITLE
Update docs to recommend using yarn workspaces instead of npmgitdev

### DIFF
--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -44,6 +44,10 @@ git checkout 4.5.0
 cd ..
 ```
 
+!!! note
+    
+    The version of TerriaJS in your `packages/terriajs` directory must be semver-compatible with the version specification in TerriaMap's `package.json`. If it's not, yarn will install a separate semver-compatible version of TerriaJS in `node_modules` instead of using the one you've put in `packages/terriajs`. The version numbers are _usually_ already aligned, but if not, change the `"terriajs": "x.y.z"` dependency in TerriaMap's `package.json` to be the exact `"version"` property in TerriaJS's `package.json`. You will generally not want to commit this change.
+
 Then, in the TerriaMap directory, run:
 
 ```

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -58,7 +58,9 @@ Yarn will:
 
 Now, we can edit TerriaJS in `packages/terriajs` with the benefit of a full-featured git repo.
 
-| *Note*: Running `yarn install` with workspaces configured will change yarn.lock.  Please do not commit the changes. |
+!!! note
+
+	Running `yarn install` with workspaces configured will change `yarn.lock`.  Please do not commit the changes.
 
 To switch TerriaMap back to using the npm version of TerriaJS (instead of the git repo), do:
 

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -90,7 +90,7 @@ Replace `branchName` with the name of the TerriaJS branch you want to use.  You 
 
 Once your TerriaJS pull request has been merged and a new version of the `terriajs` npm module has been published, please remember to update `package.json` to point to an official `terriajs` version instead of a branch in a GitHub repo.
 
-The `package.json` in the `master` branch of TerriaMap should point to official releases of `terriajs` on npm, NOT GitHub branches.
+The `package.json` in the `master` branch of TerriaMap should point to official releases of `terriajs` on npm, NOT GitHub branches.  In other words, it is ok to commit a package.json with a git URL to a branch, but do _not_ merge it to master.
 
 ## Documentation
 

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -62,6 +62,8 @@ Yarn will:
 
 Now, we can edit TerriaJS in `packages/terriajs` with the benefit of a full-featured git repo.
 
+Confirm that yarn has configured TerriaMap to use the copy of TerriaJS in `packages/terriajs` by verifying that `node_modules/terriajs` is a symlink to `packages/terriajs`.  If it's not, you probably have a version conflict.  See the note above.
+
 !!! note
 
 	Running `yarn install` with workspaces configured will change `yarn.lock`.  Please do not commit the changes.

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -14,6 +14,8 @@ First, install `yarn` globally:
 npm install -g yarn
 ```
 
+If you already have yarn installed, make sure it is at least v1.0 (we recommend using the latest version).  Older versions do not support the workspace feature.
+
 Then, enable workspaces by editing the TerriaMap `package.json` file, adding these lines to the top, just after the opening `{`:
 
 ```json

--- a/doc/contributing/using-a-custom-version-of-cesium.md
+++ b/doc/contributing/using-a-custom-version-of-cesium.md
@@ -2,21 +2,20 @@
 
 What if you need to make changes to [Cesium](https://github.com/AnalyticalGraphicsInc/cesium) while working on TerriaJS?
 
-The process of using a custom version of Cesium is much the same as using a custom version of TerriaJS.  See the [Development Environment](development-environment.md#building-a-terriamap-against-a-modified-terriajs) for information on setting up and using `npmgitdev`.  To clone Cesium, do:
+The process of using a custom version of Cesium is much the same as using a custom version of TerriaJS.  See the [Development Environment](development-environment.md#building-a-terriamap-against-a-modified-terriajs) for information on setting up and using `yarn`.  To clone Cesium, do:
 
 ```
-cd node_modules
-rm -rf terriajs-cesium
-git clone -b terriajs https://github.com/TerriaJS/cesium.git terriajs-cesium
+cd packages
+git clone -b terriajs https://github.com/TerriaJS/cesium.git
 cd ..
 ```
 
 It is important that you use the `terriajs` branch of [TerriaJS/cesium](https://github.com/TerriaJS/cesium) because it contains important changes to Cesium that are necessary for it to work with TerriaJS.  If you need to use a different branch of Cesium, you will need to merge that branch with the changes in the `terriajs` branch.
 
-If you run `npmgitdev install`, make sure that npm hasn't installed a separate version of `terriajs-cesium` under terriajs:
+And then run:
 
 ```
-rm -rf node_modules/terriajs/node_modules/terriajs-cesium
+yarn install
 ```
 
 ## Committing modifications

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -24,8 +24,8 @@ If you run into trouble or want more explanation, read on.
 
 TerriaJS can be built and run on almost any macOS, Linux, or Windows system.  The following are required to build TerriaJS:
 
-* [Node.js](https://nodejs.org) v6.0 or later.  v7.x is also known to work.  We currently recommend that you avoid using v8.x because v8.x includes npm v5.x which causes problems with some of our dependencies.  You can check your node version by running `node --version` on the command-line.
-* [npm](https://www.npmjs.com/) v3.0 or later.  We currently recommend that you avoid using v5.x.  npm is usually installed automatically alongside the above.  You can check your npm version by running `npm --version`.
+* [Node.js](https://nodejs.org) v6.0 or later.  v7.x and v8.x are also known to work.  You can check your node version by running `node --version` on the command-line.
+* [npm](https://www.npmjs.com/) v3.0 or later.  v4.x and v5.x are also known to work.  npm is usually installed automatically alongside the above.  You can check your npm version by running `npm --version`.
 
 The following components are optional:
 


### PR DESCRIPTION
I've been using yarn workspaces for develoment for a week or so now, and it's great!  It's better than npmgitdev in almost every way.

A few other people should try these instructions and make sure it works smoothly for them, too.