### PR TITLE
Add the linkedWcsCoverage when adding a WebMapServiceCatalogGroup item

### DIFF
--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -1289,6 +1289,10 @@ WebMapServiceCatalogItem.prototype._load = function() {
                       that.tokenParameterName,
                       that._lastToken
                     );
+
+                    if (that.linkedWcsUrl && that.linkedWcsCoverage === "") {
+                      that.linkedWcsCoverage = LayerDescription.Query.typeName;
+                    }
                     that.dataUrlType = "wcs-complete";
                   } else {
                     that.dataUrl = addToken(


### PR DESCRIPTION
When adding a `WebMapServiceCatalogGroup` you can't define the associated `linkedWcsCoverage` parameter on the associated `WebMapServiceCatalogItem`'s. This means that WCS downloads don't work.

````
   {
      "name": "Geoscience Australia Marine Data",
      "type": "wms-getCapabilities",
      "url": "http://marine.ga.gov.au/geoserver/marine/wms",
      "itemProperties": {
        "linkedWcsUrl": "http://marine.ga.gov.au/geoserver/marine/wcs"
      }
   }
````

This PR specifies the `linkedWcsCoverage` name on the associated items.

I've tested backward compatibility against this existing item in nationalmap and it doesn't appear to have any detrimental impacts
````
    {
      "id": "78492595",
      "name": "Landsat 5 satellite images",
      "url": "https://gsky.nci.org.au/ows/dea",
      "layers": "landsat5_nbart_daily",
      "linkedWcsUrl": "https://gsky.nci.org.au/ows/dea",
      "linkedWcsCoverage": "landsat5_nbart_daily",
      "type": "wms",
      "styles": "tc",
      "ignoreUnknownTileErrors": true,
      "useOwnClock": true,
      "opacity": 1,
      "shareKeys": [
        "eb9339e1"
      ]
    },
````
