### PR TITLE
Pass a custom update interval to leaflet tile layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### next release
+
+* Add ability to pass `leafletUpdateInterval` to an `ImageryLayerCatalogItem` to throttle the number of requests made to a server.
+
+
 ### v7.7.0
 
 * Added a quality slider for the 3D map to the Map panel, allowing control of Cesium's maximumScreenSpaceError and resolutionScale properties.

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -32,7 +32,10 @@ var CesiumTileLayer = L.TileLayer.extend({
     this._previousCredits = [];
 
     this._requestImageError = undefined;
-
+    if (!defined(this.imageryProvider._leafletUpdateInterval)) {
+      this.imageryProvider._leafletUpdateInterval = 100;
+    }
+    options.updateInterval = imageryProvider._leafletUpdateInterval;
     L.TileLayer.prototype.initialize.call(this, undefined, options);
   },
 
@@ -120,7 +123,7 @@ var CesiumTileLayer = L.TileLayer.extend({
         this._delayedUpdate = setTimeout(function() {
           that._delayedUpdate = undefined;
           that._update();
-        }, 100);
+        }, this.imageryProvider._leafletUpdateInterval);
       }
       return;
     }
@@ -180,7 +183,7 @@ var CesiumTileLayer = L.TileLayer.extend({
         that._usable = true;
 
         that._update();
-      }, 100);
+      }, this.imageryProvider._leafletUpdateInterval);
     }
 
     if (this._usable) {

--- a/lib/Map/CesiumTileLayer.js
+++ b/lib/Map/CesiumTileLayer.js
@@ -35,6 +35,7 @@ var CesiumTileLayer = L.TileLayer.extend({
     if (!defined(this.imageryProvider._leafletUpdateInterval)) {
       this.imageryProvider._leafletUpdateInterval = 100;
     }
+    options = defined(options) ? options : {};
     options.updateInterval = imageryProvider._leafletUpdateInterval;
     L.TileLayer.prototype.initialize.call(this, undefined, options);
   },

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -179,6 +179,8 @@ var ImageryLayerCatalogItem = function(terria) {
   this.intervalFilterFeature = undefined;
   this._intervalFilterCoordinates = undefined;
 
+  this.leafletUpdateInterval = 100;
+
   // Need to track initialTimeSource so we can set it in the specs after setting intervals, and then have the current time update (via the clock property).
   knockout.track(this, [
     "_clock",
@@ -673,6 +675,7 @@ freezeObject(ImageryLayerCatalogItem.defaultPropertiesForSharing);
  */
 ImageryLayerCatalogItem.prototype.createImageryProvider = function(time) {
   var result = this._createImageryProvider(time);
+  result._leafletUpdateInterval = this.leafletUpdateInterval;
   return result;
 };
 
@@ -888,7 +891,6 @@ ImageryLayerCatalogItem.enableLayer = function(
 
   let tileFailures = 0;
   let tileRetriesByMap = {};
-
   const layer = globeOrMap.addImageryProvider({
     imageryProvider: imageryProvider,
     rectangle: catalogItem.rectangle,


### PR DESCRIPTION
The current `CesiumTileLayer.js`, used to put tiles on our leaflet map had a trigger rate of 100ms when required to refresh, this was causing issues for DEA layers behind cloudfront when changing dates rapidly or panning and zooming quickly.

The PR passes an option down via the catalog item config to the ImageryLayerCatalogItem allowing that rate to be set to something higher.

This sample catalog shows it in action
````
{
  "homeCamera": {
    "north": -8,
    "east": 158,
    "south": -45,
    "west": 109
  },
  "corsDomains": ["ows.dea.ga.gov.au"],
  "catalog": [
    {
       "name": "Sentinel imagery",
       "type": "wms",
       "isEnabled": true,
       "leafletUpdateInterval": 500,
       "layers": "s2a_ard_granule_nbar_t",
       "url": "https://ows.dea.ga.gov.au/",
       "featureTimesProperty": "data_available_for_dates"

     }
  ]
}
````
From my initial testing 500ms seems like a reasonable value to prevent the SPDY errors from appearing, although the higher you set the value the more reduce the risk of them happening.