### PR TITLE
Add chrome workaround until browser bug is resolved

### DIFF
--- a/lib/ReactViews/StandardUserInterface/MapColumn.jsx
+++ b/lib/ReactViews/StandardUserInterface/MapColumn.jsx
@@ -17,6 +17,7 @@ import Styles from "./map-column.scss";
 import { observer } from "mobx-react";
 
 const isIE = FeatureDetection.isInternetExplorer();
+const chromeVersion = FeatureDetection.chromeVersion();
 
 /**
  * Right-hand column that contains the map, controls that sit over the map and sometimes the bottom dock containing
@@ -81,11 +82,21 @@ const MapColumn = observer(
     },
 
     render() {
+      // TODO: remove? see: https://bugs.chromium.org/p/chromium/issues/detail?id=1001663
+      const isAboveChrome75 =
+        chromeVersion && chromeVersion[0] && Number(chromeVersion[0]) > 75;
+      const mapCellClass = classNames(Styles.mapCell, {
+        [Styles.mapCellChrome]: isAboveChrome75
+      });
       return (
-        <div className={Styles.mapInner}>
+        <div
+          className={classNames(Styles.mapInner, {
+            [Styles.mapInnerChrome]: isAboveChrome75
+          })}
+        >
           <div className={Styles.mapRow}>
             <div
-              className={classNames(Styles.mapCell, Styles.mapCellMap)}
+              className={classNames(mapCellClass, Styles.mapCellMap)}
               ref={this.newMapCell}
             >
               <div
@@ -155,7 +166,7 @@ const MapColumn = observer(
           </div>
           <If condition={!this.props.viewState.hideMapUi()}>
             <div className={Styles.mapRow}>
-              <div className={Styles.mapCell}>
+              <div className={mapCellClass}>
                 <BottomDock
                   terria={this.props.terria}
                   viewState={this.props.viewState}

--- a/lib/ReactViews/StandardUserInterface/map-column.scss
+++ b/lib/ReactViews/StandardUserInterface/map-column.scss
@@ -10,6 +10,12 @@
     box-sizing: border-box;
   }
 }
+.map__innerChrome {
+  // Chrome only :( hack until
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1001663 gets resolved
+  display: flex;
+  flex-flow: column;
+}
 
 .map__row {
   display: table-row;
@@ -24,6 +30,12 @@
   display: table-cell;
   position: relative;
   width: 100%;
+}
+.map__cellChrome {
+  // Chrome only :( hack until
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1001663 gets resolved
+  display: block;
+  height: 100%;
 }
 
 @include empty-module("map-cell-map");

--- a/lib/ReactViews/StandardUserInterface/map-column.scss.d.ts
+++ b/lib/ReactViews/StandardUserInterface/map-column.scss.d.ts
@@ -9,12 +9,16 @@ interface CssExports {
   'map-cell-map': string;
   'map-wrapper': string;
   'mapCell': string;
+  'mapCellChrome': string;
   'mapCellMap': string;
   'mapInner': string;
+  'mapInnerChrome': string;
   'mapRow': string;
   'mapWrapper': string;
   'map__cell': string;
+  'map__cellChrome': string;
   'map__inner': string;
+  'map__innerChrome': string;
   'map__row': string;
   'print-disclaimer': string;
   'printDisclaimer': string;


### PR DESCRIPTION
See:
https://bugs.chromium.org/p/chromium/issues/detail?id=1002593
https://bugs.chromium.org/p/chromium/issues/detail?id=1001663

Use cesium browser detection for chrome workaround

Only target Chrome 76 and above

In 79 we can see the layout issue disappears,
with or without the css-hack

Cherry picked & squashed from origin/chrome-layoutng-workaround



Ports from https://github.com/TerriaJS/terriajs/pull/3686