### PR TITLE
Model architecture: Destroy the current viewer when it is detached.

### DIFF
--- a/lib/ViewModels/TerriaViewer.ts
+++ b/lib/ViewModels/TerriaViewer.ts
@@ -68,12 +68,7 @@ export default class TerriaViewer {
     keepAlive: true
   })
   get currentViewer(): GlobeOrMap {
-    let currentView: CameraView | undefined;
-    if (this._lastViewer !== undefined) {
-      currentView = this._lastViewer.getCurrentCameraView();
-      this._lastViewer.destroy();
-      this._lastViewer = undefined;
-    }
+    const currentView = this.destroyCurrentViewer();
 
     const viewerMode = this.attached ? this.viewerMode : undefined;
     console.log(`Creating a viewer: ${viewerMode}`);
@@ -103,5 +98,17 @@ export default class TerriaViewer {
   detach() {
     // Detach from a container
     this.mapContainer = undefined;
+    this.destroyCurrentViewer();
+  }
+
+  private destroyCurrentViewer() {
+    let currentView: CameraView | undefined;
+    if (this._lastViewer !== undefined) {
+      console.log(`Destroying a viewer`);
+      currentView = this._lastViewer.getCurrentCameraView();
+      this._lastViewer.destroy();
+      this._lastViewer = undefined;
+    }
+    return currentView;
   }
 }


### PR DESCRIPTION
This should fix the bug where the preview map keeps doing its thing even after the catalog panel is closed.

I was assuming that re-evaluation of the `currentViewer` property would cause the viewer to be destroyed. I failed to realize that the `currentViewer` would become un-observed in that scenario too, and so it wouldn't be re-evaluated. So now `detach` explicitly destroys the current viewer.