### PR TITLE
Fix ReferenceMixin requiring uniqueIds

### DIFF
--- a/lib/ModelMixins/ReferenceMixin.ts
+++ b/lib/ModelMixins/ReferenceMixin.ts
@@ -28,7 +28,11 @@ function ReferenceMixin<T extends Constructor<Model<RequiredTraits>>>(Base: T) {
     private _referenceLoader = new AsyncLoader(() => {
       const previousTarget = untracked(() => this._dereferenced);
       return this.forceLoadReference(previousTarget).then(target => {
-        if (target && target.uniqueId !== this.uniqueId) {
+        if (
+          target &&
+          target.uniqueId !== undefined &&
+          target.uniqueId !== this.uniqueId
+        ) {
           throw new DeveloperError(
             "The model returned by `forceLoadReference` must have the same `id` as the `ReferenceMixin` itself."
           );


### PR DESCRIPTION
Thanks to @kring
> it used to be models had to have IDs.
> and the IDs of reference targets became super awkward
> now they're allowed to be undefined