### PR TITLE
CatalogItem / DateTimeSelectorSection: Leave the timeslider visible when updating the current time.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * The location marker is now included in shared map views.
 * Fixed a bug that could cause split WMS layers to show the incorrect layer data for the date shown in the workbench.
 * Refactored current time handling for `CatalogItem` to reduce the complexity and number of duplicated current time states.
+* Change the workbench catalog item date picker so that updating the date does not disable the timeslider.
 
 ### 5.6.1
 

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -877,6 +877,22 @@ CatalogItem.prototype.useClock = function() {
 };
 
 /**
+ * Updates the current time for the catalog item.
+ * This function updates the correct clock (terria.clock or this.clock) depending on whether .useOwnClock is true or
+ * false so that the catalog items state will reflect the new time correctly.
+ *
+ * @param {JulianDate} The new time to update the current time to.
+ */
+CatalogItem.prototype.updateCurrentTime = function(newTime) {
+    if (this.useOwnClock) {
+        updateCurrentTime(this, newTime);
+    } else {
+        this.terria.clock.currentTime = JulianDate.clone(newTime);
+        this.terria.clock.tick();
+    }
+};
+
+/**
  * Move the current time to the next time interval.
  */
 CatalogItem.prototype.moveToNextTime = function() {
@@ -1358,9 +1374,7 @@ function updateIndex(catalogItem, index) {
     const time = timeAtIndex(catalogItem, index);
 
     if (defined(time)) {
-        catalogItem.useOwnClock = true;
-        updateCurrentTime(catalogItem, JulianDate.fromDate(new Date(time)));
-        catalogItem.useClock();
+        catalogItem.updateCurrentTime(JulianDate.fromDate(new Date(time)));
     }
 }
 

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -326,22 +326,33 @@ var CatalogItem = function(terria) {
     });
 
     /**
-     * Gets the CatalogItems current time.
+     * Gets / sets the CatalogItems current time.
      *
      * This property is an observable version of clock.currentTime, they will always have the same value.
      *
-     * This property is effectively an interface adapter for clock.definitionChanged which changes the structure from
-     * an Event when the current time changes to a knockout property which can be observed.
+     * When setting the currentTime through this property the correct clock (terria.clock or this.clock) is updated
+     * depending on whether .useOwnClock is true or false so that the catalog items state will reflect the new time
+     * correctly.
+     *
+     * The get component of this property is effectively an interface adapter for clock.definitionChanged which changes
+     * the structure from an Event when the current time changes to a knockout property which can be observed.
      *
      * @member {JulianDate} currentTime
      * @memberOf CatalogItem.prototype
      */
     knockout.defineProperty(this, 'currentTime', {
-        // This is defined as a property rather then a member to restrict acess to set. Clients can always
-        // `item.clock.currentTime = value` if they need to set, but since this is a copy set would need to copy the
-        // change to item.clock.currentTime.
         get : function() {
             return this._currentTime;
+        },
+        set : function(value) {
+            // Note: We don't explicitly need to set this._currentTime since our other machinery regarding updating
+            // this._currentTime should take care of this.
+            if (this.useOwnClock) {
+                updateCurrentTime(this, value);
+            } else {
+                this.terria.clock.currentTime = JulianDate.clone(value);
+                this.terria.clock.tick();
+            }
         },
     });
 
