### PR TITLE
Fix a bug which prevented new `cannotSum` behaviour from working

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.5.3
+
+* Fixed a bug in SDMX-JSON when using `cannotSum`.
+
 ### 5.5.2
 
 * Deprecated SDMX-JSON catalog items' `cannotDisplayPercentMap` in favour of `cannotSum`.

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -1387,7 +1387,9 @@ function loadAndBuildTable(item, dimensionRequestString) {
             // Usually, this means canDisplayPercent should be set to True.
             // However, there are cases where a rate, or mean, is displayed, when it still doesn't make sense.
             item.canDisplayPercent = canResultsBeSummed(item);
-            percentColumn = buildPercentColumn(item, totalColumn, regionTotalColumns[0]);
+            if (item.canDisplayPercent) {
+                percentColumn = buildPercentColumn(item, totalColumn, regionTotalColumns[0]);
+            }
         } else {
             item.canDisplayPercent = false;
         }


### PR DESCRIPTION
Fixes an embarrassing oversight.