### PR TITLE
Token-related improvements

### DIFF
--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -7,7 +7,6 @@ var Cartographic = require('terriajs-cesium/Source/Core/Cartographic');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');
 var CesiumMath = require('terriajs-cesium/Source/Core/Math');
 var defined = require('terriajs-cesium/Source/Core/defined');
-var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
 var TileProviderError = require('terriajs-cesium/Source/Core/TileProviderError');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
 

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -50,17 +50,13 @@ var CesiumTileLayer = L.TileLayer.extend({
         // retries after the promise resolves.
         var that = this;
 
-        function failure(e) {
-            var errorUrl = that.options.errorTileUrl;
-            if (errorUrl && tile.src !== errorUrl) {
-                tile.src = errorUrl;
-            }
-            done(e, tile);
-        }
-
         function doRequest(waitPromise) {
             if (waitPromise) {
-                waitPromise.then(function() { doRequest(); }).otherwise(failure);
+                waitPromise.then(function() { doRequest(); }).otherwise(function(e) {
+                    // The tile has failed irrecoverably, so invoke Leaflet's standard
+                    // tile error handler.
+                    L.TileLayer.prototype._tileOnError.call(that, done, tile, e);
+                });
                 return;
             }
 

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -7,7 +7,9 @@ var Cartographic = require('terriajs-cesium/Source/Core/Cartographic');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');
 var CesiumMath = require('terriajs-cesium/Source/Core/Math');
 var defined = require('terriajs-cesium/Source/Core/defined');
+var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
+var TileProviderError = require('terriajs-cesium/Source/Core/TileProviderError');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
 
 var pollToPromise = require('../Core/pollToPromise');
@@ -30,12 +32,62 @@ var CesiumTileLayer = L.TileLayer.extend({
         this._zSubtract = 0;
         this._previousCredits = [];
 
+        this._requestImageError = undefined;
+
         L.TileLayer.prototype.initialize.call(this, undefined, options);
     },
 
+    _tileOnError: function(done, tile, e) {
+        // Do nothing, we'll handle tile errors separately.
+    },
+
+    createTile: function(coords, done) {
+        // Create a tile (Image) as normal.
+        var tile = L.TileLayer.prototype.createTile.call(this, coords, done);
+
+        // By default, Leaflet handles tile load errors by setting the Image to the error URL and raising
+        // an error event.  We want to first raise an error event that optionally returns a promise and
+        // retries after the promise resolves.
+        var that = this;
+
+        function failure(e) {
+            var errorUrl = that.options.errorTileUrl;
+            if (errorUrl && tile.src !== errorUrl) {
+                tile.src = errorUrl;
+            }
+            done(e, tile);
+        }
+
+        function doRequest(waitPromise) {
+            if (waitPromise) {
+                waitPromise.then(function() { doRequest(); }).otherwise(failure);
+                return;
+            }
+
+            // Setting src will trigger a new load or error event, even if the
+            // new src is the same as the old one.
+            tile.src = that.getTileUrl(coords);
+        }
+
+        L.DomEvent.on(tile, 'error', function(e) {
+            var level = that._getLevelFromZ(coords);
+            var message = 'Failed to obtain image tile X: ' + coords.x + ' Y: ' + coords.y + ' Level: ' + level + '.';
+            that._requestImageError = TileProviderError.handleError(
+                that._requestImageError,
+                that.imageryProvider,
+                that.imageryProvider.errorEvent,
+                message,
+                coords.x, coords.y, level,
+                doRequest,
+                e);
+        });
+
+        return tile;
+    },
+
     getTileUrl: function(tilePoint) {
-        var z = tilePoint.z - this._zSubtract;
-        if (z < 0) {
+        var level = this._getLevelFromZ(tilePoint);
+        if (level < 0) {
             return this.options.errorTileUrl;
         }
 
@@ -46,11 +98,15 @@ var CesiumTileLayer = L.TileLayer.extend({
             tileUrl = url;
         };
 
-        this.imageryProvider.requestImage(tilePoint.x, tilePoint.y, z);
+        this.imageryProvider.requestImage(tilePoint.x, tilePoint.y, level);
 
         ImageryProvider.loadImage = oldLoad;
 
         return tileUrl;
+    },
+
+    _getLevelFromZ: function(tilePoint) {
+        return tilePoint.z - this._zSubtract;
     },
 
     _update: function() {

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -7,11 +7,11 @@ var Cartographic = require('terriajs-cesium/Source/Core/Cartographic');
 var CesiumEvent = require('terriajs-cesium/Source/Core/Event');
 var CesiumMath = require('terriajs-cesium/Source/Core/Math');
 var defined = require('terriajs-cesium/Source/Core/defined');
-var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
 var TileProviderError = require('terriajs-cesium/Source/Core/TileProviderError');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
 
+var getUrlForImageryTile = require('./getUrlForImageryTile');
 var pollToPromise = require('../Core/pollToPromise');
 
 var swScratch = new Cartographic();
@@ -87,18 +87,7 @@ var CesiumTileLayer = L.TileLayer.extend({
             return this.options.errorTileUrl;
         }
 
-        var oldLoad = ImageryProvider.loadImage;
-
-        var tileUrl = this.options.errorTileUrl;
-        ImageryProvider.loadImage = function(imageryProvider, url) {
-            tileUrl = url;
-        };
-
-        this.imageryProvider.requestImage(tilePoint.x, tilePoint.y, level);
-
-        ImageryProvider.loadImage = oldLoad;
-
-        return tileUrl;
+        return getUrlForImageryTile(this.imageryProvider, tilePoint.x, tilePoint.y, level);
     },
 
     _getLevelFromZ: function(tilePoint) {

--- a/lib/Map/getUrlForImageryTile.js
+++ b/lib/Map/getUrlForImageryTile.js
@@ -1,0 +1,28 @@
+var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
+var throttleRequestByServer = require('terriajs-cesium/Source/Core/throttleRequestByServer');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
+
+function getUrlForImageryTile(imageryProvider, x, y, level) {
+    const oldMaxRequests = throttleRequestByServer.maximumRequestsPerServer;
+    const oldLoadImage = ImageryProvider.loadImage;
+
+    let tileUrl;
+    try {
+        throttleRequestByServer.maximumRequestsPerServer = Number.MAX_SAFE_INTEGER;
+
+        ImageryProvider.loadImage = function(imageryProvider, url) {
+            tileUrl = url;
+            return when();
+        }
+
+        imageryProvider.requestImage(x, y, level);
+    } catch(e) {
+    }
+
+    throttleRequestByServer.maximumRequestsPerServer = oldMaxRequests;
+    ImageryProvider.loadImage = oldLoadImage;
+
+    return tileUrl;
+}
+
+module.exports = getUrlForImageryTile;

--- a/lib/Map/getUrlForImageryTile.js
+++ b/lib/Map/getUrlForImageryTile.js
@@ -13,7 +13,7 @@ function getUrlForImageryTile(imageryProvider, x, y, level) {
         ImageryProvider.loadImage = function(imageryProvider, url) {
             tileUrl = url;
             return when();
-        }
+        };
 
         imageryProvider.requestImage(x, y, level);
     } catch(e) {

--- a/lib/Map/getUrlForImageryTile.js
+++ b/lib/Map/getUrlForImageryTile.js
@@ -16,11 +16,10 @@ function getUrlForImageryTile(imageryProvider, x, y, level) {
         };
 
         imageryProvider.requestImage(x, y, level);
-    } catch(e) {
+    } finally {
+        throttleRequestByServer.maximumRequestsPerServer = oldMaxRequests;
+        ImageryProvider.loadImage = oldLoadImage;
     }
-
-    throttleRequestByServer.maximumRequestsPerServer = oldMaxRequests;
-    ImageryProvider.loadImage = oldLoadImage;
 
     return tileUrl;
 }

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -286,6 +286,22 @@ sending an email to <a href="mailto:' + that.terria.supportEmail + '">' + that.t
     }
 };
 
+ArcGisMapServerCatalogItem.prototype.handleTileError = function(imageryProvider, x, y, level, e) {
+    if (e && (e.statusCode === 498 || e.statusCode === 499)) {
+        if (!defined(this._newTokenRequestInFlight)) {
+            var that = this;
+            this._newTokenRequestInFlight = getToken(this).then(function(token) {
+                that.token = token;
+                that._newTokenRequestInFlight = undefined;
+            });
+        }
+
+        return imageryProvider._newTokenRequestInFlight;
+    } else {
+        return when.reject(e);
+    }
+};
+
 ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
     var maximumLevel = maximumScaleToLevel(this.maximumScale);
     var r = partsRegex.exec(this.url);

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -291,12 +291,12 @@ ArcGisMapServerCatalogItem.prototype.handleTileError = function(imageryProvider,
         if (!defined(this._newTokenRequestInFlight)) {
             var that = this;
             this._newTokenRequestInFlight = getToken(this).then(function(token) {
-                that.token = token;
+                imageryProvider.token = token;
                 that._newTokenRequestInFlight = undefined;
             });
         }
 
-        return imageryProvider._newTokenRequestInFlight;
+        return this._newTokenRequestInFlight;
     } else {
         return when.reject(e);
     }

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -1022,6 +1022,24 @@ CatalogItem.prototype.enableWithParents = function() {
     }
 };
 
+/**
+ * Handles an error in loading a tile. If this function returns a promise that resolves successfully,
+ * the tile request will be retried. If the returned promise rejects, it must reject with an instance
+ * of `RequestErrorEvent` with the details of the failure, and the default handling of tile
+ * failures will be used.  The default handling takes into account the `treat404AsError`, `treat403AsError`,
+ * and `ignoreUnknownTileErrors` properties.  The default implementation simply rejects with `e`.
+ *
+ * @param {ImageryProvider} imageryProvider
+ * @param {Number} x
+ * @param {Number} y
+ * @param {Number} level
+ * @param {RequestErrorEvent} e
+ * @returns {Promise}
+ */
+CatalogItem.prototype.handleTileError = function(imageryProvider, x, y, level, e) {
+    return when.reject(e);
+};
+
 function isEnabledChanged(catalogItem) {
     var terria = catalogItem.terria;
 

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -849,42 +849,7 @@ Cesium.prototype.addImageryProvider = function(options) {
     var errorEvent = options.imageryProvider.errorEvent;
 
     if (defined(errorEvent)) {
-        errorEvent.addEventListener(function(tileProviderError) {
-            // We're only concerned about failures for tiles that actually overlap this item's extent.
-            if (defined(options.rectangle)) {
-                var tilingScheme = options.imageryProvider.tilingScheme;
-                var tileExtent = tilingScheme.tileXYToRectangle(tileProviderError.x, tileProviderError.y, tileProviderError.level);
-                var intersection = Rectangle.intersection(tileExtent, options.rectangle);
-                if (!defined(intersection)) {
-                    return;
-                }
-            }
-
-            if (defined(tileProviderError.error) && tileProviderError.error.statusCode === 404) {
-                if(!options.treat404AsError) {
-                    return;
-                }
-            } else if (defined(tileProviderError.error) && tileProviderError.error.statusCode === 403) {
-                if(!options.treat403AsError) {
-                    return;
-                }
-                // ignoreUnknownTileErrors is only for genuinely unknown (no status code) issues
-            } else if (options.ignoreUnknownTileErrors && (!defined(tileProviderError.error) || !defined(tileProviderError.error.statusCode))) {
-                return;
-            }
-
-            // Retry 3 times.
-            if (tileProviderError.timesRetried < 3) {
-                tileProviderError.retry = true;
-                return;
-            }
-
-            // After three failures, advise the user that something is wrong and hide the catalog item.
-            // (if the item isn't already hidden, that is)
-            if (defined(options.onLoadError)) {
-                options.onLoadError(tileProviderError);
-            }
-        });
+        errorEvent.addEventListener(options.onLoadError);
     }
 
     var result = new ImageryLayer(options.imageryProvider, {
@@ -914,6 +879,10 @@ Cesium.prototype.showImageryLayer = function(options) {
 
 Cesium.prototype.hideImageryLayer = function(options) {
     options.layer.show = false;
+};
+
+Cesium.prototype.isImageryLayerShown = function(options) {
+    return options.layer.show;
 };
 
 Cesium.prototype.updateItemForSplitter = function(item) {

--- a/lib/Models/GlobeOrMap.js
+++ b/lib/Models/GlobeOrMap.js
@@ -337,6 +337,10 @@ GlobeOrMap.prototype.hideImageryLayer = function(options) {
     throw new DeveloperError('hideImageryLayer must be implemented in the derived class.');
 };
 
+GlobeOrMap.prototype.isImageryLayerShown = function(options) {
+    throw new DeveloperError('isImageryLayerShown must be implemented in the derived class.');
+};
+
 GlobeOrMap.prototype.addDataSource = function(options) {
     this.terria.dataSources.add(options.dataSource);
 };

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -597,7 +597,7 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
             let detailsPromise;
             if (defined(tileProviderError.error) && defined(tileProviderError.error.statusCode)) {
                 detailsPromise = when.reject(tileProviderError.error);
-            } else if (defined(tileProviderError.x) && defined(tileProviderError.t) && defined(tileProviderError.level)) {
+            } else if (defined(tileProviderError.x) && defined(tileProviderError.y) && defined(tileProviderError.level)) {
                 // Something went wrong, but we don't really know what, probably because this is a failed image load.
                 // Browsers tell us almost nothing on a failed image load.
                 // So re-do the request with XMLHttpRequest so we can get more details of the failure.  We need to
@@ -620,8 +620,8 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
                 // Just letting the retry promise resolve will trigger a retry of the image load.
             });
 
-            if (catalogItem.handleTileErrors) {
-                tileProviderError.retry.otherwise(function(e) {
+            if (catalogItem.handleTileError) {
+                tileProviderError.retry = tileProviderError.retry.otherwise(function(e) {
                     return catalogItem.handleTileError(imageryProvider, tileProviderError.x, tileProviderError.y, tileProviderError.level, e);
                 });
             }
@@ -629,8 +629,8 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
             tileProviderError.retry = tileProviderError.retry.otherwise(function(e) {
                 e = e || {};
 
-                // The details request failed, as expected, and now we should know why.  Now we can trigger retry
-                // by resolving or failure by rejecting, depending on the detailed nature of the failure.
+                // The details request failed, as expected, and now we should know why.  We can trigger retry
+                // by resolving or give up by rejecting, depending on the detailed nature of the failure.
 
                 // We're only concerned about failures for tiles that actually overlap this item's extent.
                 if (defined(catalogItem.rectangle)) {
@@ -658,12 +658,12 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
                 // This failure is not ok.  We allow a few "not ok" failures and then turn off the layer and
                 // display a message to the user.
 
-                // Retry 3 times. We can't count on the TileProviderError's accounting of the times retried because it will
+                // Retry 5 times. We can't count on the TileProviderError's accounting of the times retried because it will
                 // quickly spin up without taking into account our logic above that allows some types of failures.
                 ++tileFailures;
 
                 if (tileFailures <= 5) {
-                    // Let this tile fail even though it probably indicates something wrong with the server.
+                    // Let this tile fail silently, even though it probably indicates something wrong with the server.
                     return when.reject(e);
                 }
 

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -12,11 +12,15 @@ var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var ImagerySplitDirection = require('terriajs-cesium/Source/Scene/ImagerySplitDirection');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+var loadBlob = require('terriajs-cesium/Source/Core/loadBlob');
+var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
 var TimeIntervalCollection = require('terriajs-cesium/Source/Core/TimeIntervalCollection');
+var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 var CatalogItem = require('./CatalogItem');
 var CompositeCatalogItem = require('./CompositeCatalogItem');
+var getUrlForImageryTile = require('../Map/getUrlForImageryTile');
 var inherit = require('../Core/inherit');
 var TerriaError = require('../Core/TerriaError');
 var overrideProperty = require('../Core/overrideProperty');
@@ -573,6 +577,8 @@ function updateSplitDirection(item) {
 ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opacity, layerIndex, globeOrMap) {
     globeOrMap = defaultValue(globeOrMap, catalogItem.terria.currentViewer);
 
+    let tileFailures = 0;
+
     const layer = globeOrMap.addImageryProvider({
         imageryProvider: imageryProvider,
         rectangle: catalogItem.rectangle,
@@ -583,56 +589,139 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
         treat404AsError: catalogItem.treat404AsError,
         ignoreUnknownTileErrors: catalogItem.ignoreUnknownTileErrors,
         isRequiredForRendering: catalogItem.isRequiredForRendering,
-        onLoadError: function(e) {
-            if (defined(layer) && (layer.show === true || !defined(layer.show))) {
+        onLoadError: function(tileProviderError) {
+            if (tileProviderError.timesRetried === 0) {
+                tileFailures = 0;
+            }
 
-                if (catalogItem === catalogItem.terria.baseMap ||
-                    catalogItem.terria.baseMap instanceof CompositeCatalogItem && catalogItem.terria.baseMap.items.indexOf(catalogItem) >= 0) {
+            let detailsPromise;
+            if (defined(tileProviderError.error) && defined(tileProviderError.error.statusCode)) {
+                detailsPromise = when.reject(tileProviderError.error);
+            } else if (defined(tileProviderError.x) && defined(tileProviderError.t) && defined(tileProviderError.level)) {
+                // Something went wrong, but we don't really know what, probably because this is a failed image load.
+                // Browsers tell us almost nothing on a failed image load.
+                // So re-do the request with XMLHttpRequest so we can get more details of the failure.  We need to
+                // hackily get the URL out in order to do this.
+                // TODO: what if this isn't a tile request?
+                const tileUrl = getUrlForImageryTile(imageryProvider, tileProviderError.x, tileProviderError.y, tileProviderError.level);
 
-                    globeOrMap.terria.error.raiseEvent(new TerriaError({
-                        sender: catalogItem,
-                        title: 'Error accessing base map',
-                        message: '\
-An error occurred while attempting to download tiles for base map ' + catalogItem.terria.baseMap.name + '.  This may indicate that there is a \
-problem with your internet connection, that the base map is temporarily unavailable, or that the base map \
-is invalid.  Please select a different base map using the Map button in the top-right corner.  Further technical details may be found below.<br/><br/>\
-<pre>' + formatError(e) + '</pre>'
-                    }));
+                if (tileUrl) {
+                    detailsPromise = loadBlob(tileUrl);
+                }
+            }
 
-                    layer.show = false;
-                    catalogItem.terria.baseMap = undefined;
+            if (!detailsPromise) {
+                // We couldn't get any details. Oh well, carry on.
+                detailsPromise = when.reject(tileProviderError.error);
+            }
 
-                    // Don't use this base map again on startup.
-                    catalogItem.terria.setLocalProperty('basemap', undefined);
-                } else {
-                    globeOrMap.terria.error.raiseEvent(new TerriaError({
-                        sender: catalogItem,
-                        title: 'Error accessing catalogue item',
-                        message: '\
-An error occurred while attempting to download tiles for catalogue item ' + catalogItem.name + '.  This may indicate that there is a \
-problem with your internet connection, that the catalogue item is temporarily unavailable, or that the catalogue item \
-is invalid.  The catalogue item has been hidden from the map.  You may re-show it in the Now Viewing panel to try again.  Further technical details may be found below.<br/><br/>\
-<pre>' + formatError(e) + '</pre>'
-                    }));
+            tileProviderError.retry = detailsPromise.then(function() {
+                // Hey wait, the request succeeded this time!  Let's just try the image again, then.
+                // Just letting the retry promise resolve will trigger a retry of the image load.
+            });
 
-                    if (globeOrMap === catalogItem.terria.currentViewer) {
-                        catalogItem.isShown = false;
-                    } else {
+            if (catalogItem.handleTileErrors) {
+                tileProviderError.retry.otherwise(function(e) {
+                    return catalogItem.handleTileError(imageryProvider, tileProviderError.x, tileProviderError.y, tileProviderError.level, e);
+                });
+            }
+
+            tileProviderError.retry = tileProviderError.retry.otherwise(function(e) {
+                e = e || {};
+
+                // The details request failed, as expected, and now we should know why.  Now we can trigger retry
+                // by resolving or failure by rejecting, depending on the detailed nature of the failure.
+
+                // We're only concerned about failures for tiles that actually overlap this item's extent.
+                if (defined(catalogItem.rectangle)) {
+                    var tilingScheme = imageryProvider.tilingScheme;
+                    var tileExtent = tilingScheme.tileXYToRectangle(tileProviderError.x, tileProviderError.y, tileProviderError.level);
+                    var intersection = Rectangle.intersection(tileExtent, catalogItem.rectangle);
+                    if (!defined(intersection)) {
+                        return when.reject(e); // tile failed and that's ok
+                    }
+                }
+
+                // Note that ignoreUnknownTileErrors is only for genuinely unknown (no status code) issues.
+                if (e.statusCode === 404) {
+                    if(!catalogItem.treat404AsError) {
+                        return when.reject(e); // tile failed and that's ok
+                    }
+                } else if (e.statusCode === 403) {
+                    if(!catalogItem.treat403AsError) {
+                        return when.reject(e); // tile failed and that's ok
+                    }
+                } else if (catalogItem.ignoreUnknownTileErrors && !defined(e.statusCode)) {
+                    return when.reject(e); // tile failed and that's ok
+                }
+
+                // This failure is not ok.  We allow a few "not ok" failures and then turn off the layer and
+                // display a message to the user.
+
+                // Retry 3 times. We can't count on the TileProviderError's accounting of the times retried because it will
+                // quickly spin up without taking into account our logic above that allows some types of failures.
+                ++tileFailures;
+
+                if (tileFailures <= 5) {
+                    // Let this tile fail even though it probably indicates something wrong with the server.
+                    return when.reject(e);
+                }
+
+                // Too many failures!
+                if (defined(layer) && globeOrMap.isImageryLayerShown({layer})) {
+                    if (catalogItem === catalogItem.terria.baseMap ||
+                        catalogItem.terria.baseMap instanceof CompositeCatalogItem && catalogItem.terria.baseMap.items.indexOf(catalogItem) >= 0) {
+
+                        globeOrMap.terria.error.raiseEvent(new TerriaError({
+                            sender: catalogItem,
+                            title: 'Error accessing base map',
+                            message:
+                                'An error occurred while attempting to download tiles for base map ' + catalogItem.terria.baseMap.name + '.  This may indicate that there is a ' +
+                                'problem with your internet connection, that the base map is temporarily unavailable, or that the base map ' +
+                                'is invalid.  Please select a different base map using the Map button in the top-right corner.  Further technical details may be found below.<br/><br/>' +
+                                '<pre>' + formatError(e) + '</pre>'
+                        }));
+
                         globeOrMap.hideImageryLayer({
                             layer: layer
                         });
+                        catalogItem.terria.baseMap = undefined;
+
+                        // Don't use this base map again on startup.
+                        catalogItem.terria.setLocalProperty('basemap', undefined);
+                    } else {
+                        globeOrMap.terria.error.raiseEvent(new TerriaError({
+                            sender: catalogItem,
+                            title: 'Error accessing catalogue item',
+                            message:
+                                'An error occurred while attempting to download tiles for catalogue item ' + catalogItem.name + '.  This may indicate that there is a ' +
+                                'problem with your internet connection, that the catalogue item is temporarily unavailable, or that the catalogue item ' +
+                                'is invalid.  The catalogue item has been hidden from the map.  You may re-show it in the Now Viewing panel to try again.  Further technical details may be found below.<br/><br/>' +
+                                '<pre>' + formatError(e) + '</pre>'
+                        }));
+
+                        if (globeOrMap === catalogItem.terria.currentViewer) {
+                            catalogItem.isShown = false;
+                        } else {
+                            globeOrMap.hideImageryLayer({
+                                layer: layer
+                            });
+                        }
                     }
                 }
-            }
+
+                // Don't retry again.
+                return when.reject(e);
+            });
         },
         onProjectionError: function() {
             // If the TileLayer experiences an error, hide the catalog item and inform the user.
             globeOrMap.terria.error.raiseEvent({
                 sender: catalogItem,
                 title: 'Unable to display dataset',
-                message: '\
-"' + catalogItem.name + '" cannot be shown in 2D because it does not support the standard Web Mercator (EPSG:3857) projection.  \
-Please switch to 3D if it is supported on your system, update the dataset to support the projection, or use a different dataset.'
+                message:
+                    catalogItem.name + '" cannot be shown in 2D because it does not support the standard Web Mercator (EPSG:3857) projection.  ' +
+                    'Please switch to 3D if it is supported on your system, update the dataset to support the projection, or use a different dataset.'
             });
 
             if (globeOrMap === catalogItem.terria.currentViewer) {

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -602,7 +602,6 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
                 // Browsers tell us almost nothing on a failed image load.
                 // So re-do the request with XMLHttpRequest so we can get more details of the failure.  We need to
                 // hackily get the URL out in order to do this.
-                // TODO: what if this isn't a tile request?
                 const tileUrl = getUrlForImageryTile(imageryProvider, tileProviderError.x, tileProviderError.y, tileProviderError.level);
 
                 if (tileUrl) {

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -466,11 +466,7 @@ Leaflet.prototype.addImageryProvider = function(options) {
 
     var errorEvent = options.imageryProvider.errorEvent;
     if (defined(options.onLoadError) && defined(errorEvent)) {
-        errorEvent.addEventListener(function(tileProviderError) {
-            // For Leaflet, this event will never be raised for tile errors; it will only be raised for metadata errors.
-            // Just pass the error on to the user.
-            options.onLoadError(tileProviderError);
-        });
+        errorEvent.addEventListener(options.onLoadError);
     }
 
     return result;
@@ -493,6 +489,10 @@ Leaflet.prototype.showImageryLayer = function(options) {
 
 Leaflet.prototype.hideImageryLayer = function(options) {
     this.map.removeLayer(options.layer);
+};
+
+Leaflet.prototype.isImageryLayerShown = function(options) {
+    return this.map.hasLayer(options.layer);
 };
 
 // As of Internet Explorer 11.483.15063.0 and Edge 40.15063.0.0 (EdgeHTML 15.15063) there is an apparent

--- a/lib/Models/NoViewer.js
+++ b/lib/Models/NoViewer.js
@@ -137,4 +137,8 @@ NoViewer.prototype.showImageryLayer = function(options) {
 NoViewer.prototype.hideImageryLayer = function(options) {
 };
 
+NoViewer.prototype.isImageryLayerShown = function(options) {
+    return false;
+};
+
 module.exports = NoViewer;


### PR DESCRIPTION
Requires TerriaJS/cesium#27

* Make Leaflet's tile error handling closely match Cesium's. Specifically, it now uses `TileProviderError.handleError`.
* Improve the tile error handling mechanism (now used by both Cesium and Leaflet) to re-request the failed tile using XHR in order to get more detailed failure information. Allow the catalog item itself to attempt to handle errors via a new `handleTileError` method on `CatalogItem`.
* Handle the possibility of an expired token in `ArcGisMapServerCatalogItem` and get a new token and retry the tile using the `handleTileError` mechanism.

Fixes #2757 
