### PR TITLE
fix not able to apply terrain catalog item splitter direction when from sharedCatalog

### DIFF
--- a/lib/Models/TerrainCatalogItem.js
+++ b/lib/Models/TerrainCatalogItem.js
@@ -194,6 +194,7 @@ TerrainCatalogItem.defaultSerializers = clone(CatalogItem.defaultSerializers);
 freezeObject(TerrainCatalogItem.defaultSerializers);
 
 TerrainCatalogItem.defaultPropertiesForSharing = clone(CatalogItem.defaultPropertiesForSharing);
+TerrainCatalogItem.defaultPropertiesForSharing.push('supportsSplitting');
 TerrainCatalogItem.defaultPropertiesForSharing.push('splitDirection');
 
 freezeObject(TerrainCatalogItem.defaultPropertiesForSharing);


### PR DESCRIPTION
When an item comes from `sharedCatalog`, this change allow its `splitterDirection` be applied to the now viewing item