### PR TITLE
Remove `curly` eslint rule.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,7 +57,7 @@
         "block-scoped-var": 0, // see Babel section
         "complexity": 0,
         "consistent-return": 0,
-        "curly": [1, "multi-line"],
+        "curly": 0,
         "default-case": 0,
         "dot-notation": [0, {
             "allowKeywords": true,


### PR DESCRIPTION
Prettier does not conform to it.