### PR TITLE
Increment terriajs-server so that it has esri-token-auth for layers that require tokens.

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-test-renderer": "^15.5.4",
     "svg-sprite-loader": "^3.4.0",
     "terriajs-jasmine-ajax": "^3.2.1",
-    "terriajs-server": "^2.6.2",
+    "terriajs-server": "^2.7.0",
     "webpack-dev-server": "^2.9.2"
   },
   "scripts": {


### PR DESCRIPTION
Detected this error whilst testing aremi-natmap with token layers.

Would be good to also have https://github.com/TerriaJS/terriajs-server/pull/75/files reviewed and merged to improve the configuration process.