### PR TITLE
Fix closing of search in mobx

### DIFF
--- a/lib/ReactViews/Search/SidebarSearch.jsx
+++ b/lib/ReactViews/Search/SidebarSearch.jsx
@@ -1,5 +1,6 @@
 import createReactClass from "create-react-class";
 import { observer } from "mobx-react";
+import { runInAction } from "mobx";
 import PropTypes from "prop-types";
 import React from "react";
 import { addMarker } from "../../Models/LocationMarkerUtils";
@@ -19,7 +20,9 @@ const SidebarSearch = observer(
     },
 
     backToNowViewing() {
-      this.props.viewState.searchState.showLocationSearchResults = false;
+      runInAction(() => {
+        this.props.viewState.searchState.showLocationSearchResults = false;
+      });
     },
 
     onLocationClick(result) {


### PR DESCRIPTION
- use a mobx deployment
- search location (Penrith or any other)
- select one of the search results
- click on Done
- list doesn't close when clicking on Done

A mobx action error was thrown so this resolves it

Related to https://github.com/TerriaJS/nsw-digital-twin/issues/157