### PR TITLE
Prevent chart crash when splitting

### DIFF
--- a/lib/Charts/ChartRenderer.js
+++ b/lib/Charts/ChartRenderer.js
@@ -527,7 +527,7 @@ class ChartRenderer {
         // const yAxisWidth = maxTickLength > 3 ? (maxTickLength - 2) * 5 : 0;
         let offset = 0;
 
-        if (renderContext.yOffsets.length > 0 && yNodeIndex > 0) {
+        if (renderContext.yOffsets.length > 0 && realYNodeIndex > 0) {
           offset = renderContext.yOffsets
             .slice(0, realYNodeIndex)
             .reduce((a, b) => a + b);


### PR DESCRIPTION
When splitting a WMS layer in the workbench that was plotted against a line on the chart Terria would crash.
http://terria-cube.terria.io/#share=s-zxveGPabeb1Ah7uw5vRNoVYWbPO

Traced things back to this