### PR TITLE
Hopefully fix mkdocs for good

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - '6'
 script:
 - pyenv shell 2.7
-- pip install --user mkdocs mkdocs-material
+- pip install -r doc/requirements.txt
 - gulp lint docs release
 - gulp test-travis
 env:

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -47,7 +47,7 @@ cd ..
 ```
 
 !!! note
-    
+
     The version of TerriaJS in your `packages/terriajs` directory must be semver-compatible with the version specification in TerriaMap's `package.json`. If it's not, yarn will install a separate semver-compatible version of TerriaJS in `node_modules` instead of using the one you've put in `packages/terriajs`. The version numbers are _usually_ already aligned, but if not, change the `"terriajs": "x.y.z"` dependency in TerriaMap's `package.json` to be the exact `"version"` property in TerriaJS's `package.json`. You will generally not want to commit this change.
 
 Then, in the TerriaMap directory, run:
@@ -111,10 +111,10 @@ npm run gulp docs
 
 It will be placed in the `wwwroot/doc` folder.
 
-You need a standalone install of MkDocs in order to build the user guide, see [http://www.mkdocs.org/#installation](http://www.mkdocs.org/#installation) for details. You will also need to install the `mkdocs-material` theme:
+You need a standalone install of MkDocs and the `mkdocs-material` theme in order to build the user guide. Install these by running:
 
 ```
-pip install mkdocs-material
+pip install -r doc/requirements.txt
 ```
 
 ## Tests / Specs

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,12 @@
+click==6.7
+Jinja2==2.10
+livereload==2.5.1
+Markdown==2.6.11
+MarkupSafe==1.0
+mkdocs==0.17.2
+mkdocs-material==2.7.0
+Pygments==2.2.0
+pymdown-extensions==4.9
+PyYAML==3.12
+six==1.11.0
+tornado==4.5.3


### PR DESCRIPTION
Freezes Python dependencies of `mkdocs` and `mkdocs-material`. I created the `requirements.txt` as follows:
1. Make a clean python virtual environment
2. `pip install mkdocs-material mkdocs` (with `mkdocs-material` first so that tornado 4 is installed)
3. `pip freeze > doc/requirements.txt`