### PR TITLE
Model architecture: Terrain splitting and depth testing on settings panel.

### DIFF
--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -262,6 +262,7 @@ export default class Cesium extends GlobeOrMap {
     this._disposeWorkbenchMapItemsSubscription = this.observeModelLayer();
     this._disposeTerrainReaction = autorun(() => {
       this.scene.globe.terrainProvider = this._terrainProvider;
+      this.scene.globe.splitDirection = this.terria.showSplitter ? this.terria.terrainSplitDirection : ImagerySplitDirection.NONE;
     });
     this._disposeSplitterReaction = this._reactToSplitterChanges();
 

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -262,7 +262,9 @@ export default class Cesium extends GlobeOrMap {
     this._disposeWorkbenchMapItemsSubscription = this.observeModelLayer();
     this._disposeTerrainReaction = autorun(() => {
       this.scene.globe.terrainProvider = this._terrainProvider;
-      this.scene.globe.splitDirection = this.terria.showSplitter ? this.terria.terrainSplitDirection : ImagerySplitDirection.NONE;
+      this.scene.globe.splitDirection = this.terria.showSplitter
+        ? this.terria.terrainSplitDirection
+        : ImagerySplitDirection.NONE;
     });
     this._disposeSplitterReaction = this._reactToSplitterChanges();
 

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1,15 +1,18 @@
 import { action, computed, observable, runInAction, toJS } from "mobx";
 import { createTransformer } from "mobx-utils";
 import Clock from "terriajs-cesium/Source/Core/Clock";
+import defaultValue from "terriajs-cesium/Source/Core/defaultValue";
 import defined from "terriajs-cesium/Source/Core/defined";
 import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import CesiumEvent from "terriajs-cesium/Source/Core/Event";
 import queryToObject from "terriajs-cesium/Source/Core/queryToObject";
 import RuntimeError from "terriajs-cesium/Source/Core/RuntimeError";
+import ImagerySplitDirection from "terriajs-cesium/Source/Scene/ImagerySplitDirection";
 import URI from "urijs";
 import AsyncLoader from "../Core/AsyncLoader";
 import Class from "../Core/Class";
 import ConsoleAnalytics from "../Core/ConsoleAnalytics";
+import CorsProxy from "../Core/CorsProxy";
 import filterOutUndefined from "../Core/filterOutUndefined";
 import GoogleAnalytics from "../Core/GoogleAnalytics";
 import instanceOf from "../Core/instanceOf";
@@ -25,30 +28,27 @@ import TerriaError from "../Core/TerriaError";
 import PickedFeatures from "../Map/PickedFeatures";
 import GroupMixin from "../ModelMixins/GroupMixin";
 import ReferenceMixin from "../ModelMixins/ReferenceMixin";
+import TimeVarying from "../ModelMixins/TimeVarying";
 import { BaseMapViewModel } from "../ViewModels/BaseMapViewModel";
 import TerriaViewer from "../ViewModels/TerriaViewer";
 import CameraView from "./CameraView";
+import CatalogGroup from "./CatalogGroupNew";
 import CatalogMemberFactory from "./CatalogMemberFactory";
 import Catalog from "./CatalogNew";
 import CommonStrata from "./CommonStrata";
 import Feature from "./Feature";
 import GlobeOrMap from "./GlobeOrMap";
 import InitSource, { isInitOptions, isInitUrl } from "./InitSource";
+import MagdaReference from "./MagdaReference";
+import MapInteractionMode from "./MapInteractionMode";
 import Mappable from "./Mappable";
 import { BaseModel } from "./Model";
-import NoViewer from "./NoViewer";
 import ShareDataService from "./ShareDataService";
 import TimelineStack from "./TimelineStack";
 import updateModelFromJson from "./updateModelFromJson";
 import upsertModelFromJson from "./upsertModelFromJson";
-import Workbench from "./Workbench";
-import CorsProxy from "../Core/CorsProxy";
-import MapInteractionMode from "./MapInteractionMode";
-import TimeVarying from "../ModelMixins/TimeVarying";
-import MagdaReference from "./MagdaReference";
-import CatalogGroup from "./CatalogGroupNew";
 import ViewerMode from "./ViewerMode";
-import defaultValue from "terriajs-cesium/Source/Core/defaultValue";
+import Workbench from "./Workbench";
 
 interface ConfigParameters {
   [key: string]: ConfigParameters[keyof ConfigParameters];
@@ -206,6 +206,8 @@ export default class Terria {
   @observable showSplitter = false;
   @observable splitPosition = 0.5;
   @observable splitPositionVertical = 0.5;
+  @observable terrainSplitDirection: ImagerySplitDirection =
+    ImagerySplitDirection.NONE;
 
   @observable stories: any[] = [];
 

--- a/lib/ReactViews/Map/Panels/setting-panel.scss
+++ b/lib/ReactViews/Map/Panels/setting-panel.scss
@@ -20,7 +20,7 @@
   padding: $padding-mini;
 
   composes: col from "../../../Sass/common/_base.scss";
-  composes: col-4 from "../../../Sass/common/_base.scss";
+  composes: col-3 from "../../../Sass/common/_base.scss";
 }
 
 .btn--viewer {

--- a/lib/ThirdParty/terriajs-cesium/index.d.ts
+++ b/lib/ThirdParty/terriajs-cesium/index.d.ts
@@ -975,7 +975,11 @@ declare module "terriajs-cesium/Source/Scene/GetFeatureInfoFormat" {
   export default Cesium.GetFeatureInfoFormat;
 }
 declare module "terriajs-cesium/Source/Scene/Globe" {
-  export default Cesium.Globe;
+  import ImagerySplitDirection from "terriajs-cesium/Source/Scene/ImagerySplitDirection";
+  class Globe extends Cesium.Globe {
+    splitDirection: ImagerySplitDirection;
+  }
+  export default Globe;
 }
 declare module "terriajs-cesium/Source/Scene/GoogleEarthEnterpriseImageryProvider" {
   export default Cesium.GoogleEarthEnterpriseImageryProvider;
@@ -1078,9 +1082,11 @@ declare module "terriajs-cesium/Source/Scene/PrimitiveCollection" {
 }
 declare module "terriajs-cesium/Source/Scene/Scene" {
   import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+  import Globe from "terriajs-cesium/Source/Scene/Globe";
   class Scene extends Cesium.Scene {
     canvas: HTMLCanvasElement;
     tweens: any;
+    readonly globe: Globe;
     /**
      * NOTE: Private in Cesium, should only be called if there is no other alternative.
      * */


### PR DESCRIPTION
Implemented terrain splitting and the `depthTestAgainstTerrain` option in mobx. These settings are now on the Map panel instead of on the workbench like they were in master. This way even the default terrain can be split and configured to obscure underground features.

This panel is getting busy though... 😬 

![image](https://user-images.githubusercontent.com/924374/69626848-9988a300-109d-11ea-83fb-5dd0544523f3.png)
