### PR TITLE
Add rel="noreferrer noopener" to links.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
 Change Log
 ==========
 
+### Next Version
+
+* Added `rel="noreferrer noopener"` to all `target="_blank"` links. This prevents the target page from being able to navigate the source tab to a new page.
+
 ### v6.0.4
 
 * Changed `CesiumSelectionIndicator` to no longer use Knockout binding. This will avoid a problem in some environments, such as when a Content Security Policy (CSP) is in place.

--- a/lib/Core/linkifyContent.js
+++ b/lib/Core/linkifyContent.js
@@ -16,7 +16,7 @@ function linkifyContent(content) {
             if (last < match.index) {
                 result.push(content.slice(last, match.index).replace(/\r?\n/g, '<br>'));
             }
-            result.push('<a target="_blank" href="');
+            result.push('<a target="_blank" rel="noreferrer noopener" href="');
             result.push(match.url);
             result.push('">');
             result.push(match.text);

--- a/lib/ReactViews/Custom/parseCustomHtmlToReact.js
+++ b/lib/ReactViews/Custom/parseCustomHtmlToReact.js
@@ -63,7 +63,8 @@ function getProcessingInstructions(context) {
         processNode: function(node, children) { // eslint-disable-line react/display-name
             return React.createElement('a', combine({
                 key: 'anchor-' + (keyIndex++),
-                target: '_blank'
+                target: '_blank',
+                rel: 'noreferrer noopener'
             }, node.attribs), node.data, children);
         }
     });

--- a/lib/ReactViews/Mobile/MobileMenuItem.jsx
+++ b/lib/ReactViews/Mobile/MobileMenuItem.jsx
@@ -10,7 +10,7 @@ export default function MobileMenuItem(props) {
         <div className={Styles.root}>
             <Choose>
                 <When condition={props.href}>
-                    <a href={props.href} target="_blank" onClick={props.onClick}
+                    <a href={props.href} target="_blank" rel="noopener noreferrer" onClick={props.onClick}
                        className={Styles.link}>{props.caption}</a>
                 </When>
                 <Otherwise>

--- a/lib/ReactViews/Preview/Description.js
+++ b/lib/ReactViews/Preview/Description.js
@@ -237,7 +237,7 @@ const Link = createReactClass({
 
     render() {
         return (
-            <a href={this.props.url} className={Styles.link} download={this.props.download} target="_blank">{this.props.text}</a>
+            <a href={this.props.url} className={Styles.link} download={this.props.download} target="_blank" rel="noopener noreferrer">{this.props.text}</a>
         );
     },
 });

--- a/lib/ReactViews/Workbench/Controls/Legend.jsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.jsx
@@ -62,7 +62,7 @@ const Legend = createReactClass({
                         <a onError={this.onImageError.bind(this, legendUrl)}
                            href={proxiedUrl}
                            className={Styles.imageAnchor}
-                           target="_blank">
+                           target="_blank" rel="noreferrer noopener">
                             <img src={proxiedUrl}/>
                         </a>
                     </li>
@@ -70,7 +70,7 @@ const Legend = createReactClass({
                 <Otherwise>
                     <li key={proxiedUrl}>
                         <a href={proxiedUrl}
-                           target="_blank">Open legend in a separate tab
+                           target="_blank" rel="noreferrer noopener">Open legend in a separate tab
                         </a>
                     </li>
                 </Otherwise>


### PR DESCRIPTION
Fixes eslint warnings in master and eliminates a potential security vulnerability described here:
https://mathiasbynens.github.io/rel-noopener/
