### PR TITLE
icon size regression

### DIFF
--- a/lib/ReactViews/Feedback/feedback-form.scss
+++ b/lib/ReactViews/Feedback/feedback-form.scss
@@ -85,12 +85,12 @@
 .btnClose {
   composes: btn from "../../Sass/common/_buttons.scss";
   position: absolute;
-  right: 0;
-  top: 5px;
+  right: 10px;
+  top: 10px;
   svg {
     fill: $text-light;
-    height: 30px;
-    width: 30px;
+    height: 15px;
+    width: 15px;
     &:hover {
       fill: $color-primary;
     }

--- a/lib/ReactViews/Search/search-box.scss
+++ b/lib/ReactViews/Search/search-box.scss
@@ -41,14 +41,14 @@ input[type="text"].searchField {
 
 .searchClear {
   composes: btn from "../../Sass/common/_buttons.scss";
-  right: 0;
-  top: 0;
+  right: 0px;
+  top: 0px;
   position: absolute;
   height: $input-height;
   width: $input-height;
   svg {
-    height: 25px;
-    width: 25px;
+    height: 15px;
+    width: 15px;
     margin: 0 auto;
     fill: $charcoal-grey;
     fill-opacity: 0.5;


### PR DESCRIPTION
we had some icons that are too big after latest svg icon update. This Pr fixed those. 
eg: previously:
![image](https://user-images.githubusercontent.com/7508939/58071905-6a224680-7be1-11e9-84b0-9029f7ef55d8.png)
now:
![image](https://user-images.githubusercontent.com/7508939/58071960-8c1bc900-7be1-11e9-9a2a-cffa1e464c83.png)

