### PR TITLE
Wrap map click coordinates in leaflet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### v7.6.3
+
+* Fixed a bug with picking features that cross the anti-meridian in 2D mode 
+
 ### v7.6.2
 
 * Fixed a bug that made some input boxes unreadable in some web browsers.

--- a/lib/Models/Leaflet.js
+++ b/lib/Models/Leaflet.js
@@ -55,7 +55,6 @@ L.Canvas.prototype._onClick = function(e) {
   var point = this._map.mouseEventToLayerPoint(e),
     layers = [],
     layer;
-
   for (var order = this._drawFirst; order; order = order.next) {
     layer = order.layer;
     if (
@@ -164,6 +163,9 @@ var Leaflet = function(terria, map) {
   });
 
   map.on("click", function(e) {
+    // Handle click events that cross the anti-meridian
+    if (e.latlng.lng > 180 || e.latlng.lng < -180) e.latlng = e.latlng.wrap();
+
     if (!that._dragboxcompleted && that.map.dragging.enabled()) {
       pickFeatures(that, e.latlng);
     }


### PR DESCRIPTION
This PR adds a check on a leaflet map click event to make sure the `latlng` is between -180 and +180., if it's not we use [latlng.wrap()](https://leafletjs.com/reference-1.3.4.html#latlng-wrap) to wrap coordinates to within that range.

This prevents errors when trying to pick features on a zoomed out 2D map that cross the anti-meridian.
![Working](https://user-images.githubusercontent.com/6735870/59571777-8daab500-90eb-11e9-9847-fae2641cdb0e.png)

Resolves #3505