### PR TITLE
Use Ion for Bing imagery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### Next Release
+
+* We now use Cesium Ion for the Bing Maps basemaps, unless a `bingMapsKey` is provided in [config.json](https://docs.terria.io/guide/customizing/client-side-config/#parameters). You can control this behavior with the `useCesiumIonBingImagery` property. Please note that if a `bingMapsKey` is not provided, the Bing Maps geocoder will always return no results.
+
 ### v6.2.0
 
 * Added a simple WCS "clip and ship" functionality for WMS layers with corresponding a WCS endpoint and coverage.

--- a/doc/customizing/client-side-config.md
+++ b/doc/customizing/client-side-config.md
@@ -47,6 +47,7 @@ Option                      | Meaning
 `"tabbedCatalog"`           | True to create a separate explorer panel tab for each top-level catalog group to list its items in.
 `"interceptBrowserPrint"`   | True (the default) to intercept the browser's print feature and use a custom one accessible through the Share panel.
 `"useCesiumIonTerrain"`     | True to use Cesium World Terrain from Cesium ion. False to use terrain from the URL specified with the `"cesiumTerrainUrl"` property. If this property is false and `"cesiumTerrainUrl"` is not specified, the 3D view will use a smooth ellipsoid instead of a terrain surface. Defaults to true.
+`"useCesiumIonBingImagery"` | True to use Bing Maps from Cesium ion (Cesium World Imagery). By default, Ion will be used, unless the `bingMapsKey` property is specified, in which case that will be used instead. To disable the Bing Maps layers entirely, set this property to false and set `bingMapsKey` to null.
 `"cesiumIonAccessToken"`    | The access token to use with Cesium ion. If `"useCesiumIonTerrain"` is true and this property is not specified, the Cesium default Ion key will be used. It is a violation of the Ion terms of use to use the default key in a deployed application.
 `"cesiumTerrainUrl"`        | The URL to use for Cesium terrain in the 3D model. This property is ignored if `"useCesiumIonTerrain"` is set to true.
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -51,6 +51,7 @@ var defaultConfigParameters = {
     ],
     interceptBrowserPrint: true,
     useCesiumIonTerrain: true,
+    useCesiumIonBingImagery: undefined,
     cesiumIonAccessToken: undefined,
     cesiumTerrainUrl: undefined
 };

--- a/lib/ViewModels/BingMapsSearchProviderViewModel.js
+++ b/lib/ViewModels/BingMapsSearchProviderViewModel.js
@@ -31,6 +31,10 @@ var BingMapsSearchProviderViewModel = function(options) {
     this.flightDurationSeconds = defaultValue(options.flightDurationSeconds, 1.5);
     this.primaryCountry = defaultValue(options.primaryCountry, 'Australia');
     this.culture = defaultValue(options.culture, 'en-au');
+
+    if (!this.key) {
+        console.warn('The ' + this.name + ' geocoder will always return no results because a Bing Maps key has not been provided. Please get a Bing Maps key from bingmapsportal.com and add it to parameters.bingMapsKey in config.json.')
+    }
 };
 
 inherit(SearchProviderViewModel, BingMapsSearchProviderViewModel);

--- a/lib/ViewModels/BingMapsSearchProviderViewModel.js
+++ b/lib/ViewModels/BingMapsSearchProviderViewModel.js
@@ -33,7 +33,7 @@ var BingMapsSearchProviderViewModel = function(options) {
     this.culture = defaultValue(options.culture, 'en-au');
 
     if (!this.key) {
-        console.warn('The ' + this.name + ' geocoder will always return no results because a Bing Maps key has not been provided. Please get a Bing Maps key from bingmapsportal.com and add it to parameters.bingMapsKey in config.json.')
+        console.warn('The ' + this.name + ' geocoder will always return no results because a Bing Maps key has not been provided. Please get a Bing Maps key from bingmapsportal.com and add it to parameters.bingMapsKey in config.json.');
     }
 };
 

--- a/lib/ViewModels/createBingBaseMapOptions.js
+++ b/lib/ViewModels/createBingBaseMapOptions.js
@@ -1,15 +1,14 @@
 'use strict';
 
 /*global require*/
