### PR TITLE
Add support for tokens to WebMapServiceCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.5.7
+
+* Added support for using tokens to access WMS layers, particularly using the WMS interface to ArcGIS servers.
+
 ### 5.5.6
 
 * Tweaked the sizing of the feature info panel.

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -7,6 +7,7 @@ var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
 var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
+var getToken = require('./getToken');
 var ImageryLayerCatalogItem = require('./ImageryLayerCatalogItem');
 var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
 var inherit = require('../Core/inherit');
@@ -14,7 +15,6 @@ var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var Legend = require('../Map/Legend');
 var LegendUrl = require('../Map/LegendUrl');
 var loadJson = require('terriajs-cesium/Source/Core/loadJson');
-var loadWithXhr = require('terriajs-cesium/Source/Core/loadWithXhr');
 var Metadata = require('./Metadata');
 var MetadataItem = require('./MetadataItem');
 var overrideProperty = require('../Core/overrideProperty');
@@ -23,6 +23,7 @@ var proj4definitions = require ('../Map/Proj4Definitions');
 var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var replaceUnderscores = require('../Core/replaceUnderscores');
+var RequestErrorEvent = require('terriajs-cesium/Source/Core/RequestErrorEvent');
 var TerriaError = require('../Core/TerriaError');
 var unionRectangleArray = require('../Map/unionRectangleArray');
 var URI = require('urijs');
