### PR TITLE
fix firefox drag and drop abandon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ### Next Release
 
 * Add simple WCS "clip and ship" functionality for WMS layers with corresponding a WCS endpoint and coverage.
+* Fixed problems canceling drag-and-drop when using some web browsers.
 
 ### v6.1.4
 

--- a/lib/ReactViews/DragDropFile.jsx
+++ b/lib/ReactViews/DragDropFile.jsx
@@ -17,6 +17,8 @@ const DragDropFile = createReactClass({
         viewState: PropTypes.object,
     },
 
+    target: null,
+
     handleDrop(e) {
         e.preventDefault();
         e.stopPropagation();
@@ -36,6 +38,7 @@ const DragDropFile = createReactClass({
         e.preventDefault();
         e.stopPropagation();
         e.dataTransfer.dropEffect = 'copy';
+        this.lastTarget = e.target;
     },
 
     handleDragOver(e) {
@@ -43,8 +46,14 @@ const DragDropFile = createReactClass({
     },
 
     handleDragLeave(e) {
-      // when drag leave, we set the isDraggingDroppingFile to false (remove drag and drop layer)
-      this.props.viewState.isDraggingDroppingFile = false;
+        e.preventDefault();
+        if (e.screenX === 0 && e.screenY === 0) {
+            this.props.viewState.isDraggingDroppingFile = false;
+        }
+        console.log(e.target)
+         if (e.target === document || e.target === this.lastTarget) {
+             this.props.viewState.isDraggingDroppingFile = false;
+         }
     },
 
     handleMouseLeave() {

--- a/lib/ReactViews/DragDropFile.jsx
+++ b/lib/ReactViews/DragDropFile.jsx
@@ -50,7 +50,6 @@ const DragDropFile = createReactClass({
         if (e.screenX === 0 && e.screenY === 0) {
             this.props.viewState.isDraggingDroppingFile = false;
         }
-        console.log(e.target)
          if (e.target === document || e.target === this.lastTarget) {
              this.props.viewState.isDraggingDroppingFile = false;
          }

--- a/lib/ReactViews/DragDropFile.jsx
+++ b/lib/ReactViews/DragDropFile.jsx
@@ -43,9 +43,8 @@ const DragDropFile = createReactClass({
     },
 
     handleDragLeave(e) {
-        if (e.screenX === 0 && e.screenY === 0) {
-            this.props.viewState.isDraggingDroppingFile = false;
-        }
+      // when drag leave, we set the isDraggingDroppingFile to false (remove drag and drop layer)
+      this.props.viewState.isDraggingDroppingFile = false;
     },
 
     handleMouseLeave() {
@@ -72,4 +71,3 @@ const DragDropFile = createReactClass({
 });
 
 module.exports = DragDropFile;
-

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -57,15 +57,25 @@ const StandardUserInterface = createReactClass({
     /* eslint-disable-next-line camelcase */
     UNSAFE_componentWillMount() {
         const that = this;
-        this.dragOverListener = e => {
+
+        this.dragEnterListener = e => {
+            if (!e.dataTransfer.types || !arrayContains(e.dataTransfer.types, 'Files')) {
+                return;
+            }
+            e.preventDefault();
+            e.stopPropagation();
+            console.log("drag enter")
+            that.acceptDragDropFile();
+        };
+
+        this.dragOverListener = e =>{
             if (!e.dataTransfer.types || !arrayContains(e.dataTransfer.types, 'Files')) {
                 return;
             }
             e.preventDefault();
             e.stopPropagation();
             e.dataTransfer.dropEffect = 'copy';
-            that.acceptDragDropFile();
-        };
+        }
 
         this.resizeListener = () => {
             this.props.viewState.useSmallScreenInterface = this.shouldUseMobileInterface();
@@ -77,11 +87,13 @@ const StandardUserInterface = createReactClass({
     },
 
     componentDidMount() {
+        this._wrapper.addEventListener('dragenter', this.dragEnterListener, false);
         this._wrapper.addEventListener('dragover', this.dragOverListener, false);
     },
 
     componentWillUnmount() {
         window.removeEventListener('resize', this.resizeListener, false);
+        document.removeEventListener('dragenter', this.dragEnterListener, false);
         document.removeEventListener('dragover', this.dragOverListener, false);
     },
 

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -57,25 +57,15 @@ const StandardUserInterface = createReactClass({
     /* eslint-disable-next-line camelcase */
     UNSAFE_componentWillMount() {
         const that = this;
-
-        this.dragEnterListener = e => {
-            if (!e.dataTransfer.types || !arrayContains(e.dataTransfer.types, 'Files')) {
-                return;
-            }
-            e.preventDefault();
-            e.stopPropagation();
-            console.log("drag enter")
-            that.acceptDragDropFile();
-        };
-
-        this.dragOverListener = e =>{
+        this.dragOverListener = e => {
             if (!e.dataTransfer.types || !arrayContains(e.dataTransfer.types, 'Files')) {
                 return;
             }
             e.preventDefault();
             e.stopPropagation();
             e.dataTransfer.dropEffect = 'copy';
-        }
+            that.acceptDragDropFile();
+        };
 
         this.resizeListener = () => {
             this.props.viewState.useSmallScreenInterface = this.shouldUseMobileInterface();
@@ -87,13 +77,11 @@ const StandardUserInterface = createReactClass({
     },
 
     componentDidMount() {
-        this._wrapper.addEventListener('dragenter', this.dragEnterListener, false);
         this._wrapper.addEventListener('dragover', this.dragOverListener, false);
     },
 
     componentWillUnmount() {
         window.removeEventListener('resize', this.resizeListener, false);
-        document.removeEventListener('dragenter', this.dragEnterListener, false);
         document.removeEventListener('dragover', this.dragOverListener, false);
     },
 


### PR DESCRIPTION
Fixed the issue that you cannot abandon drag and drop in firefox (see https://github.com/TerriaJS/terriajs/issues/3036).

One of the changes is removing the `screenX` and `screenY` check in `handleDragLeave` function in `DragDropFile.jsx`. I don't see why that line is necessary, and it seems that firefox does not set those values to 0 when the drag is finished. Please let me know if that check is there for other reasons. 