### PR TITLE
Prevent terria from crashing when clicking on a region with no region-mapped poly and a chart

### DIFF
--- a/lib/ReactViews/Custom/Chart/Chart.jsx
+++ b/lib/ReactViews/Custom/Chart/Chart.jsx
@@ -132,6 +132,7 @@ const Chart = createReactClass({
       that.props.url,
       that.props.catalogItem
     );
+    if (!defined(promise)) return;
     promise.then(function(data) {
       chartParameters.data = data;
       ChartRenderer.create(that._element, chartParameters);
@@ -194,6 +195,8 @@ const Chart = createReactClass({
 
   componentWillUnmount() {
     const that = this;
+    if (!defined(this._promise)) return;
+
     this._promise.then(function(listener) {
       window.removeEventListener("resize", listener);
       // console.log('Removed resize listener for', that.props.url, that.rnd, listener);


### PR DESCRIPTION
Resolves #3582 

See the issue listed above for details on how to replicate crash. This PR adds some light-weight error handling to the chart component.