### PR TITLE
Unpin html-to-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "file-saver": "^1.3.8",
     "gulp": "^3.9.1",
     "hammerjs": "^2.0.6",
-    "html-to-react": "1.2.12",
+    "html-to-react": "^1.2.12",
     "imports-loader": "^0.7.0",
     "inobounce": "^0.1.2",
     "javascript-natural-sort": "^0.7.1",


### PR DESCRIPTION
It was pinned in https://github.com/TerriaJS/terriajs/commit/3bf3df8edbb46fe40ffae666d5e926960466d120 . I believe the pinning became unnecessary when we upgraded React somewhere along the way.