### PR TITLE
added support for wcs styles

### DIFF
--- a/lib/Models/callWebCoverageService.js
+++ b/lib/Models/callWebCoverageService.js
@@ -69,6 +69,12 @@ function launch(wmsCatalogItem, bbox) {
     if (defined(wmsCatalogItem.discreteTime)) {
         query.time = wmsCatalogItem.discreteTime.toISOString();
     }
+
+    const style = getStyle(wmsCatalogItem);
+    if(defined(style)) {
+        query.styles = style;
+    }
+
     var uri = new URI(wmsCatalogItem.linkedWcsUrl).query(query);
 
     var url = proxyCatalogItemUrl(wmsCatalogItem, uri.toString(), '1d');
@@ -128,6 +134,43 @@ function launch(wmsCatalogItem, bbox) {
 
     asyncResult.loadPromise = promise;
     asyncResult.isEnabled = true;
+}
+
+function getStyle(wmsItem) {
+    const thisLayer = wmsItem._thisLayerInRawMetadata;
+    if (!defined(thisLayer)) {
+        console.log("cannot find current layer");
+        return undefined;
+    }
+
+    var style;
+    const availStyles = wmsItem.availableStyles[thisLayer.Name];
+    if(availStyles.length >= 2) {
+        const layers = wmsItem.layers.split(',');
+        const layerIndex = layers.indexOf(thisLayer.Name);
+        if (layerIndex === -1) {
+            // Not a valid layer?  Something went wrong.
+            console.log("cannot find layer index");
+            return undefined;
+        }
+
+        const styles = wmsItem.styles.split(',');
+        style = styles[layerIndex];
+
+        var styleFound = false;
+        for(var i = 0; i < availStyles.length; i++) {
+            if(availStyles[i].name === style) {
+                styleFound = true;
+                break;
+            }
+        }
+
+        if(!styleFound) {
+            style = availStyles[0].name;
+        }
+    }
+
+    return style;
 }
 
 module.exports = callWebCoverageService;


### PR DESCRIPTION
When a user selects a region in TerriaJS to export data (aka. "clip-n-ship"), they would conceivably expect to obtain data for the bands used in the style of the layer they are currently viewing. For example, if a user has selected "False colour" from the style selection dropdown for a Landsat 8 layer, when using the export feature they should receive data for the "swir1", "nir" and "green" bands. If they then switched to the "True colour" style instead, the data should contain the "red", "green" and "blue" bands. In order to facilitate this behaviour, the WCS service provider would need to know both the currently selected WMS layer and style. Currently, when TerriaJS sends a WCS "GetCoverage" request it only includes the layer name (via the "coverage" parameter) and not the style. Note that a standard WCS request would explicitly specify what bands to include from an "AxisDescription" element (eg. "measurements" parameter), however in this scenario the user is attempting to export data corresponding to a WMS layer/style they are viewing and TerriaJS doesn't know what bands they correspond to as they are configured on the WMS service provider side.