### PR TITLE
Allow dropdown to still expand to fit buttons

### DIFF
--- a/lib/ReactViews/Generic/dropdown.scss
+++ b/lib/ReactViews/Generic/dropdown.scss
@@ -12,7 +12,7 @@
   @include transition(transform $animation-fast cubic-bezier(0.19, 1, 0.22, 1));
   @include transform-origin(center, top);
   position: absolute;
-  width: 100%;
+  min-width: 100%;
   overflow: hidden;
   z-index: 9999;
   box-sizing: border-box;


### PR DESCRIPTION
Stop the dropdown from cropping buttons to the width of the button above it, but still enforce a minimum width of the same as the above button.