### PR TITLE
fixed single timestamp issue

### DIFF
--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -1264,6 +1264,7 @@ function updateIntervalsFromTimes(result, times, index, defaultDuration) {
         var duration = JulianDate.secondsDifference(previousInterval.stop, previousInterval.start);
         stop = JulianDate.addSeconds(start, duration, new JulianDate());
     } else {
+        // There's exactly one timestamp, so we set stop = start.
         stop = start;
     }
     result.addInterval(new TimeInterval({

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -1264,7 +1264,6 @@ function updateIntervalsFromTimes(result, times, index, defaultDuration) {
         var duration = JulianDate.secondsDifference(previousInterval.stop, previousInterval.start);
         stop = JulianDate.addSeconds(start, duration, new JulianDate());
     } else {
-        // There's exactly one time, so treat this layer as if it is not time-varying.
         stop = start;
     }
     result.addInterval(new TimeInterval({

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -1265,7 +1265,7 @@ function updateIntervalsFromTimes(result, times, index, defaultDuration) {
         stop = JulianDate.addSeconds(start, duration, new JulianDate());
     } else {
         // There's exactly one time, so treat this layer as if it is not time-varying.
-        return undefined;
+        stop = start;
     }
     result.addInterval(new TimeInterval({
         start: start,


### PR DESCRIPTION
@kring This fixes https://github.com/TerriaJS/terriajs/issues/2956
If the time parameter is not set in the WMS request, the server side will have to support default timestamp to avoid 400 bad request.

Also from UX perspective, I think it makes sense to display the single timestamp. If no timestamp shows up in the catalog item, user might feel something went wrong.