### PR TITLE
Fix calculateImageryLayerIntervals properly

### DIFF
--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -632,7 +632,7 @@ function addDescriptionAndProperties(regionMapping, regionIndices, regionImagery
  * @param {Boolean} animateForwards Whether we are currently animating forwards (true) or backwards (false) (this defines which direction .nextInterval will be in).
  * @param {Boolean} cyclic Whether we are animating cyclicly (if nextInterval falls beyond the end of the data, do we return .nextInterval as the first interval). The default for this value if not supplied is true.
  * @return {Object} A structure with a TimeInterval for .currentInterval and .nextInterval defining periods where the values from timeColumn are static.
- *
+ * @private
  */
 function calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards, cyclic) {
     // Note: For this function we consider the case when isStartIncluded/isStopIncluded applies to the time. There is a

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -384,6 +384,12 @@ RegionMapping.prototype.loadRegionDetails = function() {
     });
 };
 
+// This is a test interface shim to provide test access to calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards, cyclic).
+// This should only ever be called from test cases.
+RegionMapping.prototype._testCalculateImageryLayerIntervals = function(timeColumn, currentTime, animateForwards, cyclic) {
+    return calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards, cyclic);
+};
+
 // Loads region ids from the region providers, and returns the region details.
 function loadRegionIds(regionMapping, rawRegionDetails) {
     var promises = rawRegionDetails.map(function(rawRegionDetail) { return rawRegionDetail.regionProvider.loadRegionIDs(); });

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -622,49 +622,121 @@ function addDescriptionAndProperties(regionMapping, regionIndices, regionImagery
 
 }
 
-function calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards) {
-    // Before and after are defined according to animation direction
-    var beforeComparison = animateForwards ? JulianDate.lessThan : JulianDate.greaterThan;
-    var afterComparison = animateForwards ? JulianDate.greaterThan : JulianDate.lessThan;
-    var beforeOrEqualsComparison = animateForwards ? JulianDate.lessThanOrEquals : JulianDate.greaterThanOrEquals;
-    var afterOrEqualsComparison = animateForwards ? JulianDate.greaterThanOrEquals : JulianDate.lessThanOrEquals;
-    // Loop over time intervals and generate a time interval for the current and next imagery layer
+/**
+ * Calculates intervals (near the current time) over which the values from the timeColumn do not change.
+ *
+ * This function will return .null for .nextInterval if we are in the last interval and cyclic is false.
+ *
+ * @param {*} timeColumn The time column containging the time intervals.
+ * @param {JulianDate} currentTime The current time to compute the current and next intervals for.
+ * @param {Boolean} animateForwards Whether we are currently animating forwards (true) or backwards (false) (this defines which direction .nextInterval will be in).
+ * @param {Boolean} cyclic Whether we are animating cyclicly (if nextInterval falls beyond the end of the data, do we return .nextInterval as the first interval). The default for this value if not supplied is true.
+ * @return {Object} A structure with a TimeInterval for .currentInterval and .nextInterval defining periods where the values from timeColumn are static.
+ *
+ */
+function calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards, cyclic) {
+    // Note: For this function we consider the case when isStartIncluded/isStopIncluded applies to the time. There is a
+    // duality between isStartIncluded and isStopIncluded, that is: isStartIncluded === true for one interval implies
+    // isStopIncluded === false for the adjacent time interval and vice versa. To simplify the logic in this function
+    // for the main logic section we always consider the case isStartIncluded, this simplifies the logic and
+    // understanding (only reverting to .isStartIncluded / isStopIncluded when we create the return structure).
+    // We define a structure with the property .time (corresponding to the start time of an interval)
+    // and property .included which is synomous with .isStartIncluded. The corresponding end times for the
+    // preceeding adjacent interval are the same .time value and .isStopIncluded = !.isStartIncluded. In this way the
+    // one structure can represent both the start time of one interval and the stop time of the preceeding interval, as
+    // such we refer to these as marker locations, rather then start / stop times for intervals. This also gives rise
+    // to the notion that .isIncluded true < false (where here < can be a synomym for 'before'), since the intstant
+    // .isStartIncluded = true occurs before .isStartIncluded = false (to restate in a different way, all times that
+    // are included when .isStartIncluded is false are included when .isStartIncluded is true, but the inverse is not
+    // true, for all instances where .isStartIncluded is true you can't say .isStartIncluded can be false).
 
-    // Need to keep track of 3 times:
+    // We need to keep track of 5 marker times:
     // - past: The closest transition time in the past (for current interval)
     // - future1: The closest transition time in the future (for current & next intervals)
     // - future2: The next closest transition time in the future (for next interval)
-    var past = null;
-    var future1 = null;
-    var future2 = null;
+    // - absFirstStart: The absolute first transition, (the start of the absolute first interval) (only used when we are using cyclic mode and want to loop from the end back to the start).
+    // - absFirstEnd: The absolute second transition, (the end of the absolute first interval) (only used when we are using cyclic mode and want to loop from the end back to the start).
+    // We refer to the following as markers as they define the point where we change from one interval to the next.
+    // .time applies to both the stop time for the previous interval and the start time for the interval begining from
+    // the marker. .isIncluded refers to .isStartIncluded for the the interval beginning from the marker, and therefore
+    // means that the .isStopIncluded for the preceeding interval is !.included.
+    var past = {time: null, included: false};
+    var future1 = {time: null, included: false};
+    var future2 = {time: null, included: false};
+    var absFirstStart = {time: null, included: false};
+    var absFirstEnd   = {time: null, included: false};
 
+
+    // Before and after are defined according to animation direction:
+    var isBeforeCondition = animateForwards ? JulianDate.lessThan : JulianDate.greaterThan;
+    var isAfterCondition = animateForwards ? JulianDate.greaterThan : JulianDate.lessThan;
+    var isBefore = (time, marker) => (marker.time === null || isBeforeCondition(time.time, marker.time) || (JulianDate.equals(time.time, marker.time) && iib( time.included) && iib(!marker.included)));
+    var isAfter  = (time, marker) => (marker.time === null || isAfterCondition(time.time, marker.time)  || (JulianDate.equals(time.time, marker.time) && iib(!time.included) && iib( marker.included)));
+    var equals = (time, marker) => (JulianDate.equals(time.time, marker.time) && (time.included === marker.included));
+    // We use the acronym iib - InvertIfBackwards, which is in controdiction to the style guide, but makes the
+    // expressions where it is used significantly more reable because of the short length which allows the expression
+    // to be parsed more simply then the more verbose full name. When reading for the first pass ignore iib's effect
+    // on the logic and then once you understand you can come back and review how iib() makes the expressions work
+    var iib = value => animateForwards ? value : !value;
+
+    // Loop over time intervals and generate a time interval for the current and next imagery layer
     timeColumn.timeIntervals.forEach(function(interval) {
         if (!defined(interval)) {
             return;
         }
 
-        [[interval.start, interval.isStartIncluded], [interval.stop, interval.isStopIncluded]].forEach(([time, isIncluded]) => {
-            const isBefore = isIncluded ? beforeOrEqualsComparison : beforeComparison;
-            const isAfter  = isIncluded ? afterOrEqualsComparison  : afterComparison;
-
-            if (isAfter(time, currentTime)) {
-                if (future1 === null || isBefore(time, future1)) {
+        // Here we convert from .isStopIncluded to the equvilent .isStartIncluded (by inverting) for implicit start for the next interval to simplify the remainder of the logic.
+        [{time: interval.start, included: interval.isStartIncluded}, {time: interval.stop, included: !interval.isStopIncluded}].forEach((time) => {
+             // If time marker is AFTER to currentTime (also dealing with the equal edge case and disambiguating based on .isIncluded to provide a strict AFTER constraint).
+            if (isAfterCondition(time.time, currentTime) || (JulianDate.equals(time.time, currentTime) && iib(!time.included))) {
+                if (isBefore(time, future1)) {
+                    // If we have already got a future1 case then move it into future2, since this case is before the future case we have.
+                    if (future1.time !== null) {
+                        future2 = future1;
+                    }
                     future1 = time;
-                } else if (isAfter(time, future1) && (future2 === null || isBefore(time, future2))) {
-                    // Stop must always be after start
+                } else if (equals(time, future1)) {
+                    // We have already recorded this case (it is a duplicate of a previous case)...don't need to do anything.
+                } else if (isBefore(time, future2)) {
                     future2 = time;
                 }
-            } else if (past === null || isAfter(time, past)) {
+            } else if (isAfter(time, past)) {   // This time marker is before the current time. If this marker is after the previous past marker we update it.
                 past = time;
+            }
+
+            // If we are computing the cyclic nextInterval then produce values for the absolute first time interval incase we need to use them.
+            if (cyclic !== false) {
+                if (isBefore(time, absFirstStart)) {
+                    // If we have already got a absFirstStart case then move it into absFirstEnd, since this case is before the case we already have.
+                    if (absFirstStart.time !== null) {
+                        absFirstEnd = absFirstStart;
+                    }
+                    absFirstStart = time;
+                } else if (equals(time, absFirstStart)) {
+                    // We have already recorded this case (it is a duplicate of a previous case)...don't need to do anything.
+                } else if (isBefore(time, absFirstEnd)) {
+                    absFirstEnd = time;
+                }
             }
         });
     });
 
-    var intervalFromDatePair = (date1, date2) => JulianDate.lessThan(date1, date2) ? new TimeInterval({start: date1, stop: date2, isStopIncluded: false}) : new TimeInterval({start: date2, stop: date1, isStopIncluded: false});
-    return {
-        currentInterval: (past && future1) ? intervalFromDatePair(past, future1) : null,
-        nextInterval: (future1 && future2) ? intervalFromDatePair(future1, future2) : null,
+    var intervalFromDatePair = (date1, date2, date1IsIncluded, date2IsIncluded) => animateForwards ? new TimeInterval({start: date1, stop: date2, isStartIncluded: date1IsIncluded, isStopIncluded: date2IsIncluded}) : new TimeInterval({start: date2, stop: date1, isStartIncluded: iib(date2IsIncluded), isStopIncluded: iib(date1IsIncluded)});
+
+    // Here we disambiguate from .included into .isStartIncluded and .isStopIncluded specifically (note specifiically the inversion on the .isStopIncluded cases).
+    var result = {
+        currentInterval: (past.time && future1.time) ? intervalFromDatePair(past.time, future1.time, past.included, !future1.included) : null,
+        nextInterval: (future1.time && future2.time) ? intervalFromDatePair(future1.time, future2.time, future1.included, !future2.included) : null,
     };
+
+    if (cyclic !== false) {
+        // If there is no next time (because we are at the end, then use the first interval).
+        if (future2.time === null) {
+            result.nextInterval = intervalFromDatePair(absFirstStart.time, absFirstEnd.time, absFirstStart.included, !absFirstEnd.included);
+        }
+    }
+
+    return result;
 }
 
 /**

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -19,6 +19,7 @@ var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTi
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 
+var calculateImageryLayerIntervals = require('./calculateImageryLayerIntervals');
 var getUniqueValues = require('../Core/getUniqueValues');
 var ImageryLayerCatalogItem = require('../Models/ImageryLayerCatalogItem');
 var ImageryProviderHooks = require('../Map/ImageryProviderHooks');
@@ -384,12 +385,6 @@ RegionMapping.prototype.loadRegionDetails = function() {
     });
 };
 
-// This is a test interface shim to provide test access to calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards, cyclic).
-// This should only ever be called from test cases.
-RegionMapping.prototype._testCalculateImageryLayerIntervals = function(timeColumn, currentTime, animateForwards, cyclic) {
-    return calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards, cyclic);
-};
-
 // Loads region ids from the region providers, and returns the region details.
 function loadRegionIds(regionMapping, rawRegionDetails) {
     var promises = rawRegionDetails.map(function(rawRegionDetail) { return rawRegionDetail.regionProvider.loadRegionIDs(); });
@@ -620,123 +615,6 @@ function addDescriptionAndProperties(regionMapping, regionIndices, regionImagery
     }
 
 
-}
-
-/**
- * Calculates intervals (near the current time) over which the values from the timeColumn do not change.
- *
- * This function will return .null for .nextInterval if we are in the last interval and cyclic is false.
- *
- * @param {*} timeColumn The time column containging the time intervals.
- * @param {JulianDate} currentTime The current time to compute the current and next intervals for.
- * @param {Boolean} animateForwards Whether we are currently animating forwards (true) or backwards (false) (this defines which direction .nextInterval will be in).
- * @param {Boolean} cyclic Whether we are animating cyclicly (if nextInterval falls beyond the end of the data, do we return .nextInterval as the first interval). The default for this value if not supplied is true.
- * @return {Object} A structure with a TimeInterval for .currentInterval and .nextInterval defining periods where the values from timeColumn are static.
- * @private
- */
-function calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards, cyclic) {
-    // Note: For this function we consider the case when isStartIncluded/isStopIncluded applies to the time. There is a
-    // duality between isStartIncluded and isStopIncluded, that is: isStartIncluded === true for one interval implies
-    // isStopIncluded === false for the adjacent time interval and vice versa. To simplify the logic in this function
-    // for the main logic section we always consider the case isStartIncluded, this simplifies the logic and
-    // understanding (only reverting to .isStartIncluded / isStopIncluded when we create the return structure).
-    // We define a structure with the property .time (corresponding to the start time of an interval)
-    // and property .included which is synomous with .isStartIncluded. The corresponding end times for the
-    // preceeding adjacent interval are the same .time value and .isStopIncluded = !.isStartIncluded. In this way the
-    // one structure can represent both the start time of one interval and the stop time of the preceeding interval, as
-    // such we refer to these as marker locations, rather then start / stop times for intervals. This also gives rise
-    // to the notion that .isIncluded true < false (where here < can be a synomym for 'before'), since the intstant
-    // .isStartIncluded = true occurs before .isStartIncluded = false (to restate in a different way, all times that
-    // are included when .isStartIncluded is false are included when .isStartIncluded is true, but the inverse is not
-    // true, for all instances where .isStartIncluded is true you can't say .isStartIncluded can be false).
-
-    // We need to keep track of 5 marker times:
-    // - past: The closest transition time in the past (for current interval)
-    // - future1: The closest transition time in the future (for current & next intervals)
-    // - future2: The next closest transition time in the future (for next interval)
-    // - absFirstStart: The absolute first transition, (the start of the absolute first interval) (only used when we are using cyclic mode and want to loop from the end back to the start).
-    // - absFirstEnd: The absolute second transition, (the end of the absolute first interval) (only used when we are using cyclic mode and want to loop from the end back to the start).
-    // We refer to the following as markers as they define the point where we change from one interval to the next.
-    // .time applies to both the stop time for the previous interval and the start time for the interval begining from
-    // the marker. .isIncluded refers to .isStartIncluded for the the interval beginning from the marker, and therefore
-    // means that the .isStopIncluded for the preceeding interval is !.included.
-    var past = {time: null, included: false};
-    var future1 = {time: null, included: false};
-    var future2 = {time: null, included: false};
-    var absFirstStart = {time: null, included: false};
-    var absFirstEnd   = {time: null, included: false};
-
-
-    // Before and after are defined according to animation direction:
-    var isBeforeCondition = animateForwards ? JulianDate.lessThan : JulianDate.greaterThan;
-    var isAfterCondition = animateForwards ? JulianDate.greaterThan : JulianDate.lessThan;
-    var isBefore = (time, marker) => (marker.time === null || isBeforeCondition(time.time, marker.time) || (JulianDate.equals(time.time, marker.time) && iib( time.included) && iib(!marker.included)));
-    var isAfter  = (time, marker) => (marker.time === null || isAfterCondition(time.time, marker.time)  || (JulianDate.equals(time.time, marker.time) && iib(!time.included) && iib( marker.included)));
-    var equals = (time, marker) => (JulianDate.equals(time.time, marker.time) && (time.included === marker.included));
-    // We use the acronym iib - InvertIfBackwards, which is in controdiction to the style guide, but makes the
-    // expressions where it is used significantly more reable because of the short length which allows the expression
-    // to be parsed more simply then the more verbose full name. When reading for the first pass ignore iib's effect
-    // on the logic and then once you understand you can come back and review how iib() makes the expressions work
-    var iib = value => animateForwards ? value : !value;
-
-    // Loop over time intervals and generate a time interval for the current and next imagery layer
-    timeColumn.timeIntervals.forEach(function(interval) {
-        if (!defined(interval)) {
-            return;
-        }
-
-        // Here we convert from .isStopIncluded to the equvilent .isStartIncluded (by inverting) for implicit start for the next interval to simplify the remainder of the logic.
-        [{time: interval.start, included: interval.isStartIncluded}, {time: interval.stop, included: !interval.isStopIncluded}].forEach((time) => {
-             // If time marker is AFTER to currentTime (also dealing with the equal edge case and disambiguating based on .isIncluded to provide a strict AFTER constraint).
-            if (isAfterCondition(time.time, currentTime) || (JulianDate.equals(time.time, currentTime) && iib(!time.included))) {
-                if (isBefore(time, future1)) {
-                    // If we have already got a future1 case then move it into future2, since this case is before the future case we have.
-                    if (future1.time !== null) {
-                        future2 = future1;
-                    }
-                    future1 = time;
-                } else if (equals(time, future1)) {
-                    // We have already recorded this case (it is a duplicate of a previous case)...don't need to do anything.
-                } else if (isBefore(time, future2)) {
-                    future2 = time;
-                }
-            } else if (isAfter(time, past)) {   // This time marker is before the current time. If this marker is after the previous past marker we update it.
-                past = time;
-            }
-
-            // If we are computing the cyclic nextInterval then produce values for the absolute first time interval incase we need to use them.
-            if (cyclic !== false) {
-                if (isBefore(time, absFirstStart)) {
-                    // If we have already got a absFirstStart case then move it into absFirstEnd, since this case is before the case we already have.
-                    if (absFirstStart.time !== null) {
-                        absFirstEnd = absFirstStart;
-                    }
-                    absFirstStart = time;
-                } else if (equals(time, absFirstStart)) {
-                    // We have already recorded this case (it is a duplicate of a previous case)...don't need to do anything.
-                } else if (isBefore(time, absFirstEnd)) {
-                    absFirstEnd = time;
-                }
-            }
-        });
-    });
-
-    var intervalFromDatePair = (date1, date2, date1IsIncluded, date2IsIncluded) => animateForwards ? new TimeInterval({start: date1, stop: date2, isStartIncluded: date1IsIncluded, isStopIncluded: date2IsIncluded}) : new TimeInterval({start: date2, stop: date1, isStartIncluded: iib(date2IsIncluded), isStopIncluded: iib(date1IsIncluded)});
-
-    // Here we disambiguate from .included into .isStartIncluded and .isStopIncluded specifically (note specifiically the inversion on the .isStopIncluded cases).
-    var result = {
-        currentInterval: (past.time && future1.time) ? intervalFromDatePair(past.time, future1.time, past.included, !future1.included) : null,
-        nextInterval: (future1.time && future2.time) ? intervalFromDatePair(future1.time, future2.time, future1.included, !future2.included) : null,
-    };
-
-    if (cyclic !== false) {
-        // If there is no next time (because we are at the end, then use the first interval).
-        if (future2.time === null) {
-            result.nextInterval = intervalFromDatePair(absFirstStart.time, absFirstEnd.time, absFirstStart.included, !absFirstEnd.included);
-        }
-    }
-
-    return result;
 }
 
 /**

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -13,7 +13,6 @@ var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var ImageryLayerFeatureInfo = require('terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
-var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var WebMapServiceImageryProvider = require('terriajs-cesium/Source/Scene/WebMapServiceImageryProvider');
 var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
 var when = require('terriajs-cesium/Source/ThirdParty/when');

--- a/lib/Models/calculateImageryLayerIntervals.js
+++ b/lib/Models/calculateImageryLayerIntervals.js
@@ -1,0 +1,124 @@
+'use strict';
+
+var defined = require('terriajs-cesium/Source/Core/defined');
+var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
+var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
+
+/**
+ * Calculates intervals (near the current time) over which the values from the timeColumn do not change.
+ *
+ * This function will return .null for .nextInterval if we are in the last interval and cyclic is false.
+ *
+ * @param {*} timeColumn The time column containging the time intervals.
+ * @param {JulianDate} currentTime The current time to compute the current and next intervals for.
+ * @param {Boolean} animateForwards Whether we are currently animating forwards (true) or backwards (false) (this defines which direction .nextInterval will be in).
+ * @param {Boolean} cyclic Whether we are animating cyclicly (if nextInterval falls beyond the end of the data, do we return .nextInterval as the first interval). The default for this value if not supplied is true.
+ * @return {Object} A structure with a TimeInterval for .currentInterval and .nextInterval defining periods where the values from timeColumn are static.
+ * @private
+ */
+function calculateImageryLayerIntervals(timeColumn, currentTime, animateForwards, cyclic) {
+    // Note: For this function we consider the case when isStartIncluded/isStopIncluded applies to the time. There is a
+    // duality between isStartIncluded and isStopIncluded, that is: isStartIncluded === true for one interval implies
+    // isStopIncluded === false for the adjacent time interval and vice versa. To simplify the logic in this function
+    // for the main logic section we always consider the case isStartIncluded, this simplifies the logic and
+    // understanding (only reverting to .isStartIncluded / isStopIncluded when we create the return structure).
+    // We define a structure with the property .time (corresponding to the start time of an interval)
+    // and property .included which is synomous with .isStartIncluded. The corresponding end times for the
+    // preceeding adjacent interval are the same .time value and .isStopIncluded = !.isStartIncluded. In this way the
+    // one structure can represent both the start time of one interval and the stop time of the preceeding interval, as
+    // such we refer to these as marker locations, rather then start / stop times for intervals. This also gives rise
+    // to the notion that .isIncluded true < false (where here < can be a synomym for 'before'), since the intstant
+    // .isStartIncluded = true occurs before .isStartIncluded = false (to restate in a different way, all times that
+    // are included when .isStartIncluded is false are included when .isStartIncluded is true, but the inverse is not
+    // true, for all instances where .isStartIncluded is true you can't say .isStartIncluded can be false).
+
+    // We need to keep track of 5 marker times:
+    // - past: The closest transition time in the past (for current interval)
+    // - future1: The closest transition time in the future (for current & next intervals)
+    // - future2: The next closest transition time in the future (for next interval)
+    // - absFirstStart: The absolute first transition, (the start of the absolute first interval) (only used when we are using cyclic mode and want to loop from the end back to the start).
+    // - absFirstEnd: The absolute second transition, (the end of the absolute first interval) (only used when we are using cyclic mode and want to loop from the end back to the start).
+    // We refer to the following as markers as they define the point where we change from one interval to the next.
+    // .time applies to both the stop time for the previous interval and the start time for the interval begining from
+    // the marker. .isIncluded refers to .isStartIncluded for the the interval beginning from the marker, and therefore
+    // means that the .isStopIncluded for the preceeding interval is !.included.
+    var past = {time: null, included: false};
+    var future1 = {time: null, included: false};
+    var future2 = {time: null, included: false};
+    var absFirstStart = {time: null, included: false};
+    var absFirstEnd   = {time: null, included: false};
+
+
+    // Before and after are defined according to animation direction:
+    var isBeforeCondition = animateForwards ? JulianDate.lessThan : JulianDate.greaterThan;
+    var isAfterCondition = animateForwards ? JulianDate.greaterThan : JulianDate.lessThan;
+    var isBefore = (time, marker) => (marker.time === null || isBeforeCondition(time.time, marker.time) || (JulianDate.equals(time.time, marker.time) && iib( time.included) && iib(!marker.included)));
+    var isAfter  = (time, marker) => (marker.time === null || isAfterCondition(time.time, marker.time)  || (JulianDate.equals(time.time, marker.time) && iib(!time.included) && iib( marker.included)));
+    var equals = (time, marker) => (JulianDate.equals(time.time, marker.time) && (time.included === marker.included));
+    // We use the acronym iib - InvertIfBackwards, which is in controdiction to the style guide, but makes the
+    // expressions where it is used significantly more reable because of the short length which allows the expression
+    // to be parsed more simply then the more verbose full name. When reading for the first pass ignore iib's effect
+    // on the logic and then once you understand you can come back and review how iib() makes the expressions work
+    var iib = value => animateForwards ? value : !value;
+
+    // Loop over time intervals and generate a time interval for the current and next imagery layer
+    timeColumn.timeIntervals.forEach(function(interval) {
+        if (!defined(interval)) {
+            return;
+        }
+
+        // Here we convert from .isStopIncluded to the equvilent .isStartIncluded (by inverting) for implicit start for the next interval to simplify the remainder of the logic.
+        [{time: interval.start, included: interval.isStartIncluded}, {time: interval.stop, included: !interval.isStopIncluded}].forEach((time) => {
+             // If time marker is AFTER to currentTime (also dealing with the equal edge case and disambiguating based on .isIncluded to provide a strict AFTER constraint).
+            if (isAfterCondition(time.time, currentTime) || (JulianDate.equals(time.time, currentTime) && iib(!time.included))) {
+                if (isBefore(time, future1)) {
+                    // If we have already got a future1 case then move it into future2, since this case is before the future case we have.
+                    if (future1.time !== null) {
+                        future2 = future1;
+                    }
+                    future1 = time;
+                } else if (equals(time, future1)) {
+                    // We have already recorded this case (it is a duplicate of a previous case)...don't need to do anything.
+                } else if (isBefore(time, future2)) {
+                    future2 = time;
+                }
+            } else if (isAfter(time, past)) {   // This time marker is before the current time. If this marker is after the previous past marker we update it.
+                past = time;
+            }
+
+            // If we are computing the cyclic nextInterval then produce values for the absolute first time interval incase we need to use them.
+            if (cyclic !== false) {
+                if (isBefore(time, absFirstStart)) {
+                    // If we have already got a absFirstStart case then move it into absFirstEnd, since this case is before the case we already have.
+                    if (absFirstStart.time !== null) {
+                        absFirstEnd = absFirstStart;
+                    }
+                    absFirstStart = time;
+                } else if (equals(time, absFirstStart)) {
+                    // We have already recorded this case (it is a duplicate of a previous case)...don't need to do anything.
+                } else if (isBefore(time, absFirstEnd)) {
+                    absFirstEnd = time;
+                }
+            }
+        });
+    });
+
+    var intervalFromDatePair = (date1, date2, date1IsIncluded, date2IsIncluded) => animateForwards ? new TimeInterval({start: date1, stop: date2, isStartIncluded: date1IsIncluded, isStopIncluded: date2IsIncluded}) : new TimeInterval({start: date2, stop: date1, isStartIncluded: iib(date2IsIncluded), isStopIncluded: iib(date1IsIncluded)});
+
+    // Here we disambiguate from .included into .isStartIncluded and .isStopIncluded specifically (note specifiically the inversion on the .isStopIncluded cases).
+    var result = {
+        currentInterval: (past.time && future1.time) ? intervalFromDatePair(past.time, future1.time, past.included, !future1.included) : null,
+        nextInterval: (future1.time && future2.time) ? intervalFromDatePair(future1.time, future2.time, future1.included, !future2.included) : null,
+    };
+
+    if (cyclic !== false) {
+        // If there is no next time (because we are at the end, then use the first interval).
+        if (future2.time === null) {
+            result.nextInterval = intervalFromDatePair(absFirstStart.time, absFirstEnd.time, absFirstStart.included, !absFirstEnd.included);
+        }
+    }
+
+    return result;
+}
+
+module.exports = calculateImageryLayerIntervals;

--- a/test/Models/RegionMappingSpec.js
+++ b/test/Models/RegionMappingSpec.js
@@ -1,0 +1,195 @@
+'use strict';
+
+/*global require,describe,it,expect,beforeEach,fail*/
+
+var CatalogItem = require('../../lib/Models/CatalogItem');
+var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
+var RegionMapping = require('../../lib/Models/RegionMapping');
+var Terria = require('../../lib/Models/Terria');
+var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
+
+describe('RegionMapping', function() {
+    let regionMapping;
+    let calculateImageryLayerIntervals;
+
+    beforeEach(function() {
+        const terria = new Terria({
+            baseUrl: './'
+        });
+        const item = new CatalogItem(terria);
+        regionMapping = new RegionMapping(item);
+        calculateImageryLayerIntervals = regionMapping._testCalculateImageryLayerIntervals;
+    });
+
+    // Syntax shortner, build a TimeInterval from the 4 key values we are using.
+    function TI(start, startIncluded, stop, stopIncluded) {
+        return new TimeInterval({start: JulianDate.fromIso8601(start), isStartIncluded: startIncluded, stop: JulianDate.fromIso8601(stop), isStopIncluded: stopIncluded});
+    }
+
+    // Syntax shortner, build a TimeCollection from a TimeInterval array.
+    function TC(intervals) {
+        return {timeIntervals: intervals};
+    }
+
+    // Syntax shortner, build the interval structure from two values.
+    function intervals(current, next) {
+        return {currentInterval: current, nextInterval: next};
+    }
+
+    it('calculateImageryLayerIntervals works correctly', function() {
+        // We use the math notation () and [] to denote time intervals exclusive of the value and inclusive of the value respectively.
+        // Note: This code in this section could be further simplified, but we have left if more verbose for readability and clarity.
+
+        // Test 1: Test [), [)
+        // [2018-01-01, 2018-01-08), [2018-01-08, 2018-01-15)
+        const tc1 = TC([TI('2018-01-01', true, '2018-01-08', false), TI('2018-01-08', true, '2018-01-15', false)]);
+        // Test 2: Test (], (]
+        // (2018-01-01, 2018-01-08], (2018-01-08, 2018-01-15]
+        const tc2 = TC([TI('2018-01-01', false, '2018-01-08', true), TI('2018-01-08', false, '2018-01-15', true)]);
+        // Test 3: Test grossly overlapping intervals: [:1 [:2 ]:1 ]:2
+        // [2018-01-01, 2018-01-12], [2018-01-05, 2018-01-15]
+        const tc3 = TC([TI('2018-01-01', true, '2018-01-12', true), TI('2018-01-05', true, '2018-01-15', true)]);
+        // Test 4: Test overall starts and ends with inclusive interval ends: [), []
+        // [2018-01-01, 2018-01-08), [2018-01-08, 2018-01-15]
+        const tc4 = TC([TI('2018-01-01', true, '2018-01-08', false), TI('2018-01-08', true, '2018-01-15', true)]);
+        // Test 5: Test overall starts and ends with inclusive interval ends: (), [)
+        // (2018-01-01, 2018-01-08), [2018-01-08, 2018-01-15)
+        const tc5 = TC([TI('2018-01-01', false, '2018-01-08', false), TI('2018-01-08', true, '2018-01-15', false)]);
+        // Test 6: Test just non touching intervals: [), (]
+        // [2018-01-01, 2018-01-08), (2018-01-08, 2018-01-15]
+        const tc6 = TC([TI('2018-01-01', true, '2018-01-08', false), TI('2018-01-08', false, '2018-01-15', true)]);
+        // Test 7: Test just overlapping intervals: [], []
+        // [2018-01-01, 2018-01-08], [2018-01-08, 2018-01-15]
+        const tc7 = TC([TI('2018-01-01', true, '2018-01-08', true), TI('2018-01-08', true, '2018-01-15', true)]);
+
+        // Define some critical time points for our tests.
+        const fistIntervalTime   = JulianDate.fromIso8601('2018-01-02');
+        const secondIntervalTime = JulianDate.fromIso8601('2018-01-14');
+        const criticalValue = JulianDate.fromIso8601('2018-01-08');
+        const criticalValue1Overlapping = JulianDate.fromIso8601('2018-01-05');
+        const criticalValue2Overlapping = JulianDate.fromIso8601('2018-01-12');
+
+        const firstOpenOpen   = TI('2018-01-01', false, '2018-01-08', false);
+        const firstOpenClose  = TI('2018-01-01', false, '2018-01-08', true);
+        const firstCloseOpen  = TI('2018-01-01', true,  '2018-01-08', false);
+        //const firstCloseClose = TI('2018-01-01', true,  '2018-01-08', true);
+        //const lastOpenOpen    = TI('2018-01-08', false, '2018-01-15', false);
+        const lastOpenClose   = TI('2018-01-08', false, '2018-01-15', true);
+        const lastCloseOpen   = TI('2018-01-08', true,  '2018-01-15', false);
+        const lastCloseClose  = TI('2018-01-08', true,  '2018-01-15', true);
+
+        const criticalClosed  = TI('2018-01-08', true, '2018-01-08', true);
+
+
+
+        // Test 1.
+        const t1ForwardBegin = intervals(firstCloseOpen, lastCloseOpen);
+        const t1ForwardEnd   = intervals(lastCloseOpen,  firstCloseOpen);
+        const t1ReverseBegin = intervals(firstCloseOpen, lastCloseOpen);
+        const t1ReverseEnd   = intervals(lastCloseOpen,  firstCloseOpen);
+        expect(calculateImageryLayerIntervals(tc1, fistIntervalTime,   true )).toEqual(t1ForwardBegin);
+        expect(calculateImageryLayerIntervals(tc1, secondIntervalTime, true )).toEqual(t1ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc1, criticalValue,      true )).toEqual(t1ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc1, fistIntervalTime,   false)).toEqual(t1ReverseBegin);
+        expect(calculateImageryLayerIntervals(tc1, secondIntervalTime, false)).toEqual(t1ReverseEnd);
+        expect(calculateImageryLayerIntervals(tc1, criticalValue,      false)).toEqual(t1ReverseEnd);
+        // Test some non cyclic edge cases.
+        const t1ForwardEndNonCyclic   = intervals(lastCloseOpen,  null);
+        const t1ReverseBeginNonCyclic = intervals(firstCloseOpen, null);
+        expect(calculateImageryLayerIntervals(tc1, secondIntervalTime, true,  false)).toEqual(t1ForwardEndNonCyclic);
+        expect(calculateImageryLayerIntervals(tc1, criticalValue,      true,  false)).toEqual(t1ForwardEndNonCyclic);
+        expect(calculateImageryLayerIntervals(tc1, fistIntervalTime,   false, false)).toEqual(t1ReverseBeginNonCyclic);
+
+
+        // Test 2.
+        const t2ForwardBegin = intervals(firstOpenClose, lastOpenClose);
+        const t2ForwardEnd   = intervals(lastOpenClose,  firstOpenClose);
+        const t2ReverseBegin = intervals(firstOpenClose, lastOpenClose);
+        const t2ReverseEnd   = intervals(lastOpenClose,  firstOpenClose);
+        expect(calculateImageryLayerIntervals(tc2, fistIntervalTime,   true )).toEqual(t2ForwardBegin);
+        expect(calculateImageryLayerIntervals(tc2, secondIntervalTime, true )).toEqual(t2ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc2, criticalValue,      true )).toEqual(t2ForwardBegin);
+        expect(calculateImageryLayerIntervals(tc2, fistIntervalTime,   false)).toEqual(t2ReverseBegin);
+        expect(calculateImageryLayerIntervals(tc2, secondIntervalTime, false)).toEqual(t2ReverseEnd);
+        expect(calculateImageryLayerIntervals(tc2, criticalValue,      false)).toEqual(t2ReverseBegin);
+        // Test some non cyclic edge cases.
+        const t2ForwardEndNonCyclic   = intervals(lastOpenClose,  null);
+        const t2ReverseBeginNonCyclic = intervals(firstOpenClose, null);
+        expect(calculateImageryLayerIntervals(tc2, secondIntervalTime, true,  false)).toEqual(t2ForwardEndNonCyclic);
+        expect(calculateImageryLayerIntervals(tc2, fistIntervalTime,   false, false)).toEqual(t2ReverseBeginNonCyclic);
+        expect(calculateImageryLayerIntervals(tc2, criticalValue,      false, false)).toEqual(t2ReverseBeginNonCyclic);
+
+
+        // Test 3.
+        const t3Begin  = TI('2018-01-01', true, '2018-01-05', false);
+        const t3Middle = TI('2018-01-05', true, '2018-01-12', true);
+        const t3End    = TI('2018-01-12', false, '2018-01-15', true);
+        const t3ForwardBegin  = intervals(t3Begin,  t3Middle);
+        const t3ForwardMiddle = intervals(t3Middle, t3End);
+        const t3ForwardEnd    = intervals(t3End,    t3Begin);
+        const t3ReverseBegin  = intervals(t3Begin,  t3End);
+        const t3ReverseMiddle = intervals(t3Middle, t3Begin);
+        const t3ReverseEnd    = intervals(t3End,    t3Middle);
+        expect(calculateImageryLayerIntervals(tc3, fistIntervalTime,          true )).toEqual(t3ForwardBegin);
+        expect(calculateImageryLayerIntervals(tc3, secondIntervalTime,        true )).toEqual(t3ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc3, criticalValue,             true )).toEqual(t3ForwardMiddle); // Note: In this instance the criticalValue is actually not the critical value, but just a middle value.
+        expect(calculateImageryLayerIntervals(tc3, criticalValue1Overlapping, true )).toEqual(t3ForwardMiddle);
+        expect(calculateImageryLayerIntervals(tc3, criticalValue2Overlapping, true )).toEqual(t3ForwardMiddle);
+        expect(calculateImageryLayerIntervals(tc3, fistIntervalTime,          false)).toEqual(t3ReverseBegin);
+        expect(calculateImageryLayerIntervals(tc3, secondIntervalTime,        false)).toEqual(t3ReverseEnd);
+        expect(calculateImageryLayerIntervals(tc3, criticalValue,             false)).toEqual(t3ReverseMiddle); // Note: In this instance the criticalValue is actually not the critical value, but just a middle value.
+        expect(calculateImageryLayerIntervals(tc3, criticalValue1Overlapping, false)).toEqual(t3ReverseMiddle);
+        expect(calculateImageryLayerIntervals(tc3, criticalValue2Overlapping, false)).toEqual(t3ReverseMiddle);
+
+
+        // Test 4.
+        const t4ForwardBegin = intervals(firstCloseOpen, lastCloseClose);
+        const t4ForwardEnd   = intervals(lastCloseClose, firstCloseOpen);
+        const t4ReverseBegin = intervals(firstCloseOpen, lastCloseClose);
+        const t4ReverseEnd   = intervals(lastCloseClose, firstCloseOpen);
+        expect(calculateImageryLayerIntervals(tc4, fistIntervalTime,   true )).toEqual(t4ForwardBegin);
+        expect(calculateImageryLayerIntervals(tc4, secondIntervalTime, true )).toEqual(t4ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc4, criticalValue,      true )).toEqual(t4ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc4, fistIntervalTime,   false)).toEqual(t4ReverseBegin);
+        expect(calculateImageryLayerIntervals(tc4, secondIntervalTime, false)).toEqual(t4ReverseEnd);
+        expect(calculateImageryLayerIntervals(tc4, criticalValue,      false)).toEqual(t4ReverseEnd);
+
+
+        // Test 5.
+        const t5ForwardBegin = intervals(firstOpenOpen, lastCloseOpen);
+        const t5ForwardEnd   = intervals(lastCloseOpen, firstOpenOpen);
+        const t5ReverseBegin = intervals(firstOpenOpen, lastCloseOpen);
+        const t5ReverseEnd   = intervals(lastCloseOpen, firstOpenOpen);
+        expect(calculateImageryLayerIntervals(tc5, fistIntervalTime,   true )).toEqual(t5ForwardBegin);
+        expect(calculateImageryLayerIntervals(tc5, secondIntervalTime, true )).toEqual(t5ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc5, criticalValue,      true )).toEqual(t5ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc5, fistIntervalTime,   false)).toEqual(t5ReverseBegin);
+        expect(calculateImageryLayerIntervals(tc5, secondIntervalTime, false)).toEqual(t5ReverseEnd);
+        expect(calculateImageryLayerIntervals(tc5, criticalValue,      false)).toEqual(t5ReverseEnd);
+
+
+        // Test 6.
+        const t6ForwardBegin    = intervals(firstCloseOpen, criticalClosed);
+        const t6ForwardCritical = intervals(criticalClosed, lastOpenClose);
+        const t6ForwardEnd      = intervals(lastOpenClose,  firstCloseOpen);
+        const t6ReverseBegin    = intervals(firstCloseOpen, lastOpenClose);
+        const t6ReverseCritical = intervals(criticalClosed, firstCloseOpen);
+        const t6ReverseEnd      = intervals(lastOpenClose,  criticalClosed);
+        expect(calculateImageryLayerIntervals(tc6, fistIntervalTime,   true )).toEqual(t6ForwardBegin);
+        expect(calculateImageryLayerIntervals(tc6, secondIntervalTime, true )).toEqual(t6ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc6, criticalValue,      true )).toEqual(t6ForwardCritical);
+        expect(calculateImageryLayerIntervals(tc6, fistIntervalTime,   false)).toEqual(t6ReverseBegin);
+        expect(calculateImageryLayerIntervals(tc6, secondIntervalTime, false)).toEqual(t6ReverseEnd);
+        expect(calculateImageryLayerIntervals(tc6, criticalValue,      false)).toEqual(t6ReverseCritical);
+
+
+        // Test 7.
+        // NOTE: This may be confusing, but the different inputs should lead to the same results as the test case 6 (that they use the same expectations is not a bug).
+        expect(calculateImageryLayerIntervals(tc7, fistIntervalTime,   true )).toEqual(t6ForwardBegin);
+        expect(calculateImageryLayerIntervals(tc7, secondIntervalTime, true )).toEqual(t6ForwardEnd);
+        expect(calculateImageryLayerIntervals(tc7, criticalValue,      true )).toEqual(t6ForwardCritical);
+        expect(calculateImageryLayerIntervals(tc7, fistIntervalTime,   false)).toEqual(t6ReverseBegin);
+        expect(calculateImageryLayerIntervals(tc7, secondIntervalTime, false)).toEqual(t6ReverseEnd);
+        expect(calculateImageryLayerIntervals(tc7, criticalValue,      false)).toEqual(t6ReverseCritical);
+    });
+});

