### PR TITLE
Set cesium rendering resolution to CSS pixel resolution.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### v7.6.11
 
 * Added a workaround for a bug in Google Chrome v76 and v77 that caused problems with sizing of the bottom dock, such as cutting off the timeline and flickering on and off over the map.
+* Set cesium rendering resolution to CSS pixel resolution. This is required because Cesium renders in native device resolution since 1.61.0.
 
 ### v7.6.10
 

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -430,11 +430,6 @@ Cesium.prototype.destroy = function() {
   window.removeEventListener("resize", this._boundNotifyRepaintRequired, false);
   window.removeEventListener("resize", this._setViewerResolution, false);
 
-  if (this._disposeDevicePixelRatioSubscription) {
-    this._disposeDevicePixelRatioSubscription();
-    this._disposeDevicePixelRatioSubscription = undefined;
-  }
-
   loadWithXhr.load = this._originalLoadWithXhr;
   TaskProcessor.prototype.scheduleTask = this._originalScheduleTask;
 

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -165,12 +165,15 @@ var Cesium = function(terria, viewer) {
     false
   );
 
-  this._updateViewerResolution();
-  this._disposeDevicePixelRatioSubscription = onDevicePixelRatioChange(
-    this._updateViewerResolution.bind(this)
-  );
-
   window.addEventListener("resize", this._boundNotifyRepaintRequired, false);
+
+  this._setViewerResolution = () => {
+    // Force rendering in CSS pixel resolution instead of native device
+    // resolution which is the default since cesium1.61.0
+    this.viewer.resolutionScale = 1.0 / window.devicePixelRatio;
+  };
+  this._setViewerResolution();
+  window.addEventListener("resize", this._setViewerResolution, false);
 
   // Force a repaint when the feature info box is closed.  Cesium can't close its info box
   // when the clock is not ticking, for reasons that are not clear.
@@ -425,6 +428,7 @@ Cesium.prototype.destroy = function() {
   );
 
   window.removeEventListener("resize", this._boundNotifyRepaintRequired, false);
+  window.removeEventListener("resize", this._setViewerResolution, false);
 
   if (this._disposeDevicePixelRatioSubscription) {
     this._disposeDevicePixelRatioSubscription();
@@ -767,12 +771,6 @@ Cesium.prototype.notifyRepaintRequired = function() {
   }
   this._lastCameraMoveTime = getTimestamp();
   this.viewer.useDefaultRenderLoop = true;
-};
-
-Cesium.prototype._updateViewerResolution = function() {
-  // Force rendering in CSS pixel resolution instead of native device
-  // resolution which is the default since cesium1.61.0
-  this.viewer.resolutionScale = 1.0 / window.devicePixelRatio;
 };
 
 /**
@@ -1446,22 +1444,6 @@ function selectFeature(cesium) {
   }
 
   cesium._selectionIndicator.update();
-}
-
-/**
- * Calls back when device pixel ratio changes.
- * Returns a disposer function to cancel the callback.
- */
-function onDevicePixelRatioChange(callback) {
-  const mqString = `(resolution: ${window.devicePixelRatio}dppx)`;
-  const mq = window && window.matchMedia(mqString);
-  if (mq) {
-    mq.addListener(callback);
-    return () => {
-      mq.removeListener(callback);
-    };
-  }
-  return () => {};
 }
 
 module.exports = Cesium;

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -1454,11 +1454,14 @@ function selectFeature(cesium) {
  */
 function onDevicePixelRatioChange(callback) {
   const mqString = `(resolution: ${window.devicePixelRatio}dppx)`;
-  const mq = matchMedia(mqString);
-  mq.addEventListener("change", callback);
-  return () => {
-    mq.removeEventListener("change", callback);
-  };
+  const mq = window && window.matchMedia(mqString);
+  if (mq) {
+    mq.addListener(callback);
+    return () => {
+      mq.removeListener(callback);
+    };
+  }
+  return () => {};
 }
 
 module.exports = Cesium;

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -100,15 +100,12 @@ var Cesium = function(terria, viewer) {
   );
   this._removeInfoBoxCloseListener = undefined;
   this._boundNotifyRepaintRequired = this.notifyRepaintRequired.bind(this);
-  this._boundUpdateViewerResolution = this.updateViewerResolution.bind(this);
 
   this._pauseMapInteractionCount = 0;
 
   this.scene.imagerySplitPosition = this.terria.splitPosition;
 
   this.supportsPolylinesOnTerrain = this.scene.context.depthTexture;
-
-  this.updateViewerResolution();
 
   // Handle left click by picking objects from the map.
   viewer.screenSpaceEventHandler.setInputAction(
@@ -168,8 +165,12 @@ var Cesium = function(terria, viewer) {
     false
   );
 
+  this._updateViewerResolution();
+  this._disposeDevicePixelRatioSubscription = onDevicePixelRatioChange(
+    this._updateViewerResolution.bind(this)
+  );
+
   window.addEventListener("resize", this._boundNotifyRepaintRequired, false);
-  window.addEventListener("resize", this._boundUpdateViewerResolution, false);
 
   // Force a repaint when the feature info box is closed.  Cesium can't close its info box
   // when the clock is not ticking, for reasons that are not clear.
@@ -424,11 +425,11 @@ Cesium.prototype.destroy = function() {
   );
 
   window.removeEventListener("resize", this._boundNotifyRepaintRequired, false);
-  window.removeEventListener(
-    "resize",
-    this._boundUpdateViewerResolution,
-    false
-  );
+
+  if (this._disposeDevicePixelRatioSubscription) {
+    this._disposeDevicePixelRatioSubscription();
+    this._disposeDevicePixelRatioSubscription = undefined;
+  }
 
   loadWithXhr.load = this._originalLoadWithXhr;
   TaskProcessor.prototype.scheduleTask = this._originalScheduleTask;
@@ -768,7 +769,7 @@ Cesium.prototype.notifyRepaintRequired = function() {
   this.viewer.useDefaultRenderLoop = true;
 };
 
-Cesium.prototype.updateViewerResolution = function() {
+Cesium.prototype._updateViewerResolution = function() {
   // Force rendering in CSS pixel resolution instead of native device
   // resolution which is the default since cesium1.61.0
   this.viewer.resolutionScale = 1.0 / window.devicePixelRatio;
@@ -1445,6 +1446,19 @@ function selectFeature(cesium) {
   }
 
   cesium._selectionIndicator.update();
+}
+
+/**
+ * Calls back when device pixel ratio changes.
+ * Returns a disposer function to cancel the callback.
+ */
+function onDevicePixelRatioChange(callback) {
+  const mqString = `(resolution: ${window.devicePixelRatio}dppx)`;
+  const mq = matchMedia(mqString);
+  mq.addEventListener("change", callback);
+  return () => {
+    mq.removeEventListener("change", callback);
+  };
 }
 
 module.exports = Cesium;

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -108,6 +108,8 @@ var Cesium = function(terria, viewer) {
 
   this.supportsPolylinesOnTerrain = this.scene.context.depthTexture;
 
+  this.updateViewerResolution();
+
   // Handle left click by picking objects from the map.
   viewer.screenSpaceEventHandler.setInputAction(
     function(e) {

--- a/lib/Models/Cesium.js
+++ b/lib/Models/Cesium.js
@@ -100,6 +100,7 @@ var Cesium = function(terria, viewer) {
   );
   this._removeInfoBoxCloseListener = undefined;
   this._boundNotifyRepaintRequired = this.notifyRepaintRequired.bind(this);
+  this._boundUpdateViewerResolution = this.updateViewerResolution.bind(this);
 
   this._pauseMapInteractionCount = 0;
 
@@ -166,6 +167,7 @@ var Cesium = function(terria, viewer) {
   );
 
   window.addEventListener("resize", this._boundNotifyRepaintRequired, false);
+  window.addEventListener("resize", this._boundUpdateViewerResolution, false);
 
   // Force a repaint when the feature info box is closed.  Cesium can't close its info box
   // when the clock is not ticking, for reasons that are not clear.
@@ -420,6 +422,11 @@ Cesium.prototype.destroy = function() {
   );
 
   window.removeEventListener("resize", this._boundNotifyRepaintRequired, false);
+  window.removeEventListener(
+    "resize",
+    this._boundUpdateViewerResolution,
+    false
+  );
 
   loadWithXhr.load = this._originalLoadWithXhr;
   TaskProcessor.prototype.scheduleTask = this._originalScheduleTask;
@@ -757,6 +764,12 @@ Cesium.prototype.notifyRepaintRequired = function() {
   }
   this._lastCameraMoveTime = getTimestamp();
   this.viewer.useDefaultRenderLoop = true;
+};
+
+Cesium.prototype.updateViewerResolution = function() {
+  // Force rendering in CSS pixel resolution instead of native device
+  // resolution which is the default since cesium1.61.0
+  this.viewer.resolutionScale = 1.0 / window.devicePixelRatio;
 };
 
 /**

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -351,10 +351,6 @@ AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO \
   //create CesiumViewer
   var viewer = new CesiumWidget(container, options);
 
-  // Force rendering in CSS pixel resolution instead of native device
-  // resolution which is the default since cesium1.61.0
-  viewer.resolutionScale = 1.0 / window.devicePixelRatio;
-
   // Disable HDR lighting for better performance and to avoid changing imagery colors.
   viewer.scene.highDynamicRange = false;
 

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -351,6 +351,10 @@ AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO \
   //create CesiumViewer
   var viewer = new CesiumWidget(container, options);
 
+  // Force rendering in CSS pixel resolution instead of native device
+  // resolution which is the default since cesium1.61.0
+  viewer.resolutionScale = 1.0 / window.devicePixelRatio;
+
   // Disable HDR lighting for better performance and to avoid changing imagery colors.
   viewer.scene.highDynamicRange = false;
 


### PR DESCRIPTION
This PR is to make cesium render in CSS pixel resolution instead of the device native resolution which is the default since v1.61.0.

Please squash and merge!