### PR TITLE
Make sure getlegendgraphic url is cleared for each layer

### DIFF
--- a/lib/Models/CswCatalogGroup.js
+++ b/lib/Models/CswCatalogGroup.js
@@ -350,7 +350,7 @@ CswCatalogGroup.prototype._load = function() {
                 // displayed in the metadata summary for the layer
                 var downloadUrls = [],
                     acceptableUrls = [],
-                    legendUrl;
+                    legendUrl = undefined;
                 for (var m = 0; m < uris.length; m++) {
                     var url = uris[m];
                     var excludedProtocol = false;


### PR DESCRIPTION
GetLegendGraphic from catalog was being carried over into layers for which it was not applicable.