### PR TITLE
Support coords crossing anti-meridian in 2D mode with geojson

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,21 +1,19 @@
 Change Log
 ==========
 
-### v7.6.11
-
-* Improve support for leaflet rendered across the anti-meridian.
 ### Next Release
 
-* Add quality slider for 3d map (toggles Cesium's maximumScreenSpaceError & resolutionScale)
-* Allow MapboxMapCatalogItems to be specified in catalog files using type "mapbox-map".
+* Added quality slider for 3d map (toggles Cesium's maximumScreenSpaceError & resolutionScale)
+* Allowed MapboxMapCatalogItems to be specified in catalog files using type "mapbox-map".
 * Chart related enhancements
-  * Add momentPoints chart type to plot points along an available line chart
-  * Add zooming and panning on chart panel
-  * Various preventative fixes to prevent chart crashes
+  * Added momentPoints chart type to plot points along an available line chart.
+  * Added zooming and panning on chart panel.
+  * Various preventative fixes to prevent chart crashes.
 * Increased the tolerance for intermittent tile failures from time-varying raster layers. More failures will now be allowed before the layer is disabled.
   * Add zooming on chart panel
   * Various preventative fixes to prevent charge crashes
-* Fix a bug where differences in available dates for `ImageryLayerCatalogItem` from original list of dates vs a new list of dates, would cause a error.
+* Fixed a bug where differences in available dates for `ImageryLayerCatalogItem` from original list of dates vs a new list of dates, would cause a error.
+* Improved support for layers rendered across the anti-meridian in 2D (Leaflet).
 
 ### v7.6.11
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### v7.6.11
+
+* Improve support for leaflet rendered across the anti-meridian.
+
 ### v7.6.10
 
 * Fixed error when opening a URL shared from an explorer tab. #3614

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -512,9 +512,11 @@ function hierarchyToLatLngs(hierarchy) {
   let lastLongitude = null;
   for (var i = 0; i < carts.length; ++i) {
     let lon = CesiumMath.toDegrees(carts[i].longitude);
-    // some anti-merdian swapping going on
+
     if (lastLongitude - lon > 180) {
       lon = lon + 360;
+    } else if (lastLongitude - lon < -180) {
+      lon = lon - 360;
     }
     latlngs.push(L.latLng(CesiumMath.toDegrees(carts[i].latitude), lon));
     lastLongitude = lon;

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -243,15 +243,22 @@ LeafletGeomVisualizer.prototype.getLatLngBounds = function() {
 
 var cartographicScratch = new Cartographic();
 
-function positionToLatLng(position) {
+function positionToLatLng(position, prevLayer) {
   var cartographic = Ellipsoid.WGS84.cartesianToCartographic(
     position,
     cartographicScratch
   );
-  return L.latLng(
-    CesiumMath.toDegrees(cartographic.latitude),
-    CesiumMath.toDegrees(cartographic.longitude)
-  );
+
+  let lon = CesiumMath.toDegrees(cartographic.longitude);
+  if (prevLayer) {
+    if (prevLayer._latlng.lng - lon > 180) {
+      lon = lon + 360;
+    } else if (prevLayer._latlng.lng - lon < -180) {
+      lon = lon - 360;
+    }
+  }
+
+  return L.latLng(CesiumMath.toDegrees(cartographic.latitude), lon);
 }
 
 LeafletGeomVisualizer.prototype._updatePoint = function(
@@ -322,8 +329,13 @@ LeafletGeomVisualizer.prototype._updatePoint = function(
       opacity: outlineColor.alpha
     };
 
+    let lastPoint = null;
+    featureGroup.eachLayer(function(layer) {
+      lastPoint = layer;
+    });
+
     layer = details.layer = L.circleMarker(
-      positionToLatLng(position),
+      positionToLatLng(position, lastPoint),
       pointOptions
     );
     layer.on("click", featureClicked.bind(undefined, this, entity));
@@ -340,7 +352,7 @@ LeafletGeomVisualizer.prototype._updatePoint = function(
   }
 
   if (!Cartesian3.equals(position, details.lastPosition)) {
-    layer.setLatLng(positionToLatLng(position));
+    layer.setLatLng(positionToLatLng(position, lastPoint));
     Cartesian3.clone(position, details.lastPosition);
   }
 

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -446,17 +446,10 @@ LeafletGeomVisualizer.prototype._updatePolygon = function(
       opacity: outlineColor.alpha
     };
 
-    // By default we use cesium entities to generate coords for our cesium map
-    // where this falls down is that Cesium Entities are transformed at the anti-meridian
-    // in which case we ought to use the raw geojson.
-    if (entity.origGeoJson) {
-      layer = details.layer = L.geoJSON(entity.origGeoJson, polygonOptions);
-    } else {
-      layer = details.layer = L.polygon(
-        hierarchyToLatLngs(hierarchy),
-        polygonOptions
-      );
-    }
+    layer = details.layer = L.polygon(
+      hierarchyToLatLngs(hierarchy),
+      polygonOptions
+    );
 
     layer.on("click", featureClicked.bind(undefined, this, entity));
     layer.on("mousedown", featureMousedown.bind(undefined, this, entity));
@@ -471,7 +464,7 @@ LeafletGeomVisualizer.prototype._updatePolygon = function(
     return;
   }
 
-  if (!entity.origGeoJson && hierarchy !== details.lastHierachy) {
+  if (hierarchy !== details.lastHierachy) {
     layer.setLatLngs(hierarchyToLatLngs(hierarchy));
     details.lastHierachy = hierarchy;
   }
@@ -516,13 +509,15 @@ function hierarchyToLatLngs(hierarchy) {
   var positions = Array.isArray(hierarchy) ? hierarchy : hierarchy.positions;
   var carts = Ellipsoid.WGS84.cartesianArrayToCartographicArray(positions);
   var latlngs = [];
+  let lastLongitude = null;
   for (var i = 0; i < carts.length; ++i) {
-    latlngs.push(
-      L.latLng(
-        CesiumMath.toDegrees(carts[i].latitude),
-        CesiumMath.toDegrees(carts[i].longitude)
-      )
-    );
+    let lon = CesiumMath.toDegrees(carts[i].longitude);
+    // some anti-merdian swapping going on
+    if (lastLongitude - lon > 180) {
+      lon = lon + 360;
+    }
+    latlngs.push(L.latLng(CesiumMath.toDegrees(carts[i].latitude), lon));
+    lastLongitude = lon;
   }
 
   return latlngs;

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -446,10 +446,18 @@ LeafletGeomVisualizer.prototype._updatePolygon = function(
       opacity: outlineColor.alpha
     };
 
-    layer = details.layer = L.polygon(
-      hierarchyToLatLngs(hierarchy),
-      polygonOptions
-    );
+    // By default we use cesium entities to generate coords for our cesium map
+    // where this falls down is that Cesium Entities are transformed at the anti-meridian
+    // in which case we ought to use the raw geojson.
+    if (entity.origGeoJson) {
+      layer = details.layer = L.geoJSON(entity.origGeoJson, polygonOptions);
+    } else {
+      layer = details.layer = L.polygon(
+        hierarchyToLatLngs(hierarchy),
+        polygonOptions
+      );
+    }
+
     layer.on("click", featureClicked.bind(undefined, this, entity));
     layer.on("mousedown", featureMousedown.bind(undefined, this, entity));
     featureGroup.addLayer(layer);
@@ -463,7 +471,7 @@ LeafletGeomVisualizer.prototype._updatePolygon = function(
     return;
   }
 
-  if (hierarchy !== details.lastHierachy) {
+  if (!entity.origGeoJson && hierarchy !== details.lastHierachy) {
     layer.setLatLngs(hierarchyToLatLngs(hierarchy));
     details.lastHierachy = hierarchy;
   }

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -318,6 +318,10 @@ LeafletGeomVisualizer.prototype._updatePoint = function(
   );
 
   var layer = details.layer;
+  let lastPoint = null;
+  featureGroup.eachLayer(function(layer) {
+    lastPoint = layer;
+  });
 
   if (!defined(layer)) {
     var pointOptions = {
@@ -328,11 +332,6 @@ LeafletGeomVisualizer.prototype._updatePoint = function(
       weight: outlineWidth,
       opacity: outlineColor.alpha
     };
-
-    let lastPoint = null;
-    featureGroup.eachLayer(function(layer) {
-      lastPoint = layer;
-    });
 
     layer = details.layer = L.circleMarker(
       positionToLatLng(position, lastPoint),

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -507,22 +507,8 @@ function hierarchyToLatLngs(hierarchy) {
   // This function currently does not handle polygons with holes.
 
   var positions = Array.isArray(hierarchy) ? hierarchy : hierarchy.positions;
-  var carts = Ellipsoid.WGS84.cartesianArrayToCartographicArray(positions);
-  var latlngs = [];
-  let lastLongitude = null;
-  for (var i = 0; i < carts.length; ++i) {
-    let lon = CesiumMath.toDegrees(carts[i].longitude);
 
-    if (lastLongitude - lon > 180) {
-      lon = lon + 360;
-    } else if (lastLongitude - lon < -180) {
-      lon = lon - 360;
-    }
-    latlngs.push(L.latLng(CesiumMath.toDegrees(carts[i].latitude), lon));
-    lastLongitude = lon;
-  }
-
-  return latlngs;
+  return convertEntityPositionsToLatLons(positions);
 }
 
 //Recolor an image using 2d canvas
@@ -815,6 +801,25 @@ LeafletGeomVisualizer.prototype._updateLabel = function(
   }
 };
 
+function convertEntityPositionsToLatLons(positions) {
+  var carts = Ellipsoid.WGS84.cartesianArrayToCartographicArray(positions);
+  var latlngs = [];
+  let lastLongitude = null;
+  for (var p = 0; p < carts.length; p++) {
+    let lon = CesiumMath.toDegrees(carts[p].longitude);
+
+    if (lastLongitude - lon > 180) {
+      lon = lon + 360;
+    } else if (lastLongitude - lon < -180) {
+      lon = lon - 360;
+    }
+
+    latlngs.push(L.latLng(CesiumMath.toDegrees(carts[p].latitude), lon));
+    lastLongitude = lon;
+  }
+  return latlngs;
+}
+
 LeafletGeomVisualizer.prototype._updatePolyline = function(
   entity,
   time,
@@ -846,16 +851,7 @@ LeafletGeomVisualizer.prototype._updatePolyline = function(
     return;
   }
 
-  var carts = Ellipsoid.WGS84.cartesianArrayToCartographicArray(positions);
-  var latlngs = [];
-  for (var p = 0; p < carts.length; p++) {
-    latlngs.push(
-      L.latLng(
-        CesiumMath.toDegrees(carts[p].latitude),
-        CesiumMath.toDegrees(carts[p].longitude)
-      )
-    );
-  }
+  const latlngs = convertEntityPositionsToLatLons(positions);
 
   var color;
   var width;

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -510,7 +510,7 @@ function loadGeoJson(geoJsonItem) {
 
     for (var i = 0; i < entities.length; ++i) {
       var entity = entities[i];
-
+      entity.origGeoJson = geoJsonItem._readyData.features[i];
       /* If no marker symbol was provided but Cesium has generated one for a point, then turn it into
                a filled circle instead of the default marker. */
       var properties = entity.properties || {};

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -510,7 +510,14 @@ function loadGeoJson(geoJsonItem) {
 
     for (var i = 0; i < entities.length; ++i) {
       var entity = entities[i];
-      entity.origGeoJson = geoJsonItem._readyData.features[i];
+      if (geoJsonItem._readyData.type === "FeatureCollection")
+        entity.origGeoJson = geoJsonItem._readyData.features[i];
+      else if (
+        geoJsonItem._readyData.type === "Feature" ||
+        geoJsonItem._readyData.type === "Geometry"
+      )
+        entity.origGeoJson = geoJsonItem._readyData;
+
       /* If no marker symbol was provided but Cesium has generated one for a point, then turn it into
                a filled circle instead of the default marker. */
       var properties = entity.properties || {};

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -510,13 +510,6 @@ function loadGeoJson(geoJsonItem) {
 
     for (var i = 0; i < entities.length; ++i) {
       var entity = entities[i];
-      if (geoJsonItem._readyData.type === "FeatureCollection")
-        entity.origGeoJson = geoJsonItem._readyData.features[i];
-      else if (
-        geoJsonItem._readyData.type === "Feature" ||
-        geoJsonItem._readyData.type === "Geometry"
-      )
-        entity.origGeoJson = geoJsonItem._readyData;
 
       /* If no marker symbol was provided but Cesium has generated one for a point, then turn it into
                a filled circle instead of the default marker. */


### PR DESCRIPTION
When using the Leaflet viewer there are issues viewing data that crosses in the anti-meridian.
![AntiMeridian](https://user-images.githubusercontent.com/6735870/64144380-ac515a00-ce57-11e9-9b86-0c26d950d64c.png)

Leaflet normally handles this by displaying coords that cross the anti-meridian by using coords that are greater than 180 degrees (eg see below).

The challenge currently is that we generate our Leaflet polygon coordinates from a Cesium `Entity` which converts the coords to a traditional range (eg geojson with a coord of `181` becomes `-179`).

This PR attaches the original geojson feature to an entity when it is created via the `GeoJsonCatalogItem`, and the LeafletVisualiser uses the original geojson if it finds it. 

````
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              176.572265625,
              -17.14079039331664
            ],
            [
              176.044921875,
              -19.72534224805787
            ],
            [
              179.82421875,
              -19.808054128088575
            ],
            [
              181.40625,
              -18.562947442888298
            ],
            [
              181.845703125,
              -17.224758206624628
            ],
            [
              179.736328125,
              -15.707662769583505
            ],
            [
              176.572265625,
              -17.14079039331664
            ]
          ]
        ]
      }
    }
  ]
}
````