### PR TITLE
added time parameter for delta catalogue item

### DIFF
--- a/lib/ReactViews/Tools/DeltaTool/DeltaTool.jsx
+++ b/lib/ReactViews/Tools/DeltaTool/DeltaTool.jsx
@@ -97,10 +97,11 @@ function DeltaTool({ terria, tool, onCloseTool }) {
     // item.loadingMessage = "Loading difference map";
     // item.isLoading = true;
 
-    item.showDeltaImagery(
-      dateParamFormat(primaryDate),
-      dateParamFormat(secondaryDate)
-    );
+    const firstDateParam = dateParamFormat(primaryDate);
+    const secondDateParam = dateParamFormat(secondaryDate);
+    item.parameters['time'] = `${firstDateParam},${secondDateParam}`;
+
+    item.showDeltaImagery(firstDateParam, secondDateParam);
     onCloseTool();
   }
 


### PR DESCRIPTION
This PR adds the `time` parameter for delta catalogue item. We need this extra parameter for the reasons as follows:
The delta catalogue item is a copy of the original WMS catalogue item with same layer and style names. This creates a problem for `GetLegendGraphic` on the server side because the URL parameters are identical between the original and delta catalogue items. In order to tell which catalogue initiates `GetLegendGraphic`, we need an extra parameter for the differentiation. Among several choices, `time` is a good choice to best take advantage of the current infrastructure of both Terria and GSKY.