### PR TITLE
Guard intervals property against tableStructure not being loaded yet.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### 5.6.4
+
+* Fixed a bug causing an error message when adding tabular data to the workbench before it was loaded.
+
 ### 5.6.3
 
 * Display of Lat Lon changed from 3 deciml places to 5 decimal places - just over 1m precision at equator.

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -222,7 +222,7 @@ var TableCatalogItem = function(terria, url, options) {
      */
     knockout.defineProperty(this, 'intervals', {
         get: function() {
-            if (defined(this.tableStructure.activeTimeColumn) && defined(this.tableStructure.activeTimeColumn.timeIntervals)) {
+            if (defined(this.tableStructure) && defined(this.tableStructure.activeTimeColumn) && defined(this.tableStructure.activeTimeColumn.timeIntervals)) {
                 return this.tableStructure.activeTimeColumn.timeIntervals.reduce(function(intervals, interval) {
                     if (defined(interval)) {
                         intervals.addInterval(interval);


### PR DESCRIPTION
Fixes an error like this when adding Auto Incidents from `#test` directly from the catalog without giving it a chance to load first:
![image](https://user-images.githubusercontent.com/924374/37748706-f62cba50-2dd8-11e8-8518-01e2f67e5d9c.png)

Also this in the console;
```
TerriaMap.js:63320 Uncaught TypeError: Cannot read property 'activeTimeColumn' of undefined
    at CsvCatalogItem.get (TerriaMap.js:63320)
```
