### PR TITLE
Model architecture: Add an option to always show the timeline

### DIFF
--- a/lib/Models/DefaultTimelineModel.ts
+++ b/lib/Models/DefaultTimelineModel.ts
@@ -1,0 +1,26 @@
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import DiscretelyTimeVaryingMixin from "../ModelMixins/DiscretelyTimeVaryingMixin";
+import DiscretelyTimeVaryingTraits from "../Traits/DiscretelyTimeVaryingTraits";
+import CommonStrata from "./CommonStrata";
+import CreateModel from "./CreateModel";
+import Terria from "./Terria";
+
+export default class DefaultTimelineModel extends DiscretelyTimeVaryingMixin(
+  CreateModel(DiscretelyTimeVaryingTraits)
+) {
+  constructor(uniqueId: string | undefined, terria: Terria) {
+    super(uniqueId, terria);
+
+    const now = JulianDate.now();
+    this.setTrait(
+      CommonStrata.defaults,
+      "startTime",
+      JulianDate.toIso8601(JulianDate.addHours(now, -12, new JulianDate()))
+    );
+    this.setTrait(
+      CommonStrata.defaults,
+      "stopTime",
+      JulianDate.toIso8601(JulianDate.addHours(now, 12, new JulianDate()))
+    );
+  }
+}

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -622,6 +622,8 @@ export default class Terria {
 
         this.workbench.items = newItems;
 
+        // TODO: the timelineStack should be populated from the `timeline` property,
+        // not from the workbench.
         this.timelineStack.items = this.workbench.items
           .filter(item => {
             return item.uniqueId && timeline.indexOf(item.uniqueId) >= 0;

--- a/lib/Models/TimelineStack.ts
+++ b/lib/Models/TimelineStack.ts
@@ -3,6 +3,7 @@ import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import TimeVarying from "../ModelMixins/TimeVarying";
 import CommonStrata from "./CommonStrata";
 import filterOutUndefined from "../Core/filterOutUndefined";
+import ReferenceMixin from "../ModelMixins/ReferenceMixin";
 
 /**
  * Manages a stack of all the time-varying datasets currently attached to the timeline. Provides
@@ -18,6 +19,9 @@ export default class TimelineStack {
 
   @observable
   items: TimeVarying[] = [];
+
+  @observable
+  defaultTimeVarying: TimeVarying | undefined;
 
   private _disposeClockAutorun: IReactionDisposer;
   private _disposeTickSubscription: Cesium.Event.RemoveCallback;
@@ -74,10 +78,21 @@ export default class TimelineStack {
    */
   @computed
   get top(): TimeVarying | undefined {
-    if (this.items.length === 0) {
-      return undefined;
-    }
-    return this.items[this.items.length - 1];
+    // Find the first item with a current, start, and stop time.
+    // Use the default if there isn't one.
+    return (
+      this.items.find(item => {
+        const dereferenced: TimeVarying =
+          ReferenceMixin.is(item) && item.target
+            ? (item.target as TimeVarying)
+            : item;
+        return (
+          dereferenced.currentTimeAsJulianDate !== undefined &&
+          dereferenced.startTimeAsJulianDate !== undefined &&
+          dereferenced.stopTimeAsJulianDate !== undefined
+        );
+      }) || this.defaultTimeVarying
+    );
   }
 
   @computed

--- a/lib/Models/TimelineStack.ts
+++ b/lib/Models/TimelineStack.ts
@@ -181,6 +181,11 @@ export default class TimelineStack {
       layer.setTrait(stratumId, "currentTime", currentTime);
       layer.setTrait(stratumId, "isPaused", isPaused);
     }
+
+    if (this.defaultTimeVarying) {
+      this.defaultTimeVarying.setTrait(stratumId, "currentTime", currentTime);
+      this.defaultTimeVarying.setTrait(stratumId, "isPaused", isPaused);
+    }
   }
 }
 

--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -65,7 +65,10 @@ const Timeline = observer(
     render() {
       const terria = this.props.terria;
       const catalogItem = terria.timelineStack.top;
-      if (!defined(catalogItem) || !defined(catalogItem.currentTimeAsJulianDate)) {
+      if (
+        !defined(catalogItem) ||
+        !defined(catalogItem.currentTimeAsJulianDate)
+      ) {
         return null;
       }
 

--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -65,7 +65,7 @@ const Timeline = observer(
     render() {
       const terria = this.props.terria;
       const catalogItem = terria.timelineStack.top;
-      if (!defined(catalogItem)) {
+      if (!defined(catalogItem) || !defined(catalogItem.currentTimeAsJulianDate)) {
         return null;
       }
 

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -56,11 +56,18 @@ const DataCatalogItem = observer(
 
     toggleEnable(event) {
       const keepCatalogOpen = event.shiftKey || event.ctrlKey;
+      const toAdd = !this.props.terria.workbench.contains(this.props.item);
+
+      if (toAdd) {
+        this.props.terria.timelineStack.addToTop(this.props.item);
+      } else {
+        this.props.terria.timelineStack.remove(this.props.item);
+      }
 
       const addPromise = addToWorkbench(
         this.props.terria.workbench,
         this.props.item,
-        !this.props.terria.workbench.contains(this.props.item)
+        toAdd
       ).then(() => {
         if (
           this.props.terria.workbench.contains(this.props.item) &&

--- a/lib/ReactViews/DataCatalog/DataCatalogReference.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogReference.jsx
@@ -61,10 +61,20 @@ const DataCatalogReference = observer(
       ) {
         this.setPreviewedItem();
       } else {
+        const toAdd = !this.props.terria.workbench.contains(
+          this.props.reference
+        );
+
+        if (toAdd) {
+          this.props.terria.timelineStack.addToTop(this.props.reference);
+        } else {
+          this.props.terria.timelineStack.remove(this.props.reference);
+        }
+
         const addPromise = addToWorkbench(
           this.props.terria.workbench,
           this.props.reference,
-          !this.props.terria.workbench.contains(this.props.reference)
+          toAdd
         ).then(() => {
           if (
             this.props.terria.workbench.contains(this.props.reference) &&

--- a/lib/ReactViews/Map/Panels/SettingPanel.jsx
+++ b/lib/ReactViews/Map/Panels/SettingPanel.jsx
@@ -7,6 +7,7 @@ import PropTypes from "prop-types";
 import Slider from "rc-slider";
 import React from "react";
 import ImagerySplitDirection from "terriajs-cesium/Source/Scene/ImagerySplitDirection";
+import DefaultTimelineModel from "../../../Models/DefaultTimelineModel";
 // eslint-disable-next-line no-unused-vars
 import Terria from "../../../Models/Terria";
 import ViewerMode from "../../../Models/ViewerMode";
@@ -183,6 +184,17 @@ class SettingPanel extends React.Component {
       }
     }
 
+    const timelineStack = this.props.terria.timelineStack;
+    const alwaysShowTimeline =
+      timelineStack.defaultTimeVarying !== undefined &&
+      timelineStack.defaultTimeVarying.startTimeAsJulianDate !== undefined &&
+      timelineStack.defaultTimeVarying.stopTimeAsJulianDate !== undefined &&
+      timelineStack.defaultTimeVarying.currentTimeAsJulianDate !== undefined;
+
+    const alwaysShowTimelineLabel = alwaysShowTimeline
+      ? "Press to start only showing the timeline when there are time-varying datasets on the workbench"
+      : "Press to start always showing the timeline, even when no time-varying datasets are on the workbench";
+
     return (
       <MenuPanel
         theme={dropdownTheme}
@@ -297,6 +309,45 @@ class SettingPanel extends React.Component {
               </li>
             </For>
           </ul>
+        </div>
+        <div className={DropdownStyles.section}>
+          <label className={DropdownStyles.heading}>Timeline</label>
+          <section
+            className={Styles.nativeResolutionWrapper}
+            title={qualityLabels[this.props.terria.quality]}
+          >
+            <button
+              id="alwaysShowTimeline"
+              type="button"
+              onClick={() => {
+                runInAction(() => {
+                  if (alwaysShowTimeline) {
+                    this.props.terria.timelineStack.defaultTimeVarying = undefined;
+                  } else {
+                    this.props.terria.timelineStack.defaultTimeVarying = new DefaultTimelineModel();
+                  }
+                });
+              }}
+              title={alwaysShowTimelineLabel}
+              className={Styles.btnNativeResolution}
+            >
+              {alwaysShowTimeline ? (
+                <Icon glyph={Icon.GLYPHS.checkboxOn} />
+              ) : (
+                <Icon glyph={Icon.GLYPHS.checkboxOff} />
+              )}
+            </button>
+            <label
+              title={alwaysShowTimelineLabel}
+              htmlFor="alwaysShowTimeline"
+              className={classNames(
+                DropdownStyles.subHeading,
+                Styles.nativeResolutionHeader
+              )}
+            >
+              Always show
+            </label>
+          </section>
         </div>
         <If condition={this.props.terria.viewerMode !== ViewerMode.Leaflet}>
           <div className={DropdownStyles.section}>

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -47,11 +47,18 @@ class MappablePreview extends React.Component {
     }
 
     const keepCatalogOpen = event.shiftKey || event.ctrlKey;
+    const toAdd = !this.props.terria.workbench.contains(this.props.previewed);
+
+    if (toAdd) {
+      this.props.terria.timelineStack.addToTop(this.props.previewed);
+    } else {
+      this.props.terria.timelineStack.remove(this.props.previewed);
+    }
 
     const addPromise = addToWorkbench(
       this.props.terria.workbench,
       this.props.previewed,
-      !this.props.terria.workbench.contains(this.props.previewed)
+      toAdd
     ).then(() => {
       if (
         this.props.terria.workbench.contains(this.props.previewed) &&

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
@@ -32,6 +32,7 @@ const ViewingControls = observer(
     removeFromMap() {
       const workbench = this.props.viewState.terria.workbench;
       workbench.remove(this.props.item);
+      this.props.viewState.terria.timelineStack.remove(this.props.item);
     },
 
     zoomTo() {

--- a/lib/ReactViews/Workbench/Workbench.jsx
+++ b/lib/ReactViews/Workbench/Workbench.jsx
@@ -7,6 +7,7 @@ import WorkbenchList from "./WorkbenchList";
 import { observer } from "mobx-react";
 
 import Styles from "./workbench.scss";
+import { runInAction } from "mobx";
 
 const Workbench = observer(
   createReactClass({
@@ -18,7 +19,10 @@ const Workbench = observer(
     },
 
     removeAll() {
-      this.props.terria.workbench.removeAll();
+      runInAction(() => {
+        this.props.terria.workbench.removeAll();
+        this.props.terria.timelineStack.items.clear();
+      });
     },
 
     render() {


### PR DESCRIPTION
This is useful to adjust the sun position for lighting and shadows even when none of the datasets on the map are actually time-varying. In the NSW Digital Twin proof of concept we made Cesium 3D Tiles datasets and glTF datasets always show a timeline, but that was kind of misleading because it made it look like the dataset itself was time varying. So now it's a thing you can enable on the Map panel instead. Still not amazing, but better, I think.