### PR TITLE
Change issue tracker link to that of a new issue

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ The following people have contributed to TerriaJS:
    * [Rebecca Dengate](https://github.com/rdengate)
    * [Ashley Stacey](https://github.com/a-stacey)
    * [Jacky Jiang](https://github.com/t83714)
+   * [Sajid Anower](https://github.com/sajidanower23)
 * [Geoscience Australia](http://www.ga.gov.au/)
    * [Darren Reid](https://github.com/Layoric)
    * [Andrew Hicks](https://github.com/andrewdhicks)

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ Get in touch!
 
 * Chat in our [Gitter chat room](https://gitter.im/TerriaJS/terriajs)
 * Join the [TerriaJS Google Group](https://groups.google.com/forum/#!forum/terriajs)
-* Raise issues in the [Github issue tracker](https://github.com/TerriaJS/TerriaJS)
+* Raise issues in the [Github issue tracker](https://github.com/TerriaJS/terriajs/issues/new)


### PR DESCRIPTION
Minor tweak: The link to reporting a bug now points to a page to open a new issue.