### PR TITLE
Model architecture: Don't switch to preview for references that turn out to be groups.

### DIFF
--- a/lib/ReactViews/DataCatalog/DataCatalogReference.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogReference.jsx
@@ -27,8 +27,9 @@ const DataCatalogReference = observer(
 
     setPreviewedItem() {
       // raiseErrorOnRejectedPromise(this.props.item.terria, this.props.item.load());
+      let loadPromise;
       if (this.props.reference.loadReference) {
-        raiseErrorOnRejectedPromise(
+        loadPromise = raiseErrorOnRejectedPromise(
           this.props.terria,
           this.props.reference.loadReference()
         );
@@ -37,10 +38,21 @@ const DataCatalogReference = observer(
         this.props.reference,
         this.props.ancestors
       );
-      // mobile switch to nowvewing
-      this.props.viewState.switchMobileView(
-        this.props.viewState.mobileViewOptions.preview
-      );
+      // mobile switch to nowvewing, but only if this is a
+      // catalog item not a group.
+      if (loadPromise) {
+        loadPromise.then(() => {
+          if (
+            this.props.viewState.previewedItem === this.props.reference &&
+            this.props.reference.target &&
+            !this.props.reference.target.isGroup
+          ) {
+            this.props.viewState.switchMobileView(
+              this.props.viewState.mobileViewOptions.preview
+            );
+          }
+        });
+      }
     },
 
     add(event) {


### PR DESCRIPTION
When tapping on a catalog reference in the mobile view, only switch to the "preview" after the reference is loaded and it turns out to be a regular item (not a group).

Without this PR, tapping a group loaded from Magda sends the user to a broken-looking blank-ish page.