### PR TITLE
Update button positioning for mobile time series

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Fixed a bug that prevented catalog item split state (left/right/both) from being shared for CSV layers.
 * Fixed a bug where the 3D globe would not immediately refresh when toggling between the "Terrain" and "Smooth" viewer modes.
 * Fixed a bug that could cause the chart panel at the bottom to flicker on and off rapidly when there is an error loading chart data.
+* Fixed map tool button positioning on small-screen devices when viewing time series layers.
 
 ### v7.0.2
 

--- a/lib/ReactViews/Map/MapNavigation.jsx
+++ b/lib/ReactViews/Map/MapNavigation.jsx
@@ -10,6 +10,9 @@ import ToggleSplitterTool from './Navigation/ToggleSplitterTool';
 import ViewerMode from '../../Models/ViewerMode';
 import ZoomControl from './Navigation/ZoomControl.jsx';
 
+import classNames from 'classnames';
+import defined from 'terriajs-cesium/Source/Core/defined';
+
 // The map navigation region
 const MapNavigation = createReactClass({
     displayName: 'MapNavigation',
@@ -29,7 +32,13 @@ const MapNavigation = createReactClass({
 
     render() {
         return (
-            <div className={Styles.mapNavigation}>
+            <div
+                className={classNames(Styles.mapNavigation, {
+                    [Styles.withTimeSeriesControls]: defined(
+                        this.props.terria.timeSeriesStack.topLayer
+                    ),
+                })}
+            >
               <Medium>
                 <div className={Styles.navs}>
                   <If condition={this.props.terria.viewerMode !== ViewerMode.Leaflet}>

--- a/lib/ReactViews/Map/map-navigation.scss
+++ b/lib/ReactViews/Map/map-navigation.scss
@@ -14,6 +14,10 @@
 
 }
 
+.with-time-series-controls {
+  bottom: 100px;
+}
+
 .control {
   @media(min-width:$sm){
     margin: 7px 0;

--- a/lib/ReactViews/StandardUserInterface/MapColumn.jsx
+++ b/lib/ReactViews/StandardUserInterface/MapColumn.jsx
@@ -9,6 +9,7 @@ import DistanceLegend from '../Map/Legend/DistanceLegend.jsx';
 import FeedbackButton from '../Feedback/FeedbackButton.jsx';
 import ObserveModelMixin from '../ObserveModelMixin';
 import BottomDock from '../BottomDock/BottomDock.jsx';
+import defined from 'terriajs-cesium/Source/Core/defined';
 import FeatureDetection from 'terriajs-cesium/Source/Core/FeatureDetection';
 import classNames from "classnames";
 
@@ -95,7 +96,13 @@ const MapColumn = createReactClass({
                             </div>
                         </If>
                         <If condition={!this.props.customFeedbacks.length && this.props.terria.configParameters.feedbackUrl && !this.props.viewState.hideMapUi()}>
-                            <div className={Styles.feedbackButtonWrapper}>
+                            <div
+                                className={classNames(Styles.feedbackButtonWrapper, {
+                                    [Styles.withTimeSeriesControls]: defined(
+                                        this.props.terria.timeSeriesStack.topLayer
+                                    ),
+                                })}
+                            >
                                 <FeedbackButton viewState={this.props.viewState}/>
                             </div>
                         </If>

--- a/lib/ReactViews/StandardUserInterface/map-column.scss
+++ b/lib/ReactViews/StandardUserInterface/map-column.scss
@@ -62,6 +62,10 @@
   margin: 4px 0;
 }
 
+.with-time-series-controls {
+  bottom: 58px;
+}
+
 .print-disclaimer {
   display: none;
 }


### PR DESCRIPTION
When viewing time series data on mobile, the map
tool buttons overlap with the BottomDock items

Fixes https://github.com/TerriaJS/terriajs/issues/3267