--- a/test/Models/calculateImageryLayerIntervalsSpec.js
+++ b/test/Models/calculateImageryLayerIntervalsSpec.js
@@ -2,23 +2,13 @@
 
 /*global require,describe,it,expect,beforeEach,fail*/
 
-var CatalogItem = require('../../lib/Models/CatalogItem');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
-var RegionMapping = require('../../lib/Models/RegionMapping');
-var Terria = require('../../lib/Models/Terria');
+var calculateImageryLayerIntervals = require('../../lib/Models/calculateImageryLayerIntervals');
 var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
 
-describe('RegionMapping', function() {
-    let regionMapping;
-    let calculateImageryLayerIntervals;
+describe('calculateImageryLayerIntervals', function() {
 
     beforeEach(function() {
-        const terria = new Terria({
-            baseUrl: './'
-        });
-        const item = new CatalogItem(terria);
-        regionMapping = new RegionMapping(item);
-        calculateImageryLayerIntervals = regionMapping._testCalculateImageryLayerIntervals;
     });
 
     // Syntax shortner, build a TimeInterval from the 4 key values we are using.
@@ -36,7 +26,7 @@ describe('RegionMapping', function() {
         return {currentInterval: current, nextInterval: next};
     }
 
-    it('calculateImageryLayerIntervals works correctly', function() {
+    it('works correctly', function() {
         // We use the math notation () and [] to denote time intervals exclusive of the value and inclusive of the value respectively.
         // Note: This code in this section could be further simplified, but we have left if more verbose for readability and clarity.
 


### PR DESCRIPTION
You might have better ideas for how to include the function into the testcase, but that just worked and so left it like that (its a common paradigm that I've used in other languages, but there might be a cleaner way in javascript).

You might have ideas on better overall formatting, but hopefully the code and the comments are sound now. There are a few opportunities for refactoring to simplify still, but it seems that this is a reasonable tradeoff between simplicity compactness and readability.