### PR TITLE
Add support for a bunch of Cesium and Ion things.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ Change Log
 
 * The previous default terrain provider, STK World Terrain, has been deprecated by its provider. *To continue using terrain in your deployed applications, you _must_ obtain a Cesium Ion key and add it to `config.json`*. See https://cesium.com/ to create an Ion account. New options are available in `config.json` to configure terrain from Cesium Ion or from another source. See https://terria.io/Documentation/guide/customizing/client-side-config/#parameters for configuration details.
 * Upgraded to Cesium v1.48.
+* Added `Cesium3DTilesCatalogItem` for visualizing [Cesium 3D Tiles](https://github.com/AnalyticalGraphicsInc/3d-tiles) datasets.
+* Added `IonImageryCatalogItem` for accessing imagery assets on [Cesium Ion](https://cesium.com/).
+* Added support for Cesium Ion terrain assets to `CesiumTerrainProvider`. To use an asset from Ion, specify the `ionAssetId` and optionally the `ionAccessToken` and `ionServer` properties instead of specifying a `url`.
 
 ### v6.0.5
 

--- a/buildprocess/ci-values.yml
+++ b/buildprocess/ci-values.yml
@@ -20,7 +20,8 @@ terriamap:
             "githubusercontent.com",
             "gov",
             "gov.uk",
-            "gov.nz"
+            "gov.nz",
+            "sample.aero3dpro.com.au"
         ]
         initPaths:
         - "/etc/config/client"

--- a/lib/Map/getUrlForImageryTile.js
+++ b/lib/Map/getUrlForImageryTile.js
@@ -1,4 +1,5 @@
 var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
+var URI = require('urijs');
 var when = require('terriajs-cesium/Source/ThirdParty/when');
 
 function getUrlForImageryTile(imageryProvider, x, y, level) {
@@ -11,6 +12,11 @@ function getUrlForImageryTile(imageryProvider, x, y, level) {
                 tileUrl = url;
             } else if (url && url.url) {
                 tileUrl = url.url;
+
+                // Add the Cesium Ion access token if there is one.
+                if (url._ionEndpoint && url._ionEndpoint.accessToken) {
+                    tileUrl = new URI(tileUrl).addQuery('access_token', url._ionEndpoint.accessToken).toString();
+                }
             }
             return when();
         };

--- a/lib/Models/Cesium3DTilesCatalogItem.js
+++ b/lib/Models/Cesium3DTilesCatalogItem.js
@@ -1,0 +1,180 @@
+'use strict';
+
+/*global require*/
+
+var CatalogItem = require('./CatalogItem');
+var Cesium3DTileset = require('terriajs-cesium/Source/Scene/Cesium3DTileset');
+var combine = require('terriajs-cesium/Source/Core/combine');
+var defined = require('terriajs-cesium/Source/Core/defined');
+var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var inherit = require('../Core/inherit');
+var IonResource = require('terriajs-cesium/Source/Core/IonResource');
+var proxyCatalogItemUrl = require('./proxyCatalogItemUrl');
+var raiseErrorToUser = require('./raiseErrorToUser');
+var TerriaError = require('../Core/TerriaError');
+
+/**
+ * A {@link CatalogItem} that is added to the map as Cesium 3D Tiles.
+ *
+ * @alias Cesium3DTilesCatalogItem
+ * @constructor
+ * @extends CatalogItem
+ * @abstract
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+var Cesium3DTilesCatalogItem = function(terria) {
+    CatalogItem.call(this, terria);
+
+    /**
+     * Gets or sets additional options to pass to Cesium's Cesium3DTileset constructor.
+     * @type {Object}
+     */
+    this.options = undefined;
+
+    /**
+     * Gets or sets the ID of the Cesium Ion asset to access. If this property is set, the {@link Cesium3DTilesCatalogItem#url}
+     * property is ignored.
+     * @type {Number}
+     */
+    this.ionAssetId = undefined;
+
+    /**
+     * Gets or sets the Cesium Ion access token to use to access the tileset. If not specified, the token specified
+     * using the `cesiumIonAccessToken` property in `config.json` is used. This property is ignored if
+     * {@link Cesium3DTilesCatalogItem#ionAssetId} is not set.
+     * @type {String}
+     */
+    this.ionAccessToken = undefined;
+
+    /**
+     * Gets or sets the Cesium Ion access token to use to access the tileset. If not specified, the default Ion
+     * server, `https://api.cesium.com/`, is used. This property is ignored if
+     * {@link Cesium3DTilesCatalogItem#ionAssetId} is not set.
+     * @type {String}
+     */
+    this.ionServer = undefined;
+
+    this._tileset = undefined;
+};
+
+inherit(CatalogItem, Cesium3DTilesCatalogItem);
+
+defineProperties(Cesium3DTilesCatalogItem.prototype, {
+    /**
+     * Gets the type of data item represented by this instance.
+     * @memberOf CesiumTerrainCatalogItem.prototype
+     * @type {String}
+     */
+    type : {
+        get : function() {
+            return '3d-tiles';
+        }
+    },
+
+    /**
+     * Gets a human-readable name for this type of data source, 'Cesium 3D Tiles'.
+     * @memberOf CesiumTerrainCatalogItem.prototype
+     * @type {String}
+     */
+    typeName : {
+        get : function() {
+            return 'Cesium 3D Tiles';
+        }
+    },
+
+    /**
+     * Gets a value indicating whether this data source, when enabled, can be reordered with respect to other data sources.
+     * Data sources that cannot be reordered are typically displayed above reorderable data sources.
+     * @memberOf Cesium3DTilesCatalogItem.prototype
+     * @type {Boolean}
+     */
+    supportsReordering : {
+        get : function() {
+            return false;
+        }
+    },
+
+    /**
+     * Gets a value indicating whether the opacity of this data source can be changed.
+     * @memberOf Cesium3DTilesCatalogItem.prototype
+     * @type {Boolean}
+     */
+    supportsOpacity : {
+        get : function() {
+            return false;
+        }
+    }
+});
+
+Cesium3DTilesCatalogItem.prototype._showInCesium = function() {
+    if (defined(this._tileset)) {
+        this._tileset.show = true;
+    }
+};
+
+Cesium3DTilesCatalogItem.prototype._hideInCesium = function() {
+    if (defined(this._tileset)) {
+        this._tileset.show = false;
+    }
+};
+
+Cesium3DTilesCatalogItem.prototype._showInLeaflet = function() {
+    this.isShown = false;
+    throw new TerriaError({
+        sender: this,
+        title: 'Not supported in 2D',
+        message: '"' + this.name + '" cannot be show in the 2D view.  Switch to 3D and try again.'
+    });
+};
+
+Cesium3DTilesCatalogItem.prototype._hideInLeaflet = function() {
+    // Nothing to be done.
+};
+
+Cesium3DTilesCatalogItem.prototype._enableInCesium = function() {
+    if (!defined(this._tileset)) {
+        let resource = proxyCatalogItemUrl(this, this.url);
+        if (defined(this.ionAssetId)) {
+            resource = IonResource.fromAssetId(this.ionAssetId, {
+                accessToken: this.ionAccessToken || this.terria.configParameters.cesiumIonAccessToken,
+                server: this.ionServer
+            }).otherwise(e => {
+                raiseErrorToUser(this.terria, e);
+            });
+        }
+
+        let options = {
+            show: this.isShown,
+            url: resource
+        };
+
+        if (this.options) {
+            options = combine(options, this.options);
+        }
+
+        this._tileset = new Cesium3DTileset(options);
+    }
+
+    const primitives = this.terria.cesium.scene.primitives;
+    if (!primitives.contains(this._tileset)) {
+        primitives.add(this._tileset);
+    }
+};
+
+Cesium3DTilesCatalogItem.prototype._disableInCesium = function() {
+    if (defined(this._tileset)) {
+        this.terria.cesium.scene.primitives.removeAndDestroy(this._tileset);
+        this._tileset = undefined;
+    }
+};
+
+Cesium3DTilesCatalogItem.prototype._enableInLeaflet = function() {
+    // Nothing to be done.
+};
+
+Cesium3DTilesCatalogItem.prototype._disableInLeaflet = function() {
+    // Nothing to be done.
+};
+
+module.exports = Cesium3DTilesCatalogItem;

