### PR TITLE
 Make CartoDB maps always use HTTPS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Change Log
 * Fixed a bug that caused a region to be selected even when clicking on a hole in that region.
 * Fixed a bug that caused Leaflet to stop rendering further points in a layer and throw errors when calculating extent when one point had invalid characters in the latitude or longitude field.
 * We now default to `autoPlay: false` if it's not specified in `config.json`.
-* CartoDB basemaps are now always loaded over HTTPS
+* CartoDB basemaps are now always loaded over HTTPS.
 
 ### 5.6.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Change Log
 * Fixed a bug that caused a region to be selected even when clicking on a hole in that region.
 * Fixed a bug that caused Leaflet to stop rendering further points in a layer and throw errors when calculating extent when one point had invalid characters in the latitude or longitude field.
 * We now default to `autoPlay: false` if it's not specified in `config.json`.
+* CartoDB basemaps are now always loaded over HTTPS
 
 ### 5.6.1
 

--- a/lib/ViewModels/createGlobalBaseMapOptions.js
+++ b/lib/ViewModels/createGlobalBaseMapOptions.js
@@ -42,7 +42,7 @@ var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
 
     var positron = new OpenStreetMapCatalogItem(terria);
     positron.name = 'Positron (Light)';
-    positron.url = '//global.ssl.fastly.net/light_all/';
+    positron.url = 'https://global.ssl.fastly.net/light_all/';
 
     // https://cartodb.com/basemaps/ gives two different attribution strings. In any case HTML gets swallowed, so we have to adapt.
     // 1 '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy;
@@ -61,7 +61,7 @@ var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
 
     var darkMatter = new OpenStreetMapCatalogItem(terria);
     darkMatter.name = 'Dark Matter';
-    darkMatter.url = '//global.ssl.fastly.net/dark_all/';
+    darkMatter.url = 'https://global.ssl.fastly.net/dark_all/';
 
     darkMatter.attribution = '© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0';
 


### PR DESCRIPTION
Hopefully they'll enable HTTP/2 and things will magically get faster.