### PR TITLE
Show axes for unitless quantities, other charting fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Highlight polygon and polyline features.
 * Replace `getUniqueValues` with `lodash.uniq`
 * Fixed a bug where the 3D globe would not immediately refresh when toggling between the "Terrain" and "Smooth" viewer modes.
+* Fixed a bug that could cause the chart panel at the bottom to flicker on and off rapidly when there is an error loading chart data.
 
 ### v7.0.2
 

--- a/lib/Charts/ChartRenderer.js
+++ b/lib/Charts/ChartRenderer.js
@@ -124,7 +124,7 @@ class ChartRenderer {
 
         const data = state.data;
         const margin = defaultValue(state.margin, defaultMargin);
-        const units = uniq(state.data.map(data => data.units).filter(units => defined(units)));
+        const units = uniq(state.data.filter(data => data.type !== 'moment').map(data => data.units));
         const size = Size.calculate(container, margin, state, state.mini ? 1 : units.length);
         const scales = Scales.calculate(size, state.domain, state.data, this.getXpadding(state));
 

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -434,6 +434,10 @@ ImageryLayerCatalogItem.defaultUpdaters.availableDates = function() {
     // Do not update/serialize availableDates.
 };
 
+ImageryLayerCatalogItem.defaultUpdaters.xAxis = function() {
+    // Do not update/serialize xAxis.
+};
+
 ImageryLayerCatalogItem.defaultUpdaters.intervalFilterFeature = function(catalogItem, json, propertyName) {
     if (defined(json.intervalFilterFeature)) {
         let mapPromise = when();
@@ -528,6 +532,10 @@ ImageryLayerCatalogItem.defaultSerializers.clock = function() {
 
 ImageryLayerCatalogItem.defaultSerializers.availableDates = function() {
     // Do not update/serialize availableDates.
+};
+
+ImageryLayerCatalogItem.defaultSerializers.xAxis = function() {
+    // Do not update/serialize xAxis.
 };
 
 ImageryLayerCatalogItem.defaultSerializers.intervalFilterFeature = function(catalogItem, json, propertyName) {

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -191,8 +191,13 @@ function expand(props, sourceIndex) {
         if (existingIndex >= 0) {
             // First, keep a copy of the active items and colors used, so we can keep them the same with the new chart.
             const oldCatalogItem = group.items[existingIndex];
-            activeConcepts = oldCatalogItem.tableStructure.columns.map(column => column.isActive);
-            existingColors = oldCatalogItem.tableStructure.columns.map(column => column.color);
+            if (defined(oldCatalogItem.tableStructure) && defined(oldCatalogItem.tableStructure.columns)) {
+                activeConcepts = oldCatalogItem.tableStructure.columns.map(column => column.isActive);
+                existingColors = oldCatalogItem.tableStructure.columns.map(column => column.color);
+            } else {
+                activeConcepts = undefined;
+                existingColors = undefined;
+            }
             oldCatalogItem.isEnabled = false;
             group.remove(oldCatalogItem);
         }

--- a/lib/ReactViews/Custom/Chart/ChartPanel.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanel.jsx
@@ -96,7 +96,7 @@ const ChartPanel = createReactClass({
                         <div className={Styles.body}>
                             <div className={Styles.header}>
                                 <label className={Styles.sectionLabel}>{loader || 'Charts'}</label>
-                                <ChartPanelDownloadButton chartableItems={this.props.terria.catalog.chartableItems} errorEvent={this.props.terria.error} />
+                                <ChartPanelDownloadButton chartableItems={this.props.terria.catalog.chartableItems} />
                                 <button type='button' className={Styles.btnCloseChartPanel} onClick={this.closePanel}>
                                     <Icon glyph={Icon.GLYPHS.close}/>
                                 </button>

--- a/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
@@ -1,22 +1,15 @@
 'use strict';
-/* global Float32Array */
-/* eslint new-parens: 0 */
-import React from 'react';
-import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-import debounce from 'lodash.debounce';
-
+import FileSaver from 'file-saver';
+import PropTypes from 'prop-types';
+import React from 'react';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import when from 'terriajs-cesium/Source/ThirdParty/when';
-
-import DataUri from '../../../Core/DataUri';
-import ObserveModelMixin from '../../ObserveModelMixin';
 import VarType from '../../../Map/VarType';
 import Icon from "../../Icon.jsx";
-
+import ObserveModelMixin from '../../ObserveModelMixin';
 import Styles from './chart-panel-download-button.scss';
 
-const RUN_WORKER_DEBOUNCE = 100; // Wait 100ms for initial setup changes to be completed.
 const TIME_COLUMN_DEFAULT_NAME = 'date';
 
 const ChartPanelDownloadButton = createReactClass({
@@ -24,70 +17,9 @@ const ChartPanelDownloadButton = createReactClass({
     mixins: [ObserveModelMixin],
 
     propTypes: {
-        chartableItems: PropTypes.array.isRequired,
-        errorEvent: PropTypes.object.isRequired
+        chartableItems: PropTypes.array.isRequired
     },
 
-    _subscription: undefined,
-
-    getInitialState: function() {
-        return {href: undefined};
-    },
-
-    /* eslint-disable-next-line camelcase */
-    UNSAFE_componentWillMount() {
-        // Changes to the graph item's catalog item results in new props being passed to this component 5 times on load...
-        // a debounce is a simple way to ensure it only gets run once for every batch of real changes.
-        this.debouncedRunWorker = debounce(this.runWorker, RUN_WORKER_DEBOUNCE);
-    },
-
-    componentDidMount() {
-        this.debouncedRunWorker(this.props.chartableItems);
-    },
-
-    /* eslint-disable-next-line camelcase */
-    UNSAFE_componentWillReceiveProps(newProps) {
-        this.debouncedRunWorker(newProps.chartableItems);
-    },
-
-    runWorker(newValue) {
-        const that = this;
-
-        if (window.Worker && (typeof Float32Array !== 'undefined')) {
-            if (that.state.href !== undefined) {
-                that.setState({href: undefined});
-            }
-
-            const loadingPromises = newValue.map(function(item) {
-                return when(item.load()).then(() => item).otherwise(() => undefined);
-            });
-
-            when.all(loadingPromises).then(items => {
-                const synthesized = that.synthesizeNameAndValueArrays(newValue.filter(item => item !== undefined));
-                // Could implement this using TaskProcessor, but requires webpack magic.
-                const HrefWorker = require('worker-loader!./downloadHrefWorker');
-                const worker = new HrefWorker;
-                // console.log('names and value arrays', synthesized.names, synthesized.values);
-                if (synthesized.values && synthesized.values.length > 0) {
-                    worker.postMessage(synthesized);
-                    worker.onmessage = function(event) {
-                        // console.log('got worker message', event.data.slice(0, 60), '...');
-                        that.setState({href: event.data});
-                    };
-                }
-            });
-        }
-        // Currently no fallback for IE9-10 - just can't download.
-    },
-
-    componentWillUnmount() {
-        if (defined(this._subscription)) {
-            this._subscription.dispose();
-        }
-        if (defined(this.debouncedRunWorker)) {
-            this.debouncedRunWorker.cancel();
-        }
-    },
     /**
      * Extracts column names and row data for CSV download.
      * @param {CatalogItem[]} chartableItems 
@@ -127,25 +59,42 @@ const ChartPanelDownloadButton = createReactClass({
         return {values: valueArrays, names: names};
     },
 
-    render() {
-        if (this.state.href) {
-            if (DataUri.checkCompatibility()) {
-                return (
-                    <a className={Styles.btnDownload}
-                       download='chart data.csv'
-                       href={this.state.href}>
-                    <Icon glyph={Icon.GLYPHS.download}/>Download</a>
-                );
-            } else {
-                return (
-                    <span className={Styles.btnDownload}
-                          onClick={DataUri.checkCompatibility.bind(null, this.props.errorEvent, this.state.href)}>
-                    <Icon glyph={Icon.GLYPHS.download}/>Download</span>
-                );
-            }
+    download() {
+        const that = this;
+
+        if (window.Worker && (typeof Float32Array !== 'undefined')) {
+            const loadingPromises = that.props.chartableItems.map(function(item) {
+                return when(item.load()).then(() => item).otherwise(() => undefined);
+            });
+
+            when.all(loadingPromises).then(items => {
+                const synthesized = that.synthesizeNameAndValueArrays(items.filter(item => item !== undefined));
+                // Could implement this using TaskProcessor, but requires webpack magic.
+                const HrefWorker = require('worker-loader!./downloadHrefWorker');
+                const worker = new HrefWorker();
+                // console.log('names and value arrays', synthesized.names, synthesized.values);
+                if (synthesized.values && synthesized.values.length > 0) {
+                    worker.postMessage(synthesized);
+                    worker.onmessage = function(event) {
+                        // console.log('got worker message', event.data.slice(0, 60), '...');
+                        const blob = new Blob([event.data], {
+                            type: 'text/csv;charset=utf-8'
+                        });
+                        FileSaver.saveAs(blob, 'chart data.csv');
+                    };
+                }
+            });
         }
-        return null;
     },
+
+    render() {
+        return (
+            <button className={Styles.btnDownload}
+                    onClick={this.download}>
+                <Icon glyph={Icon.GLYPHS.download}/>Download
+            </button>
+        );
+    }
 });
 
 /**

--- a/lib/ReactViews/Custom/Chart/downloadHrefWorker.js
+++ b/lib/ReactViews/Custom/Chart/downloadHrefWorker.js
@@ -1,7 +1,5 @@
 /* global onmessage:true */
 import defined from 'terriajs-cesium/Source/Core/defined';
-
-import DataUri from '../../../Core/DataUri';
 import sortedIndices from '../../../Core/sortedIndices';
 
 /**
@@ -123,6 +121,5 @@ onmessage = function(event) {
     const rows = toArrayOfRows(combinedValues, nameArrays);
     const joinedRows = rows.map(function(row) { return row.join(','); });
     const csvString = joinedRows.join('\n');
-    const href = DataUri.make('csv', csvString);
-    postMessage(href);
+    postMessage(csvString);
 };

--- a/lib/ReactViews/Generic/Dropdown.jsx
+++ b/lib/ReactViews/Generic/Dropdown.jsx
@@ -128,6 +128,8 @@ const Dropdown = createReactClass({
                             <Choose>
                                 <When condition={option.href}>
                                     <a href={option.href}
+                                       target="_blank"
+                                       rel="noopener noreferrer"
                                        className={classNames(Styles.btnOption, this.props.theme.btnOption || '', {[Styles.isSelected]: option === this.props.selected})}
                                        download={option.download}>
                                         {option[this.props.textProperty]}


### PR DESCRIPTION
This fixes the issue Mats described here:
https://github.com/TerriaJS/terriajs/pull/3151#issuecomment-472380328

Remaining problem: if you drag https://droughtreliefpublic.blob.core.windows.net/nationalmapdatapublic/Farm-Businesses/FMD%20industry.csv onto the map and click on Victoria, and then Expand, the 9-digit numbers on the Y-axis are cut off because they're too long. This was true previously, too, but it wasn't as bad because the Y-axis area was bigger. @chloeleichen is there a way to dynamically size the Y-axis area based on the length of the labels? That would be ideal. If not, we should at least make the area as big as it was before so we don't have a regression.