### PR TITLE
Add support for async map items.

### DIFF
--- a/lib/Core/makeRealPromise.ts
+++ b/lib/Core/makeRealPromise.ts
@@ -1,0 +1,12 @@
+import when from 'terriajs-cesium/Source/ThirdParty/when';
+
+/**
+ * Turns a Cesium when.js promise into a normal native promise.
+ * @param promise The Cesium promise.
+ * @returns The native promise;
+ */
+export default function makeRealPromise<T>(promise: ReturnType<typeof when>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        when(promise, resolve, reject);
+    });
+}

--- a/lib/ModelMixins/AsyncMappableMixin.ts
+++ b/lib/ModelMixins/AsyncMappableMixin.ts
@@ -1,0 +1,38 @@
+import { computed } from "mobx";
+import { createTransformer, fromPromise, IPromiseBasedObservable } from "mobx-utils";
+import DataSource from "terriajs-cesium/Source/DataSources/DataSource";
+import when from "terriajs-cesium/Source/ThirdParty/when";
+import Constructor from "../Core/Constructor";
+import filterOutUndefined from "../Core/filterOutUndefined";
+import { ImageryParts } from "../Models/Mappable";
+import Terria from "../Models/Terria";
+
+interface RequiredInstance {
+    terria: Terria;
+}
+
+export default function AsyncMappableMixin<T extends Constructor<RequiredInstance>>(Base: T) {
+    function handlePromiseRejection(this: AsyncMappableMixin, promise: Promise<DataSource | ImageryParts>): IPromiseBasedObservable<DataSource | ImageryParts | undefined> {
+        return fromPromise(promise.catch((e: any) => {
+            this.terria.error.raiseEvent(e);
+            return undefined;
+        }));
+    }
+
+    abstract class AsyncMappableMixin extends Base {
+        abstract get asyncMapItems(): Promise<DataSource | ImageryParts>[];
+
+        private handlePromiseRejection = createTransformer(handlePromiseRejection.bind(this));
+
+        @computed
+        get mapItems(): (DataSource | ImageryParts)[] {
+            return filterOutUndefined(this.asyncMapItems.map(promise => {
+                return this.handlePromiseRejection(promise).case({
+                    fulfilled: (mappable) => mappable
+                });
+            }));
+        }
+    }
+
+    return AsyncMappableMixin;
+}


### PR DESCRIPTION
This is a PR into @na9da's `mobx-geojson` branch.

I noticed while reviewing #3258 that a GeoJSON load/reproject error would go unreported because no one was handling the promise rejection. After discussing with @steve9164, this is our attempt to make that less error prone by having an official `asyncMapItems` (via a mixin) that handles the details of turning promises for map items into real map items. I'm not 100% sure this is the right approach, but it's a start.