### PR TITLE
Filter out times that cause fromISO8601 to throw

### DIFF
--- a/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
+++ b/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
@@ -66,10 +66,14 @@ export default function DiscretelyTimeVaryingMixin<
           if (dt.time === undefined) {
             return undefined;
           }
-          return {
-            time: JulianDate.fromIso8601(dt.time),
-            tag: dt.tag !== undefined ? dt.tag : dt.time
-          };
+          try {
+            return {
+              time: JulianDate.fromIso8601(dt.time),
+              tag: dt.tag !== undefined ? dt.tag : dt.time
+            };
+          } catch {
+            return undefined;
+          }
         })
       );
 


### PR DESCRIPTION
Primarily for non-standards conforming WMS.