### PR TITLE
Use Mapbox points in computeRingWindingOrder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Fix a bug that meant that, when the current time was updated on an `ImageryCatalogItem` while the layer wasn't shown, the old time was still shown when the layer was re-enabled.
 * Added `{{terria.currentTime}}` to feature info template.
 * Added a way to format times within a feature info tempate. E.g. `{{#terria.formatDateTime}}{"format": "dd-mm-yyyy HH:MM:ss"}{{terria.currentTime}}{{/terria.formatDateTime}}`.
+* Fixed a bug that caused a region to be selected even when clicking on a hole in that region.
 
 ### 5.6.1
 

--- a/lib/Map/MapboxVectorTileImageryProvider.js
+++ b/lib/Map/MapboxVectorTileImageryProvider.js
@@ -279,8 +279,10 @@ MapboxVectorTileImageryProvider.prototype._drawTile = function (requestedTile, n
 };
 
 function isExteriorRing(ring) {
+    // Normally an exterior ring would be clockwise but because these coordinates are in "canvas space" the ys are inverted
+    // hence check for counter-clockwise ring
     const windingOrder = computeRingWindingOrder(ring);
-    return windingOrder === WindingOrder.CLOCKWISE;
+    return windingOrder === WindingOrder.COUNTER_CLOCKWISE;
 }
 
 // Adapted from npm package "point-in-polygon" by James Halliday

--- a/lib/Map/computeRingWindingOrder.js
+++ b/lib/Map/computeRingWindingOrder.js
@@ -1,15 +1,23 @@
 'use strict';
 
 const WindingOrder = require('terriajs-cesium/Source/Core/WindingOrder');
+const DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 
+/**
+ * Determine the winding order of a polygon ring.
+ * See https://github.com/mapbox/vector-tile-spec/tree/master/2.0#4344-polygon-geometry-type && https://en.wikipedia.org/wiki/Shoelace_formula
+ * @param  {Point[]} ring The polygon ring as an array of '@mapbox/point-geometry' Points (or any points conforming to {x: number, y: number}).
+ * @return {WindingOrder} The winding order of the polygon ring.
+ */
 function computeRingWindingOrder(ring) {
-    // See https://github.com/mapbox/vector-tile-spec/tree/master/2.0#4344-polygon-geometry-type && https://en.wikipedia.org/wiki/Shoelace_formula
     const n = ring.length;
-    let twiceArea = ring[n-1][0] * (ring[0][1] - ring[n-2][1]) + ring[0][0] * (ring[1][1] - ring[n-1][1]);
+    let twiceArea = ring[n-1].x * (ring[0].y - ring[n-2].y) + ring[0].x * (ring[1].y - ring[n-1].y);
     for (let i = 1; i <= n-2; i++) {
-        twiceArea += ring[i][0] * (ring[i+1][1] - ring[i-1][1]);
+        twiceArea += ring[i].x * (ring[i+1].y - ring[i-1].y);
     }
-
+    if (isNaN(twiceArea)) {
+        throw new DeveloperError('Expected points of type {x:number, y:number}');
+    }
     return twiceArea > 0.0 ? WindingOrder.COUNTER_CLOCKWISE : WindingOrder.CLOCKWISE;
 }
 

--- a/lib/Map/featureDataToGeoJson.js
+++ b/lib/Map/featureDataToGeoJson.js
@@ -4,6 +4,7 @@
 var computeRingWindingOrder = require('../Map/computeRingWindingOrder');
 var defined = require('terriajs-cesium/Source/Core/defined');
 var pointInPolygon = require('point-in-polygon');
+var Point = require('@mapbox/point-geometry');
 var WindingOrder = require('terriajs-cesium/Source/Core/WindingOrder');
 
 /**
@@ -89,7 +90,7 @@ function getEsriGeometry(featureData, geometryType, spatialReference) {
         const outerRings = [];
         const holes = [];
         featureData.geometry.rings.forEach(function(ring) {
-            if (computeRingWindingOrder(ring) === WindingOrder.CLOCKWISE) {
+            if (computeRingWindingOrder(ring.map(p => new Point(...p))) === WindingOrder.CLOCKWISE) {
                 outerRings.push(ring);
             } else {
                 holes.push(ring);


### PR DESCRIPTION
Fixes #2740.

Could instead change Mapbox points into array-style points from `MapboxVectorTileImageryProvider`. 