### PR TITLE
fix color range not updating from share data

### DIFF
--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -333,17 +333,18 @@ var WebMapServiceCatalogItem = function(terria) {
     "_allLayersInRawMetadata"
   ]);
 
-  knockout.defineProperty(this, "_colorRange", {
+  knockout.defineProperty(this, "_colorScaleRange", {
     get: function() {
-      return this.colorScaleMaximum + "  " + this.colorScaleMinimum;
+      return [this.colorScaleMinimum, this.colorScaleMaximum];
     }
   });
 
-  knockout.getObservable(this, "_colorRange").subscribe(function(_colorRange) {
+  this._refreshInProgress = undefined;
+  knockout.getObservable(this, "_colorScaleRange").subscribe(function() {
     if (this.isEnabled && !this._refreshInProgress) {
       this._refreshInProgress = runLater(() => {
         this.refresh();
-        this._refreshInProgress = null;
+        this._refreshInProgress = undefined;
       });
     }
   }, this);

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -333,15 +333,15 @@ var WebMapServiceCatalogItem = function(terria) {
     "_allLayersInRawMetadata"
   ]);
 
-  knockout.defineProperty(this, "colorRange", {
+  knockout.defineProperty(this, "_colorRange", {
     get: function() {
       return this.colorScaleMaximum + "  " + this.colorScaleMinimum;
     }
   });
 
   knockout
-    .getObservable(this, "colorRange")
-    .subscribe(function(colorScaleMaximum) {
+    .getObservable(this, "_colorRange")
+    .subscribe(function(_colorRange) {
       if (this.isEnabled && !this._refreshInProgress) {
         this._refreshInProgress = runLater(() => {
           this.refresh();

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -339,16 +339,14 @@ var WebMapServiceCatalogItem = function(terria) {
     }
   });
 
-  knockout
-    .getObservable(this, "_colorRange")
-    .subscribe(function(_colorRange) {
-      if (this.isEnabled && !this._refreshInProgress) {
-        this._refreshInProgress = runLater(() => {
-          this.refresh();
-          this._refreshInProgress = null;
-        });
-      }
-    }, this);
+  knockout.getObservable(this, "_colorRange").subscribe(function(_colorRange) {
+    if (this.isEnabled && !this._refreshInProgress) {
+      this._refreshInProgress = runLater(() => {
+        this.refresh();
+        this._refreshInProgress = null;
+      });
+    }
+  }, this);
 
   // getCapabilitiesUrl and legendUrl are derived from url if not explicitly specified.
   overrideProperty(this, "getCapabilitiesUrl", {

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -32,6 +32,7 @@ var MetadataItem = require("./MetadataItem");
 var TerriaError = require("../Core/TerriaError");
 var ImageryLayerCatalogItem = require("./ImageryLayerCatalogItem");
 var inherit = require("../Core/inherit");
+var runLater = require("../Core/runLater");
 var overrideProperty = require("../Core/overrideProperty");
 var proxyCatalogItemUrl = require("./proxyCatalogItemUrl");
 var unionRectangleArray = require("../Map/unionRectangleArray");
@@ -331,6 +332,23 @@ var WebMapServiceCatalogItem = function(terria) {
     "_thisLayerInRawMetadata",
     "_allLayersInRawMetadata"
   ]);
+
+  knockout.defineProperty(this, "colorRange", {
+    get: function() {
+      return this.colorScaleMaximum + "  " + this.colorScaleMinimum;
+    }
+  });
+
+  knockout
+    .getObservable(this, "colorRange")
+    .subscribe(function(colorScaleMaximum) {
+      if (this.isEnabled && !this._refreshInProgress) {
+        this._refreshInProgress = runLater(() => {
+          this.refresh();
+          this._refreshInProgress = null;
+        });
+      }
+    }, this);
 
   // getCapabilitiesUrl and legendUrl are derived from url if not explicitly specified.
   overrideProperty(this, "getCapabilitiesUrl", {

--- a/lib/ReactViews/ObserveModelMixin.js
+++ b/lib/ReactViews/ObserveModelMixin.js
@@ -60,7 +60,6 @@ const ObserveModelMixin = {
         // dependency when accessing individual elements of the array.
         for (const prop in that.props) {
           if (that.props.hasOwnProperty(prop)) {
-            
             if (
               defined(that.props[prop]) &&
               defined(that.props[prop].__knockoutSubscribable)

--- a/lib/ReactViews/ObserveModelMixin.js
+++ b/lib/ReactViews/ObserveModelMixin.js
@@ -9,7 +9,6 @@ const ObserveModelMixin = {
     this.__observeModelChangeSubscriptions = undefined;
 
     const originalRender = this.render;
-
     this.render = function renderForObserveModelMixin() {
       const that = this;
       let isFirstRender = true;
@@ -61,6 +60,7 @@ const ObserveModelMixin = {
         // dependency when accessing individual elements of the array.
         for (const prop in that.props) {
           if (that.props.hasOwnProperty(prop)) {
+            
             if (
               defined(that.props[prop]) &&
               defined(that.props[prop].__knockoutSubscribable)

--- a/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
@@ -12,16 +12,40 @@ const ColorScaleRangeSection = createReactClass({
   mixins: [ObserveModelMixin],
 
   propTypes: {
-    item: PropTypes.object.isRequired
+    item: PropTypes.object.isRequired,
+    minValue: PropTypes.number,
+    maxValue: PropTypes.number
   },
 
-  minRange: -50,
-  maxRange: 50,
+  getInitialState: function() {
+    return {
+      minRange: -50,
+      maxRange: 50
+    };
+  },
+
+  componentDidUpdate() {
+    this.props.item.refresh();
+  },
+  /* eslint-disable-next-line camelcase */
+  UNSAFE_componentWillMount() {
+    this.setState({
+      minRange: this.props.minValue,
+      maxRange: this.props.maxValue
+    });
+  },
+  /* eslint-disable-next-line camelcase */
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    this.setState({
+      minRange: nextProps.minValue,
+      maxRange: nextProps.maxValue
+    });
+  },
 
   updateRange(e) {
     e.preventDefault();
 
-    const min = parseFloat(this.minRange);
+    const min = parseFloat(this.state.minRange);
     if (min !== min) {
       // is NaN?
       this.props.item.terria.error.raiseEvent({
@@ -32,7 +56,7 @@ const ColorScaleRangeSection = createReactClass({
       return;
     }
 
-    const max = parseFloat(this.maxRange);
+    const max = parseFloat(this.state.maxRange);
     if (max !== max) {
       // is NaN?
       this.props.item.terria.error.raiseEvent({
@@ -59,11 +83,15 @@ const ColorScaleRangeSection = createReactClass({
   },
 
   changeRangeMin(event) {
-    this.minRange = event.target.value;
+    this.setState({
+      minRange: event.target.value
+    });
   },
 
   changeRangeMax(event) {
-    this.maxRange = event.target.value;
+    this.setState({
+      maxRange: event.target.value
+    });
   },
 
   render() {
@@ -71,10 +99,6 @@ const ColorScaleRangeSection = createReactClass({
     if (!defined(item.colorScaleMinimum) || !defined(item.colorScaleMaximum)) {
       return null;
     }
-
-    this.minRange = item.colorScaleMinimum;
-    this.maxRange = item.colorScaleMaximum;
-
     return (
       <form className={Styles.colorscalerange} onSubmit={this.updateRange}>
         <div className={Styles.title}>Color Scale Range </div>
@@ -83,7 +107,7 @@ const ColorScaleRangeSection = createReactClass({
           className={Styles.field}
           type="text"
           name="rangeMax"
-          defaultValue={this.maxRange}
+          value={this.state.maxRange}
           onChange={this.changeRangeMax}
         />
         <label htmlFor="rangeMin">Minimum: </label>
@@ -91,7 +115,7 @@ const ColorScaleRangeSection = createReactClass({
           className={Styles.field}
           type="text"
           name="rangeMin"
-          defaultValue={this.minRange}
+          value={this.state.minRange}
           onChange={this.changeRangeMin}
         />
         <button type="submit" title="Update Range" className={Styles.btn}>

--- a/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
@@ -24,9 +24,6 @@ const ColorScaleRangeSection = createReactClass({
     };
   },
 
-  componentDidUpdate() {
-    this.props.item.refresh();
-  },
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     this.setState({
@@ -79,7 +76,6 @@ const ColorScaleRangeSection = createReactClass({
 
     this.props.item.colorScaleMinimum = min;
     this.props.item.colorScaleMaximum = max;
-    this.props.item.refresh();
   },
 
   changeRangeMin(event) {

--- a/lib/ReactViews/Workbench/WorkbenchItem.jsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.jsx
@@ -137,7 +137,11 @@ const WorkbenchItem = createReactClass({
             <DateTimeSelectorSection item={workbenchItem} />
             <SatelliteImageryTimeFilterSection item={workbenchItem} />
             <StyleSelectorSection item={workbenchItem} />
-            <ColorScaleRangeSection item={workbenchItem} />
+            <ColorScaleRangeSection
+              item={workbenchItem}
+              minValue={workbenchItem.colorScaleMinimum}
+              maxValue={workbenchItem.colorScaleMaximum}
+            />
             <DisplayAsPercentSection item={workbenchItem} />
             <Legend item={workbenchItem} />
             <If


### PR DESCRIPTION
Fixes: https://github.com/TerriaJS/terriajs/issues/3404

For the color range field to be updated from share data, it needs to be a controlled element, hence not `defaultValue` but `value` (surprising react was not giving us a warning), and we need to copy props to state when props change.

However, when the parent component is passing in `item`, any change in `item.colorMax` unfortunately does not trigger `componentWillMount`. Therefore we add the color range values directly as props to `ColorScaleRangeSection` so we can correctly copy the latest props into state.

Since we are using mixin and pre ess6 syntax, we are now using the `UNSAFE_componentWillMount` and `UNSAFE_componentWillReceiveProps`. After we update to es6 syntax we should use `static getDerivedStateFromProps()` and do the update in one go. 

Update:
The item refresh from the shared data should not rely on Ui updates, therefore max and min color range is subscribed and refresh happens when there's a change in either