### PR TITLE
Give a drag'n'dropped file a name in the workbench

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 ### Next Release
 * Fixed inability to share SOS items
+* Add the filename to a workbench item from a drag'n'dropped file so it isn't undisplayed as 'Unnamed item'.
 
 ### v7.6.4
 

--- a/lib/Models/createCatalogItemFromFileOrUrl.js
+++ b/lib/Models/createCatalogItemFromFileOrUrl.js
@@ -156,6 +156,7 @@ function loadItem(newCatalogItem, name, fileOrUrl) {
     newCatalogItem.data = fileOrUrl;
     newCatalogItem.dataSourceUrl = fileOrUrl.name;
     newCatalogItem.dataUrlType = "local";
+    newCatalogItem.name = fileOrUrl.name;
   }
 
   return when(newCatalogItem.load()).yield(newCatalogItem);


### PR DESCRIPTION
Resolves #3399 by giving a drag'n'dropped item it's filename as the name in the workbench