-var BaseMapViewModel = require('./BaseMapViewModel');
-var BingMapsCatalogItem = require('../Models/BingMapsCatalogItem');
+const BaseMapViewModel = require('./BaseMapViewModel');
+const BingMapsCatalogItem = require('../Models/BingMapsCatalogItem');
+const BingMapsStyle = require('terriajs-cesium/Source/Scene/BingMapsStyle');
 
-var BingMapsStyle = require('terriajs-cesium/Source/Scene/BingMapsStyle');
+function createBingBaseMapOptions(terria, bingMapsKey) {
+    const result = [];
 
-var createBingBaseMapOptions = function(terria, bingMapsKey) {
-    var result = [];
-
-    var bingMapsAerialWithLabels = new BingMapsCatalogItem(terria);
+    const bingMapsAerialWithLabels = new BingMapsCatalogItem(terria);
     bingMapsAerialWithLabels.name = 'Bing Maps Aerial with Labels';
     bingMapsAerialWithLabels.mapStyle = BingMapsStyle.AERIAL_WITH_LABELS;
     bingMapsAerialWithLabels.opacity = 1.0;
@@ -21,7 +20,7 @@ var createBingBaseMapOptions = function(terria, bingMapsKey) {
         catalogItem: bingMapsAerialWithLabels
     }));
 
-    var bingMapsAerial = new BingMapsCatalogItem(terria);
+    const bingMapsAerial = new BingMapsCatalogItem(terria);
     bingMapsAerial.name = 'Bing Maps Aerial';
     bingMapsAerial.mapStyle = BingMapsStyle.AERIAL;
     bingMapsAerial.opacity = 1.0;
@@ -33,7 +32,7 @@ var createBingBaseMapOptions = function(terria, bingMapsKey) {
         catalogItem: bingMapsAerial
     }));
 
-    var bingMapsRoads = new BingMapsCatalogItem(terria);
+    const bingMapsRoads = new BingMapsCatalogItem(terria);
     bingMapsRoads.name = 'Bing Maps Roads';
     bingMapsRoads.mapStyle = BingMapsStyle.ROAD;
     bingMapsRoads.opacity = 1.0;
@@ -47,6 +46,6 @@ var createBingBaseMapOptions = function(terria, bingMapsKey) {
     }));
 
     return result;
-};
+}
 
 module.exports = createBingBaseMapOptions;

--- a/lib/ViewModels/createBingBaseMapOptions.js
+++ b/lib/ViewModels/createBingBaseMapOptions.js
@@ -4,15 +4,44 @@
 const BaseMapViewModel = require('./BaseMapViewModel');
 const BingMapsCatalogItem = require('../Models/BingMapsCatalogItem');
 const BingMapsStyle = require('terriajs-cesium/Source/Scene/BingMapsStyle');
