### PR TITLE
Chart disclaimer for WMS items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Expanded test cases to ensure WorkbenchItem & Story have the correct order of components composed
 * Fix broken catalog functions when used with translation HOC
 * Make the default `Legend` width a little smaller to account for the workbench scrollbar
+* Add a `ChartDisclaimer` component to display an additional disclaimer above the chart panel in the bottom dock.
 
 ### v7.10.0
 

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -72,7 +72,7 @@ var CsvCatalogItem = function(terria, url, options) {
   this.isCsvForCharting = defaultValue(options.isCsvForCharting, false);
 
   /**
-   * A string to show above the chart as a disclaimer
+   * A HTML string to show above the chart as a disclaimer
    * @type {String}
    * @default null
    */

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -70,6 +70,13 @@ var CsvCatalogItem = function(terria, url, options) {
    * @type {Boolean}
    */
   this.isCsvForCharting = defaultValue(options.isCsvForCharting, false);
+
+  /**
+   * A string to show above the chart as a disclaimer
+   * @type {String}
+   * @default null
+   */
+  this.chartDisclaimer = defaultValue(options.chartDisclaimer, null);
 };
 
 inherit(TableCatalogItem, CsvCatalogItem);

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -314,6 +314,13 @@ var WebMapServiceCatalogItem = function(terria) {
    */
   this.tokenInvalidHttpCodes = [401, 498, 499];
 
+  /**
+   * A string to show above the chart as a disclaimer
+   * @type {String}
+   * @default null
+   */
+  this.chartDisclaimer = null;
+
   this._sourceInfoItemNames = ["GetCapabilities URL"];
 
   knockout.track(this, [

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -315,7 +315,7 @@ var WebMapServiceCatalogItem = function(terria) {
   this.tokenInvalidHttpCodes = [401, 498, 499];
 
   /**
-   * A string to show above the chart as a disclaimer
+   * A HTML string to show above the chart as a disclaimer
    * @type {String}
    * @default null
    */

--- a/lib/ReactViews/BottomDock/BottomDock.jsx
+++ b/lib/ReactViews/BottomDock/BottomDock.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import ChartPanel from "../Custom/Chart/ChartPanel.jsx";
+import ChartDisclaimer from "./ChartDisclaimer.jsx";
 import Timeline from "./Timeline/Timeline.jsx";
 import ObserveModelMixin from "../ObserveModelMixin";
 import Styles from "./bottom-dock.scss";
@@ -35,6 +36,7 @@ const BottomDock = createReactClass({
         tabIndex={0}
         onClick={this.handleClick}
       >
+        <ChartDisclaimer terria={terria} viewState={this.props.viewState} />
         <ChartPanel
           terria={terria}
           onHeightChange={this.onHeightChange}

--- a/lib/ReactViews/BottomDock/ChartDisclaimer.jsx
+++ b/lib/ReactViews/BottomDock/ChartDisclaimer.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import createReactClass from "create-react-class";
+import PropTypes from "prop-types";
+import ObserveModelMixin from "../ObserveModelMixin";
+import Styles from "./chart-disclaimer.scss";
+
+const ChartDisclaimer = createReactClass({
+  displayName: "ChartDisclaimer",
+  mixins: [ObserveModelMixin],
+
+  propTypes: {
+    terria: PropTypes.object.isRequired,
+    viewState: PropTypes.object.isRequired
+  },
+
+  render() {
+    if (
+      !this.props.viewState.chartIsOpen ||
+      this.props.terria.catalog.chartableItems.length === 0
+    )
+      return null;
+    const chartableItemsWithDisclaimers = this.props.terria.catalog.chartableItems.filter(
+      item => item.chartDisclaimer && item.type !== "wms"
+    );
+    if (chartableItemsWithDisclaimers.length === 0) return null;
+    const uniqueChartDisclaimers = [
+      ...new Set(chartableItemsWithDisclaimers.map(i => i.chartDisclaimer))
+    ];
+
+    return (
+      <div className={`${Styles.chartDisclaimerPanel}`}>
+        {uniqueChartDisclaimers.map((chartDisclaimer, i) => (
+          <p key={i}>{chartDisclaimer}</p>
+        ))}
+      </div>
+    );
+  }
+});
+
+export default ChartDisclaimer;

--- a/lib/ReactViews/BottomDock/ChartDisclaimer.jsx
+++ b/lib/ReactViews/BottomDock/ChartDisclaimer.jsx
@@ -3,6 +3,7 @@ import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import ObserveModelMixin from "../ObserveModelMixin";
 import Styles from "./chart-disclaimer.scss";
+import parseCustomHtmlToReact from "../Custom/parseCustomHtmlToReact";
 
 const ChartDisclaimer = createReactClass({
   displayName: "ChartDisclaimer",
@@ -30,7 +31,7 @@ const ChartDisclaimer = createReactClass({
     return (
       <div className={`${Styles.chartDisclaimerPanel}`}>
         {uniqueChartDisclaimers.map((chartDisclaimer, i) => (
-          <p key={i}>{chartDisclaimer}</p>
+          <p key={i}>{parseCustomHtmlToReact(chartDisclaimer)}</p>
         ))}
       </div>
     );

--- a/lib/ReactViews/BottomDock/chart-disclaimer.scss
+++ b/lib/ReactViews/BottomDock/chart-disclaimer.scss
@@ -2,8 +2,15 @@
 @import "../../Sass/common/mixins";
 
 .chart-disclaimer-panel {
-  background: #9a4c4c;
+  background: #9a4b4b;
   color: white;
-  padding: 1px 6px;
+  padding: 1px 10px;
   font-size: 0.8rem;
+  p {
+    margin: 10px 0px;
+    a,
+    a:visited {
+      color: white;
+    }
+  }
 }

--- a/lib/ReactViews/BottomDock/chart-disclaimer.scss
+++ b/lib/ReactViews/BottomDock/chart-disclaimer.scss
@@ -4,10 +4,10 @@
 .chart-disclaimer-panel {
   background: #9a4b4b;
   color: white;
-  padding: 1px 10px;
+  padding: 1px $padding;
   font-size: 0.8rem;
   p {
-    margin: 10px 0px;
+    margin: $padding 0px;
     a,
     a:visited {
       color: white;

--- a/lib/ReactViews/BottomDock/chart-disclaimer.scss
+++ b/lib/ReactViews/BottomDock/chart-disclaimer.scss
@@ -1,0 +1,9 @@
+@import "../../Sass/common/variables";
+@import "../../Sass/common/mixins";
+
+.chart-disclaimer-panel {
+  background: #9a4c4c;
+  color: white;
+  padding: 1px 6px;
+  font-size: 0.8rem;
+}

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -211,7 +211,10 @@ function expand(props, sourceIndex) {
     const url = defined(sourceIndex) ? props.sources[sourceIndex] : undefined;
     const newCatalogItem = new CsvCatalogItem(terria, url, {
       tableStyle: makeTableStyle(),
-      isCsvForCharting: true
+      isCsvForCharting: true,
+      chartDisclaimer: props.catalogItem.chartDisclaimer
+        ? props.catalogItem.chartDisclaimer
+        : null
     });
     const newGeoJsonItem = new GeoJsonCatalogItem(terria, null);
     newGeoJsonItem.isUserSupplied = true;


### PR DESCRIPTION
This PR adds some disclaimer text above a chart for configured catalog items.
Currently this only works for CSV items that are generated via a WMS item using the Expand button on the Feature Info panel

````
      {
         "name": "Some layer",
         "type": "wms",
         "url": "...",
         "layers": "....",
         "chartDisclaimer": "This layer will display disclaimer"
    },
````
![Draft1](https://user-images.githubusercontent.com/6735870/72316522-8df34900-36ea-11ea-9e6f-265a9b0a4794.png)

cc @vicborgy 