### PR TITLE
Remove Knockout binding from CesiumSelectionIndicator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### v6.0.4
+
+* Changed `CesiumSelectionIndicator` to no longer use Knockout binding. This will avoid a problem in some environments, such as when a Content Security Policy (CSP) is in place.
+
 ### v6.0.3
 
 * Fixed a bug that prevented users from being able to enter coordinates directly into catalog function point parameter fields.

--- a/lib/Map/CesiumSelectionIndicator.js
+++ b/lib/Map/CesiumSelectionIndicator.js
@@ -74,8 +74,6 @@ var CesiumSelectionIndicator = function(cesium) {
 
     var el = document.createElement('div');
     el.className = 'selection-indicator';
-//     el.setAttribute('data-bind', '\
-// style: { "top" : _screenPositionY, "left" : _screenPositionX, transform: transform, opacity: opacity }');
     this._container.appendChild(el);
     this._selectionIndicatorElement = el;
 

--- a/lib/Map/CesiumSelectionIndicator.js
+++ b/lib/Map/CesiumSelectionIndicator.js
@@ -74,8 +74,8 @@ var CesiumSelectionIndicator = function(cesium) {
 
     var el = document.createElement('div');
     el.className = 'selection-indicator';
-    el.setAttribute('data-bind', '\
-style: { "top" : _screenPositionY, "left" : _screenPositionX, transform: transform, opacity: opacity }');
+//     el.setAttribute('data-bind', '\
+// style: { "top" : _screenPositionY, "left" : _screenPositionX, transform: transform, opacity: opacity }');
     this._container.appendChild(el);
     this._selectionIndicatorElement = el;
 
@@ -86,11 +86,29 @@ style: { "top" : _screenPositionY, "left" : _screenPositionX, transform: transfo
     img.setAttribute('height', 50);
     el.appendChild(img);
 
-    knockout.applyBindings(this, this._selectionIndicatorElement);
+    var that = this;
+    function update() {
+        el.style.top = that._screenPositionY;
+        el.style.left = that._screenPositionX;
+        el.style.transform = that.transform;
+        el.style.opacity = that.opacity;
+    }
+
+    update();
+
+    this._subscriptions = [];
+
+    this._subscriptions.push(knockout.getObservable(this, '_screenPositionX').subscribe(update));
+    this._subscriptions.push(knockout.getObservable(this, '_screenPositionY').subscribe(update));
+    this._subscriptions.push(knockout.getObservable(this, 'transform').subscribe(update));
+    this._subscriptions.push(knockout.getObservable(this, 'opacity').subscribe(update));
 };
 
 CesiumSelectionIndicator.prototype.destroy = function() {
     this._selectionIndicatorElement.parentNode.removeChild(this._selectionIndicatorElement);
+    this._subscriptions.forEach(function(subscription) {
+        subscription.dispose();
+    });
 };
 
 /**


### PR DESCRIPTION
Changed `CesiumSelectionIndicator` to no longer use Knockout binding. This will avoid a problem in some environments, such as when a Content Security Policy (CSP) is in place.