### PR TITLE
Mobx - Add open/collapse property to catalog items in workbench

### DIFF
--- a/lib/ReactViews/Workbench/WorkbenchItem.jsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.jsx
@@ -44,9 +44,12 @@ const WorkbenchItem = observer(
     },
 
     toggleDisplay() {
-      const item = this.props.item;
       runInAction(() => {
-        item.setTrait(CommonStrata.user, "isOpenInWorkbench", !item.isOpenInWorkbench);
+        this.props.item.setTrait(
+          CommonStrata.user,
+          "isOpenInWorkbench",
+          !this.props.item.isOpenInWorkbench
+        );
       });
     },
 

--- a/lib/ReactViews/Workbench/WorkbenchItem.jsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.jsx
@@ -44,7 +44,10 @@ const WorkbenchItem = observer(
     },
 
     toggleDisplay() {
-      this.props.item.isLegendVisible = !this.props.item.isLegendVisible;
+      const item = this.props.item;
+      runInAction(() => {
+        item.setTrait(CommonStrata.user, "isOpenInWorkbench", !item.isOpenInWorkbench);
+      });
     },
 
     openModal() {
@@ -71,7 +74,7 @@ const WorkbenchItem = observer(
         <li
           style={this.props.style}
           className={classNames(this.props.className, Styles.workbenchItem, {
-            [Styles.isOpen]: workbenchItem.isLegendVisible
+            [Styles.isOpen]: workbenchItem.isOpenInWorkbench
           })}
         >
           <ul className={Styles.header}>
@@ -115,7 +118,7 @@ const WorkbenchItem = observer(
                 className={Styles.btnToggle}
                 onClick={this.toggleDisplay}
               >
-                {workbenchItem.isLegendVisible ? (
+                {workbenchItem.isOpenInWorkbench ? (
                   <Icon glyph={Icon.GLYPHS.opened} />
                 ) : (
                   <Icon glyph={Icon.GLYPHS.closed} />
@@ -125,7 +128,7 @@ const WorkbenchItem = observer(
             <li className={Styles.headerClearfix} />
           </ul>
 
-          <If condition={true || workbenchItem.isLegendVisible}>
+          <If condition={workbenchItem.isOpenInWorkbench}>
             <div className={Styles.inner}>
               <ViewingControls
                 item={workbenchItem}

--- a/lib/Traits/CatalogMemberTraits.ts
+++ b/lib/Traits/CatalogMemberTraits.ts
@@ -74,6 +74,13 @@ export default class CatalogMemberTraits extends ModelTraits {
   info: InfoSectionTraits[] = [];
 
   @primitiveTrait({
+    type: "boolean",
+    name: "Is catalog item open in workbench",
+    description: "Whether the item in the workbench open or collapsed."
+  })
+  isOpenInWorkbench: boolean = true;
+
+  @primitiveTrait({
     type: "string",
     name: "Short report",
     description: "A short report to show on the now viewing tab."


### PR DESCRIPTION
Allows catalog items in the workbench to be collapsed. 

Previously this was called `isLegendVisible`, which doesn't seem like the best name for what it does given that it shows or hides a lot more than just the legend... so I've renamed it to `isOpenInWorkbench`, but I'm open to suggestions.

Resolves #3890
Resolves #3874