### PR TITLE
allow notification type

### DIFF
--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -961,7 +961,7 @@ function showDisclaimer(terria, globalDisclaimerHtml, developmentDisclaimerPream
                 confirmText: (globalDisclaimer.buttonTitle || "I Agree"),
                 width: globalDisclaimer.width || 600,
                 height: globalDisclaimer.height || 550,
-                message: <div className='disclaimer'>message</div>,
+                message: message,
                 hideUi: globalDisclaimer.hideUi,
                 type: 'disclaimer'
             };

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -961,8 +961,9 @@ function showDisclaimer(terria, globalDisclaimerHtml, developmentDisclaimerPream
                 confirmText: (globalDisclaimer.buttonTitle || "I Agree"),
                 width: globalDisclaimer.width || 600,
                 height: globalDisclaimer.height || 550,
-                message: message,
-                hideUi: globalDisclaimer.hideUi
+                message: <div className='disclaimer'>message</div>,
+                hideUi: globalDisclaimer.hideUi,
+                type: 'disclaimer'
             };
 
             terria.error.raiseEvent(options);

--- a/lib/ReactViews/Notification/Notification.jsx
+++ b/lib/ReactViews/Notification/Notification.jsx
@@ -1,5 +1,6 @@
 'use strict';
 
+import defined from 'terriajs-cesium/Source/Core/defined';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
 import createReactClass from 'create-react-class';
@@ -53,6 +54,7 @@ const Notification = createReactClass({
                 denyText={notification.denyText}
                 onConfirm={this.confirm}
                 onDeny={this.deny}
+                type={defined(notification.type) ? notification.type : 'notification'}
             />);
     },
 });

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -18,7 +18,8 @@ const NotificationWindow = createReactClass({
         confirmText: PropTypes.string,
         denyText: PropTypes.string,
         onConfirm: PropTypes.func.isRequired,
-        onDeny: PropTypes.func.isRequired
+        onDeny: PropTypes.func.isRequired,
+        type: PropTypes.string
     },
 
     confirm(e) {

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -1,5 +1,6 @@
 'use strict';
 
+import classNames from 'classnames';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
 import createReactClass from 'create-react-class';
@@ -39,9 +40,9 @@ const NotificationWindow = createReactClass({
         const message = this.props.message;
         const confirmText = this.props.confirmText || 'OK';
         const denyText = this.props.denyText;
-
+        const type = this.props.type;
         return (
-            <div className={Styles.wrapper}>
+            <div className={classNames(Styles.wrapper,`${type}`)}>
                 <div className={Styles.notification}>
                     <div className={Styles.inner}>
                         <h3 className='title'>{title}</h3>


### PR DESCRIPTION
Fixes:https://github.com/TerriaJS/terriajs/issues/3166

This is not using css modules to dynamically render the class, because css module requires the style of the class to be specified, while in our case, user can define their own notification class, and they should be able to style it in app's css.

To test, create a notification even with a "type" set to any value, and that value will become a class name available in the rendered html. I also gave disclaimer a default type "disclaimer".
