### PR TITLE
Cesium fetch xhr http 202 terria json catalog function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,29 @@
 Change Log
 ==========
 
+### v7.next
+* Added ability in TerriaJsonCatalogFunction to handle long requests via HTTP:202 Accepted.
+    
+    When attemtping to specify a Resource object with 
+    ```
+    retryAttempts = 0
+    retryAttemtps = 1
+    retryAttempts =-1
+    retryFunction = undefined
+    retryFunction = false
+    retryFunction = function(){return false;}
+    timeout = 600000
+    ```
+    or any combination of the above, it would either not make the request at all or keep makng a retry attempt every two minutes and discardng the current request, which restarts the process on the processing server as a new request.
+    
+    The terria-json entry in the catalogue init file can specify a acceptedUrl property to define where the url is in the XMLHTTPResopnse.
+    - a url returned in a header field can be specified as "headers.field",
+    - a url returned as plain text in a body can be specified as "response",
+    - a url returned as a property in the body can be specified as "response.property",
+    - multiple properties can be traversed.
+    
+    If the terria-json service returned a normal status 200 request, or any other status code besides 202, the 202 handling process is skipped, and the json response continues as normal. Requires modified version of cesium with fetchXHR.
+
 ### v7.6.5
 
 * Add the filename to a workbench item from a drag'n'dropped file so it isn't undisplayed as 'Unnamed item'.

