### PR TITLE
Replace static method in parameter editor components with plain functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Improve menu bar button hover/focus states when interacting with its panel contents
 * Add ability to set opacity on `GeoJsonCatalogItem`
 * Expanded test cases to ensure WorkbenchItem & Story have the correct order of components composed
+* Fix broken catalog functions when used with translation HOC
 
 ### v7.10.0
 

--- a/lib/ReactViews/Analytics/GenericParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/GenericParameterEditor.jsx
@@ -24,7 +24,7 @@ const GenericParameterEditor = createReactClass({
         className={Styles.field}
         type="text"
         onChange={this.onChange}
-        value={this.props.parameter.value}
+        value={this.props.parameter.value || ""}
       />
     );
   }

--- a/lib/ReactViews/Analytics/GeoJsonParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/GeoJsonParameterEditor.jsx
@@ -5,10 +5,19 @@ import PropTypes from "prop-types";
 import defined from "terriajs-cesium/Source/Core/defined";
 import ObserveModelMixin from "../ObserveModelMixin";
 import Styles from "./parameter-editors.scss";
-import PointParameterEditor from "./PointParameterEditor";
-import PolygonParameterEditor from "./PolygonParameterEditor";
-import SelectAPolygonParameterEditor from "./SelectAPolygonParameterEditor";
-import RegionPicker from "./RegionPicker";
+import {
+  selectOnMap as selectPointOnMap,
+  getDisplayValue as getPointParameterDisplayValue
+} from "./PointParameterEditor";
+import {
+  selectOnMap as selectPolygonOnMap,
+  getDisplayValue as getPolygonParameterDisplayValue
+} from "./PolygonParameterEditor";
+import {
+  selectOnMap as selectExistingPolygonOnMap,
+  getDisplayValue as getExistingPolygonParameterDisplayValue
+} from "./SelectAPolygonParameterEditor";
+import { getDisplayValue as getRegionPickerDisplayValue } from "./RegionPicker";
 import createReactClass from "create-react-class";
 import GeoJsonParameter from "../../Models/GeoJsonParameter";
 import { withTranslation } from "react-i18next";
