### PR TITLE
Always initialise the notification window as the top-element.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### next release
+
+* Ensure the NotificationWindow is rendered as the top element.
+
+
 ### v7.7.0
 
 * Added a quality slider for the 3D map to the Map panel, allowing control of Cesium's maximumScreenSpaceError and resolutionScale properties.

--- a/lib/ReactViews/Notification/Notification.jsx
+++ b/lib/ReactViews/Notification/Notification.jsx
@@ -58,6 +58,7 @@ const Notification = createReactClass({
           type={defined(notification.type) ? notification.type : "notification"}
           width={notification.width}
           height={notification.height}
+          viewState={this.props.viewState}
         />
       )
     );

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -52,7 +52,7 @@ const NotificationWindow = createReactClass({
     };
 
     return (
-      <div className={classNames(Styles.wrapper, `${type}`)}>
+      <div className={classNames(Styles.wrapper, `${type}`, "top-element")}>
         <div className={Styles.notification}>
           <div className={Styles.inner} style={divStyle}>
             <h3 className="title">{title}</h3>

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -22,7 +22,8 @@ const NotificationWindow = createReactClass({
     onDeny: PropTypes.func.isRequired,
     type: PropTypes.string,
     height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    viewState: PropTypes.object.isRequired
   },
 
   confirm(e) {
@@ -30,12 +31,20 @@ const NotificationWindow = createReactClass({
     if (this.props.onConfirm) {
       this.props.onConfirm();
     }
+    this.resetTopElement();
   },
 
   deny(e) {
     e.stopPropagation();
     if (this.props.onDeny) {
       this.props.onDeny();
+    }
+    this.resetTopElement();
+  },
+
+  resetTopElement() {
+    if (this.props.viewState.topElement === "NotificationWindow") {
+      this.props.viewState.topElement = "FeatureInfo";
     }
   },
 
@@ -50,7 +59,7 @@ const NotificationWindow = createReactClass({
       height: defined(this.props.height) ? this.props.height : "auto",
       width: defined(this.props.width) ? this.props.width : "500px"
     };
-
+    this.props.viewState.topElement = "NotificationWindow";
     return (
       <div className={classNames(Styles.wrapper, `${type}`, "top-element")}>
         <div className={Styles.notification}>


### PR DESCRIPTION
Sometimes a notification window gets hidden by something else which has already been designated as the top element. This PR assigns the class `top-element` which pushes the element to the top.

Resolves #3716