### PR TITLE
Model architecture: Better duplication of loadable strata

### DIFF
--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -23,6 +23,7 @@ import createStratumInstance from "./createStratumInstance";
 import getToken from "./getToken";
 import LoadableStratum from "./LoadableStratum";
 import Mappable from "./Mappable";
+import { BaseModel } from "./Model";
 import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
 import StratumOrder from "./StratumOrder";
 
@@ -81,6 +82,16 @@ class MapServerStratum extends LoadableStratum(
     readonly token: string | undefined
   ) {
     super();
+  }
+
+  duplicateLoadableStratum(newModel: BaseModel): this {
+    return new MapServerStratum(
+      newModel as ArcGisMapServerCatalogItem,
+      this._mapServer,
+      this._allLayers,
+      this._legends,
+      this.token
+    ) as this;
   }
 
   get mapServerData() {

--- a/lib/Models/CreateModel.ts
+++ b/lib/Models/CreateModel.ts
@@ -1,4 +1,4 @@
-import { computed, observable, runInAction, trace, action } from "mobx";
+import { action, computed, observable, runInAction, trace } from "mobx";
 import { getObjectId } from "../Traits/ArrayNestedStrataMap";
 import { ModelId } from "../Traits/ModelReference";
 import ModelTraits from "../Traits/ModelTraits";
@@ -6,6 +6,7 @@ import { ObjectArrayTrait } from "../Traits/objectArrayTrait";
 import TraitsConstructor from "../Traits/TraitsConstructor";
 import addModelStrataView from "./addModelStrataView";
 import createStratumInstance from "./createStratumInstance";
+import { isLoadableStratum } from "./LoadableStratum";
 import ModelType, {
   ArrayElementTypes,
   BaseModel,
@@ -66,8 +67,11 @@ export default function CreateModel<T extends TraitsConstructor<ModelTraits>>(
 
     duplicateModel(newId: ModelId): this {
       const newModel = new (<any>this.constructor)(newId, this.terria);
-      this.strata.forEach((strata, stratumId) => {
-        newModel.strata.set(stratumId, createStratumInstance(Traits, strata));
+      this.strata.forEach((stratum, stratumId) => {
+        const newStratum = isLoadableStratum(stratum)
+          ? stratum.duplicateLoadableStratum(newModel)
+          : createStratumInstance(Traits, stratum);
+        newModel.strata.set(stratumId, newStratum);
       });
       this.terria.addModel(newModel);
       return newModel;

--- a/lib/Models/LoadableStratum.ts
+++ b/lib/Models/LoadableStratum.ts
@@ -2,11 +2,18 @@ import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import Constructor from "../Core/Constructor";
 import ModelTraits from "../Traits/ModelTraits";
 import TraitsConstructor from "../Traits/TraitsConstructor";
+import { BaseModel } from "./Model";
 import StratumFromTraits from "./StratumFromTraits";
+
+export abstract class LoadableStratumClass {
+  abstract duplicateLoadableStratum(newModel: BaseModel): this;
+}
 
 export default function LoadableStratum<
   T extends TraitsConstructor<ModelTraits>
->(Traits: T): Constructor<StratumFromTraits<InstanceType<T>>> {
+>(
+  Traits: T
+): Constructor<LoadableStratumClass & StratumFromTraits<InstanceType<T>>> {
   abstract class LoadableStratum {}
 
   // All traits return undefined by default, and throw if set.
@@ -31,4 +38,8 @@ export default function LoadableStratum<
   // The cast is necessary because TypeScript can't see that we've
   // manually defined all the necessary properties.
   return <any>LoadableStratum;
+}
+
+export function isLoadableStratum(x: any): x is LoadableStratumClass {
+  return "duplicateLoadableStratum" in x;
 }

--- a/lib/Models/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/WebMapServiceCatalogGroup.ts
@@ -1,5 +1,5 @@
-import { computed, observable, runInAction, trace, action } from "mobx";
-import LoadableStratum from "./LoadableStratum";
+import { action, computed, runInAction } from "mobx";
+import filterOutUndefined from "../Core/filterOutUndefined";
 import isReadOnlyArray from "../Core/isReadOnlyArray";
 import TerriaError from "../Core/TerriaError";
 import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
@@ -10,13 +10,13 @@ import ModelReference from "../Traits/ModelReference";
 import WebMapServiceCatalogGroupTraits from "../Traits/WebMapServiceCatalogGroupTraits";
 import CommonStrata from "./CommonStrata";
 import CreateModel from "./CreateModel";
+import LoadableStratum from "./LoadableStratum";
+import { BaseModel } from "./Model";
 import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
-import Terria from "./Terria";
 import WebMapServiceCapabilities, {
   CapabilitiesLayer
 } from "./WebMapServiceCapabilities";
 import WebMapServiceCatalogItem from "./WebMapServiceCatalogItem";
-import filterOutUndefined from "../Core/filterOutUndefined";
 
 class GetCapabilitiesStratum extends LoadableStratum(
   WebMapServiceCatalogGroupTraits
@@ -49,6 +49,13 @@ class GetCapabilitiesStratum extends LoadableStratum(
     readonly capabilities: WebMapServiceCapabilities
   ) {
     super();
+  }
+
+  duplicateLoadableStratum(model: BaseModel): this {
+    return new GetCapabilitiesStratum(
+      model as WebMapServiceCatalogGroup,
+      this.capabilities
+    ) as this;
   }
 
   @computed

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -34,7 +34,7 @@ import CreateModel from "./CreateModel";
 import createStratumInstance from "./createStratumInstance";
 import LoadableStratum from "./LoadableStratum";
 import Mappable, { ImageryParts } from "./Mappable";
-import Model from "./Model";
+import { BaseModel } from "./Model";
 import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
 import StratumFromTraits from "./StratumFromTraits";
 import WebMapServiceCapabilities, {
@@ -92,6 +92,13 @@ class GetCapabilitiesStratum extends LoadableStratum(
     readonly capabilities: WebMapServiceCapabilities
   ) {
     super();
+  }
+
+  duplicateLoadableStratum(model: BaseModel): this {
+    return new GetCapabilitiesStratum(
+      model as WebMapServiceCatalogItem,
+      this.capabilities
+    ) as this;
   }
 
   @computed

--- a/lib/Models/WebProcessingServiceCatalogItem.ts
+++ b/lib/Models/WebProcessingServiceCatalogItem.ts
@@ -15,6 +15,7 @@ import createStratumInstance from "./createStratumInstance";
 import GeoJsonCatalogItem from "./GeoJsonCatalogItem";
 import LoadableStratum from "./LoadableStratum";
 import Mappable from "./Mappable";
+import { BaseModel } from "./Model";
 import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
 import StratumFromTraits from "./StratumFromTraits";
 import StratumOrder from "./StratumOrder";
@@ -29,6 +30,12 @@ class WpsLoadableStratum extends LoadableStratum(
 
   constructor(readonly item: WebProcessingServiceCatalogItem) {
     super();
+  }
+
+  duplicateLoadableStratum(newModel: BaseModel): this {
+    return new WpsLoadableStratum(
+      newModel as WebProcessingServiceCatalogItem
+    ) as this;
   }
 
   static async load(item: WebProcessingServiceCatalogItem) {

--- a/lib/Table/TableAutomaticStylesStratum.ts
+++ b/lib/Table/TableAutomaticStylesStratum.ts
@@ -5,6 +5,7 @@ import EnumColorMap from "../Map/EnumColorMap";
 import createStratumInstance from "../Models/createStratumInstance";
 import CsvCatalogItem from "../Models/CsvCatalogItem";
 import LoadableStratum from "../Models/LoadableStratum";
+import { BaseModel } from "../Models/Model";
 import StratumFromTraits from "../Models/StratumFromTraits";
 import CsvCatalogItemTraits from "../Traits/CsvCatalogItemTraits";
 import LegendTraits, { LegendItemTraits } from "../Traits/LegendTraits";
@@ -21,6 +22,10 @@ export default class TableAutomaticStylesStratum extends LoadableStratum(
 ) {
   constructor(readonly catalogItem: CsvCatalogItem) {
     super();
+  }
+
+  duplicateLoadableStratum(newModel: BaseModel): this {
+    return new TableAutomaticStylesStratum(newModel as CsvCatalogItem) as this;
   }
 
   @computed
@@ -105,6 +110,10 @@ export default class TableAutomaticStylesStratum extends LoadableStratum(
 class ColorStyleLegend extends LoadableStratum(LegendTraits) {
   constructor(readonly catalogItem: CsvCatalogItem, readonly index: number) {
     super();
+  }
+
+  duplicateLoadableStratum(newModel: BaseModel): this {
+    return new ColorStyleLegend(newModel as CsvCatalogItem, this.index) as this;
   }
 
   @computed


### PR DESCRIPTION
`duplicateModel` was turning every stratum into a plain old object with no smarts. This isn't the right thing to do with loadable strata. So now loadable strata are required to implement a method to duplicate themselves.

Fixes #3872 