### PR TITLE
made copy of item.parameters for delta catalogue item

### DIFF
--- a/lib/ReactViews/Tools/DeltaTool/DeltaTool.jsx
+++ b/lib/ReactViews/Tools/DeltaTool/DeltaTool.jsx
@@ -196,6 +196,7 @@ PrettyLocation.displayName = "PrettyLocation";
 function duplicateItem(item) {
   const serializedItem = item.serializeToJson();
   serializedItem.name = serializedItem.name + " (copy)";
+  serializedItem.parameters = Object.assign({}, serializedItem.parameters);
   delete serializedItem.id;
   const newItem = createCatalogMemberFromType(item.type, item.terria);
   newItem.updateFromJson(serializedItem);


### PR DESCRIPTION
the `newItem` returned from function `duplicateItem` holds the same object reference to `item.parameters` as the original wms catalogue item. This causes problems when we introduced the extra `time` parameter. The following steps illustrate the problem:
1) Select a layer/style and generates its delta image as usual. You will see two different legend graphics for the original wms and the delta catalogue items respectively, which is correct.
2) Remove both delta and the original catalogue items from the left panel
3) Select the same layer again and add it to the left panel 
4) Try to select different styles a few times. For those styles with delta enabled, the original wms catalogue item will show delta legend graphics, which is incorrect.

This PR makes at least a shadow copy of `item.parameters` such that the original the duplicated catalogue items have separate `parameters` objects.