### PR TITLE
Set min-width for preview chart.

### DIFF
--- a/lib/ReactViews/Custom/Chart/chart-preview.scss
+++ b/lib/ReactViews/Custom/Chart/chart-preview.scss
@@ -8,6 +8,7 @@
 .preview-chart-wrapper {
   position: relative;
   padding: 0;
+  min-height: 110px;
 
   :global {
     .line-chart text {


### PR DESCRIPTION
This is to prevent sudden change in height of the info panel when chart loading is delayed.