### PR TITLE
mobx: Make legend styling nicer

### DIFF
--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -65,6 +65,8 @@ interface Legend {
   label?: string;
   contentType: string;
   imageData: string;
+  width: number;
+  height: number;
 }
 
 class MapServerStratum extends LoadableStratum(
@@ -221,11 +223,18 @@ class MapServerStratum extends LoadableStratum(
   }
 
   @computed get legends() {
-    function newLegendItem(title: string, imageUrl: string) {
+    function newLegendItem(
+      title: string,
+      imageUrl: string,
+      width: number,
+      height: number
+    ) {
       const item = createStratumInstance(LegendItemTraits);
       runInAction(() => {
         item.title = title;
         item.imageUrl = imageUrl;
+        item.imageHeight = width;
+        item.imageWidth = height;
       });
       return item;
     }
@@ -259,7 +268,9 @@ class MapServerStratum extends LoadableStratum(
         );
         const dataUrl = "data:" + leg.contentType + ";base64," + leg.imageData;
         if (isDefined(legend.items)) {
-          legend.items.push(newLegendItem(title, dataUrl));
+          legend.items.push(
+            newLegendItem(title, dataUrl, leg.width, leg.height)
+          );
         }
       });
     });

--- a/lib/ReactViews/Workbench/Controls/Legend.jsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.jsx
@@ -175,7 +175,7 @@ const Legend = observer(
             backgroundImage: `url(${legendItem.imageUrl})`,
             backgroundRepeat: "no-repeat",
             backgroundPosition: "center",
-            backgroundSize: "cover",
+            width: `${legendItem.imageWidth}px`,
             ...boxStyle
           };
         } else {
@@ -186,7 +186,9 @@ const Legend = observer(
           };
         }
       }
-
+      const rowStyle = {
+        height: `${legendItem.imageHeight + 2}px`
+      };
       return (
         <React.Fragment key={i}>
           {legendItem.addSpacingAbove && (
@@ -194,19 +196,15 @@ const Legend = observer(
               <td />
             </tr>
           )}
-          <tr>
-            <td className={Styles.legendBox} style={boxStyle}>
-              {boxContents}
-            </td>
+          <tr style={rowStyle}>
+            <td style={boxStyle}>{boxContents}</td>
             <td className={Styles.legendTitles}>
               {legendItem.titleAbove && (
                 <div className={Styles.legendTitleAbove}>
                   {legendItem.titleAbove}
                 </div>
               )}
-              {legendItem.title && (
-                <div className={Styles.legendTitle}>{legendItem.title}</div>
-              )}
+              <div>{legendItem.title}</div>
               {legendItem.titleBelow && (
                 <div className={Styles.legendTitleBelow}>
                   {legendItem.titleBelow}

--- a/lib/ReactViews/Workbench/Controls/legend.scss
+++ b/lib/ReactViews/Workbench/Controls/legend.scss
@@ -66,12 +66,6 @@
   padding-bottom: $legend-padding;
 }
 
-.legendBox {
-  display: inline-block;
-  width: $legend-item-width;
-  height: $legend-item-height;
-}
-
 .legendTitles {
   font-size: 12px;
   line-height: $legend-item-height;
@@ -95,11 +89,6 @@
 
 .legendTitleBelow::before {
   content: "-";
-}
-
-.legendTitle {
-  position: absolute;
-  margin-top: -($legend-item-height / 2);
 }
 
 .legendSpacer {

--- a/lib/ReactViews/Workbench/Controls/legend.scss.d.ts
+++ b/lib/ReactViews/Workbench/Controls/legend.scss.d.ts
@@ -5,13 +5,11 @@ interface CssExports {
   'imageAnchor': string;
   'legend': string;
   'legend--svg': string;
-  'legendBox': string;
   'legendImagehasError': string;
   'legendInner': string;
   'legendLegendBoxImg': string;
   'legendSpacer': string;
   'legendSvg': string;
-  'legendTitle': string;
   'legendTitleAbove': string;
   'legendTitleBelow': string;
   'legendTitles': string;

--- a/lib/Traits/LegendTraits.ts
+++ b/lib/Traits/LegendTraits.ts
@@ -67,6 +67,20 @@ export class LegendItemTraits extends ModelTraits {
     type: "boolean"
   })
   addSpacingAbove?: boolean;
+
+  @primitiveTrait({
+    name: "Legend Image Height",
+    description: "The height of the legend image.",
+    type: "number"
+  })
+  imageHeight: number = 20;
+
+  @primitiveTrait({
+    name: "Legend Image Width",
+    description: "The width of the legend image.",
+    type: "number"
+  })
+  imageWidth: number = 20;
 }
 
 export default class LegendTraits extends ModelTraits {


### PR DESCRIPTION
This PR fixes up some of the legend styling
- legend images are now more accurately sized
- legend image width & height are retrieved from arcgis server endpoints
- text wraps properly.

**Current mobx styling**
![master](https://user-images.githubusercontent.com/6735870/72778313-b0e2a780-3c6c-11ea-94c2-2d3c5dcc0ab5.png)

**Updated styling **
![legendNew](https://user-images.githubusercontent.com/6735870/72778329-bd670000-3c6c-11ea-9fc1-7ec545d3f1a1.png)

Resolves https://github.com/TerriaJS/nsw-digital-twin/issues/215