### PR TITLE
Fix bug with momentPoints chart type 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Add ability to set opacity on `GeoJsonCatalogItem`
 * Expanded test cases to ensure WorkbenchItem & Story have the correct order of components composed
 * Fix broken catalog functions when used with translation HOC
+* Fix bug with momentPoints chart type when plotting against series with null values
 
 ### v7.10.0
 

--- a/lib/Charts/MomentChartPoints.js
+++ b/lib/Charts/MomentChartPoints.js
@@ -15,6 +15,7 @@ class MomentChartPoints extends BaseChart {
   constructor() {
     super();
     this.alternateYAxis = null;
+    this._alternateYAxisFilteredPoints = null;
     this.chartData = null;
     this.yMin = null;
     this.yMax = null;
@@ -24,10 +25,14 @@ class MomentChartPoints extends BaseChart {
   render(chart, chartData, { chartTransform, scales, size }, alternateYAxis) {
     if (alternateYAxis !== null) {
       this.alternateYAxis = alternateYAxis.firstY;
+      this._alternateYAxisFilteredPoints = alternateYAxis.firstY.points.filter(
+        p => p.y !== null
+      );
       this.yMin = alternateYAxis.yMin;
       this.yMax = alternateYAxis.yMax;
     } else {
       this.alternateYAxis = null;
+      this._alternateYAxisFilteredPoints = null;
       this.yMin = 0;
       this.yMax = 1;
     }
@@ -64,7 +69,7 @@ class MomentChartPoints extends BaseChart {
             const xIndex = ch._findNearestX(d.x);
             if (
               xIndex === null ||
-              xIndex === ch.alternateYAxis.points.length - 2 ||
+              xIndex === ch._alternateYAxisFilteredPoints.length - 2 ||
               xIndex === -1
             )
               return size.plotHeight / 2;
@@ -72,14 +77,14 @@ class MomentChartPoints extends BaseChart {
             // Get the location that the marker should live along the x axis
             const xAsPercentage = ch._getXAsPercentage(
               d.x,
-              ch.alternateYAxis.points[xIndex].x,
-              ch.alternateYAxis.points[xIndex + 1].x
+              ch._alternateYAxisFilteredPoints[xIndex].x,
+              ch._alternateYAxisFilteredPoints[xIndex + 1].x
             );
 
             // find a y value based on the x
             const interNum = d3InterpolateNumber(
-              ch.alternateYAxis.points[xIndex].y,
-              ch.alternateYAxis.points[xIndex + 1].y
+              ch._alternateYAxisFilteredPoints[xIndex].y,
+              ch._alternateYAxisFilteredPoints[xIndex + 1].y
             );
             const calculatedRawY = interNum(xAsPercentage);
 
@@ -186,8 +191,11 @@ class MomentChartPoints extends BaseChart {
 
   _findNearestX(x) {
     const xToSearchFor = new Date(x).getTime();
-    for (var i = 0; i < this.alternateYAxis.points.length; i++) {
-      if (new Date(this.alternateYAxis.points[i].x).getTime() >= xToSearchFor)
+    for (var i = 0; i < this._alternateYAxisFilteredPoints.length; i++) {
+      if (
+        new Date(this._alternateYAxisFilteredPoints[i].x).getTime() >=
+        xToSearchFor
+      )
         return i - 1;
     }
     return null;


### PR DESCRIPTION
Fixes a bug with momentPoint chart when plotting against series with null values, the points would end up in no mans land because they wouldn't know where to put the y value.