### PR TITLE
Fix issue #2818: column names with white space break featureInfoTpl

### DIFF
--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -111,7 +111,7 @@ const FeatureInfoSection = createReactClass({
 
     descriptionFromTemplate() {
         const template = this.props.template;
-        const safeGuardRegex = /=(\s*{{.+?}})/g;
+        const safeGuardRegex = new RegExp("=(\\s*{{.+?}})","g");
         const templateData = this.getTemplateData();
         // If property names were changed, let the template access the original property names too.
         if (defined(templateData) && defined(templateData._terria_columnAliases)) {

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -111,6 +111,7 @@ const FeatureInfoSection = createReactClass({
 
     descriptionFromTemplate() {
         const template = this.props.template;
+        const safeGuardRegex = /=(\s*{{.+?}})/g;
         const templateData = this.getTemplateData();
         // If property names were changed, let the template access the original property names too.
         if (defined(templateData) && defined(templateData._terria_columnAliases)) {
@@ -123,8 +124,8 @@ const FeatureInfoSection = createReactClass({
         // (Recall we re-render whenever feature.definitionChanged triggers.)
         if (defined(templateData)) {
             return typeof template === 'string' ?
-                Mustache.render(template, templateData) :
-                Mustache.render(template.template, templateData, template.partials);
+            Mustache.render(template.replace(safeGuardRegex,'="$1"'), templateData) :
+            Mustache.render(template.template.replace(safeGuardRegex,'="$1"'), templateData, template.partials);
         } else {
             return 'No information available';
         }


### PR DESCRIPTION
Fix issue #2818 

This issue can be reproduced by the following catalog config:
```
{
    "version": "0.0.05",
    "initSources": [
        {
            "catalog": [
                {
                    "name": "Bird Migration",
                    "type": "csv",
                    "url": "https://gist.githubusercontent.com/RacingTadpole/f308c8d01630b3d0b15d946e259b0cff/raw/266b62cab3716d76fe4c24f9788489ebfd8c7efa/bird_migration.csv",
                    "isEnabled": true,
                    "zoomOnEnable": true,
                    "tableStyle": {
                        "columns": {
                            "speed": {
                                "name": "super velocity",
                                "format": {
                                    "maximumFractionDigits": 0
                                }
                            },
                            "bad": {
                                "type": "hidden"
                            }
                        }
                    },
                    "featureInfoTemplate": {
                        "template": "<h2>{{terria.timeSeries.title}}<h2><chart x-column={{terria.timeSeries.xName}} y-column={{terria.timeSeries.yName}} id={{terria.timeSeries.id}} column-units={{terria.timeSeries.units}}>{{terria.timeSeries.data}}</chart>"
                    }
                }
            ]
        }
    ]
}
```
 ** And [this URL] **(http://nationalmap.gov.au/#start=%7B%22version%22%3A%220.0.05%22%2C%22initSources%22%3A%5B%7B%22catalog%22%3A%5B%7B%22name%22%3A%22Bird%20Migration%22%2C%22type%22%3A%22csv%22%2C%22url%22%3A%22https%3A%2F%2Fgist.githubusercontent.com%2FRacingTadpole%2Ff308c8d01630b3d0b15d946e259b0cff%2Fraw%2F266b62cab3716d76fe4c24f9788489ebfd8c7efa%2Fbird_migration.csv%22%2C%22isEnabled%22%3Atrue%2C%22zoomOnEnable%22%3Atrue%2C%22tableStyle%22%3A%7B%22columns%22%3A%7B%22speed%22%3A%7B%22name%22%3A%22super%20velocity%22%2C%22format%22%3A%7B%22maximumFractionDigits%22%3A0%7D%7D%2C%22bad%22%3A%7B%22type%22%3A%22hidden%22%7D%7D%7D%2C%22featureInfoTemplate%22%3A%7B%22template%22%3A%22%3Ch2%3E%7B%7Bterria.timeSeries.title%7D%7D%3Ch2%3E%3Cchart%20x-column%3D%7B%7Bterria.timeSeries.xName%7D%7D%20y-column%3D%7B%7Bterria.timeSeries.yName%7D%7D%20id%3D%7B%7Bterria.timeSeries.id%7D%7D%20column-units%3D%7B%7Bterria.timeSeries.units%7D%7D%3E%7B%7Bterria.timeSeries.data%7D%7D%3C%2Fchart%3E%22%7D%7D%5D%7D%5D%7D)

