### PR TITLE
Don't hide the date picker just cause discreteTime is undefined.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Display of Lat Lon changed from 3 deciml places to 5 decimal places - just over 1m precision at equator
 * Fixed a bug that caused the timeline to appear when changing the time on the workbench for a layer not attached to the timeline.
 * The workbench date/time picker is now available for time varying point and region CSVs.
+* Fixed a bug that caused the workbench date picker controls to disappear when the item was attached to the timeline and the timeline's current time was outside the valid range for the item.
 
 ### 5.6.2
 

--- a/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.js
+++ b/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.js
@@ -69,7 +69,7 @@ const DateTimeSelectorSection = createReactClass({
         const item = this.props.item;
         const discreteTime = item.discreteTime;
 
-        if (!defined(discreteTime) || !defined(item.availableDates) || (item.availableDates.length === 0)) {
+        if (!defined(item.availableDates) || (item.availableDates.length === 0)) {
             return null;
         }
         return (


### PR DESCRIPTION
Fixes this problem:

![timeline](https://user-images.githubusercontent.com/924374/37746268-871dc4c0-2dcd-11e8-89b6-124ed95bc7ab.gif)
