### PR TITLE
Pass available layer styles to creation of WMS item when within group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+## Next Release
+
+* Fixed a bug where all available styles were being retrieved from a `GetCapabilities` for each layer within a WMS Group resulting in memory crashes on WMS's with many layers.
+
+
 ### v7.3.0
 
 * Added `GltfCatalogItem` for displaying [glTF](https://www.khronos.org/gltf/) models on the 3D scene.

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -275,7 +275,7 @@ function addLayersRecursively(wmsGroup, parentGroup, capabilities, layers, paren
             }
         }
         else {
-            parentGroup.add(createWmsDataSource(wmsGroup, capabilities, layer));
+            parentGroup.add(createWmsDataSource(wmsGroup, capabilities, layer, infoDerivedFromCapabilities));
         }
     }
 }


### PR DESCRIPTION
Resolves #3329 by ensuring available layer styles are passed to the creation of a WMS when looping through a group of WMS layers.

A WMS with 2400 layers now loads in a couple of seconds quite happily without running out of memory, eg https://geo.weather.gc.ca/geomet/?service=WMS&request=GetCapabilities
