### PR TITLE
Notification style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Fixed a bug that caused the area to the right of the Terria log on the 2D map to be registered as a click on the logo instead of a click on the map.
 * Fixed a bug that caused the standard "Give Feedback" button to fail to open the feedback panel.
 * Swapped the positions of the group expand/collapse icon and the "Remove from catalogue" icon on the My Data panel, for more consistent alignment.
+* Made notifications honor the `width` and `height` properties. Previously, these values were ignored.
 
 ### v6.3.4
 

--- a/lib/ReactViews/Notification/Notification.jsx
+++ b/lib/ReactViews/Notification/Notification.jsx
@@ -53,6 +53,8 @@ const Notification = createReactClass({
                 denyText={notification.denyText}
                 onConfirm={this.confirm}
                 onDeny={this.deny}
+                width={notification.width}
+                height={notification.height}
             />);
     },
 });

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -1,5 +1,6 @@
 'use strict';
 
+import defined from 'terriajs-cesium/Source/Core/defined';
 import ObserveModelMixin from '../ObserveModelMixin';
 import React from 'react';
 import createReactClass from 'create-react-class';
@@ -40,10 +41,15 @@ const NotificationWindow = createReactClass({
         const confirmText = this.props.confirmText || 'OK';
         const denyText = this.props.denyText;
 
+        var divStyle = {
+          height: defined(this.props.height) ? this.props.height : 'auto',
+          width: defined(this.props.width) ? this.props.width : '500px',
+        };
+
         return (
             <div className={Styles.wrapper}>
                 <div className={Styles.notification}>
-                    <div className={Styles.inner}>
+                    <div className={Styles.inner} style={divStyle}>
                         <h3 className='title'>{title}</h3>
                         {window.location.host === 'localhost:3001' && title.toLowerCase().indexOf('error') >= 0 &&
                             <div><img src='./build/TerriaJS/images/feature.gif'/></div>

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -18,7 +18,9 @@ const NotificationWindow = createReactClass({
         confirmText: PropTypes.string,
         denyText: PropTypes.string,
         onConfirm: PropTypes.func.isRequired,
-        onDeny: PropTypes.func.isRequired
+        onDeny: PropTypes.func.isRequired,
+        height: PropTypes.string,
+        width: PropTypes.string
     },
 
     confirm(e) {
@@ -41,7 +43,7 @@ const NotificationWindow = createReactClass({
         const confirmText = this.props.confirmText || 'OK';
         const denyText = this.props.denyText;
 
-        var divStyle = {
+        const divStyle = {
           height: defined(this.props.height) ? this.props.height : 'auto',
           width: defined(this.props.width) ? this.props.width : '500px',
         };

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -19,8 +19,8 @@ const NotificationWindow = createReactClass({
         denyText: PropTypes.string,
         onConfirm: PropTypes.func.isRequired,
         onDeny: PropTypes.func.isRequired,
-        height: PropTypes.string,
-        width: PropTypes.string
+        height: PropTypes.oneOfType([PropTypes.string,PropTypes.number]),
+        width: PropTypes.oneOfType([PropTypes.string,PropTypes.number])
     },
 
     confirm(e) {

--- a/lib/ReactViews/Notification/notification-window.scss
+++ b/lib/ReactViews/Notification/notification-window.scss
@@ -58,6 +58,8 @@
   height: 100%;
   max-height: calc(100vh - #{$input-height*3});
   overflow-y: auto;
+  max-width: calc(100vw - 20px);
+  box-sizing: border-box;
 }
 
 

--- a/lib/ReactViews/Notification/notification-window.scss
+++ b/lib/ReactViews/Notification/notification-window.scss
@@ -58,8 +58,6 @@
   height: 100%;
   max-height: calc(100vh - #{$input-height*3});
   overflow-y: auto;
-  // a default width when it's not set in jsx
-  width: 500px;
 }
 
 

--- a/lib/ReactViews/Notification/notification-window.scss
+++ b/lib/ReactViews/Notification/notification-window.scss
@@ -29,8 +29,6 @@
   border: 1px solid darken($dark, 3%);
   background: $dark;
   z-index: 300;
-  width: 500px;
-  height: auto;
   pre{
     // copy over scrollbar css because I can't compose within
     -webkit-overflow-scrolling: touch;
@@ -60,6 +58,8 @@
   height: 100%;
   max-height: calc(100vh - #{$input-height*3});
   overflow-y: auto;
+  // a default width when it's not set in jsx
+  width: 500px;
 }
 
 


### PR DESCRIPTION
Fixes: https://github.com/TerriaJS/terriajs/issues/3168

In the app's index.js, we allow users to define disclaimer width and height, but those values are not applied to the notification window. This PR fixes that. 

However, since it is the first time we use these values, it may affect some existing instanced of terria apps. 
