### PR TITLE
Model architecture: Support other types of Cesium 3D Tiles features.

### DIFF
--- a/lib/Models/Cesium3DTilesCatalogItem.ts
+++ b/lib/Models/Cesium3DTilesCatalogItem.ts
@@ -244,7 +244,7 @@ export default class Cesium3DTilesCatalogItem
   }
 
   buildFeatureFromPickResult(_screenPosition: Cartesian2, pickResult: any) {
-    if (pickResult instanceof Cesium3DTileFeature) {
+    if (isCesium3DTileFeature(pickResult)) {
       const properties: { [name: string]: unknown } = {};
       pickResult.getPropertyNames().forEach(name => {
         properties[name] = pickResult.getProperty(name);
@@ -258,4 +258,8 @@ export default class Cesium3DTilesCatalogItem
       return result;
     }
   }
+}
+
+function isCesium3DTileFeature(o: any): o is Cesium3DTileFeature {
+  return "getPropertyNames" in o && "getProperty" in o;
 }


### PR DESCRIPTION
Not all 3D Tiles features are instances of `Cesium3DTileFeature`, cause Cesium doesn't really use inheritance.

This makes feature info work with Cesium 3D Tiles with a `vctr` payload.