### PR TITLE
Use style name in workbench styles dropdown when no title given

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+### next
+* Fallback to style name in workbench styles dropdown when no title is given for a style in GetCapabilities.
+
 ### v6.2.1
 
 * We now use Cesium Ion for the Bing Maps basemaps, unless a `bingMapsKey` is provided in [config.json](https://docs.terria.io/guide/customizing/client-side-config/#parameters). You can control this behavior with the `useCesiumIonBingImagery` property. Please note that if a `bingMapsKey` is not provided, the Bing Maps geocoder will always return no results.

--- a/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
@@ -68,7 +68,7 @@ const StyleSelectorSection = createReactClass({
             <div key={layer.name}>
                 <label className={Styles.title} htmlFor={layer.name}>{label}</label>
                 <select className={Styles.field} name={layer.name} value={layer.style} onChange={this.changeStyle.bind(this, layer)}>
-                    {styles.map(item => <option key={item.name} value={item.name}>{item.title}</option>)}
+                    {styles.map(item => <option key={item.name} value={item.name}>{item.title || item.name}</option>)}
                 </select>
             </div>
         );


### PR DESCRIPTION
GetCapabilities is required to give a title for each style, but not all servers are conforming. This change uses the name when the title is not given, or if title is an empty string. Test with http://ci.terria.io/styles_no_title/#clean&http://static.nationalmap.nicta.com.au/northernaustralia/init/2018-10-16.json All Data -> Mining -> Mines Operating Status