### PR TITLE
Allow CkanCatalogItem names to be constructed from dataset and resource names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Added first revision of "delta feature" for change detection of WMS catalog items which indicate `supportsDeltaComparison`
 * Improve menu bar button hover/focus states when interacting with its panel contents
 * Add ability to set opacity on `GeoJsonCatalogItem` 
+* Allow `CkanCatalogItem` names to be constructed from dataset and resource names where multiple resources are available for a single dataset
 
 ### v7.10.0
 

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -123,6 +123,13 @@ var CkanCatalogGroup = function(terria) {
   this.useResourceName = false;
 
   /**
+   * Gets or sets a value indicating whether each catalog item's name should be populated from
+   * individual resources and the CKAN dataset where the are multiple resources for a single dataset.
+   * @type {Boolean}
+   */
+  this.useCombinationNameWhereMultipleResources = true;
+
+  /**
    * True to allow entire WMS servers (that is, WMS resources without a clearly-defined layer) to be
    * added to the catalog; otherwise, false.
    * @type {Boolean}
@@ -708,7 +715,9 @@ function createItemFromResource(resource, ckanGroup, itemData, extras, parent) {
     allowWfsGroups: ckanGroup.allowEntireWfsServers,
     dataCustodian: ckanGroup.dataCustodian,
     itemProperties: ckanGroup.itemProperties,
-    useResourceName: ckanGroup.useResourceName
+    useResourceName: ckanGroup.useResourceName,
+    useCombinationNameWhereMultipleResources:
+      ckanGroup.useCombinationNameWhereMultipleResources
   });
 }
 function populateGroupFromResults(ckanGroup, items) {

--- a/lib/Models/CkanCatalogItem.js
+++ b/lib/Models/CkanCatalogItem.js
@@ -353,6 +353,8 @@ freezeObject(CkanCatalogItem.defaultSerializers);
  *                                              server will be returned.
  * @param {Boolean} [options.useResourceName=false] True to use the name of the resource for the name of the catalog item; false to use the
  *                                                  name of the dataset.
+ * @param {Boolean} [options.useCombinationNameWhereMultipleResources=true] Use a combination of the name and the resource and dataset where
+                                                                            there are multiple resources for a single dataset.
  * @param {String} [options.dataCustodian] The data custodian to use, overriding any that might be inferred from the CKAN dataset.
  * @param {Object} [options.itemProperties] Additional properties to apply to the item once created.
  * @return {CatalogMember} The created catalog member, or undefined if no catalog member could be created from the resource.
@@ -458,6 +460,11 @@ CkanCatalogItem.createCatalogItemFromResource = function(options) {
 
   if (options.useResourceName) {
     newItem.name = resource.name;
+  } else if (
+    options.useCombinationNameWhereMultipleResources &&
+    itemData.resources.length > 1
+  ) {
+    newItem.name = `${itemData.title} - ${resource.name}`;
   } else {
     newItem.name = itemData.title;
   }


### PR DESCRIPTION
Currently if a dataset in CKAN has multiple resources the CkanCatalogItems will have the same name in the terria catalog.
![Current](https://user-images.githubusercontent.com/6735870/70587450-06637780-1c1e-11ea-80c8-d0f713c385f2.png)

There is a `useResourceName` property for CkanCatalogGroup however then you miss out on the dataset name which is often helpful.

This add an extra option to CkanCatalogGroup called `useCombinationNameWhereMultipleResources` which gives the CkanCatalogItem constructed from a combination of the resource name and the dataset name where a single dataset has multiple resources.

![CombinationName](https://user-images.githubusercontent.com/6735870/70587602-7e31a200-1c1e-11ea-85c5-ccc1176cb49b.png)
