### PR TITLE
Fix sort order for share URLs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,13 +3,10 @@
 Change Log
 ==========
 
-### v6.0.#
-
-* Fixed two bugs so that original now viewing order on the Workbench is preserved in share links.
-
 ### Next Version
 
 * Added `rel="noreferrer noopener"` to all `target="_blank"` links. This prevents the target page from being able to navigate the source tab to a new page.
+* Fixed a bug that caused the order of items on the Workbench to change when visiting a share link.
 
 ### v6.0.4
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### v6.0.#
+
+* Fixed two bugs so that original now viewing order on the Workbench is preserved in share links.
+
 ### v6.0.3
 
 * Fixed a bug that prevented users from being able to enter coordinates directly into catalog function point parameter fields.

--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -140,13 +140,18 @@ Catalog.prototype.serializeToJson = function(options) {
  * @returns {Promise} A promise that will resolve when all the items have been loaded and enabled.
  */
 Catalog.prototype.updateByShareKeys = function(sharedObjects) {
+    const that = this;
+
     return Object.keys(sharedObjects).reduce(function(aggregatedPromise, shareKey) {
         var itemJson = sharedObjects[shareKey];
 
         return aggregatedPromise
             .then(this._loadInSerial.bind(this, itemJson.parents || []))
             .then(this._updateAndEnable.bind(this, shareKey, itemJson));
-    }.bind(this), when());
+    }.bind(this), when()).then(() => {
+        that.terria.nowViewing.sortByNowViewingIndices();
+    }
+    );
 };
 
 /**

--- a/lib/Models/NowViewing.js
+++ b/lib/Models/NowViewing.js
@@ -263,12 +263,12 @@ NowViewing.prototype.sortByNowViewingIndices = function() {
     for (var i = 0; i < sortedItems.length; ++i) {
         var item = sortedItems[i];
         var existingIndex = this.items.indexOf(item);
-        var newIndex;
+        var lastIndex;
         // Check if raise didn't succeed (ie. item's index didn't change), and quit the loop if so.
-        while (existingIndex > i && existingIndex !== newIndex) {
+        while (existingIndex > i && existingIndex !== lastIndex) {
+            lastIndex = existingIndex;
+            this.raise(item, lastIndex);
             existingIndex = this.items.indexOf(item);
-            this.raise(item, existingIndex);
-            newIndex = this.items.indexOf(item);
         }
     }
 


### PR DESCRIPTION
Previously sortByNowViewingIndices was only done when the catalog was loaded, here:
https://github.com/TerriaJS/terriajs/blob/07f931fa6f512a511eb418f18c7849db38dfe39e/lib/Models/Catalog.js#L108

```
Catalog.prototype.updateFromJson = function(json, options) {
    var that = this;
    options = defaultValue(options, {});

    return CatalogGroup.updateItems(json, options, this.group).then(function () {
        that.terria.nowViewing.sortByNowViewingIndices();
    });
};
```

However at this point things are only partially loaded and only items that are enabled in the catalog are sorted, we also need to run the update once the items from the share are loaded. This is what this commit adds.

I also noticed that the sort algorithm seems to be broken and so fixed this as well.

I have only tested against local instances with local share links and init links. In both cases the original issue seems to present and be resolved by these commits.

