### PR TITLE
Lock svg-sprite-loader patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "simple-statistics": "^7.0.1",
     "string-replace-webpack-plugin": "^0.1.3",
     "style-loader": "^0.23.1",
-    "svg-sprite-loader": "^4.1.3",
+    "svg-sprite-loader": "4.1.3",
     "terriajs-cesium": "1.57.0",
     "terriajs-html2canvas": "1.0.0-alpha.12-terriajs-1",
     "urijs": "^1.18.12",


### PR DESCRIPTION
We should lock this until resolved?