### PR TITLE
Stub out console.error.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Fixed a bug that caused the feature info panel to stop working after clicking on a location search marker.
 * Added support for ArcGIS tokens on the 2D map. Previously, tokens only worked reliably in 3D.
 * Improved handling of tile errors, making it more consistent between 2D and 3D.
+* Fixed a bug that prevented the Add Data button from working Internet Explorer 9 unless the DevTools were also open.
 
 ### 5.5.4
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -70,7 +70,8 @@ var Terria = function(options) {
     if (typeof window.console === 'undefined') {
         window.console = {
             log: function() {},
-            warn: function() {}
+            warn: function() {},
+            error: function() {}
         };
     }
     // Polyfill Promise for old browsers


### PR DESCRIPTION
React is using this, and it's not available in IE9 unless the DevTools are open. So the Add Data button currently doesn't work in IE9 without the DevTools open. 😞 