+const IonImageryCatalogItem = require('../Models/IonImageryCatalogItem');
+const IonWorldImageryStyle = require('terriajs-cesium/Source/Scene/IonWorldImageryStyle');
 
 function createBingBaseMapOptions(terria, bingMapsKey) {
     const result = [];
 
-    const bingMapsAerialWithLabels = new BingMapsCatalogItem(terria);
+    let bingMapsAerialWithLabels;
+    let bingMapsAerial;
+    let bingMapsRoads;
+
+    if (bingMapsKey && terria.configParameters.useCesiumIonBingImagery !== true) {
+        bingMapsAerialWithLabels = new BingMapsCatalogItem(terria);
+        bingMapsAerialWithLabels.mapStyle = BingMapsStyle.AERIAL_WITH_LABELS;
+        bingMapsAerialWithLabels.key = bingMapsKey;
+
+        bingMapsAerial = new BingMapsCatalogItem(terria);
+        bingMapsAerial.mapStyle = BingMapsStyle.AERIAL;
+        bingMapsAerial.key = bingMapsKey;
+
+        bingMapsRoads = new BingMapsCatalogItem(terria);
+        bingMapsRoads.mapStyle = BingMapsStyle.ROAD;
+        bingMapsRoads.key = bingMapsKey;
+    } else if (terria.configParameters.useCesiumIonBingImagery !== false) {
+        bingMapsAerialWithLabels = new IonImageryCatalogItem(terria);
+        bingMapsAerialWithLabels.ionAssetId = IonWorldImageryStyle.AERIAL_WITH_LABELS;
+
+        bingMapsAerial = new IonImageryCatalogItem(terria);
+        bingMapsAerial.ionAssetId = IonWorldImageryStyle.AERIAL;
+
+        bingMapsRoads = new IonImageryCatalogItem(terria);
+        bingMapsRoads.ionAssetId = IonWorldImageryStyle.ROAD;
+    } else {
+        // Disable the Bing Maps layers entirely.
+        return result;
+    }
+
     bingMapsAerialWithLabels.name = 'Bing Maps Aerial with Labels';
-    bingMapsAerialWithLabels.mapStyle = BingMapsStyle.AERIAL_WITH_LABELS;
     bingMapsAerialWithLabels.opacity = 1.0;
-    bingMapsAerialWithLabels.key = bingMapsKey;
     bingMapsAerialWithLabels.isRequiredForRendering = true;
 
     result.push(new BaseMapViewModel({
@@ -20,11 +49,8 @@ function createBingBaseMapOptions(terria, bingMapsKey) {
         catalogItem: bingMapsAerialWithLabels
     }));
 
-    const bingMapsAerial = new BingMapsCatalogItem(terria);
     bingMapsAerial.name = 'Bing Maps Aerial';
-    bingMapsAerial.mapStyle = BingMapsStyle.AERIAL;
     bingMapsAerial.opacity = 1.0;
-    bingMapsAerial.key = bingMapsKey;
     bingMapsAerial.isRequiredForRendering = true;
 
     result.push(new BaseMapViewModel({
@@ -32,11 +58,8 @@ function createBingBaseMapOptions(terria, bingMapsKey) {
         catalogItem: bingMapsAerial
     }));
 
-    const bingMapsRoads = new BingMapsCatalogItem(terria);
     bingMapsRoads.name = 'Bing Maps Roads';
-    bingMapsRoads.mapStyle = BingMapsStyle.ROAD;
     bingMapsRoads.opacity = 1.0;
-    bingMapsRoads.key = bingMapsKey;
     bingMapsRoads.isRequiredForRendering = true;
 
     result.push(new BaseMapViewModel({

--- a/lib/ViewModels/selectBaseMap.js
+++ b/lib/ViewModels/selectBaseMap.js
@@ -36,11 +36,16 @@ var selectBaseMap = function(terria, baseMaps, defaultBaseMapName, useStoredPref
     knockout.getObservable(terria, 'baseMapName').subscribe(function() {
         updateBaseMap(terria.baseMapName);
     });
+
+    if (baseMaps.length === 0) {
+        return undefined;
+    }
+
     var baseMap;
     if (useStoredPreference) {
         baseMap = updateBaseMap(terria.getLocalProperty('basemap'));
     }
-    baseMap = baseMap || updateBaseMap(terria.baseMapName) || updateBaseMap(defaultBaseMapName);
+    baseMap = baseMap || updateBaseMap(terria.baseMapName) || updateBaseMap(defaultBaseMapName) || updateBaseMap(baseMaps[0].catalogItem.name);
     return baseMap;
 
 };


### PR DESCRIPTION
With this PR, if a `bingMapsKey` is provided in config.json, nothing changes.

If a `bingMapsKey` is _not_ provided, we access the Bing Maps basemaps via Cesium Ion, using Cesium's default Ion key if none is provided. Because Ion can't be used for Bing geocoding (it has its own geocoder), failing to provide a `bingMapsKey` will also mean that the Bing geocoder will always return no results.

You can tweak this behavior with `useCesiumIonBingImagery` in config.json. If it's set to true, we'll use Ion for the Bing basemaps even if a `bingMapsKey` is provided. If it's set to false, and a `bingMapsKey` is not provided, the Bing basemaps will disappear completely.

Note that if you're using Bing via Ion, you'll get an Ion logo on the map even in 2D or 3D Smooth.