--- a/lib/Models/CesiumTerrainCatalogItem.js
+++ b/lib/Models/CesiumTerrainCatalogItem.js
@@ -3,7 +3,10 @@
 /*global require*/
 
 var CesiumTerrainProvider = require('terriajs-cesium/Source/Core/CesiumTerrainProvider');
+var defined = require('terriajs-cesium/Source/Core/defined');
 var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var IonResource = require('terriajs-cesium/Source/Core/IonResource');
+var raiseErrorToUser = require('./raiseErrorToUser');
 
 var TerrainCatalogItem = require('./TerrainCatalogItem');
 var inherit = require('../Core/inherit');
@@ -19,6 +22,29 @@ var inherit = require('../Core/inherit');
  */
 var CesiumTerrainCatalogItem = function(terria) {
     TerrainCatalogItem.call(this, terria);
+
+    /**
+     * Gets or sets the ID of the Cesium Ion asset to access. If this property is set, the {@link CesiumTerrainCatalogItem#url}
+     * property is ignored.
+     * @type {Number}
+     */
+    this.ionAssetId = undefined;
+
+    /**
+     * Gets or sets the Cesium Ion access token to use to access the terrain. If not specified, the token specified
+     * using the `cesiumIonAccessToken` property in `config.json` is used. This property is ignored if
+     * {@link CesiumTerrainCatalogItem#ionAssetId} is not set.
+     * @type {String}
+     */
+    this.ionAccessToken = undefined;
+
+    /**
+     * Gets or sets the Cesium Ion access token to use to access the terrain. If not specified, the default Ion
+     * server, `https://api.cesium.com/`, is used. This property is ignored if
+     * {@link CesiumTerrainCatalogItem#ionAssetId} is not set.
+     * @type {String}
+     */
+    this.ionServer = undefined;
 };
 
 inherit(TerrainCatalogItem, CesiumTerrainCatalogItem);
