### PR TITLE
Fix styling of legend text

### DIFF
--- a/lib/ReactViews/Workbench/Controls/Legend.jsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.jsx
@@ -128,7 +128,7 @@ const Legend = observer(
           </When>
           <Otherwise>
             <li key={proxiedUrl}>
-              <a href={proxiedUrl} target="_blank" rel="noreferrer noopener">
+              <a href={proxiedUrl} target="_blank" rel="noreferrer noopener" className={Styles.legendOpenExternally}>
                 Open legend in a separate tab
               </a>
             </li>

--- a/lib/ReactViews/Workbench/Controls/legend.scss
+++ b/lib/ReactViews/Workbench/Controls/legend.scss
@@ -15,6 +15,11 @@
 
   // Small font size prevents the font from dictating the table row height.
   font-size: 5px;
+
+  .legendOpenExternally {
+    font-size: $font-size-small;
+    color: $text-light;
+  }
 }
 
 .legend__inner {

--- a/lib/ReactViews/Workbench/Controls/legend.scss.d.ts
+++ b/lib/ReactViews/Workbench/Controls/legend.scss.d.ts
@@ -9,6 +9,7 @@ interface CssExports {
   'legendImagehasError': string;
   'legendInner': string;
   'legendLegendBoxImg': string;
+  'legendOpenExternally': string;
   'legendSpacer': string;
   'legendSvg': string;
   'legendTitle': string;


### PR DESCRIPTION
Fixes the css related to the "Open legend in a separate tab" that sometimes gets displayed.

Can't actually find a catalog item that shows the above text anymore because the ArcGIS map service now works but did some manual workarounds to test 
![NewText](https://user-images.githubusercontent.com/6735870/72772210-6c98dc80-3c57-11ea-964b-df5269210429.png)

Resolves https://github.com/TerriaJS/nsw-digital-twin/issues/214