### PR TITLE
Fix double-quotes in FeatureInfoTemplate example

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@ The following people have contributed to TerriaJS:
    * [Jacky Jiang](https://github.com/t83714)
 * [Geoscience Australia](http://www.ga.gov.au/)
    * [Darren Reid](https://github.com/Layoric)
+   * [Andrew Hicks](https://github.com/andrewdhicks)
 * [Propeller Aerobotics](http://www.propelleraero.com.au/)
    * [Keat Tang](https://github.com/keattang)
 * [Urthecast](https://www.urthecast.com/)

--- a/doc/connecting-to-data/customizing-data-appearance/feature-info-template.md
+++ b/doc/connecting-to-data/customizing-data-appearance/feature-info-template.md
@@ -120,7 +120,7 @@ The date format style used for the `"format"` property is the style from the [np
 
 As with number you can also use `terria.dateTimeformat` directly in the template. This accepts an initial JSON string describing the same options as above.
 
-              "featureInfoTemplate": "template": "{{#terria.formatDateTime}}{"format": "dd-mm-yyyy HH:MM:ss"}2017-11-23T08:47:53Z{{/terria.formatDateTime}}</b>."
+              "featureInfoTemplate": "template": "{{#terria.formatDateTime}}{format: \"dd-mm-yyyy HH:MM:ss\"}2017-11-23T08:47:53Z{{/terria.formatDateTime}}</b>."
 
 ## Time-series charts
 


### PR DESCRIPTION
The double quotes around the date format string parameter need to be escaped when passing to an inline function

See: https://github.com/TerriaJS/terriajs/issues/3218