### PR TITLE
Show non-time-dynamic imagery layers too.

### DIFF
--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -757,6 +757,10 @@ ImageryLayerCatalogItem.disableLayer = function(catalogItem, layer, globeOrMap) 
 };
 
 function showDataForTime(catalogItem, currentTime, preloadNext) {
+    if (!defined(currentTime)) {
+        return;
+    }
+
     var intervals = catalogItem.intervals;
     if (!defined(intervals) || !catalogItem.isEnabled || !catalogItem.isShown) {
         return;


### PR DESCRIPTION
This fixes a recently-introduced bug that prevents imagery layers without time from appearing on the map at all.