### PR TITLE
Make legend title width a bit smaller

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Add ability to set opacity on `GeoJsonCatalogItem`
 * Expanded test cases to ensure WorkbenchItem & Story have the correct order of components composed
 * Fix broken catalog functions when used with translation HOC
+* Make the default `Legend` width a little smaller to account for the workbench scrollbar
 
 ### v7.10.0
 

--- a/lib/Map/Legend.js
+++ b/lib/Map/Legend.js
@@ -99,9 +99,9 @@ var Legend = function(props) {
   /**
    * Gets or sets the forced total width of the legend.
    * @type {Number}
-   * @default 315
+   * @default 310
    */
-  this.width = defaultValue(props.width, 315);
+  this.width = defaultValue(props.width, 310);
 
   /**
    * Gets or sets the horizontal offset of variable title.


### PR DESCRIPTION
Slight tweak to the max legend width which accounts for if the scrollbar is in play.

Resolves #3908 

sample csv content to drop on to a terria map
````
ID,Population,LGA_code_2015,Indicator #1: Case fatality rate (in HCF and Hospitals) for pneumonia in children <5yrs
1,100600,24600,VIC
````

![Screen](https://user-images.githubusercontent.com/6735870/72234727-81a3b900-3622-11ea-8aed-160117d8da85.png)
