### PR TITLE
More tweaks for running the mobx branch in node.

### DIFF
--- a/lib/Core/AsyncLoader.ts
+++ b/lib/Core/AsyncLoader.ts
@@ -55,7 +55,10 @@ export default class AsyncLoader {
           runInAction(() => {
             this._isLoading = false;
           });
-          throw e;
+
+          // Do not re-throw the exception because it's guaranteed to be
+          // unhandled. We're returning the original `newPromise`, not the
+          // result of the `.then` and `.catch` above.
         });
     }
 

--- a/lib/Core/readXml.js
+++ b/lib/Core/readXml.js
@@ -6,12 +6,16 @@ var readText = require("./readText");
 var RuntimeError = require("terriajs-cesium/Source/Core/RuntimeError");
 var when = require("terriajs-cesium/Source/ThirdParty/when");
 
-var parser = new DOMParser();
+var parser;
 
 function readXml(file) {
   return when(
     readText(file),
     function(result) {
+      if (!parser) {
+        parser = new DOMParser();
+      }
+
       var xml = parser.parseFromString(result, "application/xml");
       if (
         !xml ||

--- a/lib/Models/KmlCatalogItem.ts
+++ b/lib/Models/KmlCatalogItem.ts
@@ -34,10 +34,6 @@ class KmlCatalogItem extends AsyncMappableMixin(
 
   readonly canZoomTo = true;
 
-  constructor(id: string, terria: Terria) {
-    super(id, terria);
-  }
-
   setFileInput(file: File) {
     this._kmlFile = file;
   }

--- a/lib/Models/registerCatalogMembers.ts
+++ b/lib/Models/registerCatalogMembers.ts
@@ -10,6 +10,7 @@ import GeoJsonCatalogItem from "./GeoJsonCatalogItem";
 import GltfCatalogItem from "./GltfCatalogItem";
 import GtfsCatalogItem from "./GtfsCatalogItem";
 import IonImageryCatalogItem from "./IonImageryCatalogItem";
+import KmlCatalogItem from "./KmlCatalogItem";
 import MagdaReference from "./MagdaReference";
 import OpenStreetMapCatalogItem from "./OpenStreetMapCatalogItem";
 import WebMapServiceCatalogGroup from "./WebMapServiceCatalogGroup";
@@ -53,4 +54,5 @@ export default function registerCatalogMembers() {
     OpenStreetMapCatalogItem
   );
   CatalogMemberFactory.register(MagdaReference.type, MagdaReference);
+  CatalogMemberFactory.register(KmlCatalogItem.type, KmlCatalogItem);
 }


### PR DESCRIPTION
* Add `KmlCatalogItem` to `registerCatalogMembers`.
* Don't re-throw an impossible to catch error.
* Remove an unnecessary constructor.
* Don't attempt to create a `DOMParser` until it's needed (because it doesn't exist in node.js).
