### PR TITLE
Call .loadMapItems() only for items that define it.

### DIFF
--- a/lib/ReactViews/Custom/Chart/ChartPanel.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanel.jsx
@@ -64,7 +64,9 @@ class ChartPanel extends React.Component {
     }
     const items = this.props.terria.workbench.items;
     if (items.length > 0) {
-      const loadPromises = items.map(item => item.loadMapItems());
+      const loadPromises = items.map(
+        item => item.loadMapItems && item.loadMapItems()
+      );
       raiseErrorOnRejectedPromise(this.props.terria, Promise.all(loadPromises));
 
       chart = (


### PR DESCRIPTION
Fix chart panel error when loading a WPS item.