### PR TITLE
fixing story turning off now viewing item by mistake

### DIFF
--- a/lib/ReactViews/Story/StoryPanel.jsx
+++ b/lib/ReactViews/Story/StoryPanel.jsx
@@ -25,7 +25,9 @@ export function activateStory(story, terria) {
       }, []);
       const nowViewing = terria.nowViewing.items;
       nowViewing.slice().forEach(item => {
-        const itemToCheck = defined(item.creatorCatalogItem) ? item.creatorCatalogItem : item;
+        const itemToCheck = defined(item.creatorCatalogItem)
+          ? item.creatorCatalogItem
+          : item;
         const path = itemToCheck.uniqueId;
         if (nowViewingPaths.indexOf(path) < 0) {
           itemToCheck.isEnabled = false;

--- a/lib/ReactViews/Story/StoryPanel.jsx
+++ b/lib/ReactViews/Story/StoryPanel.jsx
@@ -8,6 +8,7 @@ import { Small, Medium } from "../Generic/Responsive";
 import Icon from "../Icon.jsx";
 import { Swipeable } from "react-swipeable";
 import when from "terriajs-cesium/Source/ThirdParty/when";
+import defined from "terriajs-cesium/Source/Core/defined";
 import Styles from "./story-panel.scss";
 
 export function activateStory(story, terria) {
@@ -24,9 +25,10 @@ export function activateStory(story, terria) {
       }, []);
       const nowViewing = terria.nowViewing.items;
       nowViewing.slice().forEach(item => {
-        const path = item.uniqueId;
+        const itemToCheck = defined(item.creatorCatalogItem) ? item.creatorCatalogItem : item;
+        const path = itemToCheck.uniqueId;
         if (nowViewingPaths.indexOf(path) < 0) {
-          item.isEnabled = false;
+          itemToCheck.isEnabled = false;
         }
       });
     });


### PR DESCRIPTION
Issue: CkanCatalogItem gets turned off by story when used in story

**Cause:** 

> these Broadband catalog items come from CKAN. So even though they're WMS layers, they start out as a CkanCatalogItem. CkanCatalogItem queries CKAN, discovers that resource is a WMS, and then _creates_ a `WebMapServiceCatalogItem` to talk to it, at which point the `CkanCatalogItem` has a property `nowViewingCatalogItem` that refers to the "resolved" `WebMapServiceCatalogItem`, and the `WebMapServiceCatalogItem` has a property `creatorCatalogItem` that points back to the `CkanCatalogItem`. the "creator" gets added to the share data. But the "nowViewing" item gets added to the now viewing list. so you can't compare their IDs, they're two different things but given a now viewing item, you can get its creator, and check if the creator is in the share data.

> *Kevin*