### PR TITLE
Replace stale reference to userAddedDataGroup.items with .members.

### DIFF
--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.jsx
@@ -304,7 +304,7 @@ const SharePanel = observer(
               .
             </p>
             <ul className={Styles.paragraph}>
-              {this.props.terria.catalog.userAddedDataGroup.items.map(
+              {this.props.terria.catalog.userAddedDataGroup.members.map(
                 (item, i) => {
                   return (
                     <li key={i}>


### PR DESCRIPTION
Fixes #3602.