### PR TITLE
Update settings panel layout in mobx

### DIFF
--- a/lib/ReactViews/Map/Panels/SettingPanel.jsx
+++ b/lib/ReactViews/Map/Panels/SettingPanel.jsx
@@ -207,7 +207,7 @@ class SettingPanel extends React.Component {
           <label className={DropdownStyles.heading}> Map View </label>
           <ul className={Styles.viewerSelector}>
             <For each="viewerMode" of={viewerModes}>
-              <li key={viewerMode} className={Styles.listItem}>
+              <li key={viewerMode} className={Styles.listItemThreeCols}>
                 <button
                   onClick={this.selectViewer.bind(this, viewerMode)}
                   className={classNames(Styles.btnViewer, {
@@ -227,7 +227,7 @@ class SettingPanel extends React.Component {
             </label>
             <ul className={Styles.viewerSelector}>
               <For each="side" of={sides}>
-                <li key={side} className={Styles.listItem}>
+                <li key={side} className={Styles.listItemThreeCols}>
                   <button
                     onClick={this.showTerrainOnSide.bind(this, side)}
                     className={classNames(Styles.btnViewer, {
@@ -290,7 +290,7 @@ class SettingPanel extends React.Component {
           </label>
           <ul className={Styles.baseMapSelector}>
             <For each="baseMap" index="i" of={this.props.terria.baseMaps}>
-              <li key={i} className={Styles.listItem}>
+              <li key={i} className={Styles.listItemFourCols}>
                 <button
                   className={classNames(Styles.btnBaseMap, {
                     [Styles.isActive]:

--- a/lib/ReactViews/Map/Panels/setting-panel.scss
+++ b/lib/ReactViews/Map/Panels/setting-panel.scss
@@ -16,11 +16,16 @@
   margin: 0 -$padding-mini;
 }
 
-.list-item {
+.list-item-four-cols {
   padding: $padding-mini;
-
   composes: col from "../../../Sass/common/_base.scss";
   composes: col-3 from "../../../Sass/common/_base.scss";
+}
+
+.list-item-three-cols {
+  padding: $padding-mini;
+  composes: col from "../../../Sass/common/_base.scss";
+  composes: col-4 from "../../../Sass/common/_base.scss";
 }
 
 .btn--viewer {

--- a/lib/ReactViews/Map/Panels/setting-panel.scss.d.ts
+++ b/lib/ReactViews/Map/Panels/setting-panel.scss.d.ts
@@ -13,8 +13,10 @@ interface CssExports {
   'dropdownInner': string;
   'is-active': string;
   'isActive': string;
-  'list-item': string;
-  'listItem': string;
+  'list-item-four-cols': string;
+  'list-item-three-cols': string;
+  'listItemFourCols': string;
+  'listItemThreeCols': string;
   'native-resolution-header': string;
   'native-resolution-wrapper': string;
   'nativeResolutionHeader': string;


### PR DESCRIPTION
This PR adds a three and four col layout options for the settings panel.

![layout](https://user-images.githubusercontent.com/6735870/72698587-ee760080-3b98-11ea-9e75-fb62ad4a1d08.png)

resolves #3935