### PR TITLE
Add ObserveModelMixin so that conditional rendering is correctly updated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.6.1
+
+* Fixed a bug that could cause the workbench UI to hang when toggling concepts, particularly for an `SdmxJsonCatalogItem`.
+
 ### 5.6.0
 
 * Upgraded to Cesium 1.41.

--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -10,6 +10,7 @@ import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import ClockRange from 'terriajs-cesium/Source/Core/ClockRange';
 import JulianDate from 'terriajs-cesium/Source/Core/JulianDate';
 
+import ObserveModelMixin from '../../ObserveModelMixin';
 import TimelineControls from './TimelineControls';
 import CesiumTimeline from './CesiumTimeline';
 import CatalogItemDateTimePicker from './CatalogItemDateTimePicker';
@@ -18,6 +19,9 @@ import {formatDateTime} from './DateFormats';
 import Styles from './timeline.scss';
 
 const Timeline = createReactClass({
+    displayName: 'Timeline',
+    mixins: [ObserveModelMixin],
+
     propTypes: {
         terria: PropTypes.object.isRequired,
         autoPlay: PropTypes.bool,


### PR DESCRIPTION
Fixes #2793.

There is perhaps still an underlying problem that an `SdmxCatalogItem` loses some of it's timeseries properties during concept updates, but I didn't sniff around long enough to confirm that it was a problem. I tested both the original conditions and some additional conditions that I thought might show up similar problems (e.g. animating the layer quickly while flicking through concepts), but no exceptions were thrown so ¯\_(ツ)_/¯.