### PR TITLE
SDMX 2.0 fixes 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### v7.6.10
+
+* Resolve a bug with `SdmxJsonCatalogItem`'s v2.0 where they were being redrawn when dimensions we're changed.
+
 ### v7.6.9
 
 * Automatically set `linkedWcsCoverage` on a WebMapServiceCatalogItem.

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -1825,7 +1825,8 @@ function loadAndBuildTable(item, dimensionRequestString) {
     .then(function(regionDetails) {
       if (regionDetails) {
         item._regionMapping.setRegionColumnType();
-        item._regionMapping.enable();
+        if (item.sdmxVersionNumber === 2.1 && !item._regionMapping.enabled)
+          item._regionMapping.enable();
         // Force a recalc of the imagery.
         // Required because we load the region details _after_ setting the active column.
         item._regionMapping.isLoading = false;


### PR DESCRIPTION
Resolves #3659 by preventing the double-enabling of items.