### PR TITLE
added support for downloading all csv columns

### DIFF
--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -85,6 +85,7 @@ var TableStructure = function(name, options) {
   this.sourceFeature = options.sourceFeature;
   this.idColumnNames = options.idColumnNames; // Actually names, ids or indexes.
   this.isSampled = options.isSampled;
+  this.downloadAllColumns = options.downloadAllColumns;
 
   /**
    * Gets or sets the active time column name, id or index.

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -145,7 +145,8 @@ function loadTableFromCsv(item, csvString) {
     displayDuration: tableStyle.displayDuration,
     replaceWithNullValues: tableStyle.replaceWithNullValues,
     replaceWithZeroValues: tableStyle.replaceWithZeroValues,
-    columnOptions: tableStyle.columns // may contain per-column replacements for these
+    columnOptions: tableStyle.columns, // may contain per-column replacements for these
+    downloadAllColumns: item.downloadAllColumns
   };
   var tableStructure = new TableStructure(undefined, options);
   tableStructure.loadFromCsv(csvString);
@@ -160,7 +161,7 @@ function loadTableFromCsv(item, csvString) {
  */
 CsvCatalogItem.prototype.loadIntoTableStructure = function(url) {
   const item = this;
-  const tableStructure = new TableStructure();
+  const tableStructure = new TableStructure(undefined, {downloadAllColumns: item.downloadAllColumns});
   // Note item is only used for its 'terria', 'forceProxy' and 'cacheDuration' properties
   // (which are all defined on CatalogMember, the base class of CatalogItem).
   return loadTextWithMime(proxyCatalogItemUrl(item, url, "0d")).then(

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -144,6 +144,13 @@ var TableCatalogItem = function(terria, url, options) {
   this.isSampled = defaultValue(options.isSampled, true);
 
   /**
+   * Gets or sets a value indicating whether to download all table columns. 
+   * @type {Boolean}
+   * @default true
+   */
+  this.downloadAllColumns = defaultValue(options.downloadAllColumns, false);
+
+  /**
    * Gets or sets which side of the splitter (if present) to display this imagery layer on.  Defaults to both sides.
    * Note that this only applies to region-mapped tables. This property is observable.
    * @type {ImagerySplitDirection}

--- a/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx
@@ -45,9 +45,12 @@ const ChartPanelDownloadButton = createReactClass({
         if (!defined(columns[0])) {
           continue;
         }
-        const yColumns = item.tableStructure.columnsByType[
+        let yColumns = item.tableStructure.columnsByType[
           VarType.SCALAR
-        ].filter(column => column.isActive);
+        ];
+        if(!item.tableStructure.downloadAllColumns) {
+          yColumns = yColumns.filter(column => column.isActive);
+        }
         if (yColumns.length > 0) {
           columns = columns.concat(yColumns);
           // Use typed array if possible so we can pass by pointer to the web worker.


### PR DESCRIPTION
Originally the download button on the csv chart panel only downloads the selected (i.e. active) csv columns as done here: https://github.com/TerriaJS/terriajs/blob/master/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.jsx#L50. This behaviour makes sense when the user wants to download what they select.

Now consider this scenario:
The raw csv data source contains large number of columns. The user who wants to use the `CsvCatalogItem` can only select a subset of the columns for visualisation in the chart because it will be too cluttered to show all the columns at the same time. Visualising a subset of columns is good for a quick qualitative analysis. For rigours quantitative analysis, however, the user might always want to download all the csv columns so that the user can kick off his own data processing pipeline from there.

This PR addes a `"downloadAllColumns": true` flag to the `CsvCatalogItem` and handles this flag in the chart related code. If this flag is set, all columns will be downloaded regardless of user selection. Otherwise the original behaviour is reproduced.

The following catalog json is for testing this PR:

```
{"catalog": [
{"downloadAllColumns": true, "data": "date,green,non-green,bare ground,total\n2019-01-01T00:00:00.000Z,11.026678,46.402496,40.866898,57.429176\n2019-02-02T00:00:00.000Z,11.228782,47.375149,39.603237,58.603931\n2019-03-06T00:00:00.000Z,13.603074,46.402256,37.982876,60.005329\n2019-04-07T00:00:00.000Z,15.950206,45.466167,36.369907,61.416374\n", "isEnabled": true, "type": "csv", "name": "test csv", "tableStyle": { "columns": { "green": { "units": "%", "chartLineColor": "#0070c0", "yAxisMin": 0, "yAxisMax": 100, "active": true }, "non-green": { "units": "%", "chartLineColor": "#00b050", "yAxisMin": 0, "yAxisMax": 100, "active": true }, "bare ground": { "units": "%", "chartLineColor": "#FF0000", "yAxisMin": 0, "yAxisMax": 100,  "active": true }, "total": { "units": "%", "chartLineColor": "#FFFFFF", "yAxisMin": 0, "yAxisMax": 100, "active": true } } } }
]
}
```