### PR TITLE
Fixed Issue/2920 Error "This dataset is already shown"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ### 5.6.4
 
 * Fixed a bug causing an error message when adding tabular data to the workbench before it was loaded.
+* Fixed a issue that 'This data source is already shown.' error is shown to user.
 
 ### 5.6.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Change Log
 ### 5.6.4
 
 * Fixed a bug causing an error message when adding tabular data to the workbench before it was loaded.
-* Fixed a issue that 'This data source is already shown.' error is shown to user.
+* Fixed an issue that caused a 'This data source is already shown' error in particular cirumstances.
 
 ### 5.6.3
 

--- a/lib/Models/SensorObservationServiceCatalogItem.js
+++ b/lib/Models/SensorObservationServiceCatalogItem.js
@@ -597,7 +597,10 @@ SensorObservationServiceCatalogItem.prototype._show = function() {
     } else if (defined(this._dataSource)) {
         var dataSources = this.terria.dataSources;
         if (dataSources.contains(this._dataSource)) {
-            throw new DeveloperError('This data source is already shown.');
+            if(console && console.log){
+                console.log(new Error('This data source is already shown.'));
+            }
+            return;
         }
         dataSources.add(this._dataSource);
     }

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -887,7 +887,10 @@ TableCatalogItem.prototype._show = function() {
     if (defined(this._dataSource)) {
         var dataSources = this.terria.dataSources;
         if (dataSources.contains(this._dataSource)) {
-            throw new DeveloperError('This data source is already shown.');
+            if(console && console.log){
+                console.log(new Error('This data source is already shown.'));
+            }
+            return;
         }
         dataSources.add(this._dataSource);
     }


### PR DESCRIPTION
Fixed #2920 

Might be a timing issue to trigger this error (seems somewhere `_show` & `_hide` not called in pairs or in the correct sequence).

It's hard to track down to the root cause.

Muted the error from UI (still output to console) could be a reasonable solution for now.