### PR TITLE
Chart zooms back out when a new date is selected in the imagery

### DIFF
--- a/lib/ReactViews/Custom/Chart/Chart.jsx
+++ b/lib/ReactViews/Custom/Chart/Chart.jsx
@@ -163,6 +163,20 @@ const Chart = createReactClass({
     });
   },
 
+  shouldComponentUpdate(nextProps) {
+    if (!defined(nextProps.data) || !defined(this.props.data)) return true;
+    if (nextProps.data.length !== this.props.data.length) return true;
+    for (let i = 0; i < nextProps.data.length; i++) {
+      if (
+        nextProps.data[i].points.length !== this.props.data[i].points.length ||
+        nextProps.data[i].color !== this.props.data[i].color
+      )
+        return true;
+    }
+    if (nextProps.axisLabel.x !== this.props.axisLabel.x) return true;
+    return false;
+  },
+
   componentDidUpdate(prevProps) {
     // Update the chart with props.data or props.tableStructure, if present.
     // If the data came from a URL, there are three possibilities:


### PR DESCRIPTION
GA picked up a bug where the chart was zooming back out when the selected date on imagery was changed.
http://terria-cube-20191011t133233.terria.io/

Basically the chart is re-rendering the chartData object changes or something like that. 

This PR re-adds some similar code I had in earlier but it I removed it in #01631a5 to fix one of @kring's comments. I've made a slight tweak to the logic and it seems to be working as expected now.
