### PR TITLE
Remove duplicate vehicle positions from GTFS feed

### DIFF
--- a/lib/Models/GtfsCatalogItem.ts
+++ b/lib/Models/GtfsCatalogItem.ts
@@ -93,24 +93,24 @@ export default class GtfsCatalogItem extends AsyncMappableMixin(
     // so we'll only display the newest record.
     // Although technically the timestamp property is optional, if none is
     // present we'll show the record.
-    const vehicleMap = new Map()
+    const vehicleMap = new Map();
     for (var i = 0; i < feedEntities.length; ++i) {
-      const entity: FeedEntity = feedEntities[i]
-      const item: VehicleData = this.convertFeedEntityToBillboardData(entity)
+      const entity: FeedEntity = feedEntities[i];
+      const item: VehicleData = this.convertFeedEntityToBillboardData(entity);
 
       if (item && item.position && item.featureInfo) {
-        const vehicleInfo = item.featureInfo.get('entity').vehicle.vehicle
+        const vehicleInfo = item.featureInfo.get("entity").vehicle.vehicle;
         if (vehicleMap.has(vehicleInfo.id) && vehicleInfo.timestamp) {
-          let existingRecord = vehicleMap.get(vehicleInfo.id)
+          let existingRecord = vehicleMap.get(vehicleInfo.id);
           if (existingRecord.timestamp < vehicleInfo.timestamp) {
-            vehicleMap.set(vehicleInfo.id, item)
+            vehicleMap.set(vehicleInfo.id, item);
           }
         } else {
-          vehicleMap.set(vehicleInfo.id, item)
+          vehicleMap.set(vehicleInfo.id, item);
         }
       }
     }
-    return [ ...vehicleMap.values() ]
+    return [...vehicleMap.values()];
   });
 
   @computed


### PR DESCRIPTION
When a GTFS update is retrieved it can many records for a single vehicle. This PR slims down the data by ensuring we only use the most recent record for a vehicle based on the timestamp.

Here is a sample catalog item
````
    {
        "name": "Ferries",
        "url": "https://api.transport.nsw.gov.au/v1/gtfs/vehiclepos/ferries",
        "type": "gtfs"
      }
````