### PR TITLE
suspend and resume events on setting geojson opacity

### DIFF
--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -805,6 +805,7 @@ function filterArray(pts, func) {
 
 function updateOpacity(item) {
   const entities = item.dataSource.entities.values;
+  item.dataSource.entities.suspendEvents();
   for (var i = 0; i < entities.length; i++) {
     const entity = entities[i];
 
@@ -838,6 +839,7 @@ function updateOpacity(item) {
         .withAlpha(item.opacity);
     }
   }
+  item.dataSource.entities.resumeEvents();
   item.terria.currentViewer.notifyRepaintRequired();
 }
 

--- a/lib/Models/GlobeOrMap.js
+++ b/lib/Models/GlobeOrMap.js
@@ -273,7 +273,7 @@ GlobeOrMap.prototype._highlightFeature = function(feature) {
       ).withAlpha(currentColor.alpha);
 
       this._removeHighlightCallback = function() {
-        const highlightFeatureColor = feature.cesiumEntity.polygon.material.getValue()
+        const highlightFeatureColor = cesiumPolygon.polygon.material.getValue()
           .color;
         cesiumPolygon.polygon.outline = polygonOutline;
         cesiumPolygon.polygon.outlineColor = polygonOutlineColor

--- a/lib/Models/GlobeOrMap.js
+++ b/lib/Models/GlobeOrMap.js
@@ -273,11 +273,12 @@ GlobeOrMap.prototype._highlightFeature = function(feature) {
       ).withAlpha(currentColor.alpha);
 
       this._removeHighlightCallback = function() {
-        cesiumPolygon.polygon.outline = polygonOutline;
-        cesiumPolygon.polygon.outlineColor = polygonOutlineColor;
-        cesiumPolygon.polygon.material = polygonMaterial;
         const highlightFeatureColor = feature.cesiumEntity.polygon.material.getValue()
           .color;
+        cesiumPolygon.polygon.outline = polygonOutline;
+        cesiumPolygon.polygon.outlineColor = polygonOutlineColor
+          .getValue()
+          .withAlpha(highlightFeatureColor.alpha);
         cesiumPolygon.polygon.material.color = currentColor.withAlpha(
           highlightFeatureColor.alpha
         );

--- a/lib/Models/GlobeOrMap.js
+++ b/lib/Models/GlobeOrMap.js
@@ -267,14 +267,20 @@ GlobeOrMap.prototype._highlightFeature = function(feature) {
       cesiumPolygon.polygon.outlineColor = Color.fromCssColorString(
         this.terria.baseMapContrastColor
       );
+      const currentColor = polygonMaterial.getValue().color;
       cesiumPolygon.polygon.material = Color.fromCssColorString(
         this.terria.baseMapContrastColor
-      ).withAlpha(0.75);
+      ).withAlpha(currentColor.alpha);
 
       this._removeHighlightCallback = function() {
         cesiumPolygon.polygon.outline = polygonOutline;
         cesiumPolygon.polygon.outlineColor = polygonOutlineColor;
         cesiumPolygon.polygon.material = polygonMaterial;
+        const highlightFeatureColor = feature.cesiumEntity.polygon.material.getValue()
+          .color;
+        cesiumPolygon.polygon.material.color = currentColor.withAlpha(
+          highlightFeatureColor.alpha
+        );
       };
     }
 


### PR DESCRIPTION
When setting opacity on geojson catalog items there would be a flicker added in #3852.

This PR adds `suspentEvents()` & `resumeEvents()` on the entityCollection to prevent excessive repaints.

Resolves #3876