### PR TITLE
Fix add data buttons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### Next
+* Fixed bug where "User data" catalog did not have add-buttons
+* Added ability to re-add "User data" CSV items once removed from workbench
+
 ### v7.9.0
 
 * Upgraded to Cesium v1.63.1. This upgrade may cause more problems than usual because Cesium has switched from AMD to ES6 modules. If you run into problems, please contact us: https://terria.io/contact

--- a/lib/ReactViews/DataCatalog/CatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/CatalogItem.jsx
@@ -34,7 +34,7 @@ function CatalogItem(props) {
         title={props.title}
         className={classNames(Styles.btnCatalogItem, {
           [Styles.btnCatalogItemIsPreviewed]: props.selected,
-          [Styles.btnCatalogItemIsRemovable]: props.selected
+          [Styles.btnCatalogItemIsTrashable]: props.selected
         })}
       >
         {props.text}
@@ -47,7 +47,7 @@ function CatalogItem(props) {
       >
         {STATE_TO_ICONS[props.btnState]}
       </button>
-      {props.removable && (
+      {props.trashable && (
         <button
           type="button"
           onClick={props.onTrashClick}
@@ -66,7 +66,7 @@ CatalogItem.propTypes = {
   selected: PropTypes.bool,
   text: PropTypes.string,
   title: PropTypes.string,
-  removable: PropTypes.bool,
+  trashable: PropTypes.bool,
   onTrashClick: PropTypes.func,
   onBtnClick: PropTypes.func,
   btnState: PropTypes.oneOf(Object.keys(STATE_TO_ICONS)),

--- a/lib/ReactViews/DataCatalog/CatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/CatalogItem.jsx
@@ -33,7 +33,8 @@ function CatalogItem(props) {
         onClick={props.onTextClick}
         title={props.title}
         className={classNames(Styles.btnCatalogItem, {
-          [Styles.btnCatalogItemIsPreviewed]: props.selected
+          [Styles.btnCatalogItemIsPreviewed]: props.selected,
+          [Styles.btnCatalogItemIsRemovable]: props.selected
         })}
       >
         {props.text}
@@ -46,6 +47,16 @@ function CatalogItem(props) {
       >
         {STATE_TO_ICONS[props.btnState]}
       </button>
+      {props.removable && (
+        <button
+          type="button"
+          onClick={props.onTrashClick}
+          title={stateToTitle["trash"]}
+          className={classNames(Styles.btnAction, Styles.btnTrash)}
+        >
+          {STATE_TO_ICONS["trash"]}
+        </button>
+      )}
     </li>
   );
 }
@@ -55,6 +66,8 @@ CatalogItem.propTypes = {
   selected: PropTypes.bool,
   text: PropTypes.string,
   title: PropTypes.string,
+  removable: PropTypes.bool,
+  onTrashClick: PropTypes.func,
   onBtnClick: PropTypes.func,
   btnState: PropTypes.oneOf(Object.keys(STATE_TO_ICONS)),
   titleOverrides: PropTypes.object

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -93,7 +93,9 @@ const DataCatalogItem = createReactClass({
           .join(" → ")}
         btnState={this.getState()}
         onBtnClick={this.onBtnClicked}
-        removable={this.props.removable}
+        // All things are "removable" - meaning add and remove from workbench,
+        //    but only user data is "trashable"
+        trashable={this.props.removable}
         onTrashClick={
           this.props.removable
             ? () => {

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -37,11 +37,13 @@ const DataCatalogItem = createReactClass({
       this.props.viewState.useSmallScreenInterface
     ) {
       this.setPreviewedItem();
-    } else if (this.props.removable) {
-      removeUserAddedData(this.props.terria, this.props.item);
     } else {
       this.toggleEnable(event);
     }
+  },
+
+  onTrashClicked() {
+    removeUserAddedData(this.props.terria, this.props.item);
   },
 
   toggleEnable(event) {
@@ -91,6 +93,14 @@ const DataCatalogItem = createReactClass({
           .join(" → ")}
         btnState={this.getState()}
         onBtnClick={this.onBtnClicked}
+        removable={this.props.removable}
+        onTrashClick={
+          this.props.removable
+            ? () => {
+                this.onTrashClicked();
+              }
+            : undefined
+        }
         titleOverrides={STATE_TO_TITLE}
       />
     );
@@ -101,10 +111,6 @@ const DataCatalogItem = createReactClass({
       return "loading";
     } else if (this.props.viewState.useSmallScreenInterface) {
       return "preview";
-    } else if (this.props.removable) {
-      return "trash";
-    } else if (addedByUser(this.props.item)) {
-      return null;
     } else if (this.props.item.isEnabled) {
       return "remove";
     } else if (!defined(this.props.item.invoke)) {

--- a/lib/ReactViews/DataCatalog/data-catalog-group.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog-group.scss
@@ -104,7 +104,7 @@
     }
   }
   &.offsetRight {
-    right: 20px;
+    right: 25px;
   }
 }
 

--- a/lib/ReactViews/DataCatalog/data-catalog-item.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog-item.scss
@@ -32,7 +32,7 @@
       opacity: 1;
     }
   }
-  &--is-removable {
+  &--is-trashable {
     padding-right: $padding * 5.7;
   }
 

--- a/lib/ReactViews/DataCatalog/data-catalog-item.scss
+++ b/lib/ReactViews/DataCatalog/data-catalog-item.scss
@@ -32,6 +32,9 @@
       opacity: 1;
     }
   }
+  &--is-removable {
+    padding-right: $padding * 5.7;
+  }
 
   @media (max-width: $sm) {
     font-size: $font-size-mid-small;
@@ -82,4 +85,8 @@
       position: absolute;
     }
   }
+}
+
+.btn-trash {
+  right: 32px;
 }

--- a/test/ReactViews/DataCatalog/DataCatalogItemSpec.jsx
+++ b/test/ReactViews/DataCatalog/DataCatalogItemSpec.jsx
@@ -149,18 +149,33 @@ describe("DataCatalogItem", () => {
         expect(getRenderedProp("btnState")).toBe("remove");
       });
 
-      it('"trash" if item removable', () => {
+      it('"add" if item removable but NOT enabled', () => {
+        // If removable, btnstate should still be add or remove
         item.isLoading = false;
         removable = true;
-        expect(getRenderedProp("btnState")).toBe("trash");
-      });
-
-      it("null is item is added by user but within a group and not loading and not on mobile", () => {
-        item.isLoading = false;
-        removable = false;
         item.parent = new CatalogItem(terria);
         makeItemUserAdded(item.parent, terria);
-        expect(getRenderedProp("btnState")).toBe(null);
+        expect(getRenderedProp("btnState")).toBe("add");
+        expect(getRenderedProp("trashable")).toBe(true);
+      });
+      it('"remove" if item removable but enabled', () => {
+        // If removable, btnstate should still be add or remove
+        item.isEnabled = true;
+        item.isLoading = false;
+        removable = true;
+        item.parent = new CatalogItem(terria);
+        makeItemUserAdded(item.parent, terria);
+        expect(getRenderedProp("btnState")).toBe("remove");
+        expect(getRenderedProp("trashable")).toBe(true);
+      });
+
+      it("add if item is added by user but within a group and not loading and not on mobile", () => {
+        item.isLoading = false;
+        // User data is always "removable"
+        removable = true;
+        item.parent = new CatalogItem(terria);
+        makeItemUserAdded(item.parent, terria);
+        expect(getRenderedProp("btnState")).toBe("add");
       });
 
       it('"add" if item is not invokeable, not enabled and not loading and not on mobile', () => {


### PR DESCRIPTION
* Fixed bug where "User data" catalog did not have add-buttons
* Added ability to re-add "User data" CSV items once removed from workbench

Catalog Items in left hand tree view has "add" again

<img width="921" alt="image" src="https://user-images.githubusercontent.com/9134432/69096037-83d11780-0ab8-11ea-96eb-cd62f480aa3f.png">

User added CSV has a mechanism for adding charts back (not fully thought out but this is better than impossible)

<img width="922" alt="image" src="https://user-images.githubusercontent.com/9134432/69096032-7c117300-0ab8-11ea-9ab1-b3a7ec62bc91.png">