@@ -29,17 +38,18 @@ const GeoJsonParameterEditor = createReactClass({
 
   selectPointOnMap() {
     this.props.parameter.value = undefined;
-    PointParameterEditor.selectOnMap(
+    selectPointOnMap(
       this.props.previewed.terria,
       this.props.viewState,
-      this.props.parameter
+      this.props.parameter,
+      this.props.t("analytics.selectLocation")
     );
     this.props.parameter.subtype = GeoJsonParameter.PointType;
   },
 
   selectPolygonOnMap() {
     this.props.parameter.value = undefined;
-    PolygonParameterEditor.selectOnMap(
+    selectPolygonOnMap(
       this.props.previewed.terria,
       this.props.viewState,
       this.props.parameter
@@ -49,7 +59,7 @@ const GeoJsonParameterEditor = createReactClass({
 
   selectExistingPolygonOnMap() {
     this.props.parameter.value = undefined;
-    SelectAPolygonParameterEditor.selectOnMap(
+    selectExistingPolygonOnMap(
       this.props.previewed.terria,
       this.props.viewState,
       this.props.parameter
@@ -100,14 +110,14 @@ const GeoJsonParameterEditor = createReactClass({
           className={Styles.field}
           type="text"
           readOnly
-          value={GeoJsonParameterEditor.getDisplayValue(
+          value={getDisplayValue(
             this.props.parameter.value,
             this.props.parameter
           )}
         />
         <If
           condition={
-            GeoJsonParameterEditor.getDisplayValue(
+            getDisplayValue(
               this.props.parameter.value,
               this.props.parameter
             ) === ""
@@ -120,20 +130,20 @@ const GeoJsonParameterEditor = createReactClass({
   }
 });
 
-GeoJsonParameterEditor.getDisplayValue = function(value, parameter) {
+function getDisplayValue(value, parameter) {
   if (!defined(parameter.subtype)) {
     return "";
   }
   if (parameter.subtype === GeoJsonParameter.PointType) {
-    return PointParameterEditor.getDisplayValue(value);
+    return getPointParameterDisplayValue(value);
   }
   if (parameter.subtype === GeoJsonParameter.SelectAPolygonType) {
-    return SelectAPolygonParameterEditor.getDisplayValue(value);
+    return getExistingPolygonParameterDisplayValue(value);
   }
   if (parameter.subtype === GeoJsonParameter.PolygonType) {
-    return PolygonParameterEditor.getDisplayValue(value);
+    return getPolygonParameterDisplayValue(value);
   }
-  return RegionPicker.getDisplayValue(value, parameter);
-};
+  return getRegionPickerDisplayValue(value, parameter);
+}
 
 module.exports = withTranslation()(GeoJsonParameterEditor);

--- a/lib/ReactViews/Analytics/LineParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/LineParameterEditor.jsx
@@ -75,9 +75,7 @@ const LineParameterEditor = createReactClass({
           className={Styles.field}
           type="text"
           onChange={this.setValueFromText}
-          value={LineParameterEditor.getDisplayValue(
-            this.props.parameter.value
-          )}
+          value={getDisplayValue(this.props.parameter.value)}
         />
         <button
           type="button"
@@ -118,7 +116,7 @@ LineParameterEditor.setValueFromText = function(e, parameter) {
  * @param {Object} value Native format of parameter value.
  * @return {String} String for display
  */
-LineParameterEditor.getDisplayValue = function(value) {
+export function getDisplayValue(value) {
   const pointsLongLats = value;
   if (!defined(pointsLongLats) || pointsLongLats.length < 1) {
     return "";
@@ -141,6 +139,6 @@ LineParameterEditor.getDisplayValue = function(value) {
   } else {
     return "";
   }
-};
+}
 
-module.exports = withTranslation()(LineParameterEditor);
+export default withTranslation()(LineParameterEditor);

--- a/lib/ReactViews/Analytics/PointParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PointParameterEditor.jsx
@@ -17,6 +17,7 @@ import ObserveModelMixin from "../ObserveModelMixin";
 
 import Styles from "./parameter-editors.scss";
 import { withTranslation, useTranslation } from "react-i18next";
+import i18n from "i18next";
 
 const PointParameterEditor = createReactClass({
   displayName: "PointParameterEditor",
@@ -47,10 +48,11 @@ const PointParameterEditor = createReactClass({
   },
 
   selectPointOnMap() {
-    PointParameterEditor.selectOnMap(
+    selectOnMap(
       this.props.previewed.terria,
       this.props.viewState,
-      this.props.parameter
+      this.props.parameter,
+      this.props.t("analytics.selectLocation")
     );
   },
 
@@ -61,7 +63,7 @@ const PointParameterEditor = createReactClass({
     }
 
     // Show the parameter's value if there is one.
-    return PointParameterEditor.getDisplayValue(this.props.parameter.value);
+    return getDisplayValue(this.props.parameter.value);
   },
 
   render() {
@@ -147,7 +149,7 @@ PointParameterEditor.setValueFromText = function(e, parameter) {
  * @param {Object} value Native format of parameter value.
  * @return {String} String for display
  */
-PointParameterEditor.getDisplayValue = function(value) {
+export function getDisplayValue(value) {
   const digits = 5;
 
   if (defined(value)) {
@@ -159,7 +161,7 @@ PointParameterEditor.getDisplayValue = function(value) {
   } else {
     return "";
   }
-};
+}
 
 /**
  * Prompt user to select/draw on map in order to define parameter.
@@ -167,12 +169,11 @@ PointParameterEditor.getDisplayValue = function(value) {
  * @param {Object} viewState ViewState.
  * @param {FunctionParameter} parameter Parameter.
  */
-PointParameterEditor.selectOnMap = function(terria, viewState, parameter) {
+export function selectOnMap(terria, viewState, parameter, interactionMessage) {
   // Cancel any feature picking already in progress.
   terria.pickedFeatures = undefined;
-  const { t } = useTranslation();
   const pickPointMode = new MapInteractionMode({
-    message: t("analytics.selectLocation"),
+    message: interactionMessage,
     onCancel: function() {
       terria.mapInteractionModeStack.pop();
       viewState.openAddData();
@@ -194,6 +195,6 @@ PointParameterEditor.selectOnMap = function(terria, viewState, parameter) {
     });
 
   viewState.explorerPanelIsVisible = false;
-};
+}
 
-module.exports = withTranslation()(PointParameterEditor);
+export default withTranslation()(PointParameterEditor);

--- a/lib/ReactViews/Analytics/PointParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PointParameterEditor.jsx
@@ -16,8 +16,7 @@ import MapInteractionMode from "../../Models/MapInteractionMode";
 import ObserveModelMixin from "../ObserveModelMixin";
 
 import Styles from "./parameter-editors.scss";
-import { withTranslation, useTranslation } from "react-i18next";
-import i18n from "i18next";
+import { withTranslation } from "react-i18next";
 
 const PointParameterEditor = createReactClass({
   displayName: "PointParameterEditor",

--- a/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
@@ -32,7 +32,7 @@ const PolygonParameterEditor = createReactClass({
   },
 
   selectPolygonOnMap() {
-    PolygonParameterEditor.selectOnMap(
+    selectOnMap(
       this.props.previewed.terria,
       this.props.viewState,
       this.props.parameter
@@ -47,9 +47,7 @@ const PolygonParameterEditor = createReactClass({
           className={Styles.field}
           type="text"
           onChange={this.setValueFromText}
-          value={PolygonParameterEditor.getDisplayValue(
-            this.props.parameter.value
-          )}
+          value={getDisplayValue(this.props.parameter.value)}
         />
         <button
           type="button"
@@ -77,7 +75,7 @@ PolygonParameterEditor.setValueFromText = function(e, parameter) {
  * @param {Object} value Native format of parameter value.
  * @return {String} String for display
  */
-PolygonParameterEditor.getDisplayValue = function(value) {
+export function getDisplayValue(value) {
   if (!defined(value) || value.length < 1) {
     return "";
   }
@@ -100,7 +98,7 @@ PolygonParameterEditor.getDisplayValue = function(value) {
   } else {
     return "";
   }
-};
+}
 
 /**
  * Helper function for processing clicked/moved points.
@@ -136,7 +134,7 @@ function getPointsLongLats(pointEntities, terria) {
  * @param {Object} viewState ViewState.
  * @param {FunctionParameter} parameter Parameter.
  */
-PolygonParameterEditor.selectOnMap = function(terria, viewState, parameter) {
+export function selectOnMap(terria, viewState, parameter) {
   const userDrawing = new UserDrawing({
     terria: terria,
     onPointClicked: function(pointEntities) {
@@ -151,6 +149,6 @@ PolygonParameterEditor.selectOnMap = function(terria, viewState, parameter) {
   });
   viewState.explorerPanelIsVisible = false;
   userDrawing.enterDrawMode();
-};
+}
 
-module.exports = withTranslation()(PolygonParameterEditor);
+export default withTranslation()(PolygonParameterEditor);

--- a/lib/ReactViews/Analytics/RegionParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionParameterEditor.jsx
@@ -9,7 +9,7 @@ import PropTypes from "prop-types";
 import ObserveModelMixin from "../ObserveModelMixin";
 
 import Styles from "./parameter-editors.scss";
-import RegionPicker from "./RegionPicker";
+import RegionPicker, { getDisplayValue } from "./RegionPicker";
 import MapInteractionMode from "../../Models/MapInteractionMode";
 
 const RegionParameterEditor = createReactClass({
@@ -37,7 +37,7 @@ const RegionParameterEditor = createReactClass({
           className={Styles.field}
           type="text"
           readOnly
-          value={RegionPicker.getDisplayValue(
+          value={getDisplayValue(
             this.props.parameter.value,
             this.props.parameter
           )}

--- a/lib/ReactViews/Analytics/RegionPicker.jsx
+++ b/lib/ReactViews/Analytics/RegionPicker.jsx
@@ -310,7 +310,7 @@ const RegionPicker = createReactClass({
           autoComplete="off"
           value={
             this.state.autocompleteText ||
-            RegionPicker.getDisplayValue(this.regionValue, this.props.parameter)
+            getDisplayValue(this.regionValue, this.props.parameter)
           }
           onChange={this.textChange}
           placeholder={t("analytics.regionName")}
@@ -349,7 +349,7 @@ const RegionPicker = createReactClass({
  * @param {Object} value Native format of parameter value.
  * @return {String} String for display
  */
-RegionPicker.getDisplayValue = function(region, parameter) {
+export function getDisplayValue(region, parameter) {
   if (!defined(region)) {
     return "";
   }
@@ -365,6 +365,6 @@ RegionPicker.getDisplayValue = function(region, parameter) {
     return "";
   }
   return regionProvider.regionType + ": " + val;
-};
+}
 
-module.exports = withTranslation()(RegionPicker);
+export default withTranslation()(RegionPicker);

--- a/lib/ReactViews/Analytics/SelectAPolygonParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/SelectAPolygonParameterEditor.jsx
@@ -55,11 +55,7 @@ const SelectAPolygonParameterEditor = createReactClass({
 /**
  * Prompts the user to select a point on the map.
  */
-SelectAPolygonParameterEditor.selectOnMap = function(
-  terria,
-  viewState,
-  parameter
-) {
+export function selectOnMap(terria, viewState, parameter) {
   // Cancel any feature picking already in progress.
   terria.pickedFeatures = undefined;
 
@@ -134,9 +130,9 @@ SelectAPolygonParameterEditor.selectOnMap = function(
     });
 
   viewState.explorerPanelIsVisible = false;
-};
+}
 
-SelectAPolygonParameterEditor.getDisplayValue = function(value) {
+export function getDisplayValue(value) {
   if (!defined(value) || value === "") {
     return "";
   }
@@ -145,6 +141,6 @@ SelectAPolygonParameterEditor.getDisplayValue = function(value) {
       return featureData.id;
     })
     .join(", ");
-};
+}
 
-module.exports = withTranslation()(SelectAPolygonParameterEditor);
+export default withTranslation()(SelectAPolygonParameterEditor);


### PR DESCRIPTION
So that we can pass them to higher-order-components like `withTranslation` without breaking code.

Fixes #3902