### PR TITLE
Remove changeBaseMap from TerriaViewer and make Notification mobx reactive

### DIFF
--- a/lib/ReactViews/Notification/Notification.jsx
+++ b/lib/ReactViews/Notification/Notification.jsx
@@ -7,8 +7,10 @@ import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import NotificationWindow from './NotificationWindow';
 import triggerResize from '../../Core/triggerResize';
+import { observer } from 'mobx-react';
 
-const Notification = createReactClass({
+
+const Notification = observer(createReactClass({
     displayName: 'Notification',
     mixins: [ObserveModelMixin],
 
@@ -45,7 +47,7 @@ const Notification = createReactClass({
     },
 
     render() {
-        const notification = this.props.viewState.notifications[0] || null;
+        const notification = this.props.viewState.notifications.length > 0 && this.props.viewState.notifications[0] || null;
         return notification && (
             <NotificationWindow
                 title={notification.title}
@@ -59,6 +61,6 @@ const Notification = createReactClass({
                 height={notification.height}
             />);
     },
-});
+}));
 
 module.exports = Notification;

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -359,9 +359,6 @@ us via email at '+that.terria.supportEmail+'.'
 
 TerriaViewer.prototype.destroy = function () {
     this.terria.beforeViewerChanged.raiseEvent();
-
-    this.terria.
-
     this.observeSubscriptions.forEach(subscription => subscription());
 
     if (defined(this.terria.cesium)) {

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -139,9 +139,6 @@ Your web browser does not appear to support WebGL, so you will see a limited, 2D
     }));
 
     this._previousBaseMap = this.terria.baseMap;
-    // this.observeSubscriptions.push(reaction(() => this.terria.baseMap, () => {
-    //     changeBaseMap(this, this.terria.baseMap);
-    // }));
 
     this.observeSubscriptions.push(reaction(() => this.terria.fogSettings, () => {
         changeFogSettings(this);
@@ -231,28 +228,6 @@ upgrade your computer\'s video driver or operating system in order to get the 3D
                 }
             }
         }
-    }
-}
-
-function changeBaseMap(viewer, newBaseMap) {
-    if (defined(viewer._previousBaseMap)) {
-        viewer._previousBaseMap.show = false;
-        // viewer._previousBaseMap._hide();
-        // viewer._previousBaseMap._disable();
-    }
-
-    if (defined(newBaseMap)) {
-        newBaseMap._enable();
-        newBaseMap._show();
-        if (defined(viewer.terria.currentViewer)) {
-            viewer.terria.currentViewer.lowerToBottom(newBaseMap);
-        }
-    }
-
-    viewer._previousBaseMap = newBaseMap;
-
-    if (defined(viewer.terria.currentViewer)) {
-        // viewer.terria.currentViewer.notifyRepaintRequired();
     }
 }
 
@@ -387,8 +362,6 @@ TerriaViewer.prototype.destroy = function () {
 
     this.terria.
 
-    changeBaseMap(this, undefined);
-
     this.observeSubscriptions.forEach(subscription => subscription());
 
     if (defined(this.terria.cesium)) {
@@ -444,7 +417,6 @@ TerriaViewer.prototype.destroyLeaflet = function() {
 
 TerriaViewer.prototype.selectViewer = function(cesium) {
 
-    changeBaseMap(this, undefined);
 
     this.terria.beforeViewerChanged.raiseEvent();
 
@@ -453,7 +425,6 @@ TerriaViewer.prototype.selectViewer = function(cesium) {
     var createViewerPromise = cesium ? this.selectCesium() : this.selectLeaflet();
     createViewerPromise.then(function() {
         that.terria.afterViewerChanged.raiseEvent();
-        changeBaseMap(that, that.terria.baseMap);
     });
 };
 


### PR DESCRIPTION
Remove `changeBaseMap` because it's current logic is no longer needed in the new mobx architecture. And it throws annoying errors sometimes.

Also fix `Notification` so that notifications can be dismissed.