### PR TITLE
Fix IE11 gyro icon misalignment in compass

### DIFF
--- a/lib/ReactViews/Map/Navigation/compass.scss
+++ b/lib/ReactViews/Map/Navigation/compass.scss
@@ -29,12 +29,9 @@
   border-radius: 50%;
   display: block;
   margin: 0 auto;
+  padding: 4px;
+  box-sizing: border-box;
   background: #ffffff;
-  svg{
-    width: 70%;
-    height: auto;
-    padding: 15%;
-  }
 }
 .rotationMarker{
   background-image: url('images/compass-rotation-marker.svg');


### PR DESCRIPTION
Problem in IE11: 
![image](https://user-images.githubusercontent.com/13863530/47829344-1c77f500-dddb-11e8-9869-de2d48e43030.png)

Fixed (also in IE11):
![image](https://user-images.githubusercontent.com/13863530/47829356-37e30000-dddb-11e8-8401-1ddb2064bec6.png)

