### PR TITLE
Move the creation of legend in ArcGisMapServerCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### v7.6.4
+
+* Fix a bug where `ArcGisMapServerCatalogItem` legends were being created during search.
+
 ### v7.6.3
 
 * Fixed a bug with picking features that cross the anti-meridian in 2D mode 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,10 @@
 Change Log
 ==========
 
-### v7.6.4
-
-* Fix a bug where `ArcGisMapServerCatalogItem` legends were being created during search.
-
 ### v7.6.3
 
 * Fixed a bug with picking features that cross the anti-meridian in 2D mode 
+* Fixed a bug where `ArcGisMapServerCatalogItem` legends were being created during search.
 
 ### v7.6.2
 

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -378,6 +378,11 @@ ArcGisMapServerCatalogItem.prototype._createImageryProvider = function() {
     imageryOptions.token = this._lastToken;
   }
 
+  // if catalog contains a hand-crafted legend image, we respect it.
+  if (!defined(this._legendUrl)) {
+    this.loadLegendFromJson(this._legendData); // a promise.
+  }
+
   var imageryProvider = new ArcGisMapServerImageryProvider(imageryOptions);
 
   var maximumLevelBeforeMessage = maximumScaleToLevel(
@@ -491,11 +496,6 @@ ArcGisMapServerCatalogItem.prototype.updateFromMetadata = function(
     "rectangle",
     getRectangleFromLayers(this._allLayersInLayersData)
   );
-
-  // if catalog contains a hand-crafted legend image, we respect it.
-  if (!defined(this._legendUrl)) {
-    this.loadLegendFromJson(legendJson); // a promise.
-  }
 
   var minimumMaxScale = Number.MAX_VALUE;
   var minimumMaxScaleWithoutNoData = Number.MAX_VALUE;


### PR DESCRIPTION
If you start searching the data catalog any `ArcGisMapServerCatalogItem` that is in the catalog starts having its legend created even though it hasn't yet been added to the map. This results in thousands of unnecessary requests  

To replicate
1. Open nationalmap and the devtools with the network tab open
2. Open the data catalogue
3. Search for anything

You'll see thousands of requests sent for images initiated by the `ArcGisMapServerCatalogItem`.

This PR moves the creation of the legend from the `updateFromMetadata` method to the `_createImageryProvider`

Resolves #2816