### PR TITLE
Fix vector tile feature info when no region

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Added an option to the mobile menu to allow a story to be resumed after it is closed.
 * The "Introducing Data Stories" prompt now only needs to be dismissed once. Previously it would continue to appear on every load until you clicked the "Story" button.
 * Fixed a crash that could occur when the feature info panel has a chart but the selected feature has no chart data.
+* Fixed a bug where the feature info panel would show information on a vector tile region mapped dataset that had no match.
 
 ### v7.6.4
 

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -3,7 +3,6 @@
 
 var CallbackProperty = require("terriajs-cesium/Source/DataSources/CallbackProperty");
 var CesiumEvent = require("terriajs-cesium/Source/Core/Event");
-var clone = require("terriajs-cesium/Source/Core/clone");
 var combine = require("terriajs-cesium/Source/Core/combine");
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue");
 var defined = require("terriajs-cesium/Source/Core/defined");

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -673,7 +673,7 @@ function addDescriptionAndProperties(
               cRowObject.string
             );
           } else {
-            return undefined;
+            return;
           }
         } else {
           // Time-varying.

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -673,7 +673,7 @@ function addDescriptionAndProperties(
               cRowObject.string
             );
           } else {
-            imageryLayerFeatureInfo.properties = clone(feature.properties);
+            return undefined;
           }
         } else {
           // Time-varying.


### PR DESCRIPTION
Currently if you click on a vector tile region mapped layer that has no matching region the feature info will show feature information of the region.

**To replicate current behaviour**
Use the following sample as a sample.csv and drop it on to https://map.terria.io/
````
add_code_2016,Value
D05,100
D06,200
````
Click somewhere there is no data and you'll get a popup 
![Prior](https://user-images.githubusercontent.com/6735870/61419340-29c11980-a941-11e9-98be-f3be66639990.png)

**The new behaviour**
This fix prevents the feature info from showing region data when there is nothing matching
![FeatureInfoVectorTiles](https://user-images.githubusercontent.com/6735870/61419361-452c2480-a941-11e9-86be-e38443fa6ad3.png)

This resolves #2750

Note: @steve9164 I've also tested on the Aremi Annual Deferral Value dataset and it doesn't appear to have any detrimental effects
https://www.nationalmap.gov.au/renewables/#share=s-7hsT0gTrwG1JpppM