### PR TITLE
Fix for catalog tab sharing

### DIFF
--- a/lib/ReactViewModels/ViewState.js
+++ b/lib/ReactViewModels/ViewState.js
@@ -308,8 +308,13 @@ export default class ViewState {
       this.previewedItem = catalogMember;
       this.openAddData();
       if (this.terria.configParameters.tabbedCatalog) {
-        // Go to specific tab
-        this.activeTabIdInCategory = getAncestors(catalogMember)[0].name;
+        const ancestors = getAncestors(catalogMember);
+        if (ancestors.length === 0) {
+          this.activeTabIdInCategory = catalogMember.name;
+        } else {
+          // Go to specific tab
+          this.activeTabIdInCategory = ancestors[0].name;
+        }
       }
     }
   }


### PR DESCRIPTION
See issue description in #3614

This fix checks for the numbers of ancestors found, rather than assuming they will be found. If no ancestors are found set the active tab to the current catalog member.

Resolves #3614