### PR TITLE
Handle if a coord array is empty in geojson

### DIFF
--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -725,6 +725,7 @@ function reprojectToGeographic(geoJsonItem, geoJson) {
       if (result) {
         filterValue(geoJson, "coordinates", function(obj, prop) {
           obj[prop] = filterArray(obj[prop], function(pts) {
+            if (pts.length === 0) return [];
             return reprojectPointList(pts, code);
           });
         });


### PR DESCRIPTION
Came across a geojson file today which had a geometry with an empty array for the `coordinates`
Technically this isn't valid geojson but looks like we'll come across it in the pacific.

````
{ 
  "type": "Feature", 
  "properties": {
      "Id": 4
   }, "geometry": {
       "type": "MultiPolygon", 
       "coordinates": [ ]
   } 
},
````
Currently proj4j will throw an error when it encounters that feature.