### PR TITLE
Add max level for WMTS items

### DIFF
--- a/lib/Models/WebMapTileServiceCatalogItem.js
+++ b/lib/Models/WebMapTileServiceCatalogItem.js
@@ -74,6 +74,12 @@ var WebMapTileServiceCatalogItem = function(terria) {
     this.tileMatrixSetLabels = undefined;
 
     /**
+     * Gets or sets the maximum level in the matrix set.  This property is observable.
+     * @type {Array}
+     */
+    this.tileMatrixMaximumLevel = undefined;
+
+    /**
      * Gets or sets the tiling scheme to pass to the WMTS server when requesting images.
      * If this property is undefiend, the default tiling scheme of the provider is used.
      * @type {Object}
@@ -112,7 +118,7 @@ var WebMapTileServiceCatalogItem = function(terria) {
 
     knockout.track(this, [
         '_dataUrl', '_dataUrlType', '_metadataUrl', '_legendUrl', '_rectangle', '_rectangleFromMetadata', '_intervalsFromMetadata',
-        'layer', 'style', 'tileMatrixSetID', 'getFeatureInfoFormats',
+        'layer', 'style', 'tileMatrixSetID', 'tileMatrixMaximumLevel', 'getFeatureInfoFormats',
         'tilingScheme', 'populateIntervalsFromTimeDimension', 'minScaleDenominator', 'format']);
 
     // dataUrl, metadataUrl, and legendUrl are derived from url if not explicitly specified.
@@ -377,8 +383,17 @@ WebMapTileServiceCatalogItem.prototype.updateFromCapabilities = function(capabil
         }
     }
 
+    if (Array.isArray(tileMatrixSetLabels)) {
+        var maxLevel = tileMatrixSetLabels
+            .map(label => Math.abs(Number(label)))
+            .reduce((currentMaximum, level) => {
+                return level > currentMaximum ? level : currentMaximum;
+            }, 0);
+    }
+
     updateValue(this, overwrite, 'tileMatrixSetID', tileMatrixSetID);
     updateValue(this, overwrite, 'tileMatrixSetLabels', tileMatrixSetLabels);
+    updateValue(this, overwrite, 'tileMatrixMaximumLevel', maxLevel);
 
     // Find the default style.
     var styles = thisLayer.Style;
@@ -433,6 +448,7 @@ WebMapTileServiceCatalogItem.prototype._createImageryProvider = function() {
         layer : this.layer,
         tileMatrixSetID: this.tileMatrixSetID,
         tileMatrixLabels: this.tileMatrixSetLabels,
+        maximumLevel: this.tileMatrixMaximumLevel,
         style: this.style,
         getFeatureInfoFormats : this.getFeatureInfoFormats,
         tilingScheme : defined(this.tilingScheme) ? this.tilingScheme : new WebMercatorTilingScheme(),

--- a/test/Models/WebMapTileServiceCatalogItemSpec.js
+++ b/test/Models/WebMapTileServiceCatalogItemSpec.js
@@ -2,8 +2,6 @@
 
 /*global require,describe,it,expect,beforeEach,fail*/
 
-var Credit = require('terriajs-cesium/Source/Core/Credit');
-var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
 var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
 var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
 var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');

--- a/test/Models/WebMapTileServiceCatalogItemSpec.js
+++ b/test/Models/WebMapTileServiceCatalogItemSpec.js
@@ -1,0 +1,199 @@
+'use strict';
+
+/*global require,describe,it,expect,beforeEach,fail*/
+
+var Credit = require('terriajs-cesium/Source/Core/Credit');
+var ImageryProvider = require('terriajs-cesium/Source/Scene/ImageryProvider');
+var JulianDate = require('terriajs-cesium/Source/Core/JulianDate');
+var Rectangle = require('terriajs-cesium/Source/Core/Rectangle');
+var TimeInterval = require('terriajs-cesium/Source/Core/TimeInterval');
+var TimeIntervalCollection = require('terriajs-cesium/Source/Core/TimeIntervalCollection');
+var WebMercatorTilingScheme = require('terriajs-cesium/Source/Core/WebMercatorTilingScheme');
+
+var ImageryLayerCatalogItem = require('../../lib/Models/ImageryLayerCatalogItem');
+var LegendUrl = require('../../lib/Map/LegendUrl');
+var Terria = require('../../lib/Models/Terria');
+var WebMapTileServiceCatalogItem = require('../../lib/Models/WebMapTileServiceCatalogItem');
+
+var terria;
+var wmtsItem;
+
+beforeEach(function() {
+    terria = new Terria({
+        baseUrl: './'
+    });
+    wmtsItem = new WebMapTileServiceCatalogItem(terria);
+});
+
+describe('WebMapTileServiceCatalogItem', function() {
+    it('has sensible type and typeName', function() {
+        expect(wmtsItem.type).toBe('wmts');
+        expect(wmtsItem.typeName).toBe('Web Map Tile Service (WMTS)');
+    });
+
+    it('throws if constructed without a Terria instance', function() {
+        expect(function() {
+            var viewModel = new WebMapTileServiceCatalogItem(); // eslint-disable-line no-unused-vars
+        }).toThrow();
+    });
+
+    it('can be constructed', function() {
+        expect(wmtsItem).toBeDefined();
+    });
+
+    it('is derived from ImageryLayerCatalogItem', function() {
+        expect(wmtsItem instanceof ImageryLayerCatalogItem).toBe(true);
+    });
+
+    describe('metadata url', function() {
+        it('derives metadata from url if metadata is not explicitly provided', function() {
+          wmtsItem.url = 'http://foo.com/bar';
+          expect(wmtsItem.metadataUrl).toBe('http://foo.com/bar?service=WMTS&request=GetCapabilities&version=1.0.0');
+        });
+    });
+
+
+    it('uses explicitly-provided metadataUrl', function() {
+        wmtsItem.metadataUrl = 'http://foo.com/metadata';
+        wmtsItem.url = 'http://foo.com/somethingElse';
+        expect(wmtsItem.metadataUrl).toBe('http://foo.com/metadata');
+    });
+
+    it('defaults to having no dataUrl', function() {
+        wmtsItem.url = 'http://foo.bar';
+        expect(wmtsItem.dataUrl).toBeUndefined();
+        expect(wmtsItem.dataUrlType).toBe('none');
+    });
+
+    it('uses explicitly-provided dataUrl and dataUrlType', function() {
+        wmtsItem.dataUrl = 'http://foo.com/data';
+        wmtsItem.dataUrlType = 'wfs-complete';
+        wmtsItem.url = 'http://foo.com/somethingElse';
+        expect(wmtsItem.dataUrl).toBe('http://foo.com/data');
+        expect(wmtsItem.dataUrlType).toBe('wfs-complete');
+    });
+
+    it('can update from json', function() {
+        wmtsItem.updateFromJson({
+            name: 'Name',
+            description: 'Description',
+            rectangle: [-10, 10, -20, 20],
+            legendUrl: 'http://legend.com',
+            dataUrlType: 'wfs',
+            dataUrl: 'http://my.wfs.com/wfs',
+            dataCustodian: 'Data Custodian',
+            url: 'http://my.wms.com',
+            layer: 'mylayer',
+            tilingScheme: new WebMercatorTilingScheme(),
+            getFeatureInfoFormats: []
+        });
+
+        expect(wmtsItem.name).toBe('Name');
+        expect(wmtsItem.description).toBe('Description');
+        expect(wmtsItem.rectangle).toEqual(Rectangle.fromDegrees(-10, 10, -20, 20));
+        expect(wmtsItem.legendUrl).toEqual(new LegendUrl('http://legend.com'));
+        expect(wmtsItem.dataUrlType).toBe('wfs');
+        expect(wmtsItem.dataUrl.indexOf('http://my.wfs.com/wfs')).toBe(0);
+        expect(wmtsItem.dataCustodian).toBe('Data Custodian');
+        expect(wmtsItem.url).toBe('http://my.wms.com');
+        expect(wmtsItem.layer).toBe('mylayer');
+        expect(wmtsItem.tilingScheme instanceof WebMercatorTilingScheme).toBe(true);
+        expect(wmtsItem.getFeatureInfoFormats).toEqual([]);
+    });
+
+    it('uses reasonable defaults for updateFromJson', function() {
+        wmtsItem.updateFromJson({});
+
+        expect(wmtsItem.name).toBe('Unnamed Item');
+        expect(wmtsItem.description).toBe('');
+        expect(wmtsItem.rectangle).toBeUndefined();
+        expect(wmtsItem.legendUrl).toBeUndefined();
+        expect(wmtsItem.dataUrlType).toBe('none');
+        expect(wmtsItem.dataUrl).toBeUndefined();
+        expect(wmtsItem.dataCustodian).toBeUndefined();
+        expect(function() {
+          // metadataUrl requires a url
+          wmtsItem.metadataUrl;
+        }).toThrow();
+        expect(wmtsItem.url).toBeUndefined();
+        expect(wmtsItem.layer).toBe('');
+        expect(wmtsItem.tilingScheme).toBeUndefined();
+        expect(wmtsItem.getFeatureInfoFormats).toBeUndefined();
+    });
+
+
+    it('can be round-tripped with serializeToJson and updateFromJson', function() {
+        wmtsItem.name = 'Name';
+        wmtsItem.id = 'Id';
+        // wmtsItem.description = 'Description';
+        wmtsItem.rectangle = Rectangle.fromDegrees(-10, 10, -20, 20);
+        wmtsItem.legendUrl = new LegendUrl('http://legend.com', 'image/png');
+        wmtsItem.dataUrlType = 'wfs';
+        wmtsItem.dataUrl = 'http://my.wfs.com/wfs';
+        wmtsItem.dataCustodian = 'Data Custodian';
+        wmtsItem.metadataUrl = 'http://my.metadata.com';
+        wmtsItem.url = 'http://my.wms.com';
+        wmtsItem.layer = 'mylayer';
+        wmtsItem.getFeatureInfoFormats = [];
+
+        // This initialTime is before any interval, so internally it will be changed to the first start date.
+        wmtsItem.initialTimeSource = '2012-01-01T12:00:00Z';
+
+        wmtsItem.intervals = new TimeIntervalCollection([
+            new TimeInterval({
+                start: JulianDate.fromIso8601('2013-08-01T15:00:00Z'),
+                stop: JulianDate.fromIso8601('2013-08-01T18:00:00Z')
+            }),
+            new TimeInterval({
+                start: JulianDate.fromIso8601('2013-09-01T11:00:00Z'),
+                stop: JulianDate.fromIso8601('2013-09-03T13:00:00Z')
+            })
+        ]);
+
+        var json = wmtsItem.serializeToJson();
+
+        var reconstructed = new WebMapTileServiceCatalogItem(terria);
+        reconstructed.updateFromJson(json);
+
+        // We'll check for these later in toEqual but this makes it a bit easier to see what's different.
+        expect(reconstructed.name).toBe(wmtsItem.name);
+        expect(reconstructed.rectangle).toEqual(wmtsItem.rectangle);
+        expect(reconstructed.legendUrl).toEqual(wmtsItem.legendUrl);
+        expect(reconstructed.legendUrls).toEqual(wmtsItem.legendUrls);
+        expect(reconstructed.dataUrlType).toBe(wmtsItem.dataUrlType);
+        expect(reconstructed.dataUrl).toBe(wmtsItem.dataUrl);
+        expect(reconstructed.dataCustodian).toBe(wmtsItem.dataCustodian);
+        expect(reconstructed.metadataUrl).toBe(wmtsItem.metadataUrl);
+        expect(reconstructed.url).toBe(wmtsItem.url);
+        expect(reconstructed.layers).toBe(wmtsItem.layers);
+        expect(reconstructed.getFeatureInfoFormats).toEqual(wmtsItem.getFeatureInfoFormats);
+        // Do not compare time, because on some systems the second could have ticked over between getting the two times.
+        var initialTimeSource = reconstructed.initialTimeSource.substr(0, 10);
+        expect(initialTimeSource).toEqual('2013-08-01');
+    });
+
+    
+
+    it('given a layer pointing at a tilematrix set, calculates the correct tileMatrixMaximumLevel', function(done) {
+        wmtsItem.updateFromJson({
+            url: 'test/WMTS/with_tilematrix.xml',
+            metadataUrl: 'test/WMTS/with_tilematrix.xml',
+            layer: 'Some_Layer1'
+        });
+        wmtsItem.load().then(function() {
+            expect(wmtsItem.tileMatrixMaximumLevel).toBe(9);
+        }).then(done).otherwise(done.fail);
+    });
+
+    it('given a layer pointing at a non-existent tilematrix set, does not set tileMatrixMaximumLevel', function(done) {
+        wmtsItem.updateFromJson({
+            url: 'test/WMTS/with_tilematrix.xml',
+            metadataUrl: 'test/WMTS/with_tilematrix.xml',
+            layer: 'Layer_With_Bad_Tilematrixset'
+        });
+        wmtsItem.load().then(function() {
+            expect(wmtsItem.tileMatrixMaximumLevel).toBe(undefined);
+        }).then(done).otherwise(done.fail);
+    });
+
+});

--- a/wwwroot/test/WMTS/with_tilematrix.xml
+++ b/wwwroot/test/WMTS/with_tilematrix.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0"
+    xmlns:ows="http://www.opengis.net/ows/1.1"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:gml="http://www.opengis.net/gml"
+    xsi:schemaLocation="http://www.opengis.net/wmts/1.0
+    http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
+    version="1.0.0">
+    <ows:ServiceIdentification>
+        <ows:Title xml:lang="en">Test WMTS</ows:Title>
+        <ows:Abstract xml:lang="en">
+            Datum. Of the test variety.
+        </ows:Abstract>
+        <ows:Keywords>
+            <ows:Keyword>Datum</ows:Keyword>
+            <ows:Keyword>Test</ows:Keyword>
+        </ows:Keywords>
+        <ows:ServiceType>OGC WMTS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+        <ows:Fees>none</ows:Fees>
+        <ows:AccessConstraints>none</ows:AccessConstraints>
+    </ows:ServiceIdentification>
+    <ows:ServiceProvider>
+        <ows:ProviderName>Some Provider</ows:ProviderName>
+        <ows:ProviderSite xlink:href="https://some.provider/"/>
+        <ows:ServiceContact>
+            <ows:IndividualName></ows:IndividualName>
+            <ows:PositionName></ows:PositionName>
+            <ows:ContactInfo>
+                <ows:Address>
+                    <ows:DeliveryPoint></ows:DeliveryPoint>
+                    <ows:City></ows:City>
+                    <ows:AdministrativeArea></ows:AdministrativeArea>
+                    <ows:PostalCode></ows:PostalCode>
+                    <ows:Country></ows:Country>
+                    <ows:ElectronicMailAddress></ows:ElectronicMailAddress>
+                </ows:Address>
+            </ows:ContactInfo>
+        </ows:ServiceContact>
+    </ows:ServiceProvider>
+    <ows:OperationsMetadata>
+        <ows:Operation name="GetCapabilities">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="https://some.provider/wmts/1.0.0/WMTSCapabilities.xml">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>RESTful</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                    <ows:Get xlink:href="https://some.provider/wmts/wmts.cgi?">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>KVP</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+        <ows:Operation name="GetTile">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="https://some.provider/wmts/">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>RESTful</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                    <ows:Get xlink:href="https://some.provider/wmts/wmts.cgi?">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>KVP</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+    </ows:OperationsMetadata>
+    <Contents>
+      <Layer>
+         <ows:Title xml:lang="en">Some Layer 1</ows:Title>
+         <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+            <ows:LowerCorner>-180 -85.051129</ows:LowerCorner>
+            <ows:UpperCorner>180 85.051129</ows:UpperCorner>
+        </ows:WGS84BoundingBox>
+         <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::3857">
+            <ows:LowerCorner>-20037508.34278925 -20037508.34278925</ows:LowerCorner>
+            <ows:UpperCorner>20037508.34278925 20037508.34278925</ows:UpperCorner>
+        </ows:BoundingBox>
+         <ows:Identifier>Some_Layer1</ows:Identifier>
+         <Style isDefault="true">
+             <ows:Title xml:lang="en">default</ows:Title>
+             <ows:Identifier>default</ows:Identifier>
+             
+             
+         </Style>
+         <Format>image/png</Format>
+         <TileMatrixSetLink>
+             <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
+         </TileMatrixSetLink>
+         <ResourceURL format="image/png" resourceType="tile" template="https://some.provider/wmts/Some_Layer1/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+      </Layer>
+      <Layer>
+         <ows:Title xml:lang="en">Some Layer 2</ows:Title>
+         <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+            <ows:LowerCorner>-180 -85.051129</ows:LowerCorner>
+            <ows:UpperCorner>180 85.051129</ows:UpperCorner>
+        </ows:WGS84BoundingBox>
+         <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::3857">
+            <ows:LowerCorner>-20037508.34278925 -20037508.34278925</ows:LowerCorner>
+            <ows:UpperCorner>20037508.34278925 20037508.34278925</ows:UpperCorner>
+        </ows:BoundingBox>
+         <ows:Identifier>Layer_With_Bad_Tilematrixset</ows:Identifier>
+         <Style isDefault="true">
+             <ows:Title xml:lang="en">default</ows:Title>
+             <ows:Identifier>default</ows:Identifier>
+             
+             
+         </Style>
+         <Format>image/png</Format>
+         <TileMatrixSetLink>
+             <TileMatrixSet>non_existent_tilematrixset</TileMatrixSet>
+         </TileMatrixSetLink>
+         <ResourceURL format="image/png" resourceType="tile" template="https://some.provider/wmts/Layer_With_Bad_Tilematrixset/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+      </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.18:3:3857</ows:SupportedCRS>
+      <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>279541132.0143589</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>2</ows:Identifier>
+        <ScaleDenominator>139770566.0071794</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4</MatrixWidth>
+        <MatrixHeight>4</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>3</ows:Identifier>
+        <ScaleDenominator>69885283.00358972</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8</MatrixWidth>
+        <MatrixHeight>8</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>4</ows:Identifier>
+        <ScaleDenominator>34942641.50179486</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>16</MatrixWidth>
+        <MatrixHeight>16</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>5</ows:Identifier>
+        <ScaleDenominator>17471320.75089743</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>32</MatrixWidth>
+        <MatrixHeight>32</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>6</ows:Identifier>
+        <ScaleDenominator>8735660.375448715</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>64</MatrixWidth>
+        <MatrixHeight>64</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>7</ows:Identifier>
+        <ScaleDenominator>4367830.187724357</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>128</MatrixWidth>
+        <MatrixHeight>128</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>8</ows:Identifier>
+        <ScaleDenominator>2183915.093862179</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>256</MatrixWidth>
+        <MatrixHeight>256</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>9</ows:Identifier>
+        <ScaleDenominator>1091957.546931089</ScaleDenominator>
+        <TopLeftCorner>-20037508.34278925 20037508.34278925</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>512</MatrixWidth>
+        <MatrixHeight>512</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+    <TileMatrixSet>
+      <ows:Identifier>GoogleMapsCompatible_Level12</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.18:3:3857</ows:SupportedCRS>
+      <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>
+    </TileMatrixSet>
+    </Contents>
+    <ServiceMetadataURL xlink:href="https://some.metadata1"/>
+</Capabilities>


### PR DESCRIPTION
Resolves #2945

For testing, visit https://nationalmap.gov.au/#share=s-zpQ3N5tMgOZHoCV7f731Pcw83tG

And enable the "Reference Labels (OSM)" layer, observe that tile requests with `tilematrix=undefined` are made.

New behaviour limiting the tilematrix calculation via zoomlevel:
https://ci.terria.io/2945-wmts-zoom-bug/#share=s-rYHgDVZslTvhqzPRIfDFBHCyiQX