@@ -48,8 +74,18 @@ defineProperties(CesiumTerrainCatalogItem.prototype, {
 });
 
 CesiumTerrainCatalogItem.prototype._createTerrainProvider = function() {
+    var resource = this.url;
+    if (defined(this.ionAssetId)) {
+        resource = IonResource.fromAssetId(this.ionAssetId, {
+            accessToken: this.ionAccessToken || this.terria.configParameters.cesiumIonAccessToken,
+            server: this.ionServer
+        }).otherwise(e => {
+            raiseErrorToUser(this.terria, e);
+        });
+    }
+
     return new CesiumTerrainProvider({
-        url: this.url
+        url: resource
     });
 };
 

--- a/lib/Models/IonImageryCatalogItem.js
+++ b/lib/Models/IonImageryCatalogItem.js
@@ -1,0 +1,77 @@
+'use strict';
+
+/*global require*/
+
+var IonImageryProvider = require('terriajs-cesium/Source/Scene/IonImageryProvider');
+var defineProperties = require('terriajs-cesium/Source/Core/defineProperties');
+var ImageryLayerCatalogItem = require('./ImageryLayerCatalogItem');
+var inherit = require('../Core/inherit');
+
+/**
+ * A {@link ImageryLayerCatalogItem} representing an imagery layer from Cesium Ion.
+ *
+ * @alias IonImageryCatalogItem
+ * @constructor
+ * @extends ImageryLayerCatalogItem
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+var IonImageryCatalogItem = function(terria) {
+    ImageryLayerCatalogItem.call(this, terria);
+
+    /**
+     * Gets or sets the ID of the Cesium Ion asset to access.
+     * @type {Number}
+     */
+    this.ionAssetId = undefined;
+
+    /**
+     * Gets or sets the Cesium Ion access token to use to access the imagery. If not specified, the token specified
+     * using the `cesiumIonAccessToken` property in `config.json` is used.
+     * @type {String}
+     */
+    this.ionAccessToken = undefined;
+
+    /**
+     * Gets or sets the Cesium Ion access token to use to access the imagery. If not specified, the default Ion
+     * server, `https://api.cesium.com/`, is used.
+     * @type {String}
+     */
+    this.ionServer = undefined;
+};
+
+inherit(ImageryLayerCatalogItem, IonImageryCatalogItem);
+
+defineProperties(IonImageryCatalogItem.prototype, {
+    /**
+     * Gets the type of data item represented by this instance.
+     * @memberOf UrlTemplateCatalogItem.prototype
+     * @type {String}
+     */
+    type : {
+        get : function() {
+            return 'ion-imagery';
+        }
+    },
+
+    /**
+     * Gets a human-readable name for this type of data source, 'Cesium Ion Imagery'.
+     * @memberOf UrlTemplateCatalogItem.prototype
+     * @type {String}
+     */
+    typeName : {
+        get : function() {
+            return 'Cesium Ion Imagery';
+        }
+    }
+});
+
+IonImageryCatalogItem.prototype._createImageryProvider = function() {
+    return new IonImageryProvider({
+        assetId: this.ionAssetId,
+        accessToken: this.ionAccessToken,
+        server: this.ionServer
+    });
+};
+
+module.exports = IonImageryCatalogItem;

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -12,6 +12,7 @@ var ArcGisMapServerCatalogItem = require('./ArcGisMapServerCatalogItem');
 var ResultPendingCatalogItem = require('./ResultPendingCatalogItem');
 var BingMapsCatalogItem = require('./BingMapsCatalogItem');
 var CatalogGroup = require('./CatalogGroup');
