### PR TITLE
Add additional tests around date-time handling for WMS

### DIFF
--- a/test/Models/WebMapServiceCatalogItemSpec.js
+++ b/test/Models/WebMapServiceCatalogItemSpec.js
@@ -454,6 +454,20 @@ describe("WebMapServiceCatalogItem", function() {
       .load()
       .then(function() {
         expect(wmsItem.intervals.length).toEqual(13);
+        
+        const firstInterval = wmsItem.intervals.get(0);
+        expect(firstInterval.data).toEqual("2002-01-01T00:00:00.000Z");
+        expect(firstInterval.start.dayNumber).toEqual(2452275);
+        expect(firstInterval.start.secondsOfDay).toEqual(43232);
+        expect(firstInterval.stop.dayNumber).toEqual(2452640);
+        expect(firstInterval.stop.secondsOfDay).toEqual(43232);
+
+        const lastInterval = wmsItem.intervals.get(12);
+        expect(lastInterval.data).toEqual("2014-01-01T00:00:00.000Z");
+        expect(lastInterval.start.dayNumber).toEqual(2456658);
+        expect(lastInterval.start.secondsOfDay).toEqual(43235);
+        expect(lastInterval.stop.dayNumber).toEqual(2457023);
+        expect(lastInterval.stop.secondsOfDay).toEqual(43235);
       })
       .then(done)
       .otherwise(done.fail);
@@ -472,6 +486,15 @@ describe("WebMapServiceCatalogItem", function() {
       .load()
       .then(function() {
         expect(wmsItem.intervals.length).toEqual(1);
+
+        const firstInterval = wmsItem.intervals.get(0);
+        // expect(firstInterval.data).toEqual("2015-04-27T06:15:00.000Z");
+        // expect(typeof firstInterval.data).toEqual("string");
+
+        expect(firstInterval.start.dayNumber).toEqual(2457140);
+        expect(firstInterval.start.secondsOfDay).toEqual(15335);
+        expect(firstInterval.stop.dayNumber).toEqual(2457140);
+        expect(firstInterval.stop.secondsOfDay).toEqual(24335);
       })
       .then(done)
       .otherwise(done.fail);
@@ -490,9 +513,65 @@ describe("WebMapServiceCatalogItem", function() {
       .load()
       .then(function() {
         expect(wmsItem.intervals.length).toEqual(11);
+
+        const firstInterval = wmsItem.intervals.get(0);
+        expect(firstInterval.data).toEqual("2015-04-27T16:15:00Z");
+        expect(typeof firstInterval.data).toEqual("string");
+        expect(typeof firstInterval.start).toEqual(typeof new JulianDate());
+        expect(typeof firstInterval.stop).toEqual(typeof new JulianDate());
+
+        expect(firstInterval.start.dayNumber).toEqual(2457140);
+        expect(firstInterval.start.secondsOfDay).toEqual(15335);
+        expect(firstInterval.stop.dayNumber).toEqual(2457140);
+        expect(firstInterval.stop.secondsOfDay).toEqual(16235);
+
+        const lastInterval = wmsItem.intervals.get(10);
+        expect(lastInterval.data).toEqual("2015-04-27T18:45:00Z");
       })
       .then(done)
       .otherwise(done.fail);
+  });
+
+  it("can understand three-part period date with no time", function(done) {
+    // <Dimension name="time" units="ISO8601" />
+    //   <Extent name="time">2015-04-27/2015-04-29/P1D</Extent>
+    wmsItem.updateFromJson({
+      url: "http://example.com",
+      metadataUrl: "test/WMS/period_date_notime.xml",
+      layers: "single_period",
+      dataUrl: "" // to prevent a DescribeLayer request
+    });
+    wmsItem
+      .load()
+      .then(function() {
+        expect(wmsItem.intervals.length).toEqual(3);
+
+        const firstInterval = wmsItem.intervals.get(0);
+        expect(firstInterval.data).toEqual("2015-04-27");
+
+        const lastInterval = wmsItem.intervals.get(2);
+        expect(lastInterval.data).toEqual("2015-04-29");
+      })
+      .then(done)
+      .otherwise(done.fail);
+  });
+
+  it("limits intervals returned", function(done) {
+    // <Dimension name="time" units="ISO8601" />
+    //   <Extent name="time">2015-04-27T16:15:00/2018-04-27T18:45:00/PT15M</Extent>
+    wmsItem.updateFromJson({
+      url: "http://example.com",
+      metadataUrl: "test/WMS/period_datetimes_many_intervals.xml",
+      layers: "single_period",
+      dataUrl: "" // to prevent a DescribeLayer request
+    });
+    wmsItem
+    .load()
+    .then(function() {
+        expect(wmsItem.intervals.length).toEqual(1000);
+    })
+    .then(done)
+    .otherwise(done.fail);
   });
 
   it("supports multiple units in a single period", function(done) {

--- a/test/Models/WebMapServiceCatalogItemSpec.js
+++ b/test/Models/WebMapServiceCatalogItemSpec.js
@@ -454,7 +454,7 @@ describe("WebMapServiceCatalogItem", function() {
       .load()
       .then(function() {
         expect(wmsItem.intervals.length).toEqual(13);
-        
+
         const firstInterval = wmsItem.intervals.get(0);
         expect(firstInterval.data).toEqual("2002-01-01T00:00:00.000Z");
         expect(firstInterval.start.dayNumber).toEqual(2452275);
@@ -566,12 +566,12 @@ describe("WebMapServiceCatalogItem", function() {
       dataUrl: "" // to prevent a DescribeLayer request
     });
     wmsItem
-    .load()
-    .then(function() {
+      .load()
+      .then(function() {
         expect(wmsItem.intervals.length).toEqual(1000);
-    })
-    .then(done)
-    .otherwise(done.fail);
+      })
+      .then(done)
+      .otherwise(done.fail);
   });
 
   it("supports multiple units in a single period", function(done) {

--- a/wwwroot/test/WMS/period_date_notime.xml
+++ b/wwwroot/test/WMS/period_date_notime.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WMT_MS_Capabilities version="1.1.1">
+    <Service>
+        <Name>OGC:WMS</Name>
+        <Title>wms Server</Title>
+        <Abstract></Abstract>
+        <KeywordList>
+
+            <Keyword></Keyword>
+
+        </KeywordList>
+        <OnlineResource href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <ContactInformation>
+            <ContactPersonPrimary>
+                <ContactPerson></ContactPerson>
+                <ContactOrganization></ContactOrganization>
+            </ContactPersonPrimary>
+            <ContactPosition></ContactPosition>
+            <ContactAddress>
+                <AddressType>postal</AddressType>
+                <Address></Address>
+                <City></City>
+                <StateOrProvince></StateOrProvince>
+                <PostCode></PostCode>
+                <Country></Country>
+            </ContactAddress>
+            <ContactVoiceTelephone></ContactVoiceTelephone>
+            <ContactElectronicMailAddress></ContactElectronicMailAddress>
+        </ContactInformation>
+    </Service>
+    <Capability>
+        <Request>
+            <GetCapabilities>
+                <Format>application/vnd.ogc.wms_xml</Format>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetCapabilities>
+            <GetMap>
+                <Format>image/png</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetMap>
+            <GetFeatureInfo>
+                <Format>image/png</Format>
+                <Format>text/csv</Format>
+                <Format>text/javascript</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetFeatureInfo>
+            <GetLegendGraphic>
+                <Format>image/png</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetLegendGraphic>
+        </Request>
+        <Exception>
+            <Format>text/html</Format>
+        </Exception>
+        <Layer>
+            <Title>Test dataset</Title>
+            <Abstract>Test data set</Abstract>
+            <SRS>EPSG:3857</SRS>
+            <SRS>MERCATOR</SRS>
+
+            <Layer opaque="0" queryable="1">
+                <Name>single_period</Name>
+                <Title>average_data</Title>
+                <Abstract></Abstract>
+                <SRS>EPSG:3857</SRS>
+                <LatLonBoundingBox maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
+                <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
+                <Dimension name="time" units="ISO8601" />
+
+                    <Extent name="time">2015-04-27/2015-04-29/P1D</Extent>
+
+                <Style>
+                    <Name>jet</Name>
+                    <Title>jet</Title>
+                    <Abstract></Abstract>
+                    <LegendURL width="72" height="72">
+                        <Format>image/gif</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        xlink:type="simple"
+                                        xlink:href="http://www.example.com"/>
+                    </LegendURL>
+                </Style>
+            </Layer>
+
+        </Layer>
+    </Capability>
+</WMT_MS_Capabilities>

--- a/wwwroot/test/WMS/period_datetimes_many_intervals.xml
+++ b/wwwroot/test/WMS/period_datetimes_many_intervals.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WMT_MS_Capabilities version="1.1.1">
+    <Service>
+        <Name>OGC:WMS</Name>
+        <Title>wms Server</Title>
+        <Abstract></Abstract>
+        <KeywordList>
+
+            <Keyword></Keyword>
+
+        </KeywordList>
+        <OnlineResource href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+        <ContactInformation>
+            <ContactPersonPrimary>
+                <ContactPerson></ContactPerson>
+                <ContactOrganization></ContactOrganization>
+            </ContactPersonPrimary>
+            <ContactPosition></ContactPosition>
+            <ContactAddress>
+                <AddressType>postal</AddressType>
+                <Address></Address>
+                <City></City>
+                <StateOrProvince></StateOrProvince>
+                <PostCode></PostCode>
+                <Country></Country>
+            </ContactAddress>
+            <ContactVoiceTelephone></ContactVoiceTelephone>
+            <ContactElectronicMailAddress></ContactElectronicMailAddress>
+        </ContactInformation>
+    </Service>
+    <Capability>
+        <Request>
+            <GetCapabilities>
+                <Format>application/vnd.ogc.wms_xml</Format>
+                <Format>text/xml</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetCapabilities>
+            <GetMap>
+                <Format>image/png</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetMap>
+            <GetFeatureInfo>
+                <Format>image/png</Format>
+                <Format>text/csv</Format>
+                <Format>text/javascript</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetFeatureInfo>
+            <GetLegendGraphic>
+                <Format>image/png</Format>
+                <DCPType>
+                    <HTTP>
+                        <Get>
+                            <OnlineResource xlink:href="http://example.com/wms/datasets/ugridtest?REQUEST=GetCapabilities" xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" />
+                        </Get>
+                    </HTTP>
+                </DCPType>
+            </GetLegendGraphic>
+        </Request>
+        <Exception>
+            <Format>text/html</Format>
+        </Exception>
+        <Layer>
+            <Title>Test dataset</Title>
+            <Abstract>Test data set</Abstract>
+            <SRS>EPSG:3857</SRS>
+            <SRS>MERCATOR</SRS>
+
+            <Layer opaque="0" queryable="1">
+                <Name>single_period</Name>
+                <Title>average_data</Title>
+                <Abstract></Abstract>
+                <SRS>EPSG:3857</SRS>
+                <LatLonBoundingBox maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
+                <BoundingBox SRS="EPSG:4326" maxx="46.3841552734" maxy="-123.29158783" minx="46.0292739868" miny="-124.177688599" />
+                <Dimension name="time" units="ISO8601" />
+
+                    <Extent name="time">2015-04-27T16:15:00/2018-04-27T18:45:00/PT1M</Extent>
+
+                <Style>
+                    <Name>jet</Name>
+                    <Title>jet</Title>
+                    <Abstract></Abstract>
+                    <LegendURL width="72" height="72">
+                        <Format>image/gif</Format>
+                        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        xlink:type="simple"
+                                        xlink:href="http://www.example.com"/>
+                    </LegendURL>
+                </Style>
+            </Layer>
+
+        </Layer>
+    </Capability>
+</WMT_MS_Capabilities>


### PR DESCRIPTION
To support the work in #3352 to remove momentjs works I've written a bunch more tests to help ensure that all the avenues to interval creation produce legit and equivalent results. 

These tests are running against the `master` branch at moment and so I can then pull them into my branch and ensure I get the same results.

