### PR TITLE
Remove automatic polyfilling of Promise and console

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
     "parser": "babel-eslint",
     "env": {
         "browser": true,
-        "commonjs": true
+        "commonjs": true,
+        "es6": true
     },
     "plugins": [
         "react",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### Next Release
 
 * Breaking Changes:
+  * An application-level polyfill suite is now highly recommended, and it is required for Internet Explorer 9, 10, and 11 compatibility. The easiest approach is to add `<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>` to the `<head>` element of your application's HTML page, which will deliver a polyfill suite tailored to the end-user's browser.
   * TerriaJS now requires Node.js v8.0 or later.
   * TerriaJS now requires Webpack v4.0 or later.
   * TerriaJS now uses Gulp v4.0. If you have Gulp 3 installed globally, you'll need to use `npm run gulp` to run TerriaJS gulp tasks, or upgrade your global Gulp to v4 with `npm install -g gulp@4`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Change Log
 ### Next Release
 
 * Breaking Changes:
-  * An application-level polyfill suite is now highly recommended, and it is required for Internet Explorer 9, 10, and 11 compatibility. The easiest approach is to add `<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>` to the `<head>` element of your application's HTML page, which will deliver a polyfill suite tailored to the end-user's browser.
+  * TerriaJS no longer supports Internet Explorer 9 or 10.
+  * An application-level polyfill suite is now highly recommended, and it is required for Internet Explorer 11 compatibility. The easiest approach is to add `<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>` to the `<head>` element of your application's HTML page, which will deliver a polyfill suite tailored to the end-user's browser.
   * TerriaJS now requires Node.js v8.0 or later.
   * TerriaJS now requires Webpack v4.0 or later.
   * TerriaJS now uses Gulp v4.0. If you have Gulp 3 installed globally, you'll need to use `npm run gulp` to run TerriaJS gulp tasks, or upgrade your global Gulp to v4 with `npm install -g gulp@4`.

--- a/buildprocess/createKarmaBaseConfig.js
+++ b/buildprocess/createKarmaBaseConfig.js
@@ -17,6 +17,7 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
+            'https://cdn.polyfill.io/v2/polyfill.min.js',
             'build/TerriaJS-specs.js',
             {
                 pattern: '**/*',
@@ -33,7 +34,7 @@ module.exports = function(config) {
             '/test': '/base/test',
             '/build': '/base/build'
         },
-        
+
         // list of files to exclude
         exclude: [],
 

--- a/lib/Models/Terria.js
+++ b/lib/Models/Terria.js
@@ -9,7 +9,6 @@ var combine = require('terriajs-cesium/Source/Core/combine');
 var DataSourceCollection = require('terriajs-cesium/Source/DataSources/DataSourceCollection');
 var defaultValue = require('terriajs-cesium/Source/Core/defaultValue');
 var defined = require('terriajs-cesium/Source/Core/defined');
-var deprecationWarning = require('terriajs-cesium/Source/Core/deprecationWarning');
 var DeveloperError = require('terriajs-cesium/Source/Core/DeveloperError');
 var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 var queryToObject = require('terriajs-cesium/Source/Core/queryToObject');
@@ -29,7 +28,6 @@ var isCommonMobilePlatform = require('../Core/isCommonMobilePlatform');
 var loadJson5 = require('../Core/loadJson5');
 var NoViewer = require('./NoViewer');
 var NowViewing = require('./NowViewing');
-var Promise = require('../Core/Promise');
 var runLater = require('../Core/runLater');
 var ServerConfig = require('../Core/ServerConfig');
 var Services = require('./Services');
@@ -72,22 +70,6 @@ var directInitSourceProperties = ['baseMapName', 'fogSettings', 'splitPosition']
  * @param {AddressGeocoder} [options.batchGeocoder] Geocoder to use for geocoding addresses in CSV files.
  */
 var Terria = function(options) {
-    // IE9 doesn't have a console object until the debugging tools are opened.
-    // Add a shim.
-    if (typeof window.console === 'undefined') {
-        window.console = {
-            log: function() {},
-            warn: function() {},
-            error: function() {}
-        };
-    }
-
-    // Polyfill Promise for old browsers
-    if (!defined(window.Promise)) {
-        deprecationWarning('promise-polyfill', 'This browser does not have Promise support. It will be polyfilled automatically, but an external polyfill (e.g. polyfill.io) will be required starting in TerriaJS v7.0');
-        window.Promise = Promise;
-    }
-
     if (!defined(options) || !defined(options.baseUrl)) {
         throw new DeveloperError('options.baseUrl is required.');
     }

--- a/wwwroot/SpecRunner.html
+++ b/wwwroot/SpecRunner.html
@@ -16,9 +16,10 @@
         window.ga = function() {};
     </script>
 
-    <script type="text/javascript" src="./build/TerriaJS-specs.js"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
 </head>
 
 <body>
+    <script type="text/javascript" src="./build/TerriaJS-specs.js"></script>
 </body>
 </html>


### PR DESCRIPTION
A polyfill suite is now required in browsers that don't have these features.