### PR TITLE
Ignore browser messages that originate from react devtools

### DIFF
--- a/lib/ViewModels/updateApplicationOnMessageFromParentWindow.js
+++ b/lib/ViewModels/updateApplicationOnMessageFromParentWindow.js
@@ -26,6 +26,11 @@ var updateApplicationOnMessageFromParentWindow = function(terria, window) {
             delete event.data.allowOrigin;
         }
 
+        // Ignore react devtools
+        if((/^react-devtools/gi).test(event.data.source)) {
+            return;
+        }
+
         terria.updateFromStartData(event.data).otherwise(function(e) {
             raiseErrorToUser(terria, e);
         });


### PR DESCRIPTION
When Terria gets react devtools messages it can throw errors or continuously request catalog files, both of which are annoying for debugging.