### PR TITLE
Update styles dropdown

### DIFF
--- a/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
@@ -5,6 +5,7 @@ import React from "react";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import ObserveModelMixin from "../../ObserveModelMixin";
+import Icon from "./../../Icon.jsx";
 
 import Styles from "./style-selector-section.scss";
 
@@ -88,6 +89,7 @@ const StyleSelectorSection = createReactClass({
             </option>
           ))}
         </select>
+        <Icon glyph={Icon.GLYPHS.opened} />
       </div>
     );
   }

--- a/lib/ReactViews/Workbench/Controls/style-selector-section.scss
+++ b/lib/ReactViews/Workbench/Controls/style-selector-section.scss
@@ -21,6 +21,9 @@ $button-bg: rgba(250, 250, 250, 0.4);
     background: $button-bg;
     color: white;
     border: none;
+    option {
+      color: black;
+    }
   }
 }
 

--- a/lib/ReactViews/Workbench/Controls/style-selector-section.scss
+++ b/lib/ReactViews/Workbench/Controls/style-selector-section.scss
@@ -1,10 +1,27 @@
 @import "~terriajs-variables";
+$button-bg: rgba(250, 250, 250, 0.4);
 
 .style-selector {
   font-size: 0.9rem;
   margin-top: 10px;
+
   label {
     margin-right: $padding-small;
+  }
+  svg {
+    position: relative;
+    fill: white;
+    width: 20px;
+    height: 20px;
+    top: -28px;
+    float: right;
+    padding-right: 10px;
+    pointer-events: none;
+  }
+  select {
+    background: $button-bg;
+    color: white;
+    border: none;
   }
 }
 

--- a/lib/ReactViews/Workbench/Controls/style-selector-section.scss
+++ b/lib/ReactViews/Workbench/Controls/style-selector-section.scss
@@ -25,6 +25,9 @@ $button-bg: rgba(250, 250, 250, 0.4);
       color: black;
     }
   }
+  select::-ms-expand {
+    display: none;
+  }
 }
 
 .title {

--- a/lib/ReactViews/Workbench/Controls/style-selector-section.scss
+++ b/lib/ReactViews/Workbench/Controls/style-selector-section.scss
@@ -4,7 +4,6 @@ $button-bg: rgba(250, 250, 250, 0.4);
 .style-selector {
   font-size: 0.9rem;
   margin-top: 10px;
-
   label {
     margin-right: $padding-small;
   }


### PR DESCRIPTION
Resolves #3709 

The style dropdown on a workbench item is currently plain with no indication that it can be changed. This PR adds some basic styling to the element as well as an icon. 

Unfortunately the select element can't have a `:before` or `:after` added to it which may've been an alternate for the dropdown icon, this PR just add it as another element after the `select`.

![StyleDropdown](https://user-images.githubusercontent.com/6735870/66791961-24746a80-ef42-11e9-8901-f6a34903059a.gif)

@philipgrimmett requested that we keep the default browser styling for the actual dropdown state.



