### PR TITLE
Don't encode unique ID on WMS groups

### DIFF
--- a/lib/Models/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/WebMapServiceCatalogGroup.ts
@@ -59,7 +59,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
           return undefined;
         }
         return (
-          this.catalogGroup.uniqueId + "/" + encodeURIComponent(layer.Name)
+          this.catalogGroup.uniqueId + "/" + layer.Name
         );
       })
     );
@@ -104,7 +104,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
     }
 
     const id = this.catalogGroup.uniqueId;
-    const layerId = id + "/" + encodeURIComponent(layer.Name);
+    const layerId = id + "/" + layer.Name;
     const existingModel = this.catalogGroup.terria.getModelById(
       WebMapServiceCatalogItem,
       layerId


### PR DESCRIPTION
UniqueID should leave encoding/decoding to the consumer, the base
unique ID isn't encoded, so if we don't change this, we end up
with a mix of non-encoded and encoded parts in a given ID