### PR TITLE
fix zooming on momentchart

### DIFF
--- a/lib/Charts/MomentChart.js
+++ b/lib/Charts/MomentChart.js
@@ -43,10 +43,8 @@ class MomentChart extends BaseChart {
       .style("width", 3);
   }
 
-  zoomOnAxisX(chart, newScaleX) {
-    chart
-      .select(".content")
-      .selectAll(".render")
+  zoomOnAxisX(newScaleX) {
+    d3Select(`#${this.id}`)
       .selectAll("rect")
       .attr("x", d => newScaleX(d.x));
   }


### PR DESCRIPTION
Was testing on terriacube and realised that zooming wasnt working on `moment` charts (not to be confused with `momentPoint`).