### PR TITLE
MagdaCatalogItem tweaks

### DIFF
--- a/lib/ModelMixins/CatalogMemberMixin.ts
+++ b/lib/ModelMixins/CatalogMemberMixin.ts
@@ -86,10 +86,18 @@ function CatalogMemberMixin<T extends Constructor<CatalogMember>>(Base: T) {
                 }
             });
         }
+
+        @computed
+        get hasDescription(): boolean {
+            return (this.description !== undefined && this.description.length > 0) ||
+                   (this.info !== undefined && this.info.some(info => descriptionRegex.test(info.name || '')));
+        }
     }
 
     return CatalogMemberMixin;
 }
+
+const descriptionRegex = /description/i;
 
 namespace CatalogMemberMixin {
     export interface CatalogMemberMixin extends InstanceType<ReturnType<typeof CatalogMemberMixin>> {}

--- a/lib/Models/MagdaCatalogItem.ts
+++ b/lib/Models/MagdaCatalogItem.ts
@@ -1,4 +1,4 @@
-import { computed, observable } from "mobx";
+import { computed, observable, toJS } from "mobx";
 import createGuid from "terriajs-cesium/Source/Core/createGuid";
 import JsonValue, { isJsonObject, JsonArray } from "../Core/Json";
 import loadJson from "../Core/loadJson";
@@ -16,67 +16,6 @@ import { BaseModel } from "./Model";
 import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
 import Terria from "./Terria";
 import upsertModelFromJson from "./upsertModelFromJson";
-
-const defaultDistributionFormats = [
-    createStratumInstance(MagdaDistributionFormatTraits, {
-        id: 'WMS',
-        formatRegex: '^wms$',
-        terriaDefinition: {
-            type: 'wms'
-        }
-    }),
-    createStratumInstance(MagdaDistributionFormatTraits, {
-        id: 'EsriMapServer',
-        formatRegex: '^esri rest$',
-        urlRegex: 'MapServer',
-        terriaDefinition: {
-            type: 'esri-mapServer'
-        }
-    }),
-    createStratumInstance(MagdaDistributionFormatTraits, {
-        id: 'CSV',
-        formatRegex: '^csv(-geo-)?',
-        terriaDefinition: {
-            type: 'csv'
-        }
-    }),
-    createStratumInstance(MagdaDistributionFormatTraits, {
-        id: 'CZML',
-        formatRegex: '^czml$',
-        terriaDefinition: {
-            type: 'czml'
-        }
-    }),
-    createStratumInstance(MagdaDistributionFormatTraits, {
-        id: 'KML',
-        formatRegex: '^km[lz]$',
-        terriaDefinition: {
-            type: 'kml'
-        }
-    }),
-    createStratumInstance(MagdaDistributionFormatTraits, {
-        id: 'GeoJSON',
-        formatRegex: '^geojson$',
-        terriaDefinition: {
-            type: 'geojson'
-        }
-    }),
-    createStratumInstance(MagdaDistributionFormatTraits, {
-        id: 'WFS',
-        formatRegex: '^wfs$',
-        terriaDefinition: {
-            type: 'wfs'
-        }
-    }),
-    createStratumInstance(MagdaDistributionFormatTraits, {
-        id: 'EsriFeatureServer',
-        formatRegex: '^esri rest$',
-        urlRegex: 'FeatureServer',
-        terriaDefinition: {
-            type: 'esri-featureServer'
-        }
-    })
-];
 
 export default class MagdaCatalogItem extends ReferenceMixin(UrlMixin(CatalogMemberMixin(CreateModel(MagdaCatalogItemTraits)))) {
     static readonly type = 'magda';
@@ -248,13 +187,11 @@ export default class MagdaCatalogItem extends ReferenceMixin(UrlMixin(CatalogMem
                     continue;
                 }
 
-                const formatRegex = formatRegexs[i];
-                const urlRegex = urlRegexs[i];
                 if (formatRegex !== undefined && !formatRegex.test(format) || urlRegex !== undefined && !urlRegex.test(url)) {
                     continue;
                 }
 
-                const definition = Object.assign({}, distributionFormat.terriaDefinition);
+                const definition = Object.assign({}, toJS(this.definition), toJS(distributionFormat.definition));
                 definition.localId = createGuid();
 
                 try {
@@ -273,3 +210,64 @@ export default class MagdaCatalogItem extends ReferenceMixin(UrlMixin(CatalogMem
         return undefined;
     }
 }
+
+const defaultDistributionFormats = [
+    createStratumInstance(MagdaDistributionFormatTraits, {
+        id: 'WMS',
+        formatRegex: '^wms$',
+        definition: {
+            type: 'wms'
+        }
+    }),
+    createStratumInstance(MagdaDistributionFormatTraits, {
+        id: 'EsriMapServer',
+        formatRegex: '^esri rest$',
+        urlRegex: 'MapServer',
+        definition: {
+            type: 'esri-mapServer'
+        }
+    }),
+    createStratumInstance(MagdaDistributionFormatTraits, {
+        id: 'CSV',
+        formatRegex: '^csv(-geo-)?',
+        definition: {
+            type: 'csv'
+        }
+    }),
+    createStratumInstance(MagdaDistributionFormatTraits, {
+        id: 'CZML',
+        formatRegex: '^czml$',
+        definition: {
+            type: 'czml'
+        }
+    }),
+    createStratumInstance(MagdaDistributionFormatTraits, {
+        id: 'KML',
+        formatRegex: '^km[lz]$',
+        definition: {
+            type: 'kml'
+        }
+    }),
+    createStratumInstance(MagdaDistributionFormatTraits, {
+        id: 'GeoJSON',
+        formatRegex: '^geojson$',
+        definition: {
+            type: 'geojson'
+        }
+    }),
+    createStratumInstance(MagdaDistributionFormatTraits, {
+        id: 'WFS',
+        formatRegex: '^wfs$',
+        definition: {
+            type: 'wfs'
+        }
+    }),
+    createStratumInstance(MagdaDistributionFormatTraits, {
+        id: 'EsriFeatureServer',
+        formatRegex: '^esri rest$',
+        urlRegex: 'FeatureServer',
+        definition: {
+            type: 'esri-featureServer'
+        }
+    })
+];

--- a/lib/Traits/CatalogMemberTraits.ts
+++ b/lib/Traits/CatalogMemberTraits.ts
@@ -14,9 +14,10 @@ export class InfoSectionTraits extends ModelTraits {
     @primitiveTrait({
         type: 'string',
         name: 'Content',
-        description: 'The content of the section, in Markdown and HTML format.'
+        description: 'The content of the section, in Markdown and HTML format.',
+        isNullable: true
     })
-    content?: string;
+    content?: string | null;
 
     static isRemoval(infoSection: InfoSectionTraits) {
         return infoSection.content === null;

--- a/lib/Traits/MagdaCatalogItemTraits.ts
+++ b/lib/Traits/MagdaCatalogItemTraits.ts
@@ -30,13 +30,13 @@ export class MagdaDistributionFormatTraits extends ModelTraits {
     urlRegex?: string;
 
     @anyTrait({
-        name: 'Terria Definition',
-        description: 'The Terria catalog member definition to use when the URL and Format regular expressions match. The `URL` property will also be set.'
+        name: 'Definition',
+        description: 'The catalog member definition to use when the URL and Format regular expressions match. The `URL` property will also be set.'
     })
-    terriaDefinition?: JsonObject | null;
+    definition?: JsonObject | null;
 
     static isRemoval(format: MagdaDistributionFormatTraits) {
-        return format.terriaDefinition === null;
+        return format.definition === null;
     }
 }
 
@@ -70,4 +70,10 @@ export default class MagdaCatalogItemTraits extends mixTraits(
         idProperty: 'id'
     })
     distributionFormats?: MagdaDistributionFormatTraits[];
+
+    @anyTrait({
+        name: 'Definition',
+        description: 'The catalog member definition to use for _all_ catalog items, regardless of type. The format-specified definition will be layered on top of this one.'
+    })
+    definition?: JsonObject;
 }

--- a/lib/Traits/primitiveTrait.ts
+++ b/lib/Traits/primitiveTrait.ts
@@ -8,6 +8,7 @@ type PrimitiveType = 'string' | 'number' | 'boolean';
 
 export interface PrimitiveTraitOptions<T> extends TraitOptions {
     type: PrimitiveType;
+    isNullable?: boolean;
 }
 
 export default function primitiveTrait<T>(options: PrimitiveTraitOptions<T>) {
@@ -22,10 +23,12 @@ export default function primitiveTrait<T>(options: PrimitiveTraitOptions<T>) {
 
 export class PrimitiveTrait<T> extends Trait {
     readonly type: PrimitiveType;
+    readonly isNullable: boolean;
 
     constructor(id: string, options: PrimitiveTraitOptions<T>) {
         super(id, options);
         this.type = options.type;
+        this.isNullable = options.isNullable || false;
     }
 
     getValue(strataTopToBottom: StratumFromTraits<ModelTraits>[]): T | undefined {
@@ -41,7 +44,7 @@ export class PrimitiveTrait<T> extends Trait {
     }
 
     fromJson(model: BaseModel, stratumName: string, jsonValue: any): T {
-        if (typeof jsonValue !== this.type) {
+        if (typeof jsonValue !== this.type && (!this.isNullable || jsonValue !== null)) {
             throw new TerriaError({
                 title: 'Invalid property',
                 message: `Property ${this.id} is expected to be of type ${this.type} but instead it is of type ${typeof jsonValue}.`
@@ -52,6 +55,6 @@ export class PrimitiveTrait<T> extends Trait {
     }
 
     isSameType(trait: Trait): boolean {
-        return trait instanceof PrimitiveTrait && trait.type === this.type;
+        return trait instanceof PrimitiveTrait && trait.type === this.type && trait.isNullable === this.isNullable;
     }
 }

--- a/test/Models/WebMapServiceCatalogItemSpec.ts
+++ b/test/Models/WebMapServiceCatalogItemSpec.ts
@@ -37,7 +37,7 @@ describe('WebMapServiceCatalogItem', function() {
         const cleanup = autorun(() => {
             if (wms.info !== undefined) {
                 const descSection = wms.info.find(section => section.name === 'Data Description');
-                if (descSection !== undefined && descSection.content !== undefined) {
+                if (descSection !== undefined && descSection.content !== undefined && descSection.content !== null) {
                     description = descSection.content;
                 }
             }


### PR DESCRIPTION
* Add `hasDescription` property to `CatalogMemberMixin` so that the UI doesn't show a useless description when there are other descriptions in `info`.
* Renamed `terriaDefinition` to `definition` in the Magda format traits.
* Added new `definition` that is applied to loaded catalog items of any type.
* Make primitives optionally nullable so that e.g. the `content` property of an info section can be set to null to say "don't show this info section".