### PR TITLE
Bump to version 7.6.10.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### v7.6.10
+
+* Fixed error when opening a URL shared from an explorer tab. #3614
+
 ### v7.6.9
 
 * Automatically set `linkedWcsCoverage` on a WebMapServiceCatalogItem.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### v7.6.10
 
 * Fixed error when opening a URL shared from an explorer tab. #3614
-* Resolve a bug with `SdmxJsonCatalogItem`'s v2.0 where they were being redrawn when dimensions we're changed.
+* Resolve a bug with `SdmxJsonCatalogItem`'s v2.0 where they were being redrawn when dimensions we're changed. #3659
 
 ### v7.6.9
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 * Fixed error when opening a URL shared from an explorer tab. #3614
 * Resolve a bug with `SdmxJsonCatalogItem`'s v2.0 where they were being redrawn when dimensions we're changed. #3659
+* Upgrades terriajs-cesium to 1.61.0
 
 ### v7.6.9
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "7.6.9",
+  "version": "7.6.10",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {
@@ -79,7 +79,7 @@
     "string-replace-webpack-plugin": "^0.1.3",
     "style-loader": "^0.23.1",
     "svg-sprite-loader": "4.1.3",
-    "terriajs-cesium": "1.60.1",
+    "terriajs-cesium": "1.61.0",
     "terriajs-html2canvas": "1.0.0-alpha.12-terriajs-1",
     "urijs": "^1.18.12",
     "url-loader": "^1.1.2",


### PR DESCRIPTION
Changes:

* Fixes error when opening a URL shared from an explorer tab. #3614
* Resolves a bug with `SdmxJsonCatalogItem`'s v2.0 where they were being redrawn when dimensions we're changed. #3659
* Upgrades to terriajs-cesium 1.61.0