### PR TITLE
Fix time change whilst WMS item not shown.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Change Log
 
 * Fixed a bug that could cause split WMS layers to show the incorrect layer data for the date shown in the workbench.
 * Refactored current time handling for `CatalogItem` to reduce the complexity and number of duplicated current time states.
-* Fix a bug that meant that when the current time was updated on an `ImagryCatalogItem` while the layer wasn't shown that the old layer was still shown when the layer was re-enabled.
+* Fix a bug that meant that, when the current time was updated on an `ImageryCatalogItem` while the layer wasn't shown, the old time was still shown when the layer was re-enabled.
 
 ### 5.6.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 
 * Fixed a bug that could cause split WMS layers to show the incorrect layer data for the date shown in the workbench.
 * Refactored current time handling for `CatalogItem` to reduce the complexity and number of duplicated current time states.
+* Fix a bug that meant that when the current time was updated on an `ImagryCatalogItem` while the layer wasn't shown that the old layer was still shown when the layer was re-enabled.
 
 ### 5.6.1
 

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -507,6 +507,10 @@ ImageryLayerCatalogItem.prototype._disable = function() {
 };
 
 ImageryLayerCatalogItem.prototype._show = function() {
+    // When the layer is not shown .showDataForTime() has no effect so if someone has updated the currentTime while the
+    // item was not shown update the layer now.
+    showDataForTime(this, this.currentTime);
+
     ImageryLayerCatalogItem.showLayer(this, this._imageryLayer);
     ImageryLayerCatalogItem.showLayer(this, this._nextLayer);
 };

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -805,7 +805,6 @@ function showDataForTime(catalogItem, currentTime, preloadNext) {
 
         if (preload) {
             // Prefetch the (predicted) next layer.
-            var index = catalogItem._currentIntervalIndex;
             // Here we use the terria clock because we want to optomise for the case where the item is playing on the
             // timeline (which is linked to the terria clock) and preload the layer at the next time that the timeslider
             // will move to.

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -752,11 +752,12 @@ ImageryLayerCatalogItem.disableLayer = function(catalogItem, layer, globeOrMap) 
     });
 };
 
-function showDataForTime (catalogItem, currentTime) {
+function showDataForTime(catalogItem, currentTime, preloadNext) {
     var intervals = catalogItem.intervals;
     if (!defined(intervals) || !catalogItem.isEnabled || !catalogItem.isShown) {
         return;
     }
+    const preload = defaultValue(preloadNext, true);
     var index = catalogItem._currentIntervalIndex;
 
     if (index < 0 || index >= intervals.length || !TimeInterval.contains(intervals.get(index), currentTime)) {
@@ -797,6 +798,26 @@ function showDataForTime (catalogItem, currentTime) {
         catalogItem._nextLayer = undefined;
         catalogItem._nextIntervalIndex = -1;
         catalogItem._currentIntervalIndex = index;
+
+        if (preload) {
+            // Prefetch the (predicted) next layer.
+            var index = catalogItem._currentIntervalIndex;
+            // Here we use the terria clock because we want to optomise for the case where the item is playing on the
+            // timeline (which is linked to the terria clock) and preload the layer at the next time that the timeslider
+            // will move to.
+            var nextIndex = catalogItem.terria.clock.multiplier >= 0.0 ? index + 1 : index - 1;
+            if ((nextIndex === intervals.length) && (catalogItem.terria.clock.clockRange === ClockRange.LOOP_STOP)) {
+                nextIndex = 0;
+            }
+            if (nextIndex >= 0 && nextIndex < intervals.length && nextIndex !== catalogItem._nextIntervalIndex) {
+                var nextImageryProvider = catalogItem.createImageryProvider(catalogItem.intervals.get(nextIndex).data);
+                nextImageryProvider.enablePickFeatures = false;
+                catalogItem._nextLayer = ImageryLayerCatalogItem.enableLayer(catalogItem, nextImageryProvider, 0.0);
+                updateSplitDirection(catalogItem);
+                ImageryLayerCatalogItem.showLayer(catalogItem, catalogItem._nextLayer);
+                catalogItem._nextIntervalIndex = nextIndex;
+            }
+        }
     }
 }
 
@@ -806,24 +827,6 @@ function onClockTick(catalogItem) {
         return;
     }
     showDataForTime(catalogItem, catalogItem.clock.currentTime);
-    // Prefetch the (predicted) next layer.
-    var index = catalogItem._currentIntervalIndex;
-    // Here we use the terria clock because we want to optomise for the case where the item is playing on the
-    // timeline (which is linked to the terria clock) and preload the layer at the next time that the timeslider
-    // will move to.
-    var nextIndex = catalogItem.terria.clock.multiplier >= 0.0 ? index + 1 : index - 1;
-    if ((nextIndex === intervals.length) && (catalogItem.terria.clock.clockRange === ClockRange.LOOP_STOP)) {
-        nextIndex = 0;
-    }
-    if (nextIndex < 0 || nextIndex >= intervals.length || nextIndex === catalogItem._nextIntervalIndex) {
-        return;
-    }
-    var nextImageryProvider = catalogItem.createImageryProvider(catalogItem.intervals.get(nextIndex).data);
-    nextImageryProvider.enablePickFeatures = false;
-    catalogItem._nextLayer = ImageryLayerCatalogItem.enableLayer(catalogItem, nextImageryProvider, 0.0);
-    updateSplitDirection(catalogItem);
-    ImageryLayerCatalogItem.showLayer(catalogItem, catalogItem._nextLayer);
-    catalogItem._nextIntervalIndex = nextIndex;
 }
 
 


### PR DESCRIPTION
This PR should be merged first https://github.com/TerriaJS/terriajs/pull/2819 as it is an upstream change that is needed for this work.

I have also moved the preloading of the next time instant into showDataForTime() so that preloading is handled uniformly irrespective of the way that the time has changed. Now that we have the forward buttons with the date picker and that the timeline can be started at any point this seems to make the most sense so that in these cases it "just works" from the start without any inital jitter (although if they never use the next it is just wasted bandwidth...still seems like the best compromise). Although logically it belongs in this function to me I don't love that the function is still called showDataForTime(), as the name makes this action feel like a side-effect rather then that it belongs in there, but I feel that the structure is right here and the name is the thing that is wrong...I just can't think of a better name for this function that indicates that at the moment.