### PR TITLE
drag feature info from header only 

### DIFF
--- a/lib/ReactViews/DragWrapper.jsx
+++ b/lib/ReactViews/DragWrapper.jsx
@@ -5,9 +5,6 @@ import interact from 'interactjs';
 class DragWrapper extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-        isDragging: 0
-    };
     this.resizeListener = null;
 }
 
@@ -28,23 +25,12 @@ class DragWrapper extends React.Component {
          // update the posiion attributes
          target.setAttribute('data-x', x);
          target.setAttribute('data-y', y);
-         // set a threashhold for drag -> moving event to stop other interaction
-         if(Math.abs(event.dx) > 5 || Math.abs(event.dy) > 5) {
-            this.setState({
-                isDragging: 1
-            });
-         }
-     };
-
-      const onend = ()=> {
-          setTimeout(()=> {
-              this.setState({
-                  isDragging: 0
-              });
-          }, 100);
       };
-      interact(node)
+
+     interact(node)
         .draggable({
+          ignoreFrom: 'button',
+          allowFrom: '.drag-handle',
           inertia: true,
           onmove: dragMoveListener,
           // keep the element within the area of it's parent
@@ -53,7 +39,6 @@ class DragWrapper extends React.Component {
               endOnly: true,
               elementRect: { left: 0, right: 1, top: 0, bottom: 1 }
           },
-          onend: onend
       });
 
   this.resizeListener = ()=> {
@@ -72,7 +57,7 @@ componentWillUnmount() {
 }
 
   render() {
-      return <div data-is-dragging={this.state.isDragging} ref={node => this.node = node} >{this.props.children}</div>;
+      return <div ref={node => this.node = node} >{this.props.children}</div>;
   }
 }
 

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -79,11 +79,7 @@ const FeatureInfoPanel = createReactClass({
             this._pickedFeaturesSubscription = undefined;
         }
     },
-
-    isDragging() {
-        return +this.ref.current.node.getAttribute('data-is-dragging');
-    },
-
+   
     getFeatureInfoCatalogItems() {
         const {catalogItems, featureCatalogItemPairs} = getFeaturesGroupedByCatalogItems(this.props.terria);
 
@@ -117,19 +113,15 @@ const FeatureInfoPanel = createReactClass({
     },
 
     toggleCollapsed(event) {
-        if(!this.isDragging()) {
-            this.props.viewState.featureInfoPanelIsCollapsed = !this.props.viewState.featureInfoPanelIsCollapsed;
-        }
+        this.props.viewState.featureInfoPanelIsCollapsed = !this.props.viewState.featureInfoPanelIsCollapsed;
     },
 
     toggleOpenFeature(feature) {
-        if(!this.isDragging()) {
-            const terria = this.props.terria;
-            if (feature === terria.selectedFeature) {
-                terria.selectedFeature = undefined;
-            } else {
-                terria.selectedFeature = feature;
-            }
+        const terria = this.props.terria;
+        if (feature === terria.selectedFeature) {
+            terria.selectedFeature = undefined;
+        } else {
+            terria.selectedFeature = feature;
         }
     },
 
@@ -245,7 +237,7 @@ const FeatureInfoPanel = createReactClass({
                         className={panelClassName}
                         aria-hidden={!viewState.featureInfoPanelIsVisible}>
                         {!this.props.printView && <div className={Styles.header}>
-                            <div className={Styles.btnPanelHeading}>
+                            <div className={classNames('drag-handle', Styles.btnPanelHeading)}>
                                 <span>Feature Information</span>
                                 <button type='button' onClick={ this.toggleCollapsed } className={Styles.btnToggleFeature}>
                                     {this.props.viewState.featureInfoPanelIsCollapsed ? <Icon glyph={Icon.GLYPHS.closed}/> : <Icon glyph={Icon.GLYPHS.opened}/>}


### PR DESCRIPTION
a provisional fix for : https://github.com/TerriaJS/terriajs/issues/3211

Downside: user can only drag feature info panel by dragging the header. This is to prevent touch screen users from not able to scroll feature info panel. This is also how https://koordinates.com/search/?q=water does draggable feature info. 

More research needed to come up with a better solution.