+var Cesium3DTilesCatalogItem = require('./Cesium3DTilesCatalogItem');
 var CesiumTerrainCatalogItem = require('./CesiumTerrainCatalogItem');
 var CkanCatalogGroup = require('./CkanCatalogGroup');
 var CkanCatalogItem = require('./CkanCatalogItem');
@@ -23,6 +24,7 @@ var CswCatalogGroup = require('./CswCatalogGroup');
 var CzmlCatalogItem = require('./CzmlCatalogItem');
 var GeoJsonCatalogItem = require('./GeoJsonCatalogItem');
 var GpxCatalogItem = require('./GpxCatalogItem');
+var IonImageryCatalogItem = require('./IonImageryCatalogItem');
 var KmlCatalogItem = require('./KmlCatalogItem');
 var OgrCatalogItem = require('./OgrCatalogItem');
 var OpenStreetMapCatalogItem = require('./OpenStreetMapCatalogItem');
@@ -44,6 +46,7 @@ var WfsFeaturesCatalogGroup = require('./WfsFeaturesCatalogGroup');
 var MagdaCatalogItem = require('./MagdaCatalogItem');
 
 var registerCatalogMembers = function() {
+    createCatalogMemberFromType.register('3d-tiles', Cesium3DTilesCatalogItem);
     createCatalogMemberFromType.register('abs-itt', AbsIttCatalogItem);
     createCatalogMemberFromType.register('abs-itt-dataset-list', AbsIttCatalogGroup);
     createCatalogMemberFromType.register('result-pending', ResultPendingCatalogItem);
@@ -63,6 +66,7 @@ var registerCatalogMembers = function() {
     createCatalogMemberFromType.register('geojson', GeoJsonCatalogItem);
     createCatalogMemberFromType.register('gpx', GpxCatalogItem);
     createCatalogMemberFromType.register('group', CatalogGroup);
+    createCatalogMemberFromType.register('ion-imagery', IonImageryCatalogItem);
     createCatalogMemberFromType.register('kml', KmlCatalogItem);
     createCatalogMemberFromType.register('kmz', KmlCatalogItem);
     createCatalogMemberFromType.register('ogr', OgrCatalogItem);

--- a/wwwroot/test/init/cesium3dtiles.json
+++ b/wwwroot/test/init/cesium3dtiles.json
@@ -1,0 +1,19 @@
+{
+    "catalog": [
+        {
+            "name": "Cesium 3D Tiles",
+            "type": "group",
+            "items": [
+                {
+                    "name": "Brisbane 3D city model (aero3Dpro)",
+                    "type": "3d-tiles",
+                    "url": "https://sample.aero3dpro.com.au/BrisbaneCBD/Scene/recon_h_3DTiles.json",
+                    "options": {
+                        "maximumScreenSpaceError": 1,
+                        "maximumNumberOfLoadedTiles": 1000
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/wwwroot/test/init/ion.json
+++ b/wwwroot/test/init/ion.json
@@ -1,0 +1,20 @@
+{
+    "catalog": [
+        {
+            "name": "Cesium Ion",
+            "type": "group",
+            "items": [
+                {
+                    "name": "PAMap Terrain",
+                    "type": "cesium-terrain",
+                    "ionAssetId": 3957
+                },
+                {
+                    "name": "Earth at Night",
+                    "type": "ion-imagery",
+                    "ionAssetId": 3812
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
* Added `Cesium3DTilesCatalogItem` for visualizing [Cesium 3D Tiles](https://github.com/AnalyticalGraphicsInc/3d-tiles) datasets.
* Added `IonImageryCatalogItem` for accessing imagery assets on [Cesium Ion](https://cesium.com/).
* Added support for Cesium Ion terrain assets to `CesiumTerrainProvider`. To use an asset from Ion, specify the `ionAssetId` and optionally the `ionAccessToken` and `ionServer` properties instead of specifying a `url`.