### PR TITLE
New Model Architecture: Add preview map click to toggle "zoom to extent"

### DIFF
--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -84,6 +84,7 @@ export default class Leaflet extends GlobeOrMap {
   private readonly _disposeShowSplitterSubscription: () => void;
   private readonly _selectionIndicator: LeafletSelectionIndicator;
   private readonly _disposeSelectedFeatureSubscription: () => void;
+  private readonly _disposeDisableMouseInteractionSubscription: () => void;
 
   private _createImageryLayer: (
     ip: Cesium.ImageryProvider
@@ -189,6 +190,23 @@ export default class Leaflet extends GlobeOrMap {
           this._updateItemForSplitter(item, clips);
         }
       });
+    });
+
+    this._disposeDisableMouseInteractionSubscription = autorun(() => {
+      const map = this.map;
+      const interactions = [
+        map.touchZoom,
+        map.doubleClickZoom,
+        map.scrollWheelZoom,
+        map.boxZoom,
+        map.keyboard,
+        map.dragging
+      ];
+      if (this.terriaViewer.disableMouseInteraction) {
+        interactions.forEach(handler => handler.disable());
+      } else {
+        interactions.forEach(handler => handler.enable());
+      }
     });
   }
 

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -63,16 +63,14 @@ class MappablePreview extends React.Component {
   }
 
   render() {
+    // TODO: re-introduce disablePreview to catalog items
+    const catalogItem = this.props.previewed;
     return (
       <div className={Styles.root}>
-        <If
-          condition={
-            Mappable.is(this.props.previewed) && !catalogItem.disablePreview
-          }
-        >
+        <If condition={Mappable.is(catalogItem) && !catalogItem.disablePreview}>
           <DataPreviewMap
             terria={this.props.terria}
-            previewed={this.props.previewed}
+            previewed={catalogItem}
             showMap={
               !this.props.viewState.explorerPanelAnimating ||
               this.props.viewState.useSmallScreenInterface
@@ -84,13 +82,13 @@ class MappablePreview extends React.Component {
           onClick={this.toggleOnMap}
           className={Styles.btnAdd}
         >
-          {this.props.terria.workbench.contains(this.props.previewed)
+          {this.props.terria.workbench.contains(catalogItem)
             ? "Remove from the map"
             : "Add to the map"}
         </button>
         <div className={Styles.previewedInfo}>
-          <h3 className={Styles.h3}>{this.props.previewed.name}</h3>
-          <Description item={this.props.previewed} />
+          <h3 className={Styles.h3}>{catalogItem.name}</h3>
+          <Description item={catalogItem} />
         </div>
       </div>
     );

--- a/lib/ViewModels/TerriaViewer.ts
+++ b/lib/ViewModels/TerriaViewer.ts
@@ -53,6 +53,10 @@ export default class TerriaViewer {
   @observable
   viewerOptions: ViewerOptions = viewerOptionsDefaults;
 
+  // Disable all mouse (& keyboard) interaction
+  @observable
+  disableMouseInteraction: boolean = false;
+
   // Random rectangle. Work out reactivity
   // Should this be homeView instead (and have 3D view properties)?
   defaultExtent: Rectangle = Rectangle.fromDegrees(120, -45, 155, -15);


### PR DESCRIPTION
Adds zooming to extent in preview map

Introduces an observable that allows disabling mouse & keyboard interaction. Only honoured by leaflet viewer at the moment. (Cesium viewer lack of support noted in #3499).
