### PR TITLE
Remove sos:procedure entries from GetFeatureOfInterest request.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 * Changed the "My Data" interface to be much more intuitive and tweaked the visual style of the catalog.
 * Made it possible to configure the compass control's colors using CSS.
+* Added "filterByProcedures" property to "sos" item (default: true). When false, the list of procedures is not passed as a filter to GetFeatureOfInterest request, which works better for BoM Water Data Online services.
 
 ### v6.2.2
 

--- a/lib/Models/SensorObservationServiceCatalogItem.js
+++ b/lib/Models/SensorObservationServiceCatalogItem.js
@@ -642,7 +642,7 @@ SensorObservationServiceCatalogItem.prototype.showOnSeparateMap = function(globe
 function loadFeaturesOfInterest(item) {
     const filter = {
         observedProperty:  item.observableProperties.map(observable => observable.identifier)  // eg. 'http://bom.gov.au/waterdata/services/parameters/Storage Level'
-    }
+    };
     if (item.filterByProcedures) {
         filter.procedure = item.procedures.map(procedure => procedure.identifier); // eg. 'http://bom.gov.au/waterdata/services/tstypes/Pat7_C_B_1_YearlyMean',
     }

--- a/lib/Models/SensorObservationServiceCatalogItem.js
+++ b/lib/Models/SensorObservationServiceCatalogItem.js
@@ -179,6 +179,13 @@ var SensorObservationServiceCatalogItem = function(terria, url) {
      */
     this.representAsGeoJson = false;
 
+    /**
+     * Whether to include the list of procedures in GetFeatureOfInterest calls, so that only locations that support
+     * those procedures are returned. For some servers (such as BoM's Water Data Online), this causes the request to time out.
+     * @default true
+     */
+    this.filterByProcedures = true;
+
     // Which columns of the tableStructure define a unique feature.
     // Use both because sometimes identifier is not unique (!).
     this._idColumnNames = ['identifier', 'id'];
@@ -626,19 +633,23 @@ SensorObservationServiceCatalogItem.prototype.showOnSeparateMap = function(globe
     }
 };
 
+/**
+ * Performs the GetFeatureOfInterest request to obtain the locations of sources of data that match the required 
+ * observed properties and procedures.
+ * @param {SensorObservationServiceCatalogItem} item 
+ * @return Promise for the request.
+ */
 function loadFeaturesOfInterest(item) {
-    // return querySos(item, {
-    //     request: 'GetFeatureOfInterest'
-    // }).then(function(featuresResponse) {
-    var paramArray = convertObjectToNameValueArray({
-        // Disabled as per https://github.com/TerriaJS/terriajs/issues/3118 but could be re-enabled via an option if a use case warrants it.
-        //procedure: item.procedures.map(procedure => procedure.identifier), // eg. 'http://bom.gov.au/waterdata/services/tstypes/Pat7_C_B_1_YearlyMean',
+    const filter = {
         observedProperty:  item.observableProperties.map(observable => observable.identifier)  // eg. 'http://bom.gov.au/waterdata/services/parameters/Storage Level'
-    });
+    }
+    if (item.filterByProcedures) {
+        filter.procedure = item.procedures.map(procedure => procedure.identifier); // eg. 'http://bom.gov.au/waterdata/services/tstypes/Pat7_C_B_1_YearlyMean',
+    }
     const templateContext = {
         action: 'GetFeatureOfInterest',
         actionClass: 'foiRetrieval',
-        parameters: paramArray,
+        parameters: convertObjectToNameValueArray(filter),
         temporalFilters: getTemporalFiltersContext(item)
     };
     return loadSoapBody(item, templateContext).then(function(body) {

--- a/lib/Models/SensorObservationServiceCatalogItem.js
+++ b/lib/Models/SensorObservationServiceCatalogItem.js
@@ -633,7 +633,7 @@ SensorObservationServiceCatalogItem.prototype.showOnSeparateMap = function(globe
     }
 };
 
-/**
+/*
  * Performs the GetFeatureOfInterest request to obtain the locations of sources of data that match the required 
  * observed properties and procedures.
  * @param {SensorObservationServiceCatalogItem} item 

--- a/lib/Models/SensorObservationServiceCatalogItem.js
+++ b/lib/Models/SensorObservationServiceCatalogItem.js
@@ -631,7 +631,8 @@ function loadFeaturesOfInterest(item) {
     //     request: 'GetFeatureOfInterest'
     // }).then(function(featuresResponse) {
     var paramArray = convertObjectToNameValueArray({
-        procedure: item.procedures.map(procedure => procedure.identifier), // eg. 'http://bom.gov.au/waterdata/services/tstypes/Pat7_C_B_1_YearlyMean',
+        // Disabled as per https://github.com/TerriaJS/terriajs/issues/3118 but could be re-enabled via an option if a use case warrants it.
+        //procedure: item.procedures.map(procedure => procedure.identifier), // eg. 'http://bom.gov.au/waterdata/services/tstypes/Pat7_C_B_1_YearlyMean',
         observedProperty:  item.observableProperties.map(observable => observable.identifier)  // eg. 'http://bom.gov.au/waterdata/services/parameters/Storage Level'
     });
     const templateContext = {


### PR DESCRIPTION
Fixes #3118.
Not entirely sure why they were there before. BoM's services interpret their
presence in a way which means vast quantities of data are being processed,
which makes the request fail.