### PR TITLE
Revert i18n changes to basemap naming

### DIFF
--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -427,16 +427,7 @@
     "searchCatalogueItem" : "Catalogue Items",
     "searchNoCatalogueItem" : "Sorry, no catalogue items match your search query.",
     "inMultipleLocations" : "In multiple locations including: ",
-    "inDataCatalogue" : "In Data Catalogue",
-    "bingMapsAerialWithLabels" : "Bing Maps Aerial with Labels",
-    "bingMapsAerial" : "Bing Maps Aerial",
-    "bingMapRoads" : "Bing Maps Roads",
-    "naturalEarthII" : "Natural Earth II",
-    "nasaBlackMarble" : "NASA Black Marble",
-    "positronLight" : "Positron (Light)",
-    "positronAttribution" : "© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0",
-    "darkMatter" : "Dark Matter",
-    "darkMatterAttribution": "© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0"
+    "inDataCatalogue" : "In Data Catalogue"
   },
   "terriaViewer" : {
     "slowWebGLAvailableTitle" : "Poor WebGL performance",

--- a/lib/ViewModels/createBingBaseMapOptions.js
+++ b/lib/ViewModels/createBingBaseMapOptions.js
@@ -8,7 +8,6 @@ const BingMapsStyle = require("terriajs-cesium/Source/Scene/BingMapsStyle")
 const IonImageryCatalogItem = require("../Models/IonImageryCatalogItem");
 const IonWorldImageryStyle = require("terriajs-cesium/Source/Scene/IonWorldImageryStyle")
   .default;
-import i18next from "i18next";
 
 function createBingBaseMapOptions(terria, bingMapsKey) {
   const result = [];
@@ -45,9 +44,7 @@ function createBingBaseMapOptions(terria, bingMapsKey) {
     return result;
   }
 
-  bingMapsAerialWithLabels.name = i18next.t(
-    "viewModels.bingMapsAerialWithLabels"
-  );
+  bingMapsAerialWithLabels.name = "Bing Maps Aerial with Labels";
   bingMapsAerialWithLabels.opacity = 1.0;
   bingMapsAerialWithLabels.isRequiredForRendering = true;
 
@@ -58,7 +55,7 @@ function createBingBaseMapOptions(terria, bingMapsKey) {
     })
   );
 
-  bingMapsAerial.name = i18next.t("viewModels.bingMapsAerial");
+  bingMapsAerial.name = "Bing Maps Aerial";
   bingMapsAerial.opacity = 1.0;
   bingMapsAerial.isRequiredForRendering = true;
 
@@ -69,7 +66,7 @@ function createBingBaseMapOptions(terria, bingMapsKey) {
     })
   );
 
-  bingMapsRoads.name = i18next.t("viewModels.bingMapsAerialWithLabels");
+  bingMapsRoads.name = "Bing Maps Roads";
   bingMapsRoads.opacity = 1.0;
   bingMapsRoads.isRequiredForRendering = true;
 

--- a/lib/ViewModels/createGlobalBaseMapOptions.js
+++ b/lib/ViewModels/createGlobalBaseMapOptions.js
@@ -5,13 +5,12 @@ var createBingBaseMapOptions = require("./createBingBaseMapOptions");
 var BaseMapViewModel = require("./BaseMapViewModel");
 var WebMapServiceCatalogItem = require("../Models/WebMapServiceCatalogItem");
 var OpenStreetMapCatalogItem = require("../Models/OpenStreetMapCatalogItem");
-import i18next from "i18next";
 
 var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
   var result = createBingBaseMapOptions(terria, bingMapsKey);
 
   var naturalEarthII = new WebMapServiceCatalogItem(terria);
-  naturalEarthII.name = i18next.t("viewModels.naturalEarthII");
+  naturalEarthII.name = "Natural Earth II";
   naturalEarthII.url =
     "http://geoserver.nationalmap.nicta.com.au/imagery/natural-earth-ii/wms";
   naturalEarthII.layers = "natural-earth-ii:NE2_HR_LC_SR_W_DR";
@@ -29,7 +28,7 @@ var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
   );
 
   var blackMarble = new WebMapServiceCatalogItem(terria);
-  blackMarble.name = i18next.t("viewModels.nasaBlackMarble");
+  blackMarble.name = "NASA Black Marble";
   blackMarble.url =
     "http://geoserver.nationalmap.nicta.com.au/imagery/nasa-black-marble/wms";
   blackMarble.layers =
@@ -48,7 +47,7 @@ var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
   );
 
   var positron = new OpenStreetMapCatalogItem(terria);
-  positron.name = i18next.t("viewModels.positronLight");
+  positron.name = "Positron (Light)";
   positron.url = "https://global.ssl.fastly.net/light_all/";
 
   // https://cartodb.com/basemaps/ gives two different attribution strings. In any case HTML gets swallowed, so we have to adapt.
@@ -56,7 +55,8 @@ var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
   //   <a href="http://cartodb.com/attributions">CartoDB</a>'
   // 2 Map tiles by <a href="http://cartodb.com/attributions#basemaps">CartoDB</a>, under <a href="https://creativecommons.org/licenses/by/3.0/">
   //   CC BY 3.0</a>. Data by <a href="http://www.openstreetmap.org/">OpenStreetMap</a>, under ODbL.
-  positron.attribution = i18next.t("viewModels.positronAttribution");
+  positron.attribution =
+    "© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0";
 
   positron.opacity = 1.0;
   positron.subdomains = [
@@ -74,10 +74,11 @@ var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
   );
 
   var darkMatter = new OpenStreetMapCatalogItem(terria);
-  darkMatter.name = i18next.t("viewModels.darkMatter");
+  darkMatter.name = "Dark Matter";
   darkMatter.url = "https://global.ssl.fastly.net/dark_all/";
 
-  darkMatter.attribution = i18next.t("viewModels.darkMatterAttribution");
+  darkMatter.attribution =
+    "© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0";
 
   darkMatter.opacity = 1.0;
   darkMatter.subdomains = [


### PR DESCRIPTION
Basemap names are used in code, config files and share json. At the moment Terria isn't set up to allow them changing names. If you do need basemaps to have a different name from their defaults it would be best to replace the files that create the basemaps, and that way you can also change the basemap images. You can then use those new names in config files.

@zoran995 FYI.