### PR TITLE
Prevents setting selectedFeature when panel is closed.

### DIFF
--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -67,6 +67,11 @@ const FeatureInfoPanel = createReactClass({
           }
           if (defined(pickedFeatures.allFeaturesAvailablePromise)) {
             pickedFeatures.allFeaturesAvailablePromise.then(() => {
+              if (this.props.viewState.featureInfoPanelIsVisible === false) {
+                // Panel is closed, refrain from setting selectedFeature
+                return;
+              }
+
               // We only show features that are associated with a catalog item, so make sure the one we select to be
               // open initially is one we're actually going to show.
               const featuresShownAtAll = pickedFeatures.features.filter(x =>


### PR DESCRIPTION
Fixes #3397.

When the `pickedFeature` promise returns, we set `selectedFeature` only if the panel is visible. Otherwise it triggers changes that will make the selection target reappear.