### PR TITLE
Patch 7.11.0 release 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ Change Log
 
 ### Next Release
 
+### v7.11.1
+
+* Fix for color of markers on the map associated with chart items
+
 
 ### v7.11.0
 

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -218,7 +218,9 @@ function expand(props, sourceIndex) {
         : null
     });
     const items = [newCatalogItem];
+    let newGeoJsonAvailable = false;
     if (defined(feature.position._value)) {
+      newGeoJsonAvailable = true;
       const newGeoJsonItem = new GeoJsonCatalogItem(terria, null);
       newGeoJsonItem.isUserSupplied = true;
       newGeoJsonItem.style = {
@@ -243,7 +245,6 @@ function expand(props, sourceIndex) {
         }
       };
       newGeoJsonItem.isMappable = true;
-      newGeoJsonItem.style["marker-color"] = newCatalogItem.getNextColor();
       items.push(newGeoJsonItem);
     }
 
@@ -340,6 +341,8 @@ function expand(props, sourceIndex) {
     newCatalogItem.isMappable = false;
     newCatalogItem.isEnabled = true;
     newCatalogItem.creatorCatalogItem = compositeItem;
+    if (newGeoJsonAvailable)
+      items[1].style["marker-color"] = newCatalogItem.getNextColor();
 
     terria.catalog.addChartableItem(newCatalogItem); // Notify the chart panel so it shows "loading".
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "7.11.0",
+  "version": "7.11.1",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Patch 7.11.0 release with minor bug fix colour of marker associated with chart items.

Basically when you click on feature and expand the chart via the feature info it creates a marker on the map which should be the same colour as the line in the chart. I accidentally introduced this bug in #3763 

![MarkerColors](https://user-images.githubusercontent.com/6735870/73499761-12e1a080-4415-11ea-9265-948f0b6fbf87.png)