--- a/lib/Models/TerriaJsonCatalogFunction.js
+++ b/lib/Models/TerriaJsonCatalogFunction.js
@@ -188,14 +188,14 @@ function TerriaJsonCatalogFunction(terria) {
 
   /*
    * Gets or sets the part of a HTTP 202 response to poll again for content.
-   * A HTTP 202 response is returned as an object with 
+   * A HTTP 202 response is returned as an object with
    * {
    *   status: 202
    *   headers: responseHeaders
    *   respone: responseBody
    * }
    * where
-   * responseHeaders is an object with key-value pairs of all HTTP response 
+   * responseHeaders is an object with key-value pairs of all HTTP response
    * 	headers
    * responseBody is the unaltered XMLHttpRequest.response
    * If you were to supply a 202 response with the url as a location header,
@@ -210,9 +210,9 @@ function TerriaJsonCatalogFunction(terria) {
    *   }
    * }
    * acceptedUrl can be specified as response.prop1.prop3
-   * If you were to supply a 202 response with the url as plain text in the 
+   * If you were to supply a 202 response with the url as plain text in the
    * response body, acceptedUrl can be specified as response
-   * If you were to supply a 202 response with the url as a property of some 
+   * If you were to supply a 202 response with the url as a property of some
    * other mime type/format, eg. XML, YAML
    * This is open source software, add the code yourself.
    * Leave undefined for new functionality to be off by default
@@ -221,7 +221,7 @@ function TerriaJsonCatalogFunction(terria) {
   this.acceptedUrl = undefined;
 
   /*
-   * Gets or sets the time in milliseconds to wait before polling a 
+   * Gets or sets the time in milliseconds to wait before polling a
    * HTTP 202 response acceptedUrl
    * default 10 seconds
    * is unused if acceptUrl is not defined
@@ -421,71 +421,73 @@ TerriaJsonCatalogFunction.prototype.invoke = function() {
   const uri = new URI(this.url).addQuery(queryParameters);
   const proxiedUrl = proxyCatalogItemUrl(this, uri.toString(), "1d");
   const promise = Resource.fetchXHR({
-      url: proxiedUrl,
-      responseType: "text",
-      headers: {
-        Accept: "application/json,*/*;q=0.01"
-      },
-      returnType: "XHRJSONHEADERS"
-    }).then(xhr => this._handleHttp202(xhr)).then(json => {
-    asyncResult.isEnabled = false;
+    url: proxiedUrl,
+    responseType: "text",
+    headers: {
+      Accept: "application/json,*/*;q=0.01"
+    },
+    returnType: "XHRJSONHEADERS"
+  })
+    .then(xhr => this._handleHttp202(xhr))
+    .then(json => {
+      asyncResult.isEnabled = false;
 
-    // JSON response may be:
-    // 1. A single catalog member; it will be added to the workbench.
-    // 2. An array of catalog members; they'll all be added to the workbench.
-    // 3. A TerriaJS init source (catalog file); it will be merged into the catalogue.
-    // 4. A TerriaJS "share data" object, which may contain multiple init sources.
+      // JSON response may be:
+      // 1. A single catalog member; it will be added to the workbench.
+      // 2. An array of catalog members; they'll all be added to the workbench.
+      // 3. A TerriaJS init source (catalog file); it will be merged into the catalogue.
+      // 4. A TerriaJS "share data" object, which may contain multiple init sources.
 
-    if (json.version && json.initSources) {
-      // Case #4
-      return this.terria.updateFromStartData(json);
-    } else if (Array.isArray(json.catalog)) {
-      // Case #3
-      return this.terria.addInitSource(json);
-    }
-
-    // Case #1 or #2
-    const items = Array.isArray(json) ? json : [json];
-    items.forEach(function(item) {
-      // Make sure it shows up on the workbench, unless explicitly told not to.
-      if (!defined(item.isEnabled)) {
-        item.isEnabled = true;
+      if (json.version && json.initSources) {
+        // Case #4
+        return this.terria.updateFromStartData(json);
+      } else if (Array.isArray(json.catalog)) {
+        // Case #3
+        return this.terria.addInitSource(json);
       }
 
-      item.name = item.name || asyncResult.name;
-      item.description = item.description || asyncResult.description;
+      // Case #1 or #2
+      const items = Array.isArray(json) ? json : [json];
+      items.forEach(function(item) {
+        // Make sure it shows up on the workbench, unless explicitly told not to.
+        if (!defined(item.isEnabled)) {
+          item.isEnabled = true;
+        }
+
+        item.name = item.name || asyncResult.name;
+        item.description = item.description || asyncResult.description;
+      });
+
+      // Create a group in the catalog to hold the results
+      const resultsGroupId = this.uniqueId + "-results";
+      let resultsGroup = this.terria.catalog.shareKeyIndex[resultsGroupId];
+
+      if (!resultsGroup) {
+        const parent =
+          this.parent && this.parent.items
+            ? this.parent
+            : this.terria.catalog.group;
+        let index = parent.items.indexOf(this);
+        if (index >= 0) {
+          ++index;
+        } else {
+          index = parent.items.length;
+        }
+
+        resultsGroup = new CatalogGroup(this.terria);
+        resultsGroup.id = resultsGroupId;
+        resultsGroup.name = this.name + " Results";
+        parent.items.splice(index, 0, resultsGroup);
+      }
+
+      return CatalogGroup.updateItems(
+        items,
+        {
+          isUserSupplied: true
+        },
+        resultsGroup
+      );
     });
-
-    // Create a group in the catalog to hold the results
-    const resultsGroupId = this.uniqueId + "-results";
-    let resultsGroup = this.terria.catalog.shareKeyIndex[resultsGroupId];
-
-    if (!resultsGroup) {
-      const parent =
-        this.parent && this.parent.items
-          ? this.parent
-          : this.terria.catalog.group;
-      let index = parent.items.indexOf(this);
-      if (index >= 0) {
-        ++index;
-      } else {
-        index = parent.items.length;
-      }
-
-      resultsGroup = new CatalogGroup(this.terria);
-      resultsGroup.id = resultsGroupId;
-      resultsGroup.name = this.name + " Results";
-      parent.items.splice(index, 0, resultsGroup);
-    }
-
-    return CatalogGroup.updateItems(
-      items,
-      {
-        isUserSupplied: true
-      },
-      resultsGroup
-    );
-  });
 
   asyncResult.loadPromise = promise;
   asyncResult.isEnabled = true;
@@ -493,112 +495,181 @@ TerriaJsonCatalogFunction.prototype.invoke = function() {
   return promise;
 };
 
+// case insenitive hasOwnProperty variants
+// headers case insensitive, javascript case sensitive
+// check for headers all lowercase, all uppercase,
+// first letter uppercase, or if as specified
+function hasPropertyUpperCase(obj, prop) {
+  return (
+    Object.keys(obj).filter(function(key) {
+      return key === prop.toUpperCase();
+    }).length > 0
+  );
+}
+function hasPropertyLowerCase(obj, prop) {
+  return (
+    Object.keys(obj).filter(function(key) {
+      return key === prop.toLowerCase();
+    }).length > 0
+  );
+}
+function hasPropertyUpperCaseFirstLetter(obj, prop) {
+  return (
+    Object.keys(obj).filter(function(key) {
+      return (
+        key ===
+        prop.toLowerCase().replace(prop.charAt(0), prop.charAt(0).toUpperCase())
+      );
+    }).length > 0
+  );
+}
+
 // private method split into function to make it recursive
 TerriaJsonCatalogFunction.prototype._handleHttp202 = function(xhr) {
-    //  A HTTP 202 response to try and get the data from polling acceptedUrl 
-    //    after a delay of acceptedDelay || 10 seconds
+  //  A HTTP 202 response to try and get the data from polling acceptedUrl
+  //    after a delay of acceptedDelay || 10 seconds
 
-    // If MisconfiguredError manages to be called, then acceptedUrl should have been defined
-    var MisconfiguredError = function(xhr,catalogFunction){
-        if (catalogFunction.acceptedUrl === undefined || catalogFunction.acceptedUrl === "") {
-            return new TerriaError({
-                sender: catalogFunction,
-                title: "Misconfigured init file",
-                message: "Service not configured for TerriaJsonCatalogFunction HTTP 202."
-            });
-        }
-        return new TerriaError({
-            sender: catalogFunction,
-            title: "Misconfigured init file",
-            message: "HTTP 202 configuration "+catalogFunction.acceptedUrl+" not present in response "+JSON.stringify(xhr)
-        });
-    };
-    // acceptedUrl = undefined as off by default
-    if (this.acceptedUrl !== undefined && xhr.status !== undefined && xhr.status === 202) {
-      if (typeof this.acceptedUrl !== "string") {
-          throw MisconfiguredError(xhr,this);
-      }
-     
-      // JSON-ify the body here, used Resorce.fetch, so body must be text
-      if (xhr.response !== undefined && typeof xhr.response === "string" &&
-          xhr.response !== "") {
-          try {
-              xhr.response = JSON.parse(xhr.response);
-          } catch {
-              // add support for 202 bodies that are not json here if desired
-              // this is not an error condition as xhr.response might be legitimately
-              // empty and the desired information could be in the headers.
-              // JSON.parse(null), JSON.parse(undefined) or JSON.parse("")
-              // cause syntax errors
-          }
-      }
-      var newResourceOpts = {
-        url: "",
-        responseType: "text",
-        headers: {
-          Accept: "application/json,*/*;q=0.01"
-        },
-        returnType: "XHRJSONHEADERS"
-      };
-      // ability to handle Accepted URL locations like first.second
-      // or Headers.location or Body.prop1.prop2.whatever.etc
-      var iteratorXhr = xhr;
-      var referenceIterator = this.acceptedUrl.split('.');
-      var iteratorCurrent;
-      for (iteratorCurrent of referenceIterator) {
-        if (!iteratorXhr.hasOwnProperty(iteratorCurrent)) {
-            throw MisconfiguredError(xhr,this);
-        }
-        iteratorXhr = iteratorXhr[iteratorCurrent];
-      }
-      newResourceOpts.url = proxyCatalogItemUrl(this, iteratorXhr, "1d");
-
-      // waitms is a function because i think it is a little easier to read
-      var waitms = function(inputs) {
-        return new Promise((resolve => {
-          setTimeout (() => {
-            resolve(inputs.callback(inputs.terria));
-          }, inputs.delay);
-        }));
-      };
-      // prefer not to copy terria object as this will recursively consume 
-      // stack memory, unless terria is defined as a reference of an object 
-      // where the reference is passed by value
-      var that = new Proxy(this, {});
-      // wait for acceptedDelay before polling 202 link specified by 
-      // 202 reponse and acceptedUrl
-      return waitms({
-        delay: this.acceptedDelay,
-        terria: that,
-        callback: function(terria) {
-          return Resource.fetchXHR(newResourceOpts).then(
-            xhr => terria._handleHttp202(xhr)
-          );}
+  // If MisconfiguredError manages to be called, then acceptedUrl should have been defined
+  var MisconfiguredError = function(xhr, catalogFunction) {
+    if (
+      catalogFunction.acceptedUrl === undefined ||
+      catalogFunction.acceptedUrl === ""
+    ) {
+      return new TerriaError({
+        sender: catalogFunction,
+        title: "Misconfigured init file",
+        message:
+          "Service not configured for TerriaJsonCatalogFunction HTTP 202."
       });
-    } else {
-      // shold now have the promised JSON
-      // goes straight here if JSON was returned first with status 200
-      // or if off by acceptedUrl = undefined default
-      if (xhr.status !== undefined && xhr.status >= 200 && xhr.status < 300) {
-        if (xhr.status === 204) {return {};}
-        try {
-          return JSON.parse(xhr.response);
-        }
-        catch(err) {
-          throw new TerriaError({
-            sender: this,
-            title: "Service response not JSON string",
-            message: "TerriaJsonCatalogFunction was supposed to receive a JSON string, received " + JSON.stringify(xhr)
-          });
-        }
-      } else {
-          throw new TerriaError({
-              sender: this,
-              title: "Request Failed",
-              message: "Request failed with status code "+ xhr.status + "."
-          });
+    }
+    return new TerriaError({
+      sender: catalogFunction,
+      title: "Misconfigured init file",
+      message:
+        "HTTP 202 configuration " +
+        catalogFunction.acceptedUrl +
+        " not present in response " +
+        JSON.stringify(xhr)
+    });
+  };
+  // acceptedUrl = undefined as off by default
+  if (
+    this.acceptedUrl !== undefined &&
+    xhr.status !== undefined &&
+    xhr.status === 202
+  ) {
+    if (typeof this.acceptedUrl !== "string") {
+      throw MisconfiguredError(xhr, this);
+    }
+
+    // JSON-ify the body here, used Resorce.fetch, so body must be text
+    if (
+      xhr.response !== undefined &&
+      typeof xhr.response === "string" &&
+      xhr.response !== ""
+    ) {
+      try {
+        xhr.response = JSON.parse(xhr.response);
+      } catch {
+        // add support for 202 bodies that are not json here if desired
+        // this is not an error condition as xhr.response might be legitimately
+        // empty and the desired information could be in the headers.
+        // JSON.parse(null), JSON.parse(undefined) or JSON.parse("")
+        // cause syntax errors
       }
     }
+    var newResourceOpts = {
+      url: "",
+      responseType: "text",
+      headers: {
+        Accept: "application/json,*/*;q=0.01"
+      },
+      returnType: "XHRJSONHEADERS"
+    };
+    // ability to handle Accepted URL locations like first.second
+    // or Headers.location or Body.prop1.prop2.whatever.etc
+    // header fields having lower or upper case first letters seems to be
+    // operating systems dependant
+    // Windows/Firefox headers have first letters uppercase
+    // (Linux/Andriod)/(Firefox/Chrome) headers have first letters lowercase
+    // headers are case insensitive.
+    var iteratorXhr = xhr;
+    var referenceIterator = this.acceptedUrl.split(".");
+    var iteratorCurrent;
+    for (iteratorCurrent of referenceIterator) {
+      var iteratorCaseMatched = iteratorCurrent;
+      if (hasPropertyUpperCase(iteratorXhr, iteratorCurrent)) {
+        iteratorCaseMatched = iteratorCaseMatched.toUpperCase();
+      } else if (hasPropertyLowerCase(iteratorXhr, iteratorCurrent)) {
+        iteratorCaseMatched = iteratorCaseMatched.toLowerCase();
+      } else if (
+        hasPropertyUpperCaseFirstLetter(iteratorXhr, iteratorCurrent)
+      ) {
+        iteratorCaseMatched = iteratorCaseMatched
+          .toLowerCase()
+          .replace(
+            iteratorCaseMatched.charAt(0),
+            iteratorCaseMatched.charAt(0).toUpperCase()
+          );
+      }
+      //if attemtps to match case unsuccessful, declare as misconigured
+      if (!iteratorXhr.hasOwnProperty(iteratorCaseMatched)) {
+        throw MisconfiguredError(xhr, this);
+      }
+      iteratorXhr = iteratorXhr[iteratorCaseMatched];
+    }
+    newResourceOpts.url = proxyCatalogItemUrl(this, iteratorXhr, "1d");
+
+    // waitms is a function because i think it is a little easier to read
+    var waitms = function(inputs) {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve(inputs.callback(inputs.terria));
+        }, inputs.delay);
+      });
+    };
+    // prefer not to copy terria object as this will recursively consume
+    // stack memory, unless terria is defined as a reference of an object
+    // where the reference is passed by value
+    var that = new Proxy(this, {});
+    // wait for acceptedDelay before polling 202 link specified by
+    // 202 reponse and acceptedUrl
+    return waitms({
+      delay: this.acceptedDelay,
+      terria: that,
+      callback: function(terria) {
+        return Resource.fetchXHR(newResourceOpts).then(xhr =>
+          terria._handleHttp202(xhr)
+        );
+      }
+    });
+  } else {
+    // shold now have the promised JSON
+    // goes straight here if JSON was returned first with status 200
+    // or if off by acceptedUrl = undefined default
+    if (xhr.status !== undefined && xhr.status >= 200 && xhr.status < 300) {
+      if (xhr.status === 204) {
+        return {};
+      }
+      try {
+        return JSON.parse(xhr.response);
+      } catch (err) {
+        throw new TerriaError({
+          sender: this,
+          title: "Service response not JSON string",
+          message:
+            "TerriaJsonCatalogFunction was supposed to receive a JSON string, received " +
+            JSON.stringify(xhr)
+        });
+      }
+    } else {
+      throw new TerriaError({
+        sender: this,
+        title: "Request Failed",
+        message: "Request failed with status code " + xhr.status + "."
+      });
+    }
+  }
 };
 
 module.exports = TerriaJsonCatalogFunction;

--- a/lib/Models/TerriaJsonCatalogFunction.js
+++ b/lib/Models/TerriaJsonCatalogFunction.js
@@ -15,6 +15,7 @@ var ResultPendingCatalogItem = require("./ResultPendingCatalogItem");
 var sprintf = require("terriajs-cesium/Source/ThirdParty/sprintf");
 var URI = require("urijs");
 var Resource = require("terriajs-cesium/Source/Core/Resource");
+var TerriaError = require("../Core/TerriaError");
 
 /**
  * A {@link CatalogFunction} that issues an HTTP GET to a service with a set of query parameters specified by the
@@ -499,10 +500,11 @@ TerriaJsonCatalogFunction.prototype._handleHttp202 = function(all) {
     // and it does not have a status property
       if (this.acceptedUrl === undefined || 
         typeof this.acceptedUrl !== "string") {
-          console.log("fill in the init file");
-          return {};
-          // replace this with a proper error return
-          // service not configured for TerriaJsonCatalogFunction HTTP 202
+          throw new TerriaError({
+            sender: this,
+            title: "Misconfigured init file",
+            message: "Service not configured for TerriaJsonCatalogFunction HTTP 202."
+          });
       }
      
       // JSON-ify the body here, used Resorce.fetch, so body must be text
@@ -517,7 +519,6 @@ TerriaJsonCatalogFunction.prototype._handleHttp202 = function(all) {
         // add support for 202 bodies that are not json here if desired
         // not returning here because acceptedUrl might not reference Body
         // and this is not an error condition
-        all.response = {};
       }
       var newResourceOpts = {
         url: "",
@@ -566,23 +567,22 @@ TerriaJsonCatalogFunction.prototype._handleHttp202 = function(all) {
           );}
       });
     } else {
-      var json;
       // shold now have the promised JSON
+      // goes straight here if JSON was returned first
       if (all.status !== undefined && all.status === 200) {
-        json = JSON.parse(all.response);
-        if (typeof json === "object") {
-            return json; 
-        } else {
-          console.log("request failed");
-          console.log("typeof all is " + typeof(all));
-          console.log(all);
-          return {};
-          // replace this with a proper error return
-          // "TerriaJsonCatalogFunction was supposed to receive JSON, received "
-          // + all;
+        try {
+          return JSON.parse(all.response);
+        }
+        catch(err) {
+          throw new TerriaError({
+            sender: this,
+            title: "Service response not JSON string",
+            message: "TerriaJsonCatalogFunction was supposed to receive a JSON string, received " + all.toString()
+          });
         }
       } else {
-        //maybe f you get a HTTP 204
+        // maybe if you get a HTTP 204
+        // not an error
         console.log("got HTTP status "+all.status.toString());
         return {};
       }

--- a/lib/Models/TerriaJsonCatalogFunction.js
+++ b/lib/Models/TerriaJsonCatalogFunction.js
@@ -211,10 +211,11 @@ function TerriaJsonCatalogFunction(terria) {
    * }
    * acceptedUrl can be specified as response.prop1.prop3
    * If you were to supply a 202 response with the url as plain text in the 
-   * response body, acceptedUrl can be specified as response (i think)
+   * response body, acceptedUrl can be specified as response
    * If you were to supply a 202 response with the url as a property of some 
    * other mime type/format, eg. XML, YAML
    * This is open source software, add the code yourself.
+   * Leave undefined for new functionality to be off by default
    * @type {String}
    */
   this.acceptedUrl = undefined;
@@ -223,6 +224,7 @@ function TerriaJsonCatalogFunction(terria) {
    * Gets or sets the time in milliseconds to wait before polling a 
    * HTTP 202 response acceptedUrl
    * default 10 seconds
+   * is unused if acceptUrl is not defined
    * @type {Number}
    */
   this.acceptedDelay = 10000;
@@ -233,7 +235,7 @@ function TerriaJsonCatalogFunction(terria) {
    */
   this.inputs = [];
 
-  knockout.track(this, ["url", "acceptedUrl", "aceptedDelay", "inputs"]);
+  knockout.track(this, ["url", "inputs"]);
 }
 
 inherit(CatalogFunction, TerriaJsonCatalogFunction);
@@ -425,7 +427,7 @@ TerriaJsonCatalogFunction.prototype.invoke = function() {
         Accept: "application/json,*/*;q=0.01"
       },
       returnType: "XHRJSONHEADERS"
-    }).then(all => this._handleHttp202(all)).then(json => {
+    }).then(xhr => this._handleHttp202(xhr)).then(json => {
     asyncResult.isEnabled = false;
 
     // JSON response may be:
@@ -492,33 +494,43 @@ TerriaJsonCatalogFunction.prototype.invoke = function() {
 };
 
 // private method split into function to make it recursive
-TerriaJsonCatalogFunction.prototype._handleHttp202 = function(all) {
+TerriaJsonCatalogFunction.prototype._handleHttp202 = function(xhr) {
     //  A HTTP 202 response to try and get the data from polling acceptedUrl 
     //    after a delay of acceptedDelay || 10 seconds
-    if (all.status !== undefined && all.status === 202) {
-    // else not a 202 response, all is text from Resource.fetch
-    // and it does not have a status property
-      if (this.acceptedUrl === undefined || 
-        typeof this.acceptedUrl !== "string") {
-          throw new TerriaError({
-            sender: this,
+
+    // If MisconfiguredError manages to be called, then acceptedUrl should have been defined
+    var MisconfiguredError = function(xhr,catalogFunction){
+        if (catalogFunction.acceptedUrl === undefined || catalogFunction.acceptedUrl === "") {
+            return new TerriaError({
+                sender: catalogFunction,
+                title: "Misconfigured init file",
+                message: "Service not configured for TerriaJsonCatalogFunction HTTP 202."
+            });
+        }
+        return new TerriaError({
+            sender: catalogFunction,
             title: "Misconfigured init file",
-            message: "Service not configured for TerriaJsonCatalogFunction HTTP 202."
-          });
+            message: "HTTP 202 configuration "+catalogFunction.acceptedUrl+" not present in response "+JSON.stringify(xhr)
+        });
+    };
+    // acceptedUrl = undefined as off by default
+    if (this.acceptedUrl !== undefined && xhr.status !== undefined && xhr.status === 202) {
+      if (typeof this.acceptedUrl !== "string") {
+          throw MisconfiguredError(xhr,this);
       }
      
       // JSON-ify the body here, used Resorce.fetch, so body must be text
-      var jsonBody;
-      if (all.response !== undefined && typeof all.response === "string" &&
-          all.response !== "") {
-          jsonBody = JSON.parse(all.response);
-      }
-      if (typeof jsonBody === "object") {
-          all.response = jsonBody;
-      } else {
-        // add support for 202 bodies that are not json here if desired
-        // not returning here because acceptedUrl might not reference Body
-        // and this is not an error condition
+      if (xhr.response !== undefined && typeof xhr.response === "string" &&
+          xhr.response !== "") {
+          try {
+              xhr.response = JSON.parse(xhr.response);
+          } catch {
+              // add support for 202 bodies that are not json here if desired
+              // this is not an error condition as xhr.response might be legitimately
+              // empty and the desired information could be in the headers.
+              // JSON.parse(null), JSON.parse(undefined) or JSON.parse("")
+              // cause syntax errors
+          }
       }
       var newResourceOpts = {
         url: "",
@@ -530,19 +542,16 @@ TerriaJsonCatalogFunction.prototype._handleHttp202 = function(all) {
       };
       // ability to handle Accepted URL locations like first.second
       // or Headers.location or Body.prop1.prop2.whatever.etc
-      // cant be a static input and 
-      // needs to be called to re-initialise the first next value,
-      var referenceIterator = this.acceptedUrl.split('.')[Symbol.iterator]();
-      var iteratorCurrent = referenceIterator.next().value;
-      // want to copy the all object because the copy will get modified
-      var iteratorAll = all;
-      while (iteratorCurrent !== undefined) {
-        iteratorAll = iteratorAll[iteratorCurrent];
-        iteratorCurrent = referenceIterator.next().value;
+      var iteratorXhr = xhr;
+      var referenceIterator = this.acceptedUrl.split('.');
+      var iteratorCurrent;
+      for (iteratorCurrent of referenceIterator) {
+        if (!iteratorXhr.hasOwnProperty(iteratorCurrent)) {
+            throw MisconfiguredError(xhr,this);
+        }
+        iteratorXhr = iteratorXhr[iteratorCurrent];
       }
-      // is proxying this a good idea?
-      // newResourceOpts.url = iteratorAll;
-      newResourceOpts.url = proxyCatalogItemUrl(this, iteratorAll, "1d");
+      newResourceOpts.url = proxyCatalogItemUrl(this, iteratorXhr, "1d");
 
       // waitms is a function because i think it is a little easier to read
       var waitms = function(inputs) {
@@ -563,28 +572,31 @@ TerriaJsonCatalogFunction.prototype._handleHttp202 = function(all) {
         terria: that,
         callback: function(terria) {
           return Resource.fetchXHR(newResourceOpts).then(
-            all => terria._handleHttp202(all)
+            xhr => terria._handleHttp202(xhr)
           );}
       });
     } else {
       // shold now have the promised JSON
-      // goes straight here if JSON was returned first
-      if (all.status !== undefined && all.status === 200) {
+      // goes straight here if JSON was returned first with status 200
+      // or if off by acceptedUrl = undefined default
+      if (xhr.status !== undefined && xhr.status >= 200 && xhr.status < 300) {
+        if (xhr.status === 204) {return {};}
         try {
-          return JSON.parse(all.response);
+          return JSON.parse(xhr.response);
         }
         catch(err) {
           throw new TerriaError({
             sender: this,
             title: "Service response not JSON string",
-            message: "TerriaJsonCatalogFunction was supposed to receive a JSON string, received " + all.toString()
+            message: "TerriaJsonCatalogFunction was supposed to receive a JSON string, received " + JSON.stringify(xhr)
           });
         }
       } else {
-        // maybe if you get a HTTP 204
-        // not an error
-        console.log("got HTTP status "+all.status.toString());
-        return {};
+          throw new TerriaError({
+              sender: this,
+              title: "Request Failed",
+              message: "Request failed with status code "+ xhr.status + "."
+          });
       }
     }
 };

--- a/lib/Models/TerriaJsonCatalogFunction.js
+++ b/lib/Models/TerriaJsonCatalogFunction.js
@@ -10,11 +10,11 @@ var defineProperties = require("terriajs-cesium/Source/Core/defineProperties");
 var freezeObject = require("terriajs-cesium/Source/Core/freezeObject");
 var inherit = require("../Core/inherit");
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout");
-var loadJson = require("../Core/loadJson");
 var proxyCatalogItemUrl = require("./proxyCatalogItemUrl");
 var ResultPendingCatalogItem = require("./ResultPendingCatalogItem");
 var sprintf = require("terriajs-cesium/Source/ThirdParty/sprintf");
 var URI = require("urijs");
+var Resource = require("terriajs-cesium/Source/Core/Resource");
 
 /**
  * A {@link CatalogFunction} that issues an HTTP GET to a service with a set of query parameters specified by the
@@ -185,13 +185,54 @@ function TerriaJsonCatalogFunction(terria) {
    */
   this.url = undefined;
 
+  /*
+   * Gets or sets the part of a HTTP 202 response to poll again for content.
+   * A HTTP 202 response is returned as an object with 
+   * {
+   *   status: 202
+   *   headers: responseHeaders
+   *   respone: responseBody
+   * }
+   * where
+   * responseHeaders is an object with key-value pairs of all HTTP response 
+   * 	headers
+   * responseBody is the unaltered XMLHttpRequest.response
+   * If you were to supply a 202 response with the url as a location header,
+   * acceptedUrl can be specified as "headers.location" to poll it again
+   * after acceptedDelay
+   * If you were to supply a 202 response with the url as a property of a
+   * JSON object in the response body, for example
+   * {
+   *   prop1: {
+   *     prop2: "something",
+   *     prop3: url
+   *   }
+   * }
+   * acceptedUrl can be specified as response.prop1.prop3
+   * If you were to supply a 202 response with the url as plain text in the 
+   * response body, acceptedUrl can be specified as response (i think)
+   * If you were to supply a 202 response with the url as a property of some 
+   * other mime type/format, eg. XML, YAML
+   * This is open source software, add the code yourself.
+   * @type {String}
+   */
+  this.acceptedUrl = undefined;
+
+  /*
+   * Gets or sets the time in milliseconds to wait before polling a 
+   * HTTP 202 response acceptedUrl
+   * default 10 seconds
+   * @type {Number}
+   */
+  this.acceptedDelay = 10000;
+
   /**
    * Gets or sets the input parameters to the service.
    * @type {FunctionParameter[]}
    */
   this.inputs = [];
 
-  knockout.track(this, ["url", "inputs"]);
+  knockout.track(this, ["url", "acceptedUrl", "aceptedDelay", "inputs"]);
 }
 
 inherit(CatalogFunction, TerriaJsonCatalogFunction);
@@ -208,7 +249,7 @@ defineProperties(TerriaJsonCatalogFunction.prototype, {
     }
   },
 
-  /**
+  /**acceptedUrl
    * Gets a human-readable name for this type of data source, 'Terria JSON Catalog Function'.
    * @memberOf TerriaJSONCatalogFunction.prototype
    * @type {String}
@@ -374,11 +415,16 @@ TerriaJsonCatalogFunction.prototype.invoke = function() {
 
     queryParameters[parameter.id] = parameter.formatForService();
   });
-
   const uri = new URI(this.url).addQuery(queryParameters);
   const proxiedUrl = proxyCatalogItemUrl(this, uri.toString(), "1d");
-
-  const promise = loadJson(proxiedUrl).then(json => {
+  const promise = Resource.fetchXHR({
+      url: proxiedUrl,
+      responseType: "text",
+      headers: {
+        Accept: "application/json,*/*;q=0.01"
+      },
+      returnType: "XHRJSONHEADERS"
+    }).then(all => this._handleHttp202(all)).then(json => {
     asyncResult.isEnabled = false;
 
     // JSON response may be:
@@ -386,6 +432,7 @@ TerriaJsonCatalogFunction.prototype.invoke = function() {
     // 2. An array of catalog members; they'll all be added to the workbench.
     // 3. A TerriaJS init source (catalog file); it will be merged into the catalogue.
     // 4. A TerriaJS "share data" object, which may contain multiple init sources.
+
     if (json.version && json.initSources) {
       // Case #4
       return this.terria.updateFromStartData(json);
@@ -441,6 +488,105 @@ TerriaJsonCatalogFunction.prototype.invoke = function() {
   asyncResult.isEnabled = true;
 
   return promise;
+};
+
+// private method split into function to make it recursive
+TerriaJsonCatalogFunction.prototype._handleHttp202 = function(all) {
+    //  A HTTP 202 response to try and get the data from polling acceptedUrl 
+    //    after a delay of acceptedDelay || 10 seconds
+    if (all.status !== undefined && all.status === 202) {
+    // else not a 202 response, all is text from Resource.fetch
+    // and it does not have a status property
+      if (this.acceptedUrl === undefined || 
+        typeof this.acceptedUrl !== "string") {
+          console.log("fill in the init file");
+          return {};
+          // replace this with a proper error return
+          // service not configured for TerriaJsonCatalogFunction HTTP 202
+      }
+     
+      // JSON-ify the body here, used Resorce.fetch, so body must be text
+      var jsonBody;
+      if (all.response !== undefined && typeof all.response === "string" &&
+          all.response !== "") {
+          jsonBody = JSON.parse(all.response);
+      }
+      if (typeof jsonBody === "object") {
+          all.response = jsonBody;
+      } else {
+        // add support for 202 bodies that are not json here if desired
+        // not returning here because acceptedUrl might not reference Body
+        // and this is not an error condition
+        all.response = {};
+      }
+      var newResourceOpts = {
+        url: "",
+        responseType: "text",
+        headers: {
+          Accept: "application/json,*/*;q=0.01"
+        },
+        returnType: "XHRJSONHEADERS"
+      };
+      // ability to handle Accepted URL locations like first.second
+      // or Headers.location or Body.prop1.prop2.whatever.etc
+      // cant be a static input and 
+      // needs to be called to re-initialise the first next value,
+      var referenceIterator = this.acceptedUrl.split('.')[Symbol.iterator]();
+      var iteratorCurrent = referenceIterator.next().value;
+      // want to copy the all object because the copy will get modified
+      var iteratorAll = all;
+      while (iteratorCurrent !== undefined) {
+        iteratorAll = iteratorAll[iteratorCurrent];
+        iteratorCurrent = referenceIterator.next().value;
+      }
+      // is proxying this a good idea?
+      // newResourceOpts.url = iteratorAll;
+      newResourceOpts.url = proxyCatalogItemUrl(this, iteratorAll, "1d");
+
+      // waitms is a function because i think it is a little easier to read
+      var waitms = function(inputs) {
+        return new Promise((resolve => {
+          setTimeout (() => {
+            resolve(inputs.callback(inputs.terria));
+          }, inputs.delay);
+        }));
+      };
+      // prefer not to copy terria object as this will recursively consume 
+      // stack memory, unless terria is defined as a reference of an object 
+      // where the reference is passed by value
+      var that = new Proxy(this, {});
+      // wait for acceptedDelay before polling 202 link specified by 
+      // 202 reponse and acceptedUrl
+      return waitms({
+        delay: this.acceptedDelay,
+        terria: that,
+        callback: function(terria) {
+          return Resource.fetchXHR(newResourceOpts).then(
+            all => terria._handleHttp202(all)
+          );}
+      });
+    } else {
+      var json;
+      // shold now have the promised JSON
+      if (all.status !== undefined && all.status === 200) {
+        json = JSON.parse(all.response);
+        if (typeof json === "object") {
+            return json; 
+        } else {
+          console.log("request failed");
+          console.log("typeof all is " + typeof(all));
+          console.log(all);
+          return {};
+          // replace this with a proper error return
+          // "TerriaJsonCatalogFunction was supposed to receive JSON, received "
+          // + all;
+        }
+      } else {
+        //maybe f you get a HTTP 204
+        console.log("got HTTP status "+all.status.toString());
+        return {};
+      }
+    }
 };
 
 module.exports = TerriaJsonCatalogFunction;


### PR DESCRIPTION
based off the feedback from the last attempt at integrating longer requests, the headers and status need to be passed back to be handled in the catalog function.
if the function receives JSON instead of a 202:Accepted, the new behavior returns the JSON immediately