### PR TITLE
Added KMZ to whitelisted formats for MagdaCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ### Next release
 
 * When clicking a `Split` button on the workbench, the new catalog item will no longer be attached to the timeline even if the original was. This avoids a confusing situation where both catalog items would be locked to the same time.
+* Added KMZ to the whitelisted formats for `MagdaCatalogItem`.
 
 ### v6.1.2
 

--- a/lib/Models/MagdaCatalogItem.js
+++ b/lib/Models/MagdaCatalogItem.js
@@ -103,7 +103,7 @@ function MagdaCatalogItem(terria) {
      * Gets or sets a regular expression that, when it matches a distribution's format, indicates that the distribution is a KML distribution.
      * @type {RegExp}
      */
-    this.kmlDistributionFormat = /^kml$/i;
+    this.kmlDistributionFormat = /^km[lz]$/i;
 
     /**
      * Gets or sets a value indicating whether this may be a CSV distribution.


### PR DESCRIPTION
Passing up a change that we've made downstream in Magda - previously we were only allowing KMLs, but Terria can do KMZs as well.