### PR TITLE
Prevent error when filtering by time intervals that don't exist on an ImageryLayerCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
   * Add momentPoints chart type to plot points along an available line chart
   * Add zooming on chart panel
   * Various preventative fixes to prevent charge crashes
+* Fix a bug where differences in available dates for `ImageryLayerCatalogItem` from original list of dates vs a new list of dates, would cause a error.
 
 ### v7.6.11
 

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -212,11 +212,13 @@ var ImageryLayerCatalogItem = function(terria) {
 
       const featureTimes = featureTimesProperty.getValue(this.currentTime);
       return new TimeIntervalCollection(
-        featureTimes.map(time => {
-          return this._allIntervals.findIntervalContainingDate(
-            JulianDate.fromIso8601(time)
-          );
-        })
+        featureTimes
+          .map(time => {
+            return this._allIntervals.findIntervalContainingDate(
+              JulianDate.fromIso8601(time)
+            );
+          })
+          .filter(i => i !== undefined)
       );
     }
   });


### PR DESCRIPTION
This problem was discovered when filtering a WMS. The GetCapabilities was returning a set number of dates, when the GetFeatureInfo request was returned to detect imagery availability at a certain location it would return a number of additional dates.

Prevent Terria from throwing an error when dates are returned in a GetFeatureInfo response that aren't in a GetCapabilities response.

To see the existing error click 'Filter by Location' on the WMS layer
https://map.terria.io/#share=s-bTTtHNBWuiSoyd8xCbkXcuOugym


Here's a catalog for testing
````
{
  "homeCamera": {
    "north": -8,
    "east": 158,
    "south": -45,
    "west": 109
  },
  "catalog": [
    {
       "name": "Sentinel imagery",
       "type": "wms",
       "isEnabled": true,
       "layers": "s2a_ard_granule_nbar_t",
       "url": "https://ows.services.dea.ga.gov.au/",
       "linkedWcsUrl": "https://ows.dea.ga.gov.au/",
       "linkedWcsCoverage": "s2_ard_granule_nbar_t",
       "ignoreUnknownTileErrors": true,
       "chartType": "momentPoints",
       "chartColor": "white",
       "opacity": 1,
       "featureInfoTemplate": {
          "formats": {
             "lat": {
                "maximumFractionDigits": 5
             },
             "lon": {
                "maximumFractionDigits": 5
             }
          },
          "template": "<table>  <tr><td><b>Time</b></td><td>{{time}}</td></tr>  <tr><td><b>Narrow Blue - 440</b></td><td>{{bands.nbart_coastal_aerosol}}</td></tr>  <tr><td><b>Blue - 490</b></td><td>{{bands.nbart_blue}}</td></tr>  <tr><td><b>Green - 560</b></td><td>{{bands.nbart_green}}</td></tr>  <tr><td><b>Red - 670</b></td><td>{{bands.nbart_red}}</td></tr>  <tr><td><b>Vegetation Red Edge - 710</b></td><td>{{bands.nbart_red_edge_1}}</td></tr>  <tr><td><b>Vegetation Red Edge - 740</b></td><td>{{bands.nbart_red_edge_2}}</td></tr>  <tr><td><b>Vegetation Red Edge - 780</b></td><td>{{bands.nbart_red_edge_3}}</td></tr>  <tr><td><b>Near Infrared (NIR) - 840</b></td><td>{{bands.nbart_nir_1}}</td></tr>  <tr><td><b>Narrow Near Infrared - 870</b></td><td>{{bands.nbart_nir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 1610</b></td><td>{{bands.nbart_swir_2}}</td></tr>  <tr><td><b>Shortwave Infrared (SWIR) - 2190</b></td><td>{{bands.nbart_swir_3}}</td></tr>  <tr><td><b>NDVI - Red, NIR</b></td><td>{{band_derived.ndvi}}</td></tr>  <tr><td><b>NDWI - Green, NIR</b></td><td>{{band_derived.ndwi}}</td></tr></table><p><chart id='{{lat}}{{lon}}{{time}}' title='NBART at {{lat}},{{lon}}' column-units='Wavelength (nm), Reflectance x 10k' preview-x-label='NBART Reflectance'>nm,NBART Reflectance\n440,{{bands.nbart_coastal_aerosol}}\n490,{{bands.nbart_blue}}\n560,{{bands.nbart_green}}\n670,{{bands.nbart_red}}\n710,{{bands.nbart_red_edge_1}}\n740,{{bands.nbart_red_edge_2}}\n780,{{bands.nbart_red_edge_3}}\n840,{{bands.nbart_nir_1}}\n870,{{bands.nbart_nir_2}}\n1610,{{bands.nbart_swir_2}}\n2190,{{bands.nbart_swir_3}}</chart></p><p><b>Imagery available for dates:</b>{{#data_available_for_dates}}<br/>{{.}}{{/data_available_for_dates}}</p>"
       },
       "featureTimesProperty": "data_available_for_dates"
    }
  ]
}
````