@@ -877,22 +888,6 @@ CatalogItem.prototype.useClock = function() {
 };
 
 /**
- * Updates the current time for the catalog item.
- * This function updates the correct clock (terria.clock or this.clock) depending on whether .useOwnClock is true or
- * false so that the catalog items state will reflect the new time correctly.
- *
- * @param {JulianDate} The new time to update the current time to.
- */
-CatalogItem.prototype.updateCurrentTime = function(newTime) {
-    if (this.useOwnClock) {
-        updateCurrentTime(this, newTime);
-    } else {
-        this.terria.clock.currentTime = JulianDate.clone(newTime);
-        this.terria.clock.tick();
-    }
-};
-
-/**
  * Move the current time to the next time interval.
  */
 CatalogItem.prototype.moveToNextTime = function() {
@@ -1374,7 +1369,7 @@ function updateIndex(catalogItem, index) {
     const time = timeAtIndex(catalogItem, index);
 
     if (defined(time)) {
-        catalogItem.updateCurrentTime(JulianDate.fromDate(new Date(time)));
+        catalogItem.currentTime = JulianDate.fromDate(new Date(time));
     }
 }
 

--- a/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.js
+++ b/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.js
@@ -27,9 +27,7 @@ const DateTimeSelectorSection = createReactClass({
         // Set the time on the item, set it to use its own clock, update the imagery and repaint.
         const item = this.props.item;
         const targetJulianDate = JulianDate.fromDate(new Date(time));
-        item.useOwnClock = true;  // A side-effect of setting useOwnClock is it sets the time to the timeline time.
-        item.clock.currentTime = targetJulianDate;  // So update the clock's time afterwards.
-        item.useClock(); // Adds this item to the timeline.
+        item.updateCurrentTime(targetJulianDate);
         item.terria.currentViewer.notifyRepaintRequired();
     },
 

--- a/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.js
+++ b/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.js
@@ -26,8 +26,7 @@ const DateTimeSelectorSection = createReactClass({
     changeDateTime(time) {
         // Set the time on the item, set it to use its own clock, update the imagery and repaint.
         const item = this.props.item;
-        const targetJulianDate = JulianDate.fromDate(new Date(time));
-        item.updateCurrentTime(targetJulianDate);
+        item.currentTime = JulianDate.fromDate(new Date(time));
         item.terria.currentViewer.notifyRepaintRequired();
     },
 

--- a/test/Models/CatalogItemSpec.js
+++ b/test/Models/CatalogItemSpec.js
@@ -6,6 +6,8 @@ var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var CatalogItem = require('../../lib/Models/CatalogItem');
 var CatalogGroup = require('../../lib/Models/CatalogGroup');
 var Catalog = require('../../lib/Models/Catalog');
+var DataSourceClock = require('terriajs-cesium/Source/DataSources/DataSourceClock');
+var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var Terria = require('../../lib/Models/Terria');
 var createCatalogMemberFromType = require('../../lib/Models/createCatalogMemberFromType');
 
@@ -51,6 +53,138 @@ describe('CatalogItem', function () {
         // When a rectangle is defined, it can be zoomed-to.
         item.rectangle = Rectangle.fromDegrees(1, 2, 3, 4);
         expect(item.canZoomTo).toBe(true);
+    });
+
+    it('keeps its .clock.currentTime and .currentTime in sync with terria.clock.currentTime when .useOwnClock is false', function() {
+        item.useOwnClock = false;
+        item.clock = new DataSourceClock();
+        item.clock.currentTime = JulianDate.fromIso8601('2019-07-03');
+        item.isEnabled = true;
+        // These are sanity checks to make sure this test cases is established correctly.
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+
+        // Update the terria.clock and make sure that the all clocks show the update time.
+        terria.clock.currentTime = JulianDate.fromIso8601('2021-05-11');
+        // Force the time to propogate from the terria.clock to the catalogItems.clock.
+        terria.clock.tick();
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+
+        // Again update the terria.clock and make sure that the all clocks show the update time.
+        terria.clock.currentTime = JulianDate.fromIso8601('2023-02-17');
+        // Force the time to propogate from the terria.clock to the catalogItems.clock.
+        terria.clock.tick();
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2023-02-17'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2023-02-17'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2023-02-17'));
+
+    });
+
+    it('does not change .clock.currentTime or .currentTime when terria.clock is updated when .useOwnClock is true', function() {
+        item.useOwnClock = true;
+        item.clock = new DataSourceClock();
+        item.clock.currentTime = JulianDate.fromIso8601('2019-07-03');
+        item.isEnabled = true;
+        // These are sanity checks to make sure this test cases is established correctly.
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+
+        // Update the terria.clock and make sure that only the terria.clock is effected.
+        terria.clock.currentTime = JulianDate.fromIso8601('2021-05-11');
+        // Force the time to propogate from the terria.clock to the catalogItems.clock (this should have no effect but we want to be sure).
+        terria.clock.tick();
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+
+        // Again update the terria.clock and make sure that only the terria.clock is effected.
+        terria.clock.currentTime = JulianDate.fromIso8601('2023-02-17');
+        // Force the time to propogate from the terria.clock to the catalogItems.clock (this should have no effect but we want to be sure).
+        terria.clock.tick();
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2023-02-17'));
+    });
+
+    it('correctly updates .clock.currentTime and .currentTime when .useOwnClock true -> false', function() {
+        item.useOwnClock = true;
+        item.clock = new DataSourceClock();
+        item.clock.currentTime = JulianDate.fromIso8601('2019-07-03');
+        terria.clock.currentTime = JulianDate.fromIso8601('2021-05-11');
+        item.isEnabled = true;
+        // These are sanity checks to make sure this test cases is established correctly.
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+
+        item.useOwnClock = false;
+        // Don't need to explicitly propogate the value (using .tick() ) as it should be copied when useOwnClock is changed.
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+    });
+
+    it('correctly updates .clock.currentTime and .currentTime when .useOwnClock false -> true', function() {
+        item.useOwnClock = false;
+        item.clock = new DataSourceClock();
+        item.clock.currentTime = JulianDate.fromIso8601('2019-07-03');
+        terria.clock.currentTime = JulianDate.fromIso8601('2021-05-11');
+        item.isEnabled = true;
+        // Force the time to propogate from the terria.clock to the catalogItems.clock.
+        terria.clock.tick();
+        // These are sanity checks to make sure this test cases is established correctly.
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+
+        terria.clock.currentTime = JulianDate.fromIso8601('2023-11-29');
+        // Don't need to explicitly propogate the value as it should be copied when useOwnClock is changed.
+        item.useOwnClock = true;
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2023-11-29'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2023-11-29'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2023-11-29'));
+    });
+
+    it('setting .currentTime correctly updates .clock.currentTime, .currentTime and terria.clock.currentTime when .useOwnClock is true', function() {
+        item.useOwnClock = true;
+        item.clock = new DataSourceClock();
+        item.clock.currentTime = JulianDate.fromIso8601('2019-07-03');
+        terria.clock.currentTime = JulianDate.fromIso8601('2021-05-11');
+        item.isEnabled = true;
+        // Force the time to propogate from the terria.clock to the catalogItems.clock.
+        terria.clock.tick();
+        // These are sanity checks to make sure this test cases is established correctly.
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2019-07-03'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+
+        item.currentTime = JulianDate.fromIso8601('2031-03-23');
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2031-03-23'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2031-03-23'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+    });
+
+    it('setting .currentTime correctly updates .clock.currentTime, .currentTime and terria.clock.currentTime when .useOwnClock is false', function() {
+        item.useOwnClock = false;
+        item.clock = new DataSourceClock();
+        item.clock.currentTime = JulianDate.fromIso8601('2019-07-03');
+        terria.clock.currentTime = JulianDate.fromIso8601('2021-05-11');
+        item.isEnabled = true;
+        // Force the time to propogate from the terria.clock to the catalogItems.clock.
+        terria.clock.tick();
+        // These are sanity checks to make sure this test cases is established correctly.
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2021-05-11'));
+
+        item.currentTime = JulianDate.fromIso8601('2031-03-23');
+        // Force the time to propogate from the terria.clock to the catalogItems.clock.
+        terria.clock.tick();
+        expect(item.clock.currentTime).toEqual(JulianDate.fromIso8601('2031-03-23'));
+        expect(item.currentTime).toEqual(JulianDate.fromIso8601('2031-03-23'));
+        expect(terria.clock.currentTime).toEqual(JulianDate.fromIso8601('2031-03-23'));
     });
 
     describe('time series data: ', function() {


### PR DESCRIPTION
Updates the workbench controls so they no longer disable the timeslider.

I don't love that there are now two `updateCurrentTime()` functions in lib/Models/CatalogItem.js, but I can't think of a better name for either one (did try `setCurrentTime`, but didn't really feel that it differentiated between them enough or add any real value over direct name confusion).

Also not directly related to this commit, but something that I observed in the process was that I don't love the name of `useClock()`...doesn't really describe the functionality well...but again can't think of a better name right now.