### PR TITLE
Fix improper matching of some states when using STE number codes in a State column

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### next minor
+
+* Fixed an error in `regionMapping.json` that causes some states to be mismatched when using Australian state codes in a column labelled "state". It is still recommended to use "ste", "ste_code" or "ste_code_2016" over "state" for column labels when matching against Australian state codes.
+
 ### v7.9.0
 
 * Upgraded to Cesium v1.63.1. This upgrade may cause more problems than usual because Cesium has switched from AMD to ES6 modules. If you run into problems, please contact us: https://terria.io/contact

--- a/wwwroot/data/regionMapping.json
+++ b/wwwroot/data/regionMapping.json
@@ -1331,7 +1331,7 @@
               159.11,
               -9.14
             ]
-        },          
+        },
         "SED_CODE11": {
             "layerName": "FID_SED_2011_AUST",
             "server": "https://vector-tiles.terria.io/FID_SED_2011_AUST/{z}/{x}/{y}.pbf",
@@ -2074,14 +2074,18 @@
                 ],
                 [
                     "^6$",
-                    "Northern Territory"
+                    "Tasmania"
                 ],
                 [
                     "^7$",
-                    "Australian Capital Territory"
+                    "Northern Territory"
                 ],
                 [
                     "^8$",
+                    "Australian Capital Territory"
+                ],
+                [
+                    "^9$",
                     "Other Territories"
                 ]
             ],
@@ -2176,14 +2180,18 @@
                 ],
                 [
                     "^6$",
-                    "Northern Territory"
+                    "Tasmania"
                 ],
                 [
                     "^7$",
-                    "Australian Capital Territory"
+                    "Northern Territory"
                 ],
                 [
                     "^8$",
+                    "Australian Capital Territory"
+                ],
+                [
+                    "^9$",
                     "Other Territories"
                 ]
             ],


### PR DESCRIPTION
This will fix TerriaJS/aremi-natmap#399 when AREMI is packaged and deployed again.

The new replacements are generated directly from the shapefiles, so they correctly line up with regions.