### PR TITLE
Model architecture: Avoid blank at the bottom of the catalog tree

### DIFF
--- a/lib/ReactViews/DataCatalog/data-catalog.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog.scss
@@ -18,7 +18,7 @@
 
   @media (min-width: $sm) {
     padding-right: $padding-small;
-    height: calc(100% - #{$input-height + $padding * 3});
+    height: 100%; // replace with this once the search bar is back: calc(100% - #{$input-height + $padding * 3});
     position: static;
   }
 }


### PR DESCRIPTION
It appeared when we removed the catalog search box.