@@ -47,6 +48,8 @@ var ArcGisMapServerCatalogItem = function(terria) {
     this._layersData = undefined;    // cached JSON response of layers metadata
     this._thisLayerInLayersData = undefined; // cached JSON response of one single layer
     this._allLayersInLayersData = undefined; // cached JSON response of either all layers, or [one layer].
+    this._lastToken = undefined; // cached token
+    this._newTokenRequestInFlight = undefined; // a promise for an in-flight token request
 
     /**
      * Gets or sets the comma-separated list of layer IDs to show.  If this property is undefined,
@@ -202,38 +205,6 @@ function getJson(item, uri) {
     return loadJson(proxyCatalogItemUrl(item, uri.addQuery('f', 'json').toString(), '1d'));
 }
 
-function getToken(item) {
-    const options = {
-        url: item.tokenUrl,
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        data: JSON.stringify({'url': item.url})
-    };
-
-    return loadWithXhr(options).then(function (result) {
-        const token = JSON.parse(result);
-
-        if (defined(token.token)) {
-            item._lastToken = token.token;
-            return token.token;
-        }
-
-        item._lastToken = undefined;
-        throw new TerriaError({
-            title: 'ArcGIS Mapserver Error',
-            message: '<p>The token server responded with an invalid token.</p><p>Please report it by \
-sending an email to <a href="mailto:' + item.terria.supportEmail + '">' + item.terria.supportEmail + '</a>.</p>'
-        });
-    }).otherwise(() => {
-        item._lastToken = undefined;
-        throw new TerriaError({
-            title: 'ArcGIS Mapserver Error',
-            message: '<p>Unable to request a token from the token server.</p><p>Please report it by \
-sending an email to <a href="mailto:' + item.terria.supportEmail + '">' + item.terria.supportEmail + '</a>.</p>'
-        });
-    });
-}
-
 ArcGisMapServerCatalogItem.prototype._load = function() {
     var that = this;
 
@@ -248,16 +219,17 @@ ArcGisMapServerCatalogItem.prototype._load = function() {
 
         var promise = when();
         if (this.tokenUrl) {
-            promise = getToken(this);
+            promise = getToken(this.terria, this.tokenUrl, this.url);
         }
 
         return promise.then(function (token) {
+            that._lastToken = token;
+
             var serviceUri = getBaseURI(that);
             var layersUri = getBaseURI(that).segment(layers); // either 'layers' or a number
             var legendUri = getBaseURI(that).segment('legend');
 
-            if (token)
-            {
+            if (token) {
                 serviceUri.addQuery('token', token);
                 layersUri.addQuery('token', token);
                 legendUri.addQuery('token', token);
@@ -286,21 +258,46 @@ sending an email to <a href="mailto:' + that.terria.supportEmail + '">' + that.t
     }
 };
 
-ArcGisMapServerCatalogItem.prototype.handleTileError = function(imageryProvider, x, y, level, e) {
-    if (e && (e.statusCode === 498 || e.statusCode === 499)) {
-        if (!defined(this._newTokenRequestInFlight)) {
-            var that = this;
-            this._newTokenRequestInFlight = getToken(this).then(function(token) {
-                imageryProvider.token = token;
-                that._newTokenRequestInFlight = undefined;
-            });
+ArcGisMapServerCatalogItem.prototype.handleTileError = function(detailsRequestPromise, imageryProvider, x, y, level) {
+    const that = this;
+    return detailsRequestPromise.otherwise(function(e) {
+        if (e && (e.statusCode === 498 || e.statusCode === 499)) {
+            return requestToken(that, imageryProvider);
+        } else {
+            return when.reject(e);
+        }
+    }).then(function(responseText) {
+        // On an `export` request with an expired or invalid token, ArcGIS returns
+        // a 200 response with a JSON payload indicating an error.
+        try {
+            const json = JSON.parse(responseText);
+            if (json && json.error && json.error.code) {
+                if (json.error.code === 498 || json.error.code === 499) {
+                    return requestToken(that, imageryProvider);
+                } else {
+                    // A non-token error occurred, tile fails.
+                    return when.reject(new RequestErrorEvent(json.error.code, json.error.message));
+                }
+            }
+        } catch (e) {
         }
 
-        return this._newTokenRequestInFlight;
-    } else {
-        return when.reject(e);
-    }
+        // Not JSON or not an error, so let's retry.
+        return responseText;
+    });
 };
+
+function requestToken(catalogItem, imageryProvider) {
+    if (!defined(catalogItem._newTokenRequestInFlight)) {
+        catalogItem._newTokenRequestInFlight = getToken(catalogItem.terria, catalogItem.tokenUrl, catalogItem.url).then(function(token) {
+            catalogItem._lastToken = token;
+            imageryProvider.token = token;
+            catalogItem._newTokenRequestInFlight = undefined;
+        });
+    }
+
+    return catalogItem._newTokenRequestInFlight;
+}
 
 ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
     var maximumLevel = maximumScaleToLevel(this.maximumScale);
@@ -321,14 +318,10 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
         usePreCachedTilesIfAvailable: !dynamicRequired
     };
 
-    if (this.tokenUrl) {
-        imageryOptions.requestNewToken = () => getToken(this);
-
-        if (defined(this._lastToken)) {
-            // Using the last token is an optimization; if its still valid it will speed up
-            // the operation and if its not then it will just be requested when its needed.
-            imageryOptions.token = this._lastToken;
-        }
+    if (defined(this._lastToken)) {
+        // Using the last token is an optimization; if its still valid it will speed up
+        // the operation and if its not then it will just be requested when its needed.
+        imageryOptions.token = this._lastToken;
     }
 
     var imageryProvider = new ArcGisMapServerImageryProvider(imageryOptions);

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -259,6 +259,10 @@ sending an email to <a href="mailto:' + that.terria.supportEmail + '">' + that.t
 };
 
 ArcGisMapServerCatalogItem.prototype.handleTileError = function(detailsRequestPromise, imageryProvider, x, y, level) {
+    if (!defined(this.tokenUrl)) {
+        return detailsRequestPromise;
+    }
+
     const that = this;
     return detailsRequestPromise.otherwise(function(e) {
         if (e && (e.statusCode === 498 || e.statusCode === 499)) {

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -1027,17 +1027,19 @@ CatalogItem.prototype.enableWithParents = function() {
  * the tile request will be retried. If the returned promise rejects, it must reject with an instance
  * of `RequestErrorEvent` with the details of the failure, and the default handling of tile
  * failures will be used.  The default handling takes into account the `treat404AsError`, `treat403AsError`,
- * and `ignoreUnknownTileErrors` properties.  The default implementation simply rejects with `e`.
+ * and `ignoreUnknownTileErrors` properties.  The default implementation simply returns `detailsRequestPromise`.
  *
- * @param {ImageryProvider} imageryProvider
- * @param {Number} x
- * @param {Number} y
- * @param {Number} level
- * @param {RequestErrorEvent} e
- * @returns {Promise}
+ * @param {Promise} detailsRequestPromise A promise which is the result of a simple call to `loadWithXhr` for the URL
+ *                  that failed. If it resolves, it will resolve to the successfully-download content of the tile URL,
+ *                  as text. If it rejects, it will reject with a `RequestErrorEvent`.
+ * @param {ImageryProvider} imageryProvider The imagery provider that generated the failed request.
+ * @param {Number} x The x coordinate of the failed tile.
+ * @param {Number} y The y coordinate of the failed tile.
+ * @param {Number} level The level of the failed tile.
+ * @returns {Promise} A promise, as described above.
  */
-CatalogItem.prototype.handleTileError = function(imageryProvider, x, y, level, e) {
-    return when.reject(e);
+CatalogItem.prototype.handleTileError = function(detailsRequestPromise, imageryProvider, x, y, level) {
+    return detailsRequestPromise;
 };
 
 function isEnabledChanged(catalogItem) {

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -12,7 +12,7 @@ var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var ImagerySplitDirection = require('terriajs-cesium/Source/Scene/ImagerySplitDirection');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
-var loadBlob = require('terriajs-cesium/Source/Core/loadBlob');
+var loadWithXhr = require('terriajs-cesium/Source/Core/loadWithXhr');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
 var TimeIntervalCollection = require('terriajs-cesium/Source/Core/TimeIntervalCollection');
@@ -590,13 +590,19 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
         ignoreUnknownTileErrors: catalogItem.ignoreUnknownTileErrors,
         isRequiredForRendering: catalogItem.isRequiredForRendering,
         onLoadError: function(tileProviderError) {
+            if (!defined(layer) || !globeOrMap.isImageryLayerShown({layer})) {
+                // If the layer is no longer shown, ignore errors and don't retry.
+                return undefined;
+            }
+
             if (tileProviderError.timesRetried === 0) {
                 tileFailures = 0;
             }
 
-            let detailsPromise;
+            tileProviderError.retry = undefined;
+
             if (defined(tileProviderError.error) && defined(tileProviderError.error.statusCode)) {
-                detailsPromise = when.reject(tileProviderError.error);
+                tileProviderError.retry = when.reject(tileProviderError.error);
             } else if (defined(tileProviderError.x) && defined(tileProviderError.y) && defined(tileProviderError.level)) {
                 // Something went wrong, but we don't really know what, probably because this is a failed image load.
                 // Browsers tell us almost nothing on a failed image load.
@@ -605,25 +611,25 @@ ImageryLayerCatalogItem.enableLayer = function(catalogItem, imageryProvider, opa
                 const tileUrl = getUrlForImageryTile(imageryProvider, tileProviderError.x, tileProviderError.y, tileProviderError.level);
 
                 if (tileUrl) {
-                    detailsPromise = loadBlob(tileUrl);
+                    tileProviderError.retry = loadWithXhr({
+                        url: tileUrl
+                    });
                 }
             }
 
-            if (!detailsPromise) {
+            if (!tileProviderError.retry) {
                 // We couldn't get any details. Oh well, carry on.
-                detailsPromise = when.reject(tileProviderError.error);
+                tileProviderError.retry = when.reject(tileProviderError.error);
             }
 
-            tileProviderError.retry = detailsPromise.then(function() {
+            if (catalogItem.handleTileError) {
+                tileProviderError.retry = catalogItem.handleTileError(tileProviderError.retry, imageryProvider, tileProviderError.x, tileProviderError.y, tileProviderError.level);
+            }
+
+            tileProviderError.retry = tileProviderError.retry.then(function() {
                 // Hey wait, the request succeeded this time!  Let's just try the image again, then.
                 // Just letting the retry promise resolve will trigger a retry of the image load.
             });
-
-            if (catalogItem.handleTileError) {
-                tileProviderError.retry = tileProviderError.retry.otherwise(function(e) {
-                    return catalogItem.handleTileError(imageryProvider, tileProviderError.x, tileProviderError.y, tileProviderError.level, e);
-                });
-            }
 
             tileProviderError.retry = tileProviderError.retry.otherwise(function(e) {
                 e = e || {};

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -13,12 +13,14 @@ var Ellipsoid = require('terriajs-cesium/Source/Core/Ellipsoid');
 var freezeObject = require('terriajs-cesium/Source/Core/freezeObject');
 var GeographicTilingScheme = require('terriajs-cesium/Source/Core/GeographicTilingScheme');
 var GetFeatureInfoFormat = require('terriajs-cesium/Source/Scene/GetFeatureInfoFormat');
+var getToken = require('./getToken');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var loadXML = require('terriajs-cesium/Source/Core/loadXML');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
 var TimeIntervalCollection = require('terriajs-cesium/Source/Core/TimeIntervalCollection');
+var UrlTemplateImageryProvider = require('terriajs-cesium/Source/Scene/UrlTemplateImageryProvider');
 var WebMapServiceImageryProvider = require('terriajs-cesium/Source/Scene/WebMapServiceImageryProvider');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
@@ -57,6 +59,9 @@ var WebMapServiceCatalogItem = function(terria) {
     this._rectangle = undefined;
     this._rectangleFromMetadata = undefined;
     this._intervalsFromMetadata = undefined;
+
+    this._lastToken = undefined;
+    this._newTokenRequestInFlight = undefined;
 
     /**
      * Gets or sets the WMS layers to include.  To specify multiple layers, separate them
@@ -252,6 +257,29 @@ var WebMapServiceCatalogItem = function(terria) {
      */
     this.dimensions = undefined;
 
+    /**
+     * Gets or sets the URL to use for requesting tokens. Typically, this is set to `/esri-token-auth` to use
+     * the ArcGIS token mechanism built into terriajs-server.
+     * @type {String}
+     */
+    this.tokenUrl = undefined;
+
+    /**
+     * Gets or sets the name of the URL query parameter used to provide the token
+     * to the server. This property is ignored if {@link WebMapServiceCatalogItem#tokenUrl} is undefined.
+     * @type {String}
+     * @default 'token'
+     */
+    this.tokenParameterName = 'token';
+
+    /**
+     * Gets or sets the set of HTTP status codes that indicate that a token is invalid.
+     * This property is ignored if {@link WebMapServiceCatalogItem#tokenUrl} is undefined.
+     * @type {Number[]}
+     * @default [401, 498, 499]
+     */
+    this.tokenInvalidHttpCodes = [401, 498, 499];
+
     this._sourceInfoItemNames = ['GetCapabilities URL'];
 
     knockout.track(this, [
@@ -259,7 +287,8 @@ var WebMapServiceCatalogItem = function(terria) {
         'layers', 'styles', 'parameters', 'getFeatureInfoFormats',
         'tilingScheme', 'populateIntervalsFromTimeDimension', 'minScaleDenominator',
         'disableUserChanges', 'availableStyles', 'colorScaleMinimum', 'colorScaleMaximum',
-        'availableDimensions', 'dimensions']);
+        'availableDimensions', 'dimensions', 'tokenUrl', 'tokenParameterName', 'tokenInvalidHttpCodes',
+        '_lastToken']);
 
     // getCapabilitiesUrl and legendUrl are derived from url if not explicitly specified.
     overrideProperty(this, 'getCapabilitiesUrl', {
@@ -869,62 +898,134 @@ function loadFromCapabilities(wmsItem) {
     }
 }
 
+function addToken(url, tokenParameterName, token) {
+    if (!defined(token)) {
+        return url;
+    } else {
+        return new URI(url).setQuery(tokenParameterName, token).toString();
+    }
+}
+
 WebMapServiceCatalogItem.prototype._load = function() {
     var that = this;
-    var promises = [];
 
-    if (!defined(this._rawMetadata) && defined(this.getCapabilitiesUrl)) {
-        promises.push(loadXML(proxyCatalogItemUrl(this, this.getCapabilitiesUrl, '1d')).then(function(xml) {
-            var metadata = capabilitiesXmlToJson(that, xml);
-            that.updateFromCapabilities(metadata, false);
+    var promise = when();
+    if (this.tokenUrl) {
+        promise = getToken(this.terria, this.tokenUrl, this.url);
+    }
+
+    return promise.then(function(token) {
+        that._lastToken = token;
+
+        var promises = [];
+
+        if (!defined(that._rawMetadata) && defined(that.getCapabilitiesUrl)) {
+            promises.push(loadXML(proxyCatalogItemUrl(that, addToken(that.getCapabilitiesUrl, that.tokenParameterName, that._lastToken), '1d')).then(function(xml) {
+                var metadata = capabilitiesXmlToJson(that, xml);
+                that.updateFromCapabilities(metadata, false);
+                loadFromCapabilities(that);
+            }));
+        } else {
             loadFromCapabilities(that);
-        }));
-    } else {
-        loadFromCapabilities(this);
-    }
+        }
 
-    // Query WMS for wfs or wcs URL if no dataUrl is present
-    if (!defined(this.dataUrl) && defined(this.url)) {
-        var describeLayersURL = cleanUrl(this.url) + '?service=WMS&version=1.1.1&sld_version=1.1.0&request=DescribeLayer&layers=' + encodeURIComponent(this.layers);
+        // Query WMS for wfs or wcs URL if no dataUrl is present
+        if (!defined(that.dataUrl) && defined(that.url)) {
+            var describeLayersURL = cleanUrl(that.url) + '?service=WMS&version=1.1.1&sld_version=1.1.0&request=DescribeLayer&layers=' + encodeURIComponent(that.layers);
 
-        promises.push(loadXML(proxyCatalogItemUrl(this, describeLayersURL, '1d')).then(function(xml) {
-            var json = xml2json(xml);
-            // LayerDescription could be an array. If so, only use the first element
-            var LayerDescription = (json.LayerDescription instanceof Array) ? json.LayerDescription[0] : json.LayerDescription;
-            if (defined(LayerDescription) && defined(LayerDescription.owsURL) && defined(LayerDescription.owsType)) {
-                switch (LayerDescription.owsType.toLowerCase()) {
-                    case 'wfs':
-                        if (defined(LayerDescription.Query) && defined(LayerDescription.Query.typeName)) {
-                            that.dataUrl = cleanUrl(LayerDescription.owsURL) + '?service=WFS&version=1.1.0&request=GetFeature&typeName=' + LayerDescription.Query.typeName + '&srsName=EPSG%3A4326&maxFeatures=1000';
-                            that.dataUrlType = 'wfs-complete';
-                        }
-                        else {
-                            that.dataUrl = cleanUrl(LayerDescription.owsURL);
-                            that.dataUrlType = 'wfs';
-                        }
-                        break;
-                    case 'wcs':
-                        if (defined(LayerDescription.Query) && defined(LayerDescription.Query.typeName)) {
-                            that.dataUrl = cleanUrl(LayerDescription.owsURL) + '?service=WCS&version=1.1.1&request=DescribeCoverage&identifiers=' + LayerDescription.Query.typeName;
-                            that.dataUrlType = 'wcs-complete';
-                        }
-                        else {
-                            that.dataUrl = cleanUrl(LayerDescription.owsURL);
-                            that.dataUrlType = 'wcs';
-                        }
-                        break;
+            promises.push(loadXML(proxyCatalogItemUrl(that, addToken(describeLayersURL, that.tokenParameterName, that._lastToken), '1d')).then(function(xml) {
+                var json = xml2json(xml);
+                // LayerDescription could be an array. If so, only use the first element
+                var LayerDescription = (json.LayerDescription instanceof Array) ? json.LayerDescription[0] : json.LayerDescription;
+                if (defined(LayerDescription) && defined(LayerDescription.owsURL) && defined(LayerDescription.owsType)) {
+                    switch (LayerDescription.owsType.toLowerCase()) {
+                        case 'wfs':
+                            if (defined(LayerDescription.Query) && defined(LayerDescription.Query.typeName)) {
+                                that.dataUrl = addToken(cleanUrl(LayerDescription.owsURL) + '?service=WFS&version=1.1.0&request=GetFeature&typeName=' + LayerDescription.Query.typeName + '&srsName=EPSG%3A4326&maxFeatures=1000', that.tokenParameterName, that._lastToken);
+                                that.dataUrlType = 'wfs-complete';
+                            }
+                            else {
+                                that.dataUrl = addToken(cleanUrl(LayerDescription.owsURL), that.tokenParameterName, that._lastToken);
+                                that.dataUrlType = 'wfs';
+                            }
+                            break;
+                        case 'wcs':
+                            if (defined(LayerDescription.Query) && defined(LayerDescription.Query.typeName)) {
+                                that.dataUrl = addToken(cleanUrl(LayerDescription.owsURL) + '?service=WCS&version=1.1.1&request=DescribeCoverage&identifiers=' + LayerDescription.Query.typeName, that.tokenParameterName, that._lastToken);
+                                that.dataUrlType = 'wcs-complete';
+                            }
+                            else {
+                                that.dataUrl = addToken(cleanUrl(LayerDescription.owsURL), that.tokenParameterName, that._lastToken);
+                                that.dataUrlType = 'wcs';
+                            }
+                            break;
+                    }
                 }
-            }
-        }).otherwise(function(err) { })); // Catch potential XML error - doesn't matter if URL can't be retrieved
-    }
+            }).otherwise(function(err) { })); // Catch potential XML error - doesn't matter if URL can't be retrieved
+        }
 
-    return when.all(promises);
+        return when.all(promises);
+    });
+};
+
+function fixPlaceholders(urlString) {
+    return urlString.replace(/%7B/g, '{').replace(/%7D/g, '}');
+}
+
+WebMapServiceCatalogItem.prototype.handleTileError = function(detailsRequestPromise, imageryProvider, x, y, level) {
+    const that = this;
+    return detailsRequestPromise.otherwise(function(e) {
+        if (e && (e.statusCode === 498 || e.statusCode === 499)) {
+            // This looks like an invalid token error, so try requesting a new one.
+            if (!defined(that._newTokenRequestInFlight)) {
+                that._newTokenRequestInFlight = getToken(that.terria, that.tokenUrl, that.url).then(function(token) {
+                    that._lastToken = token;
+
+                    // Turns out setting a parameter after the WMS provider is created is not a thing we can do elegantly.
+                    // So here we do it super hackily.
+                    const oldTemplateProvider = imageryProvider._tileProvider;
+                    const newTemplateProvider = new UrlTemplateImageryProvider({
+                        url: fixPlaceholders(addToken(oldTemplateProvider.url, that.tokenParameterName, that._lastToken)),
+                        pickFeaturesUrl: fixPlaceholders(addToken(oldTemplateProvider.pickFeaturesUrl, that.tokenParameterName, that._lastToken)),
+                        tilingScheme: oldTemplateProvider.tilingScheme,
+                        rectangle: oldTemplateProvider.rectangle,
+                        tileWidth: oldTemplateProvider.tileWidth,
+                        tileHeight: oldTemplateProvider.tileHeight,
+                        minimumLevel: oldTemplateProvider.minimumLevel,
+                        maximumLevel: oldTemplateProvider.maximumLevel,
+                        proxy: oldTemplateProvider.proxy,
+                        subdomains: oldTemplateProvider.subdomains,
+                        tileDiscardPolicy: oldTemplateProvider.tileDiscardPolicy,
+                        credit: oldTemplateProvider.credit,
+                        getFeatureInfoFormats: oldTemplateProvider.getFeatureInfoFormats,
+                        enablePickFeatures: oldTemplateProvider.enablePickFeatures,
+                        hasAlphaChannel: oldTemplateProvider.hasAlphaChannel,
+                        urlSchemeZeroPadding: oldTemplateProvider.urlSchemeZeroPadding
+                    });
+                    newTemplateProvider._errorEvent = oldTemplateProvider._errorEvent;
+
+                    imageryProvider._tileProvider = newTemplateProvider;
+
+                    that._newTokenRequestInFlight = undefined;
+                });
+            }
+
+            return that._newTokenRequestInFlight;
+        } else {
+            return when.reject(e);
+        }
+    });
 };
 
 WebMapServiceCatalogItem.prototype._createImageryProvider = function(time) {
     var parameters = objectToLowercase(this.parameters);
+
     if (defined(time)) {
         parameters = combine({ time: time }, parameters);
+    }
+
+    if (defined(this._lastToken)) {
+        parameters = combine({ [this.tokenParameterName]: this._lastToken });
     }
 
     parameters = combine(parameters, WebMapServiceCatalogItem.defaultParameters);
@@ -1547,7 +1648,7 @@ function computeLegendForLayer(catalogItem, thisLayer, styleName) {
 
         }
 
-        return new LegendUrl(legendUri.toString(), legendMimeType);
+        return new LegendUrl(addToken(legendUri.toString(), catalogItem.tokenParameterName, catalogItem._lastToken), legendMimeType);
     }
 
     return undefined;

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -973,6 +973,10 @@ function fixPlaceholders(urlString) {
 }
 
 WebMapServiceCatalogItem.prototype.handleTileError = function(detailsRequestPromise, imageryProvider, x, y, level) {
+    if (!defined(this.tokenUrl)) {
+        return detailsRequestPromise;
+    }
+
     const that = this;
     return detailsRequestPromise.otherwise(function(e) {
         if (e && (e.statusCode === 498 || e.statusCode === 499)) {

--- a/lib/Models/getToken.js
+++ b/lib/Models/getToken.js
@@ -1,0 +1,36 @@
+const defined = require('terriajs-cesium/Source/Core/defined');
+const loadWithXhr = require('terriajs-cesium/Source/Core/loadWithXhr');
+const TerriaError = require('../Core/TerriaError');
+
+function getToken(terria, tokenUrl, url) {
+    const options = {
+        url: tokenUrl,
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        data: JSON.stringify({
+            url: url
+        })
+    };
+
+    return loadWithXhr(options).then(function (result) {
+        const tokenResponse = JSON.parse(result);
+
+        if (!defined(tokenResponse.token)) {
+            throw new TerriaError({
+                title: 'Token Error',
+                message: '<p>The token server responded with an invalid token.</p><p>Please report it by ' +
+                         'sending an email to <a href="mailto:' + terria.supportEmail + '">' + terria.supportEmail + '</a>.</p>'
+            });
+        }
+
+        return tokenResponse.token;
+    }).otherwise(() => {
+        throw new TerriaError({
+            title: 'Token Error',
+            message: '<p>Unable to request a token from the token server.</p><p>Please report it by ' +
+                     'sending an email to <a href="mailto:' + terria.supportEmail + '">' + terria.supportEmail + '</a>.</p>'
+        });
+    });
+}
+
+module.exports = getToken;


### PR DESCRIPTION
This is primarily - but not exclusively - useful to access a token-protected ArcGIS server using its WMS interface.

This PR also makes the token mechanism work with non-tiled ArcGIS servers, which return token errors as a 200 code with JSON indicating an error, for some reason.