### PR TITLE
Mobx: ArcGIS MapServer extent

### DIFF
--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -506,14 +506,17 @@ function maximumScaleToLevel(maximumScale: number | undefined) {
   return levelAtMinScaleDenominator | 0;
 }
 
-function updateBbox (extent: any, rectangle: RectangleExtent) {
-  if (extent.xmin < rectangle.west) rectangle.west = extent.xmax
-  if (extent.ymin < rectangle.south) rectangle.south = extent.ymin
-  if (extent.xmax > rectangle.east) rectangle.east = extent.xmin
-  if (extent.ymax > rectangle.north) rectangle.north = extent.ymax
+function updateBbox(extent: any, rectangle: RectangleExtent) {
+  if (extent.xmin < rectangle.west) rectangle.west = extent.xmax;
+  if (extent.ymin < rectangle.south) rectangle.south = extent.ymin;
+  if (extent.xmax > rectangle.east) rectangle.east = extent.xmin;
+  if (extent.ymax > rectangle.north) rectangle.north = extent.ymax;
 }
 
-function getRectangleFromLayer(thisLayerJson: Layer, rectangle: RectangleExtent) {
+function getRectangleFromLayer(
+  thisLayerJson: Layer,
+  rectangle: RectangleExtent
+) {
   const extent = thisLayerJson.extent;
   if (
     isDefined(extent) &&
@@ -522,7 +525,7 @@ function getRectangleFromLayer(thisLayerJson: Layer, rectangle: RectangleExtent)
   ) {
     const wkid = "EPSG:" + extent.spatialReference.wkid;
     if (extent.spatialReference.wkid === 4326) {
-      return updateBbox(extent, rectangle)
+      return updateBbox(extent, rectangle);
     }
 
     if (!isDefined((proj4definitions as any)[wkid])) {
@@ -542,29 +545,39 @@ function getRectangleFromLayer(thisLayerJson: Layer, rectangle: RectangleExtent)
     const east = p[0];
     const north = p[1];
 
-    return updateBbox({xmin: east, ymin: south, xmax: west, ymax: north}, rectangle);
+    return updateBbox(
+      { xmin: east, ymin: south, xmax: west, ymax: north },
+      rectangle
+    );
   }
 
   return undefined;
 }
 
-function getRectangleFromLayers(layers: Layer[])
-  : StratumFromTraits<RectangleTraits> | undefined {
-  const rectangle:RectangleExtent = {
+function getRectangleFromLayers(
+  layers: Layer[]
+): StratumFromTraits<RectangleTraits> | undefined {
+  const rectangle: RectangleExtent = {
     west: Infinity,
     south: Infinity,
     east: -Infinity,
     north: -Infinity
-  }
+  };
   if (!Array.isArray(layers)) {
     getRectangleFromLayer(layers, rectangle);
   } else {
     layers.forEach(function(item) {
       getRectangleFromLayer(item, rectangle);
-    })
+    });
   }
-  if (rectangle.east === Infinity || rectangle.south === Infinity || rectangle.west === -Infinity || rectangle.north === -Infinity) return undefined;
-  return rectangle
+  if (
+    rectangle.east === Infinity ||
+    rectangle.south === Infinity ||
+    rectangle.west === -Infinity ||
+    rectangle.north === -Infinity
+  )
+    return undefined;
+  return rectangle;
 }
 
 function cleanAndProxyUrl(

--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -506,7 +506,7 @@ function maximumScaleToLevel(maximumScale: number | undefined) {
   return levelAtMinScaleDenominator | 0;
 }
 
-function updateBbox(extent: any, rectangle: RectangleExtent) {
+function updateBbox(extent: Extent, rectangle: RectangleExtent) {
   if (extent.xmin < rectangle.west) rectangle.west = extent.xmax;
   if (extent.ymin < rectangle.south) rectangle.south = extent.ymin;
   if (extent.xmax > rectangle.east) rectangle.east = extent.xmin;

--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -507,10 +507,10 @@ function maximumScaleToLevel(maximumScale: number | undefined) {
 }
 
 function updateBbox (extent: any, rectangle: RectangleExtent) {
-  if (rectangle.west < extent.xmax) rectangle.west = extent.xmax
-  if (rectangle.south < extent.ymin) rectangle.south = extent.ymin
-  if (rectangle.east < extent.xmin) rectangle.east = extent.xmin
-  if (rectangle.north < extent.ymax) rectangle.north = extent.ymax
+  if (extent.xmin < rectangle.west) rectangle.west = extent.xmax
+  if (extent.ymin < rectangle.south) rectangle.south = extent.ymin
+  if (extent.xmax > rectangle.east) rectangle.east = extent.xmin
+  if (extent.ymax > rectangle.north) rectangle.north = extent.ymax
 }
 
 function getRectangleFromLayer(thisLayerJson: Layer, rectangle: RectangleExtent) {
@@ -523,8 +523,8 @@ function getRectangleFromLayer(thisLayerJson: Layer, rectangle: RectangleExtent)
     const wkid = "EPSG:" + extent.spatialReference.wkid;
     if (extent.spatialReference.wkid === 4326) {
       return updateBbox(extent, rectangle)
-
     }
+
     if (!isDefined((proj4definitions as any)[wkid])) {
       return undefined;
     }
@@ -542,7 +542,7 @@ function getRectangleFromLayer(thisLayerJson: Layer, rectangle: RectangleExtent)
     const east = p[0];
     const north = p[1];
 
-    return updateBbox({west, south, east, north}, rectangle);
+    return updateBbox({xmin: east, ymin: south, xmax: west, ymax: north}, rectangle);
   }
 
   return undefined;
@@ -550,7 +550,12 @@ function getRectangleFromLayer(thisLayerJson: Layer, rectangle: RectangleExtent)
 
 function getRectangleFromLayers(layers: Layer[])
   : StratumFromTraits<RectangleTraits> | undefined {
-  const rectangle:RectangleExtent = {east: Infinity, south: Infinity, west: -Infinity, north: -Infinity}
+  const rectangle:RectangleExtent = {
+    west: Infinity,
+    south: Infinity,
+    east: -Infinity,
+    north: -Infinity
+  }
   if (!Array.isArray(layers)) {
     getRectangleFromLayer(layers, rectangle);
   } else {
@@ -558,7 +563,7 @@ function getRectangleFromLayers(layers: Layer[])
       getRectangleFromLayer(item, rectangle);
     })
   }
-
+  if (rectangle.east === Infinity || rectangle.south === Infinity || rectangle.west === -Infinity || rectangle.north === -Infinity) return undefined;
   return rectangle
 }
 

--- a/test/Models/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.ts
@@ -8,6 +8,7 @@ import _loadWithXhr from "../../lib/Core/loadWithXhr";
 import ArcGisMapServerCatalogItem from "../../lib/Models/ArcGisMapServerCatalogItem";
 import Terria from "../../lib/Models/Terria";
 import { RectangleTraits } from "../../lib/Traits/MappableTraits";
+import createStratumInstance from "../../lib/createStratumInstance";
 
 configure({
   enforceActions: "observed",
@@ -219,16 +220,14 @@ describe("ArcGisMapServerCatalogItem", function() {
 
     it("defines a rectangle", function() {
       expect(item.rectangle).toBeDefined();
-      if (item.rectangle) {
-        expect(rectangleFromTraits(item.rectangle)).toEqual(
-          Rectangle.fromDegrees(
-            97.90759300700006,
-            -54.25906877199998,
-            167.2820957260001,
-            0.9835908000000587
-          )
-        );
-      }
+      expect(item.rectangle).toEqual(
+        createStratumInstance(RectangleTraits, {
+          east: 97.90759300700006,
+          south: -54.25906877199998,
+          west: 167.2820957260001,
+          north: 0.9835908000000587
+        })
+      );
     });
 
     it("defines info", function() {

--- a/test/Models/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.ts
@@ -8,7 +8,7 @@ import _loadWithXhr from "../../lib/Core/loadWithXhr";
 import ArcGisMapServerCatalogItem from "../../lib/Models/ArcGisMapServerCatalogItem";
 import Terria from "../../lib/Models/Terria";
 import { RectangleTraits } from "../../lib/Traits/MappableTraits";
-import createStratumInstance from "../../lib/createStratumInstance";
+import createStratumInstance from "../../lib/Models/createStratumInstance";
 
 configure({
   enforceActions: "observed",

--- a/test/Models/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.ts
@@ -221,11 +221,11 @@ describe("ArcGisMapServerCatalogItem", function() {
       expect(item.rectangle).toBeDefined();
       if (item.rectangle) {
         expect(rectangleFromTraits(item.rectangle)).toEqual(
-          new Rectangle(
-            1.7088098606747266,
-            -0.946999399137436,
-            2.919623350055036,
-            0.017166897952326066
+          new Rectangle.fromDegrees(
+            97.90759300700006,
+            -54.25906877199998,
+            167.2820957260001,
+            0.9835908000000587
           )
         );
       }

--- a/test/Models/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.ts
@@ -245,7 +245,3 @@ describe("ArcGisMapServerCatalogItem", function() {
     });
   });
 });
-
-function rectangleFromTraits({ west, south, east, north }: RectangleTraits) {
-  return new Rectangle(west, south, east, north);
-}

--- a/test/Models/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.ts
@@ -221,7 +221,7 @@ describe("ArcGisMapServerCatalogItem", function() {
       expect(item.rectangle).toBeDefined();
       if (item.rectangle) {
         expect(rectangleFromTraits(item.rectangle)).toEqual(
-          new Rectangle.fromDegrees(
+          Rectangle.fromDegrees(
             97.90759300700006,
             -54.25906877199998,
             167.2820957260001,

--- a/test/Models/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.ts
@@ -220,14 +220,10 @@ describe("ArcGisMapServerCatalogItem", function() {
 
     it("defines a rectangle", function() {
       expect(item.rectangle).toBeDefined();
-      expect(item.rectangle).toEqual(
-        createStratumInstance(RectangleTraits, {
-          east: 97.90759300700006,
-          south: -54.25906877199998,
-          west: 167.2820957260001,
-          north: 0.9835908000000587
-        })
-      );
+      expect(item.rectangle.west).toEqual(97.90759300700006);
+      expect(item.rectangle.south).toEqual(-54.25906877199998);
+      expect(item.rectangle.east).toEqual(167.2820957260001);
+      expect(item.rectangle.north).toEqual(0.9835908000000587);
     });
 
     it("defines info", function() {

--- a/wwwroot/test/ArcGisMapServer/Dynamic_National_Map_Hydrography_and_Marine/31.json
+++ b/wwwroot/test/ArcGisMapServer/Dynamic_National_Map_Hydrography_and_Marine/31.json
@@ -1,1 +1,200 @@
-{"currentVersion":10.04,"id":31,"name":"Offshore_Rocks_And_Wrecks","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Offshore Rock - A rock located offshore that represents a hazard to shipping. Wreck - A disabled vessel, either submerged or visible, which is attached to, or foul of, the bottom or cast up on the shore. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70000,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"FEATURETYPE","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Offshore Rock","label":"Offshore Rocks","description":"","symbol":{"type":"esriPMS","url":"1d036967","imageData":"iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAahJREFUKJF1kT1IW3EUxX95fclLFL+CWGMgIIihgdTBweKWgoUMJoJQoy5S1EEcHFzsXBBKwUFsVytIUmih4EfaZHIQFbFk86NQFcQSTVI1at4/z7w4PJ7QwQN3ueeew+UcGROR7w4KhVHuLGFFwi0gAySo1GeJDeTMMxmAcLRZuVHjAosXCYTBtQKd3EjjSveXkFjq2zAEw98UJa0tC/CaLi8bbLjqbCzuXwPUC8rLdEXbSPafyKS1NwJ8AB21MiNBDwDtfhee1QNUTWdmK+vEbnkLjMlAyHRurLISfvWMq2sVh93K1FgncwvbJt1jCtzmZmLQx1kmj8/rAuBv+pLACw9Dx3nmd/ONkJRkdDJIhuD30T9sticPwWlaiYM/Wc4vNYAcdOkykAACAOupcyIhP5s7R9Q7K6mptlMqlVk5VQHLDyOlovUjdm0ccH/ey1Pxfg1/Sx3t/qdMftjgtqgDqBTL7wxBsvfKGYyFcjJxoOFT6gJSF/D10PysAAzwM7L3UFwuHvlFd/S5oktTQiqHgSYgCyS4k6aJv97/v2mApf60gAmMeRT3E5KRoCNLAYgAAAAASUVORK5CYII=","contentType":"image/png","color":null,"width":9,"height":9,"angle":0,"xoffset":0,"yoffset":0}},{"value":"Wreck","label":"Wrecks","description":"","symbol":{"type":"esriPMS","url":"15b6458","imageData":"iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAcxJREFUKJF1kUFIU3Ecxz/v9bb3YuSaiaSLwgoNIa0ZBBZBgYTQtkjKTTBIUiFkGF3aoqAId+pi0bGLhxnhEBRW2yGWYoQoQhR2iGB1Wa2Zi+H+b6/3OjwWdegDv9P397l8vwo1QrPb2doawZCCqoxXQAFI4zIfMj1QrL0pAAQTLWq5khJIbcgg7KwV6KYsj6n+pwEx1//aFq7OqGq+Oi+gratOITbQyqEDDQj9F4srn4kkcw0Ca56eRCeZ8BeFfHVIQHtvs8aj6AleLn0iNrlMnUvh8rmDLN1povvem3o0KQZcU4AAwN3Rozx59hb/mf1c6T+GXjWYmlmjZY+byQt7iSRz52uCF2CnW8PjVjnu2weApjoY7DvCyO0M1wc7IJnbDRlZwaSADJZl4dnh5G+cDoVS2UB1bgMoQo+pAGngtGlavFr9SvBsmV0eFwDLazn8J5tY/1gApOd2S7rjMVp1bGr2vTc62sWNeJZTvkY2fupsbAqGLh7m0q1sBd26bwuZvlJ973RgYuFbCt413hz2IcsSkiTxY7NCJL5YWSkZYV6E1v8MV0yFVvEnOh5kC9GJhWwQaAa+A2kMOU4q9OHfpQHmwnkB49j3X34DPWWfqP0jHosAAAAASUVORK5CYII=","contentType":"image/png","color":null,"width":9,"height":9,"angle":0,"xoffset":0,"yoffset":0}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.11904000000004,"ymin":-43.66633999999999,"xmax":153.62995,"ymax":-9.063350000000014,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":12,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"SOURCE","type":"esriFieldTypeString","alias":"SOURCE","length":50,"domain":null},{"name":"UFI","type":"esriFieldTypeString","alias":"UFI","length":10,"domain":null},{"name":"CREATIONDATE","type":"esriFieldTypeDate","alias":"CREATIONDATE","length":8,"domain":null},{"name":"RETIREMENTDATE","type":"esriFieldTypeDate","alias":"RETIREMENTDATE","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"FEATUREWIDTH","type":"esriFieldTypeDouble","alias":"FEATUREWIDTH","domain":null},{"name":"ORIENTATION","type":"esriFieldTypeSmallInteger","alias":"ORIENTATION","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"}
+{
+  "currentVersion": 10.04,
+  "id": 31,
+  "name": "Offshore_Rocks_And_Wrecks",
+  "type": "Feature Layer",
+  "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Offshore Rock - A rock located offshore that represents a hazard to shipping. Wreck - A disabled vessel, either submerged or visible, which is attached to, or foul of, the bottom or cast up on the shore. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)",
+  "definitionExpression": "",
+  "geometryType": "esriGeometryPoint",
+  "copyrightText": "Geoscience Australia",
+  "parentLayer": null,
+  "subLayers": [],
+  "minScale": 0,
+  "maxScale": 70000,
+  "drawingInfo": {
+    "renderer": {
+      "type": "uniqueValue",
+      "field1": "FEATURETYPE",
+      "field2": null,
+      "field3": null,
+      "fieldDelimiter": ", ",
+      "defaultSymbol": null,
+      "defaultLabel": "<all other values>",
+      "uniqueValueInfos": [
+        {
+          "value": "Offshore Rock",
+          "label": "Offshore Rocks",
+          "description": "",
+          "symbol": {
+            "type": "esriPMS",
+            "url": "1d036967",
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAahJREFUKJF1kT1IW3EUxX95fclLFL+CWGMgIIihgdTBweKWgoUMJoJQoy5S1EEcHFzsXBBKwUFsVytIUmih4EfaZHIQFbFk86NQFcQSTVI1at4/z7w4PJ7QwQN3ueeew+UcGROR7w4KhVHuLGFFwi0gAySo1GeJDeTMMxmAcLRZuVHjAosXCYTBtQKd3EjjSveXkFjq2zAEw98UJa0tC/CaLi8bbLjqbCzuXwPUC8rLdEXbSPafyKS1NwJ8AB21MiNBDwDtfhee1QNUTWdmK+vEbnkLjMlAyHRurLISfvWMq2sVh93K1FgncwvbJt1jCtzmZmLQx1kmj8/rAuBv+pLACw9Dx3nmd/ONkJRkdDJIhuD30T9sticPwWlaiYM/Wc4vNYAcdOkykAACAOupcyIhP5s7R9Q7K6mptlMqlVk5VQHLDyOlovUjdm0ccH/ey1Pxfg1/Sx3t/qdMftjgtqgDqBTL7wxBsvfKGYyFcjJxoOFT6gJSF/D10PysAAzwM7L3UFwuHvlFd/S5oktTQiqHgSYgCyS4k6aJv97/v2mApf60gAmMeRT3E5KRoCNLAYgAAAAASUVORK5CYII=",
+            "contentType": "image/png",
+            "color": null,
+            "width": 9,
+            "height": 9,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0
+          }
+        },
+        {
+          "value": "Wreck",
+          "label": "Wrecks",
+          "description": "",
+          "symbol": {
+            "type": "esriPMS",
+            "url": "15b6458",
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAcxJREFUKJF1kUFIU3Ecxz/v9bb3YuSaiaSLwgoNIa0ZBBZBgYTQtkjKTTBIUiFkGF3aoqAId+pi0bGLhxnhEBRW2yGWYoQoQhR2iGB1Wa2Zi+H+b6/3OjwWdegDv9P397l8vwo1QrPb2doawZCCqoxXQAFI4zIfMj1QrL0pAAQTLWq5khJIbcgg7KwV6KYsj6n+pwEx1//aFq7OqGq+Oi+gratOITbQyqEDDQj9F4srn4kkcw0Ca56eRCeZ8BeFfHVIQHtvs8aj6AleLn0iNrlMnUvh8rmDLN1povvem3o0KQZcU4AAwN3Rozx59hb/mf1c6T+GXjWYmlmjZY+byQt7iSRz52uCF2CnW8PjVjnu2weApjoY7DvCyO0M1wc7IJnbDRlZwaSADJZl4dnh5G+cDoVS2UB1bgMoQo+pAGngtGlavFr9SvBsmV0eFwDLazn8J5tY/1gApOd2S7rjMVp1bGr2vTc62sWNeJZTvkY2fupsbAqGLh7m0q1sBd26bwuZvlJ973RgYuFbCt413hz2IcsSkiTxY7NCJL5YWSkZYV6E1v8MV0yFVvEnOh5kC9GJhWwQaAa+A2kMOU4q9OHfpQHmwnkB49j3X34DPWWfqP0jHosAAAAASUVORK5CYII=",
+            "contentType": "image/png",
+            "color": null,
+            "width": 9,
+            "height": 9,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0
+          }
+        }
+      ]
+    },
+    "transparency": 0,
+    "labelingInfo": null
+  },
+  "defaultVisibility": true,
+  "extent": {
+    "xmin": 113.11904000000004,
+    "ymin": -43.66633999999999,
+    "xmax": 153.62995,
+    "ymax": -9.063350000000014,
+    "spatialReference": {
+      "wkid": 4283
+    }
+  },
+  "hasAttachments": false,
+  "htmlPopupType": null,
+  "displayField": "NAME",
+  "typeIdField": null,
+  "fields": [
+    {
+      "name": "OBJECTID",
+      "type": "esriFieldTypeOID",
+      "alias": "OBJECTID",
+      "domain": null
+    },
+    {
+      "name": "FEATURETYPE",
+      "type": "esriFieldTypeString",
+      "alias": "FEATURETYPE",
+      "length": 32,
+      "domain": null
+    },
+    {
+      "name": "TYPE",
+      "type": "esriFieldTypeInteger",
+      "alias": "TYPE",
+      "domain": null
+    },
+    {
+      "name": "NAME",
+      "type": "esriFieldTypeString",
+      "alias": "NAME",
+      "length": 60,
+      "domain": null
+    },
+    {
+      "name": "RELATIONSHIP",
+      "type": "esriFieldTypeString",
+      "alias": "RELATIONSHIP",
+      "length": 12,
+      "domain": null
+    },
+    {
+      "name": "FEATURERELIABILITY",
+      "type": "esriFieldTypeDate",
+      "alias": "FEATURERELIABILITY",
+      "length": 8,
+      "domain": null
+    },
+    {
+      "name": "ATTRIBUTERELIABILITY",
+      "type": "esriFieldTypeDate",
+      "alias": "ATTRIBUTERELIABILITY",
+      "length": 8,
+      "domain": null
+    },
+    {
+      "name": "PLANIMETRICACCURACY",
+      "type": "esriFieldTypeSmallInteger",
+      "alias": "PLANIMETRICACCURACY",
+      "domain": null
+    },
+    {
+      "name": "SOURCE",
+      "type": "esriFieldTypeString",
+      "alias": "SOURCE",
+      "length": 50,
+      "domain": null
+    },
+    {
+      "name": "UFI",
+      "type": "esriFieldTypeString",
+      "alias": "UFI",
+      "length": 10,
+      "domain": null
+    },
+    {
+      "name": "CREATIONDATE",
+      "type": "esriFieldTypeDate",
+      "alias": "CREATIONDATE",
+      "length": 8,
+      "domain": null
+    },
+    {
+      "name": "RETIREMENTDATE",
+      "type": "esriFieldTypeDate",
+      "alias": "RETIREMENTDATE",
+      "length": 8,
+      "domain": null
+    },
+    {
+      "name": "PID",
+      "type": "esriFieldTypeInteger",
+      "alias": "PID",
+      "domain": null
+    },
+    {
+      "name": "SYMBOL",
+      "type": "esriFieldTypeSmallInteger",
+      "alias": "SYMBOL",
+      "domain": null
+    },
+    {
+      "name": "FEATUREWIDTH",
+      "type": "esriFieldTypeDouble",
+      "alias": "FEATUREWIDTH",
+      "domain": null
+    },
+    {
+      "name": "ORIENTATION",
+      "type": "esriFieldTypeSmallInteger",
+      "alias": "ORIENTATION",
+      "domain": null
+    },
+    {
+      "name": "TEXTNOTE",
+      "type": "esriFieldTypeString",
+      "alias": "TEXTNOTE",
+      "length": 50,
+      "domain": null
+    },
+    {
+      "name": "SHAPE",
+      "type": "esriFieldTypeGeometry",
+      "alias": "SHAPE",
+      "domain": null
+    }
+  ],
+  "types": null,
+  "relationships": [],
+  "capabilities": "Map,Query,Data"
+}

--- a/wwwroot/test/ArcGisMapServer/Dynamic_National_Map_Hydrography_and_Marine/layers.json
+++ b/wwwroot/test/ArcGisMapServer/Dynamic_National_Map_Hydrography_and_Marine/layers.json
@@ -1,1 +1,17372 @@
-{"layers":[{"currentVersion":10.04,"id":0,"name":"No_Labels_National_Scale_to_300K_Scale","type":"Feature Layer","description":"This is a customised layer to show the user of the web map service where the 250K data labels are not appropriate to use past between these scales (National Scale to 1:300,000 Scale).","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":300000,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":[{"labelPlacement":null,"labelExpression":"[TEXT_LABEL]","useCodedValues":true,"symbol":{"type":"esriTS","color":[78,78,78,255],"backgroundColor":null,"borderLineColor":null,"verticalAlignment":"baseline","horizontalAlignment":"left","rightToLeft":false,"angle":0,"xoffset":0,"yoffset":0,"font":{"family":"Arial","size":14,"style":"normal","weight":"bold","decoration":"none"}},"minScale":0,"maxScale":0}]},"defaultVisibility":true,"extent":{"xmin":97.90759300700006,"ymin":-54.25906877199998,"xmax":167.28209572600008,"ymax":0.9835908000000586,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"TEXT_LABEL","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"TEXT_LABEL","type":"esriFieldTypeString","alias":"TEXT","length":254,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":1,"name":"No_Labels_National_Scale_to_10Million_Scale","type":"Feature Layer","description":"This is a customised layer to show the user of the web map service where the 250K data labels for Rivers and Lakes/Reservoirs are not appropriate to use between these scales (National Scale to 10 Million Scale).","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":1.0000001E7,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":[{"labelPlacement":null,"labelExpression":"[TEXT_LABEL]","useCodedValues":true,"symbol":{"type":"esriTS","color":[78,78,78,255],"backgroundColor":null,"borderLineColor":null,"verticalAlignment":"baseline","horizontalAlignment":"left","rightToLeft":false,"angle":0,"xoffset":0,"yoffset":0,"font":{"family":"Arial","size":14,"style":"normal","weight":"bold","decoration":"none"}},"minScale":0,"maxScale":0}]},"defaultVisibility":true,"extent":{"xmin":97.90759300700006,"ymin":-54.25906877199998,"xmax":167.28209572600008,"ymax":0.9835908000000586,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"TEXT_LABEL","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"TEXT_LABEL","type":"esriFieldTypeString","alias":"TEXT","length":254,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":2,"name":"No_Data","type":"Feature Layer","description":"This is a customised layer to show the user of the web map service where the 250K data is not appropriate to use past this scale (1:70,000).","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":70000,"maxScale":0,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":[{"labelPlacement":null,"labelExpression":"[TEXT_LABEL]","useCodedValues":true,"symbol":{"type":"esriTS","color":[78,78,78,255],"backgroundColor":null,"borderLineColor":null,"verticalAlignment":"baseline","horizontalAlignment":"left","rightToLeft":false,"angle":0,"xoffset":0,"yoffset":0,"font":{"family":"Arial","size":14,"style":"normal","weight":"bold","decoration":"none"}},"minScale":0,"maxScale":0}]},"defaultVisibility":true,"extent":{"xmin":97.90759300700006,"ymin":-54.25906877199998,"xmax":167.28209572600008,"ymax":0.9835908000000302,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"TEXT_LABEL","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"TEXT_LABEL","type":"esriFieldTypeString","alias":"TEXT","length":254,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":3,"name":"Offshore_Rocks_and_Wrecks_Labels","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. This layer is only for labelling. 250K Specification Description -> Offshore Rock - A rock located offshore that represents a hazard to shipping. Wreck - A disabled vessel, either submerged or visible, which is attached to, or foul of, the bottom or cast up on the shore. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70000,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,255],"size":4,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.11904000000004,"ymin":-43.66633999999999,"xmax":153.62995,"ymax":-9.063350000000014,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":12,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"SOURCE","type":"esriFieldTypeString","alias":"SOURCE","length":50,"domain":null},{"name":"UFI","type":"esriFieldTypeString","alias":"UFI","length":10,"domain":null},{"name":"CREATIONDATE","type":"esriFieldTypeDate","alias":"CREATIONDATE","length":8,"domain":null},{"name":"RETIREMENTDATE","type":"esriFieldTypeDate","alias":"RETIREMENTDATE","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"FEATUREWIDTH","type":"esriFieldTypeDouble","alias":"FEATUREWIDTH","domain":null},{"name":"ORIENTATION","type":"esriFieldTypeSmallInteger","alias":"ORIENTATION","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":4,"name":"Lighthouses_Labels","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. This layer is only for labelling. 250K Specification Description -> Lighthouse - A building or structure housing a light used as a navigation aid to shipping. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,0],"size":4,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.97203000000002,"ymin":-43.65735999999998,"xmax":153.63570000000004,"ymax":-9.140769999999975,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"SOURCE","type":"esriFieldTypeString","alias":"SOURCE","length":50,"domain":null},{"name":"UFI","type":"esriFieldTypeString","alias":"UFI","length":10,"domain":null},{"name":"CREATIONDATE","type":"esriFieldTypeDate","alias":"CREATIONDATE","length":8,"domain":null},{"name":"RETIREMENTDATE","type":"esriFieldTypeDate","alias":"RETIREMENTDATE","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"FEATUREWIDTH","type":"esriFieldTypeDouble","alias":"FEATUREWIDTH","domain":null},{"name":"ORIENTATION","type":"esriFieldTypeSmallInteger","alias":"ORIENTATION","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":5,"name":"Reefs_and_Shoals_Labels","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. This layer is only for labelling. 250K Specification Description -> Reef - An area of rock or coral that is exposed between mean high water and lowest tide, or just below approximate lowest tide, which is visually prominent or a hazard to shipping. Shoal - A detached area of any material the depth over which constitutes a danger to surface navigation of marine craft. The term shoal is not generally used for dangers which are composed entirely of rock or coral. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.92034999999998,"ymin":-43.54730999999998,"xmax":153.54714,"ymax":-8.99857000000003,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":12,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"SOURCE","type":"esriFieldTypeString","alias":"SOURCE","length":50,"domain":null},{"name":"UFI","type":"esriFieldTypeString","alias":"UFI","length":10,"domain":null},{"name":"CREATIONDATE","type":"esriFieldTypeDate","alias":"CREATIONDATE","length":8,"domain":null},{"name":"RETIREMENTDATE","type":"esriFieldTypeDate","alias":"RETIREMENTDATE","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":6,"name":"Locks_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Lock - An enclosure in a water body with gates at both ends to raise or lower the water level to enable vessels to pass from one level to another. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Victorian Department of Environment, Land, Water and Planning and South Australia Department for Environment, Water and Natural Resources","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,0],"size":4,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":138.80938000000003,"ymin":-35.94261,"xmax":144.46687999999995,"ymax":-33.996730000000014,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":7,"name":"Waterfalls_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Waterfall Point - A sudden descent of water over a step or ledge in the bed of a watercourse. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,0],"size":4,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":115.8425565,"ymin":-43.49456650000002,"xmax":153.048539,"ymax":-10.643486999999993,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":8,"name":"Springs_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Springs - A place where water issues from the ground naturally. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,255],"size":7,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1.0001}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.13675999999998,"ymin":-38.23244999999997,"xmax":147.96740999999997,"ymax":-11.52388000000002,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":9,"name":"Waterholes_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Waterhole - A natural depression which holds perennial water, within a non-perennial watercourse or a non-perennial lake. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,255],"size":6.9999,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1.0001}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.69557699999996,"ymin":-43.52217000000002,"xmax":153.21927000000005,"ymax":-10.171490000000006,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":10,"name":"Bores_Labels","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. This layer is only for labelling. 250K Specification Description -> Bore - A small diameter hole in the ground for the purpose of obtaining subterranean water by natural flow or mechanical pumping. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,132,168,255],"size":6.9999,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1.4173}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.93203749999998,"ymin":-38.20881000000003,"xmax":152.06205999999997,"ymax":-11.051049999999975,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":11,"name":"Natural_Water_Points_GnammaHoles_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Gnamma Hole - Small holes of varying shape, diameter and depth, found in hard granite outcrops and in the decomposed granite of a breakaway, which can and usually does hold water.(Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,255],"size":7,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1.4173}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":118.13149999999996,"ymin":-31.627049999999997,"xmax":127.64131999999995,"ymax":-26.031510000000026,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":12,"name":"Natural_Water_Points_NativeWells_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Native Well - An isolated natural depression which holds water, not within Watercourses. The natural phenomena is sometimes improved by indigenous persons for their own water collection purposes. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,255],"size":7,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1.4173}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.79952000000003,"ymin":-31.973419999999976,"xmax":147.03940999999998,"ymax":-20.273979999999995,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":13,"name":"Natural_Water_Points_Pools_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Pool - A small body of still or standing water, permanent or temporary in an isolated natural depression, not within Watercourses. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,255],"size":7,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1.4173}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.56568400000003,"ymin":-43.248490000000004,"xmax":153.09348,"ymax":-10.072709999999972,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":14,"name":"Natural_Water_Points_Rockholes_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Rockhole - A hole excavated in solid rock by water action. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,255],"size":7,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1.4173}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.76517999999999,"ymin":-33.262159999999994,"xmax":142.18583999999998,"ymax":-17.009979999999985,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":15,"name":"Natural_Water_Points_Soaks_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Soak - A depression holding moisture after rain, especially the damp or swamp spots around the base of granite rocks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,255],"size":7,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1.4173}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.07808950000003,"ymin":-33.145550000000014,"xmax":142.09559000000002,"ymax":-15.118119999999976,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":16,"name":"Dams_and_Tanks_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Dam - An open body of water collected and stored behind a constructed barrier consisting of earth, rock, concrete and/or masonry. Generally designed to capture run-off from the surrounding landscape or rainfall. The storage of water may occur on or below ground level. Water Tank -  Water Tanks are storage containers for water, usually used for human consumption and other purposes such as irrigation, agriculture, fire suppression, agricultural farming and livestock, chemical manufacturing and food preparation. Water Tanks are constructed of various materials including plastic (polyethylene or polypropylene), fiberglass, reinforced concrete, steel (welded or bolted, carbon or stainless). Those used for human consumption are generally fully enclosed. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,0,0,0],"size":4,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":1}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.07836999999995,"ymin":-43.14695999999998,"xmax":153.49998400000004,"ymax":-9.95177000000001,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":17,"name":"Dam_Walls_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Dam Wall - A barrier of earth and rock, concrete or masonry constructed to form a reservoir for water storage purposes or to raise the water level. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Culture.html)","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":2},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":115.00212,"ymin":-43.1877,"xmax":153.30629,"ymax":-10.57169,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":{"type":"codedValue","name":"dm_UpperScale25K","codedValues":[{"name":"25000","code":25000},{"name":"50000","code":50000},{"name":"100000","code":100000},{"name":"250000","code":250000},{"name":"1000000","code":1000000},{"name":"2500000","code":2500000},{"name":"5000000","code":5000000},{"name":"10000000","code":10000000},{"name":"0","code":0}]}},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":10,"domain":{"type":"codedValue","name":"dm_USCertainty25K","codedValues":[{"name":"Definite","code":"Definite"},{"name":"Indefinite","code":"Indefinite"},{"name":"Undefined","code":"Undefined"}]}},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"FEATUREWIDTH","type":"esriFieldTypeDouble","alias":"FEATUREWIDTH","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":18,"name":"Watercourse_Areas_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Watercourse Area -  A natural channel along which water may flow from time to time. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.56261099999995,"ymin":-43.58997599999998,"xmax":153.62839150000002,"ymax":-8.933329000000015,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":19,"name":"Watercourses_Major_Rivers_Scale_10Million_to_5Million_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays between the 1:10,000,000 and 1:5,050,000 scale to avoid clutter. Refer to other Watercourses layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":1.0E7,"maxScale":5050001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":1.5},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":115.76303800000005,"ymin":-42.77677,"xmax":150.790599,"ymax":-12.004185500000006,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"Shape","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":10,"domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"Enabled","type":"esriFieldTypeSmallInteger","alias":"Enabled","domain":null},{"name":"Shape_Length","type":"esriFieldTypeDouble","alias":"Shape_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":20,"name":"Watercourses_Major_Rivers_Scale_5Million_to_300000_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays between 1:5,050,000 to 1:300,000 scales to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":5050000,"maxScale":300001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":1},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.62140150000005,"ymin":-43.552824499999986,"xmax":153.586911,"ymax":-9.408074499999998,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"Shape","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":10,"domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"Enabled","type":"esriFieldTypeSmallInteger","alias":"Enabled","domain":null},{"name":"Shape_Length","type":"esriFieldTypeDouble","alias":"Shape_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":21,"name":"Watercourses_All_Rivers_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":1},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.37534500000004,"ymin":-43.62811399999998,"xmax":153.63163999999995,"ymax":-9.242297500000006,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":20,"domain":null},{"name":"STATUS","type":"esriFieldTypeString","alias":"STATUS","length":18,"domain":null},{"name":"RESTRICTIONS","type":"esriFieldTypeString","alias":"RESTRICTIONS","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":22,"name":"Waterbody_Lakes_Scale_10Million_to_5Million_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays between the 1:10,000,000 of 1:5,050,000 scale and a size criteria of area greater than 0.1 map units to avoid clutter. Refer to other Waterbody - Lake layers at different scales for the National Map.","definitionExpression":"\"SHAPE_Area\" > 0.1","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":1.0E7,"maxScale":5050001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.99395000000004,"ymin":-43.53222699999998,"xmax":153.59316149999995,"ymax":-8.937880000000007,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":23,"name":"Waterbody_Lakes_Scale_5Million_to_300000_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays between 1:5,050,000 and 1:300,001 scales and a size criteria of area greater than 0.003 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.","definitionExpression":"\"SHAPE_Area\" > 0.003","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":5050000,"maxScale":300001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.99395000000004,"ymin":-43.53222699999998,"xmax":153.59316149999995,"ymax":-8.937880000000007,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":24,"name":"Waterbody_Reservoirs_Scale_10Million_to_300000_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays from 1:10,000,000 1:300,001 and a size criteria of area greater than 0.003 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.","definitionExpression":"\"SHAPE_Area\" > 0.003","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":1.0E7,"maxScale":300001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.99600999999996,"ymin":-43.19614250000001,"xmax":153.54449950000003,"ymax":-12.558189500000026,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":25,"name":"Waterbody_Extra_Lakes_and_Reservoirs_Labels","type":"Feature Layer","description":"Custom Dataset - These are extra waterbodies added at this scale that fall under the size criteria in Waterbody Lake and Reservoir.(Only displays polygons with area greater than 0.03 map units). This layer is only for labelling. ","definitionExpression":"\"SHAPE_Area\" < 0.003","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":5050000,"maxScale":300001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.47902999999997,"ymin":-43.039570000000026,"xmax":153.35022999999995,"ymax":-8.933329000000015,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"HYDROID","type":"esriFieldTypeInteger","alias":"HYDROID","domain":null},{"name":"AHGFFTYPE","type":"esriFieldTypeInteger","alias":"AHGFFeatureType","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIAL","type":"esriFieldTypeString","alias":"Perenniality","length":255,"domain":null},{"name":"NETNODEID","type":"esriFieldTypeInteger","alias":"NetworkNodeID","domain":null},{"name":"MAPNODEID","type":"esriFieldTypeInteger","alias":"MappedNodeID","domain":null},{"name":"WSTOREUSE","type":"esriFieldTypeString","alias":"WaterStoreUse","length":30,"domain":null},{"name":"SRCFCNAME","type":"esriFieldTypeString","alias":"SourceFeatureClassName","length":25,"domain":null},{"name":"SRCFTYPE","type":"esriFieldTypeString","alias":"SourceFeatureType","length":32,"domain":null},{"name":"SRCTYPE","type":"esriFieldTypeInteger","alias":"SourceType","domain":null},{"name":"SOURCEID","type":"esriFieldTypeInteger","alias":"SOURCEID","domain":null},{"name":"FEATREL","type":"esriFieldTypeDate","alias":"FeatureReliability","length":8,"domain":null},{"name":"FSOURCE","type":"esriFieldTypeString","alias":"FeatureSource","length":25,"domain":null},{"name":"ATTRREL","type":"esriFieldTypeDate","alias":"AttributeReliability","length":8,"domain":null},{"name":"ATTRSOURCE","type":"esriFieldTypeString","alias":"AttributeSource","length":25,"domain":null},{"name":"PLANACC","type":"esriFieldTypeSmallInteger","alias":"PlanimetricAccuracy","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":26,"name":"Waterbody_All_Lakes_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70000,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.99395000000004,"ymin":-43.53222699999998,"xmax":153.59316149999995,"ymax":-8.937880000000007,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":27,"name":"Waterbody_All_Reservoirs_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70000,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.99600999999996,"ymin":-43.19614250000001,"xmax":153.54449950000003,"ymax":-12.558189500000026,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":28,"name":"Waterbody_All_Flood_Irrigation_Storage_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Flood Irrigation Storage - A body of water collected and stored behind constructed barriers, for the specific use of flooding pastures via internal irrigation systems. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70000,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":143.18679150000003,"ymin":-30.01566150000002,"xmax":152.4470235,"ymax":-17.072844999999973,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":29,"name":"Flats_Swamps_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Swamp - Land which is so saturated with water that it is not suitable for agricultural or pastoral use and presents a barrier to free passage. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.75390100000004,"ymin":-43.60268000000002,"xmax":153.61275,"ymax":-8.933329000000015,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":30,"name":"Flats_MarineSwamps_Labels","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Marine Swamp - That low lying part of the backshore area of tidal waters, usually immediately behind saline coastal flat, which maintains a high salt water content, and is covered with characteristic thick grasses and reed growths. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":118.79958999999997,"ymin":-20.298429,"xmax":142.18464100000006,"ymax":-10.93128999999999,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":31,"name":"Offshore_Rocks_And_Wrecks","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Offshore Rock - A rock located offshore that represents a hazard to shipping. Wreck - A disabled vessel, either submerged or visible, which is attached to, or foul of, the bottom or cast up on the shore. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70000,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"FEATURETYPE","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Offshore Rock","label":"Offshore Rocks","description":"","symbol":{"type":"esriPMS","url":"1d036967","imageData":"iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAahJREFUKJF1kT1IW3EUxX95fclLFL+CWGMgIIihgdTBweKWgoUMJoJQoy5S1EEcHFzsXBBKwUFsVytIUmih4EfaZHIQFbFk86NQFcQSTVI1at4/z7w4PJ7QwQN3ueeew+UcGROR7w4KhVHuLGFFwi0gAySo1GeJDeTMMxmAcLRZuVHjAosXCYTBtQKd3EjjSveXkFjq2zAEw98UJa0tC/CaLi8bbLjqbCzuXwPUC8rLdEXbSPafyKS1NwJ8AB21MiNBDwDtfhee1QNUTWdmK+vEbnkLjMlAyHRurLISfvWMq2sVh93K1FgncwvbJt1jCtzmZmLQx1kmj8/rAuBv+pLACw9Dx3nmd/ONkJRkdDJIhuD30T9sticPwWlaiYM/Wc4vNYAcdOkykAACAOupcyIhP5s7R9Q7K6mptlMqlVk5VQHLDyOlovUjdm0ccH/ey1Pxfg1/Sx3t/qdMftjgtqgDqBTL7wxBsvfKGYyFcjJxoOFT6gJSF/D10PysAAzwM7L3UFwuHvlFd/S5oktTQiqHgSYgCyS4k6aJv97/v2mApf60gAmMeRT3E5KRoCNLAYgAAAAASUVORK5CYII=","contentType":"image/png","color":null,"width":9,"height":9,"angle":0,"xoffset":0,"yoffset":0}},{"value":"Wreck","label":"Wrecks","description":"","symbol":{"type":"esriPMS","url":"15b6458","imageData":"iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAcxJREFUKJF1kUFIU3Ecxz/v9bb3YuSaiaSLwgoNIa0ZBBZBgYTQtkjKTTBIUiFkGF3aoqAId+pi0bGLhxnhEBRW2yGWYoQoQhR2iGB1Wa2Zi+H+b6/3OjwWdegDv9P397l8vwo1QrPb2doawZCCqoxXQAFI4zIfMj1QrL0pAAQTLWq5khJIbcgg7KwV6KYsj6n+pwEx1//aFq7OqGq+Oi+gratOITbQyqEDDQj9F4srn4kkcw0Ca56eRCeZ8BeFfHVIQHtvs8aj6AleLn0iNrlMnUvh8rmDLN1povvem3o0KQZcU4AAwN3Rozx59hb/mf1c6T+GXjWYmlmjZY+byQt7iSRz52uCF2CnW8PjVjnu2weApjoY7DvCyO0M1wc7IJnbDRlZwaSADJZl4dnh5G+cDoVS2UB1bgMoQo+pAGngtGlavFr9SvBsmV0eFwDLazn8J5tY/1gApOd2S7rjMVp1bGr2vTc62sWNeJZTvkY2fupsbAqGLh7m0q1sBd26bwuZvlJ973RgYuFbCt413hz2IcsSkiTxY7NCJL5YWSkZYV6E1v8MV0yFVvEnOh5kC9GJhWwQaAa+A2kMOU4q9OHfpQHmwnkB49j3X34DPWWfqP0jHosAAAAASUVORK5CYII=","contentType":"image/png","color":null,"width":9,"height":9,"angle":0,"xoffset":0,"yoffset":0}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.11904000000004,"ymin":-43.66633999999999,"xmax":153.62995,"ymax":-9.063350000000014,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":12,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"SOURCE","type":"esriFieldTypeString","alias":"SOURCE","length":50,"domain":null},{"name":"UFI","type":"esriFieldTypeString","alias":"UFI","length":10,"domain":null},{"name":"CREATIONDATE","type":"esriFieldTypeDate","alias":"CREATIONDATE","length":8,"domain":null},{"name":"RETIREMENTDATE","type":"esriFieldTypeDate","alias":"RETIREMENTDATE","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"FEATUREWIDTH","type":"esriFieldTypeDouble","alias":"FEATUREWIDTH","domain":null},{"name":"ORIENTATION","type":"esriFieldTypeSmallInteger","alias":"ORIENTATION","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":32,"name":"Lighthouses","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Lighthouse - A building or structure housing a light used as a navigation aid to shipping. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriPMS","url":"ebc37da5","imageData":"iVBORw0KGgoAAAANSUhEUgAAABQAAAATCAYAAACQjC21AAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAk1JREFUOI2t0z9oE1EcB/BvmrTPLkofFYSQwQweLYSCmpRcIqHFDrqI4JJrwFaFSIkUipMdFLzlMkiIAaGmhC7BwQ6xhIAtZGiuIJQ41KEZxIZD3i2+pT3sq3jn1FpC0z+kv/F9f3zefw/OuTxn6O0F8PvcQELIayHE83MBKaU3CCHPGGMvAVgdg4qipHK5XA+AOwA+dgwyxu6l02lUq9WJSqXSGUgpHdrZ2bk0OTmJ+fn5MQAXAOyeCFJKg1NTU96RkZHrhxtqtdptSZK6+vv7MTo66qRSqfeDg4M/9nPbtv9ms9m1paUlA8DmAcg531ZV9ZWqqkPj4+OO1+t17WfhcBgAkEgkSKlUShiGAQDY2NhwKpWKC8AnAI9at7wJYJgQkl5fX384OztrDwwM9B1erSzLkGUZjuNgZWXFyOfzFMALANl2ZyiEENONRuNzNBpdyGQyZjwev+Lx/G+zLAuqqv6cm5vbBXALwNcjz7ClypzzgKZp30OhECRJOgh0XYeu69uc85s44k0ed8u93d3dxO/3w7ZtbG1tOX6/3xUIBOB2u31o8w3bgoqiTMRisS7LspyZmRmzWCxe1jRtO5lM9vl8vh5CSEQIsXqWFSaEEHvBYPCPYRgLQog3mqa9W15eHotEIhcVRXlaKBRODXoXFxev6rpumqapCCGqAMAYe1Aul5/U6/W3kiTdBeAC4JwGvA+g1Gw2HwP41ZLlGWOrnPMPlNIQ5/zLiSCldI1znmszGQA0hBDDlNJrrcGRIOe8fgy2X3uMsW+tg/8ALm/uzGg889IAAAAASUVORK5CYII=","contentType":"image/png","color":null,"width":15,"height":14,"angle":0,"xoffset":0,"yoffset":0},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.97203000000002,"ymin":-43.65735999999998,"xmax":153.63570000000004,"ymax":-9.140769999999975,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"SOURCE","type":"esriFieldTypeString","alias":"SOURCE","length":50,"domain":null},{"name":"UFI","type":"esriFieldTypeString","alias":"UFI","length":10,"domain":null},{"name":"CREATIONDATE","type":"esriFieldTypeDate","alias":"CREATIONDATE","length":8,"domain":null},{"name":"RETIREMENTDATE","type":"esriFieldTypeDate","alias":"RETIREMENTDATE","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"FEATUREWIDTH","type":"esriFieldTypeDouble","alias":"FEATUREWIDTH","domain":null},{"name":"ORIENTATION","type":"esriFieldTypeSmallInteger","alias":"ORIENTATION","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":33,"name":"Marine_Infrastructure_Lines","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Breakwater - A solid structure to break the force of the waves, sometimes detached from the coast, protecting a harbour or anchorage. Jetty - A structure projecting into a body of water for use as a promenade or as a platform alongside which vessels may be secured for loading and unloading passengers and cargo. Sea Wall - A solid structure usually of concrete masonry or earth, built to prevent erosion or encroachment by the sea. Wharf Line - A structure built along the shoreline to provide for the berthing (or mooring) of vessels. In large commercial ports it may be associated with warehouses and storage facilities for shipping containers. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"FEATURETYPE","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Breakwater","label":"Breakwaters","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[255,255,190,255],"width":3}},{"value":"Jetty","label":"Jetties","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[255,255,190,255],"width":3}},{"value":"Sea Wall","label":"Sea Walls","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[255,255,190,255],"width":3}},{"value":"Wharf Line","label":"Wharves","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[255,255,190,255],"width":3}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.32462999999996,"ymin":-43.161,"xmax":153.59193000000005,"ymax":-9.062450000000013,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":"Type","fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"SOURCE","type":"esriFieldTypeString","alias":"SOURCE","length":50,"domain":null},{"name":"UFI","type":"esriFieldTypeString","alias":"UFI","length":10,"domain":null},{"name":"CREATIONDATE","type":"esriFieldTypeDate","alias":"CREATIONDATE","length":8,"domain":null},{"name":"RETIREMENTDATE","type":"esriFieldTypeDate","alias":"RETIREMENTDATE","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":[{"id":3,"name":"Jetty","domains":{}},{"id":2,"name":"Breakwater","domains":{}},{"id":4,"name":"SeaWall","domains":{}},{"id":5,"name":"WharfLine","domains":{}}],"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":34,"name":"Reefs_And_Shoals","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Reef - An area of rock or coral that is exposed between mean high water and lowest tide, or just below approximate lowest tide, which is visually prominent or a hazard to shipping. Shoal - A detached area of any material the depth over which constitutes a danger to surface navigation of marine craft. The term shoal is not generally used for dangers which are composed entirely of rock or coral. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"FEATURETYPE","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Reef","label":"Reefs","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[0,197,255,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}}},{"value":"Shoal","label":"Shoals","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":null,"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":1.0000609919999999}}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.92034999999998,"ymin":-43.54730999999998,"xmax":153.54714,"ymax":-8.99857000000003,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":12,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"SOURCE","type":"esriFieldTypeString","alias":"SOURCE","length":50,"domain":null},{"name":"UFI","type":"esriFieldTypeString","alias":"UFI","length":10,"domain":null},{"name":"CREATIONDATE","type":"esriFieldTypeDate","alias":"CREATIONDATE","length":8,"domain":null},{"name":"RETIREMENTDATE","type":"esriFieldTypeDate","alias":"RETIREMENTDATE","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":35,"name":"Locks","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Lock - An enclosure in a water body with gates at both ends to raise or lower the water level to enable vessels to pass from one level to another. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Victorian Department of Environment, Land, Water and Planning and South Australia Department for Environment, Water and Natural Resources","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriPMS","url":"f2dd16b8","imageData":"iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAGJJREFUKJFjYYh+tpeBgUGZgRjwi1GLhZ2BQfonA4M8URq+sTKxEKUQCaBoWBXNzcDOyoii4MLt3wz1R39i1+DjyMPAycGEooGH+wsDAy4NJDtpEGrgSnlJAxt+LpXSIEUDAHlHElohkmM3AAAAAElFTkSuQmCC","contentType":"image/png","color":null,"width":9,"height":9,"angle":0,"xoffset":0,"yoffset":0},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":138.80938000000003,"ymin":-35.94261,"xmax":144.46687999999995,"ymax":-33.996730000000014,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":36,"name":"Waterfalls","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Waterfall Point - A sudden descent of water over a step or ledge in the bed of a watercourse. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriPMS","url":"ae94f8b1","imageData":"iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAYAAADEUlfTAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAHtJREFUCJltyaEOgVEYANDzcTfBFE2RKALy/xzmMWwUzYxEYPMmFC/gJf4saLrAVUwwp54EJrkn8pzokEvV2NhFmZqTPLyHC1EHovA0as1yke5hjU98NW5Pq4S+/wYJV7T/5DXJtsLxJ7KKTXKIk2ke116WD7oosbCP8xso1yAds4y0NgAAAABJRU5ErkJggg==","contentType":"image/png","color":null,"width":5,"height":5,"angle":0,"xoffset":0,"yoffset":0},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":115.8425565,"ymin":-43.49456650000002,"xmax":153.048539,"ymax":-10.643486999999993,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":37,"name":"Springs","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Springs - A place where water issues from the ground naturally. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[190,232,255,255],"size":5,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":0}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.13675999999998,"ymin":-38.23244999999997,"xmax":147.96740999999997,"ymax":-11.52388000000002,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":38,"name":"Waterholes","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Waterhole - A natural depression which holds perennial water, within a non-perennial watercourse or a non-perennial lake. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[115,178,255,255],"size":5,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":0}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.69557699999996,"ymin":-43.52217000000002,"xmax":153.21927000000005,"ymax":-10.171490000000006,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":39,"name":"Bores","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Bore - A small diameter hole in the ground for the purpose of obtaining subterranean water by natural flow or mechanical pumping. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"Geoscience Australia","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[0,132,168,255],"size":5,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":0}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.93203749999998,"ymin":-38.20881000000003,"xmax":152.06205999999997,"ymax":-11.051049999999975,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":40,"name":"Natural_Water_Points_GnammaHole","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Gnamma Hole - Small holes of varying shape, diameter and depth, found in hard granite outcrops and in the decomposed granite of a breakaway, which can and usually does hold water. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[115,223,255,255],"size":5,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":0}},"label":"Gnamma Holes","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":118.13149999999996,"ymin":-31.627049999999997,"xmax":127.64131999999995,"ymax":-26.031510000000026,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":41,"name":"Natural_Water_Points_NativeWell","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Native Well - An isolated natural depression which holds water, not within Watercourses. The natural phenomena is sometimes improved by indigenous persons for their own water collection purposes. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[115,223,255,255],"size":5,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":0}},"label":"Native Wells","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.79952000000003,"ymin":-31.973419999999976,"xmax":147.03940999999998,"ymax":-20.273979999999995,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":42,"name":"Natural_Water_Points_Pool","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Pool - A small body of still or standing water, permanent or temporary in an isolated natural depression, not within Watercourses. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[115,223,255,255],"size":5,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":0}},"label":"Pools","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.56568400000003,"ymin":-43.248490000000004,"xmax":153.09348,"ymax":-10.072709999999972,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":43,"name":"Natural_Water_Points_Rockhole","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Rockhole - A hole excavated in solid rock by water action. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[115,223,255,255],"size":5,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":0}},"label":"Rockholes","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.76517999999999,"ymin":-33.262159999999994,"xmax":142.18583999999998,"ymax":-17.009979999999985,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":44,"name":"Natural_Water_Points_Soak","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Soak - A depression holding moisture after rain, especially the damp or swamp spots around the base of granite rocks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSMS","style":"esriSMSCircle","color":[115,223,255,255],"size":5,"angle":0,"xoffset":0,"yoffset":0,"outline":{"color":[0,0,0,255],"width":0}},"label":"Soaks","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.07808950000003,"ymin":-33.145550000000014,"xmax":142.09559000000002,"ymax":-15.118119999999976,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":45,"name":"Dams_and_Tanks","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Dam - An open body of water collected and stored behind a constructed barrier consisting of earth, rock, concrete and/or masonry. Generally designed to capture run-off from the surrounding landscape or rainfall. The storage of water may occur on or below ground level. Water Tank - Water Tanks are storage containers for water, usually used for human consumption and other purposes such as irrigation, agriculture, fire suppression, agricultural farming and livestock, chemical manufacturing and food preparation. Water Tanks are constructed of various materials including plastic (polyethylene or polypropylene), fiberglass, reinforced concrete, steel (welded or bolted, carbon or stainless). Those used for human consumption are generally fully enclosed. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPoint","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriPMS","url":"4113ea2d","imageData":"iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAC1JREFUCJljKXnwP53xPwMnAxJgZGA4yfKPgaGViZFBGFni7///rSwMOAAVJQC/Egm/kHbQMwAAAABJRU5ErkJggg==","contentType":"image/png","color":null,"width":4,"height":4,"angle":0,"xoffset":0,"yoffset":0},"label":"Dams and Tanks","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.07836999999995,"ymin":-43.14695999999998,"xmax":153.49998400000004,"ymax":-9.95177000000001,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":46,"name":"Canal_Lines","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Canal Line - An artificial open channel which provides the supply, distribution or removal of water for irrigation purposes, or for a significant infrastructure function (such as salt interception, land reclamation, or drainage between water features for environmental management purposes). (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":1.5},"label":"Canal Lines","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.35392000000002,"ymin":-42.343290000000025,"xmax":153.5903475,"ymax":-12.52460000000002,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":20,"domain":null},{"name":"STATUS","type":"esriFieldTypeString","alias":"STATUS","length":18,"domain":null},{"name":"RESTRICTIONS","type":"esriFieldTypeString","alias":"RESTRICTIONS","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":47,"name":"Dam_Walls","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Dam Wall - A barrier of earth and rock, concrete or masonry constructed to form a reservoir for water storage purposes or to raise the water level. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Culture.html)","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[0,77,168,255],"width":2},"label":"Dam Walls","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":115.00212,"ymin":-43.1877,"xmax":153.30629,"ymax":-10.57169,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":{"type":"codedValue","name":"dm_UpperScale25K","codedValues":[{"name":"25000","code":25000},{"name":"50000","code":50000},{"name":"100000","code":100000},{"name":"250000","code":250000},{"name":"1000000","code":1000000},{"name":"2500000","code":2500000},{"name":"5000000","code":5000000},{"name":"10000000","code":10000000},{"name":"0","code":0}]}},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":10,"domain":{"type":"codedValue","name":"dm_USCertainty25K","codedValues":[{"name":"Definite","code":"Definite"},{"name":"Indefinite","code":"Indefinite"},{"name":"Undefined","code":"Undefined"}]}},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"FEATUREWIDTH","type":"esriFieldTypeDouble","alias":"FEATUREWIDTH","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":48,"name":"Rapid_Lines","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Rapid Line - An area of broken, fast flowing water in a watercourse, where the slope of the bed increases (but without a prominent break of slope which might result in a waterfall), or where a gently dipping bar of harder rock outcrops. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[0,255,197,255],"width":2},"label":"Rapid Lines","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":131.66452000000004,"ymin":-35.70256999999998,"xmax":149.13694999999996,"ymax":-10.705489999999998,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":20,"domain":null},{"name":"STATUS","type":"esriFieldTypeString","alias":"STATUS","length":18,"domain":null},{"name":"RESTRICTIONS","type":"esriFieldTypeString","alias":"RESTRICTIONS","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":49,"name":"Spillways","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Spillway - A channel or duct formed around the side of a reservoir past the end of the dam wall, to convey flood discharge from the watercourse above the reservoir into the watercourse below the dam wall. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[0,197,255,255],"width":3},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":117.10128,"ymin":-42.10383,"xmax":153.28249,"ymax":-20.97787,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"FEATURETYPE","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":50,"name":"Levees","type":"Feature Layer","description":"These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Levee - A low earth wall erected to restrain flood waters or to contain irrigation water. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Physiography.html)","definitionExpression":"FEATURETYPE = 'Levee'","geometryType":"esriGeometryPolyline","copyrightText":"","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"FEATURETYPE","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Levee","label":"Levees","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[127,127,205,255],"width":2}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.92145000000005,"ymin":-43.65649000000002,"xmax":153.46622000000002,"ymax":-11.006910000000005,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"FEATURETYPE","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"SOURCE","type":"esriFieldTypeString","alias":"SOURCE","length":50,"domain":null},{"name":"UFI","type":"esriFieldTypeString","alias":"UFI","length":10,"domain":null},{"name":"CREATIONDATE","type":"esriFieldTypeDate","alias":"CREATIONDATE","length":8,"domain":null},{"name":"RETIREMENTDATE","type":"esriFieldTypeDate","alias":"RETIREMENTDATE","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":51,"name":"Canal_Areas","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Canal Area - An artificial open channel which provides the supply, distribution or removal of water for irrigation purposes, or for a significant infrastructure function (such as salt interception, land reclamation, or drainage between water features for environmental management purposes). (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}},"label":"Canal Areas","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":115.70707100000004,"ymin":-42.85125799999997,"xmax":148.20427600000005,"ymax":-32.52941900000002,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":52,"name":"Rapid_Areas","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Rapid Area - An area of broken, fast flowing water in a watercourse, where the slope of the bed increases (but without a prominent break of slope which might result in a waterfall), or where a gently dipping bar of harder rock outcrops. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}},"label":"Rapid Areas","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":131.03976999999998,"ymin":-33.99536999999998,"xmax":149.38968999999997,"ymax":-12.680119999999988,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":53,"name":"Watercourse_Areas","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse Area - A natural channel along which water may flow from time to time. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"FEATURETYPE","field2":"PERENNIALITY","field3":"HIERARCHY","fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Watercourse Area, Perennial, Major","label":"Watercourse Areas, Major and Minor Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}}},{"value":"Watercourse Area, Perennial, Minor","label":"Watercourse Areas, Major and Minor Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}}},{"value":"Watercourse Area, Non Perennial, Major","label":"Watercourse Areas, Major and Minor Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}},{"value":"Watercourse Area, Non-perennial, Major","label":"Watercourse Areas, Major and Minor Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}},{"value":"Watercourse Area, Non-perennial, Minor","label":"Watercourse Areas, Major and Minor Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.56261099999995,"ymin":-43.58997599999998,"xmax":153.62839150000002,"ymax":-8.933329000000015,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":54,"name":"PondageArea_AquacultureAreas","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Aquaculture Area - Shallow beds, usually segmented by constructed walls, for the use of aquaculture. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[158,204,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[102,153,205,255],"width":1}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.23868000000004,"ymin":-35.87101000000001,"xmax":144.99723100000006,"ymax":-12.58411000000001,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":55,"name":"Pondage_Areas_Salt_Evaporators","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Salt Evaporator - A flat area, usually segmented, used for the commercial production of salt by evaporation.(Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[158,204,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[102,153,205,255],"width":1}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.31874100000005,"ymin":-35.29845999999998,"xmax":139.22114,"ymax":-12.360050000000001,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":56,"name":"Pondage_Areas_Settling_Ponds","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Settling Pond -  Shallow beds, usually segmented by constructed walls, for the treatment of sewage or other wastes. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[158,204,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[102,153,205,255],"width":1}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.66103999999996,"ymin":-41.754831000000024,"xmax":146.87972549999995,"ymax":-12.191229000000021,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":57,"name":"Foreshore_Flats","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Foreshore Flat - That part of the seabed or estuarine areas, between mean high water and the line of lowest astronomical tide. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[242,233,219,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":null,"width":0.4}},"label":"Foreshore Flats","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.00706000000002,"ymin":-43.511829999999975,"xmax":153.57853,"ymax":-9.00711,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"FEATURETYPE","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":58,"name":"Waterbody_Lakes_National_Scale_to_5Million","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays between the National Scale of 1:5,050,000 scale and a size criteria of area greater than 0.1 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.","definitionExpression":"\"SHAPE_Area\" > 0.1","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":5050001,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"PERENNIALITY","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Perennial","label":"Lakes, Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}}},{"value":"Not Applicable","label":"Lakes, Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}}},{"value":"Non-perennial","label":"Lakes, Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}},{"value":"Non Perennial","label":"Lakes, Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.99395000000004,"ymin":-43.53222699999998,"xmax":153.59316149999995,"ymax":-8.937880000000007,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":59,"name":"Waterbody_Lakes_Scale_5Million_to_300000","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays between 1:5,050,000 and 1:300,001 scales and a size criteria of area greater than 0.003 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.","definitionExpression":"\"SHAPE_Area\" > 0.003","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":5050000,"maxScale":300001,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"PERENNIALITY","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Perennial","label":"Lakes, Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}}},{"value":"Not Applicable","label":"Lakes, Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}}},{"value":"Non-perennial","label":"Lakes, Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}},{"value":"Non Perennial","label":"Lakes, Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.99395000000004,"ymin":-43.53222699999998,"xmax":153.59316149999995,"ymax":-8.937880000000007,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":60,"name":"Waterbody_Reservoirs_National_Scale_to_300000","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Town Water Storage - A body of water collected and stored behind a constructed barrier for some specific use (with the exception of Flood Irrigation Storage). Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays from national scale to a scale of 1:300,001 and a size criteria of area greater than 0.003 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.","definitionExpression":"\"SHAPE_Area\" > 0.003","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":300001,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"FEATURETYPE","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Reservoir Area","label":"Reservoir Area","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.99600999999996,"ymin":-43.19614250000001,"xmax":153.54449950000003,"ymax":-12.558189500000026,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":61,"name":"Waterbody_Extra_Lakes_and_Reservoirs","type":"Feature Layer","description":"Custom Dataset - These are extra waterbodies added at this scale that fall under the size criteria in Waterbody Lake and Reservoirs. (Only displays polygons with area greater than 0.03 map units)","definitionExpression":"\"SHAPE_Area\" < 0.003","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":5050000,"maxScale":300001,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"AHGFFTYPE","field2":"PERENNIAL","field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"26, Perennial","label":"Lake, Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}}},{"value":"26, Non-perennial","label":"Lake, Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}},{"value":"25,  ","label":"Reservoir","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.47902999999997,"ymin":-43.039570000000026,"xmax":153.35022999999995,"ymax":-8.933329000000015,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":null,"displayField":"Name","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"HYDROID","type":"esriFieldTypeInteger","alias":"HYDROID","domain":null},{"name":"AHGFFTYPE","type":"esriFieldTypeInteger","alias":"AHGFFeatureType","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIAL","type":"esriFieldTypeString","alias":"Perenniality","length":255,"domain":null},{"name":"NETNODEID","type":"esriFieldTypeInteger","alias":"NetworkNodeID","domain":null},{"name":"MAPNODEID","type":"esriFieldTypeInteger","alias":"MappedNodeID","domain":null},{"name":"WSTOREUSE","type":"esriFieldTypeString","alias":"WaterStoreUse","length":30,"domain":null},{"name":"SRCFCNAME","type":"esriFieldTypeString","alias":"SourceFeatureClassName","length":25,"domain":null},{"name":"SRCFTYPE","type":"esriFieldTypeString","alias":"SourceFeatureType","length":32,"domain":null},{"name":"SRCTYPE","type":"esriFieldTypeInteger","alias":"SourceType","domain":null},{"name":"SOURCEID","type":"esriFieldTypeInteger","alias":"SOURCEID","domain":null},{"name":"FEATREL","type":"esriFieldTypeDate","alias":"FeatureReliability","length":8,"domain":null},{"name":"FSOURCE","type":"esriFieldTypeString","alias":"FeatureSource","length":25,"domain":null},{"name":"ATTRREL","type":"esriFieldTypeDate","alias":"AttributeReliability","length":8,"domain":null},{"name":"ATTRSOURCE","type":"esriFieldTypeString","alias":"AttributeSource","length":25,"domain":null},{"name":"PLANACC","type":"esriFieldTypeSmallInteger","alias":"PlanimetricAccuracy","domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":62,"name":"Waterbody_All_Lakes","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70000,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"PERENNIALITY","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Perennial","label":"Lakes - Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.5}}},{"value":"Not Applicable","label":"Lakes - Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.5}}},{"value":"Non-perennial","label":"Lakes - Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}},{"value":"Non Perennial","label":"Lakes - Non Perennial","description":"","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,242,222,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[190,210,255,255],"width":0.4}}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":112.99395000000004,"ymin":-43.53222699999998,"xmax":153.59316149999995,"ymax":-8.937880000000007,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":63,"name":"Waterbody_All_Reservoirs","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Town Water Storage - A body of water collected and stored behind a constructed barrier for some specific use (with the exception of Flood Irrigation Storage). Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70000,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":114.99600999999996,"ymin":-43.19614250000001,"xmax":153.54449950000003,"ymax":-12.558189500000026,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":64,"name":"Waterbody_All_Flood_Irrigation_Storage","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Flood Irrigation Storage - A body of water collected and stored behind constructed barriers, for the specific use of flooding pastures via internal irrigation systems. Town Water Storage - A body of water collected and stored behind a constructed barrier for some specific use (with the exception of Flood Irrigation Storage). Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70000,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[212,232,247,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":0.2}},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":143.18679150000003,"ymin":-30.01566150000002,"xmax":152.4470235,"ymax":-17.072844999999973,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":65,"name":"Farm_Dam_Area","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Rural Water Storage - A body of water collected and stored behind a constructed barrier for some specific use. Rural Water Storage are bodies of water stored for rural farming and agricultural practices (with the exception of Flood Irrigation Storage) and/or for the consumption of the associated land owners. The water is not treated by government authorities or connected to government regulated water networks. Dam - An open body of water collected and stored behind a constructed barrier consisting of earth, rock, concrete and/or masonry. Generally designed to capture run-off from the surrounding landscape or rainfall. The storage of water may occur on or below ground level. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[158,215,194,255],"outline":{"type":"esriSLS","style":"esriSLSSolid","color":[0,77,168,255],"width":0.4}},"label":"Farm Dam Areas","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":115.08154049999996,"ymin":-38.096869500000025,"xmax":153.56586049999999,"ymax":-10.57168999999999,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":66,"name":"Watercourses_Major_Rivers_National_Scale_to_5Million","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays between the National Scale and 1:5,050,000 scale to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":4.0E7,"maxScale":5050001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[115,178,255,255],"width":1.5},"label":"","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":115.76303800000005,"ymin":-42.77677,"xmax":150.790599,"ymax":-12.004185500000006,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"Shape","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":10,"domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"Enabled","type":"esriFieldTypeSmallInteger","alias":"Enabled","domain":null},{"name":"Shape_Length","type":"esriFieldTypeDouble","alias":"Shape_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":67,"name":"Watercourses_Major_Rivers_Scale_5Million_to_300000","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays between 1:5,050,000 to 1:300,000 scales to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":5050000,"maxScale":300001,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"HIERARCHY","field2":"PERENNIALITY","field3":"FEATURETYPE","fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Major, Perennial, Watercourse","label":"Watercourse, Major Perennial","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1.5}},{"value":"Major, Perennial, Connector","label":"Watercourse, Major Perennial","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1.5}},{"value":"Major, Non Perennial, Watercourse","label":"Watercourse, Major Non Perennial","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1}},{"value":"Major, Non-perennial, Watercourse","label":"Watercourse, Major Non Perennial","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1}},{"value":"Major, Non Perennial, Connector","label":"Watercourse, Major Non Perennial","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1}},{"value":"Major, Non-perennial, Connector","label":"Watercourse, Major Non Perennial","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1}},{"value":"Minor, Non Perennial, Connector","label":"Watercourse, Major Non Perennial","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.62140150000005,"ymin":-43.552824499999986,"xmax":153.586911,"ymax":-9.408074499999998,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"Shape","type":"esriFieldTypeGeometry","alias":"Shape","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"PID","type":"esriFieldTypeInteger","alias":"PID","domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":10,"domain":null},{"name":"SYMBOL","type":"esriFieldTypeSmallInteger","alias":"SYMBOL","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"Enabled","type":"esriFieldTypeSmallInteger","alias":"Enabled","domain":null},{"name":"Shape_Length","type":"esriFieldTypeDouble","alias":"Shape_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":68,"name":"Watercourses_All_Rivers_Connectors","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70000,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"HIERARCHY","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Major","label":"Major Connectors","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1.5}},{"value":"Minor","label":"Minor Connectors","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1}},{"value":"Not Applicable","label":"Minor Connectors","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.45159100000001,"ymin":-43.53306900000001,"xmax":153.6077815,"ymax":-9.948831999999982,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":20,"domain":null},{"name":"STATUS","type":"esriFieldTypeString","alias":"STATUS","length":18,"domain":null},{"name":"RESTRICTIONS","type":"esriFieldTypeString","alias":"RESTRICTIONS","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":69,"name":"Watercourses_All_Rivers_Watercourse_Lines","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.","definitionExpression":"","geometryType":"esriGeometryPolyline","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":300000,"maxScale":70000,"drawingInfo":{"renderer":{"type":"uniqueValue","field1":"HIERARCHY","field2":null,"field3":null,"fieldDelimiter":", ","defaultSymbol":null,"defaultLabel":"<all other values>","uniqueValueInfos":[{"value":"Major","label":"Major Watercourses","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1.5}},{"value":"Minor","label":"Minor Watercourses","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1}},{"value":"<Null>","label":"Minor Watercourses","description":"","symbol":{"type":"esriSLS","style":"esriSLSSolid","color":[89,153,230,255],"width":1}}]},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.37534500000004,"ymin":-43.62811399999998,"xmax":153.63163999999995,"ymax":-9.242297500000006,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"RELATIONSHIP","type":"esriFieldTypeString","alias":"RELATIONSHIP","length":20,"domain":null},{"name":"STATUS","type":"esriFieldTypeString","alias":"STATUS","length":18,"domain":null},{"name":"RESTRICTIONS","type":"esriFieldTypeString","alias":"RESTRICTIONS","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":70,"name":"Flats_Swamps","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Swamp - Land which is so saturated with water that it is not suitable for agricultural or pastoral use and presents a barrier to free passage. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[219,227,255,255],"outline":{"type":"esriSLS","style":"esriSLSNull","color":[110,110,110,255],"width":0}},"label":"Swamps","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.75390100000004,"ymin":-43.60268000000002,"xmax":153.61275,"ymax":-8.933329000000015,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":71,"name":"Flats_MarineSwamps","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Marine Swamp - That low lying part of the backshore area of tidal waters, usually immediately behind saline coastal flat, which maintains a high salt water content, and is covered with characteristic thick grasses and reed growths. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"\"FEATURETYPE\" = 'Marine Swamp' OR \"FEATURETYPE\" = 'Swamp'","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[133,212,196,255],"outline":{"type":"esriSLS","style":"esriSLSNull","color":[110,110,110,255],"width":0}},"label":"Marine Swamps","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":118.79958999999997,"ymin":-20.298429,"xmax":142.18464100000006,"ymax":-10.93128999999999,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":72,"name":"Flats_LandSubjectToInundation","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Land Subject to Inundation - Low lying land usually adjacent to lakes or watercourses, which is regularly covered with flood water for short periods. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[230,230,230,255],"outline":{"type":"esriSLS","style":"esriSLSNull","color":null,"width":0}},"label":"Land Subject to Inundation","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.64665000000002,"ymin":-42.842738999999995,"xmax":153.42711099999997,"ymax":-8.933329000000015,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"},{"currentVersion":10.04,"id":73,"name":"Flats_SalineCoastalFlats","type":"Feature Layer","description":"All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Saline Coastal Flat - That nearly level tract of land between mean high water and the line of the highest astronomical tide. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)","definitionExpression":"NOT (\"FEATURETYPE\" = 'Marine Swamp' OR \"FEATURETYPE\" = 'Swamp')","geometryType":"esriGeometryPolygon","copyrightText":"AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","parentLayer":null,"subLayers":[],"minScale":0,"maxScale":70001,"drawingInfo":{"renderer":{"type":"simple","symbol":{"type":"esriSFS","style":"esriSFSSolid","color":[196,214,215,255],"outline":{"type":"esriSLS","style":"esriSLSNull","color":[110,110,110,255],"width":0}},"label":"Saline Coastal Flats","description":""},"transparency":0,"labelingInfo":null},"defaultVisibility":true,"extent":{"xmin":113.00808099999995,"ymin":-34.003108999999995,"xmax":153.05944999999997,"ymax":-10.12682000000001,"spatialReference":{"wkid":4283}},"hasAttachments":false,"htmlPopupType":"esriServerHTMLPopupTypeAsHTMLText","displayField":"NAME","typeIdField":null,"fields":[{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID","domain":null},{"name":"SHAPE","type":"esriFieldTypeGeometry","alias":"SHAPE","domain":null},{"name":"geodb_oid","type":"esriFieldTypeInteger","alias":"geodb_oid","domain":null},{"name":"FEATURETYPE","type":"esriFieldTypeString","alias":"FEATURETYPE","length":32,"domain":null},{"name":"TYPE","type":"esriFieldTypeInteger","alias":"TYPE","domain":null},{"name":"NAME","type":"esriFieldTypeString","alias":"NAME","length":60,"domain":null},{"name":"PERENNIALITY","type":"esriFieldTypeString","alias":"PERENNIALITY","length":14,"domain":null},{"name":"HIERARCHY","type":"esriFieldTypeString","alias":"HIERARCHY","length":14,"domain":null},{"name":"DIMENSION","type":"esriFieldTypeDouble","alias":"DIMENSION","domain":null},{"name":"FEATURERELIABILITY","type":"esriFieldTypeDate","alias":"FEATURERELIABILITY","length":8,"domain":null},{"name":"FEATURESOURCE","type":"esriFieldTypeString","alias":"FEATURESOURCE","length":50,"domain":null},{"name":"ATTRIBUTERELIABILITY","type":"esriFieldTypeDate","alias":"ATTRIBUTERELIABILITY","length":8,"domain":null},{"name":"ATTRIBUTESOURCE","type":"esriFieldTypeString","alias":"ATTRIBUTESOURCE","length":50,"domain":null},{"name":"PLANIMETRICACCURACY","type":"esriFieldTypeSmallInteger","alias":"PLANIMETRICACCURACY","domain":null},{"name":"REVISED","type":"esriFieldTypeDate","alias":"REVISED","length":8,"domain":null},{"name":"GAID","type":"esriFieldTypeInteger","alias":"GAID","domain":null},{"name":"LEVEL","type":"esriFieldTypeString","alias":"LEVEL","length":30,"domain":null},{"name":"AUSHYDRO_ID","type":"esriFieldTypeInteger","alias":"AUSHYDRO_ID","domain":null},{"name":"DEMH","type":"esriFieldTypeSmallInteger","alias":"DEMH","domain":null},{"name":"EDITCODE","type":"esriFieldTypeSmallInteger","alias":"EDITCODE","domain":null},{"name":"TEXTNOTE","type":"esriFieldTypeString","alias":"TEXTNOTE","length":50,"domain":null},{"name":"STKEHDRID","type":"esriFieldTypeString","alias":"STKEHDRID","length":50,"domain":null},{"name":"STKEHDRNAME","type":"esriFieldTypeString","alias":"STKEHDRNAME","length":250,"domain":null},{"name":"STKEHDRSUPPLYDATE","type":"esriFieldTypeDate","alias":"STKEHDRSUPPLYDATE","length":8,"domain":null},{"name":"UPPERSCALE","type":"esriFieldTypeInteger","alias":"UPPERSCALE","domain":null},{"name":"USCERTAINTY","type":"esriFieldTypeString","alias":"USCERTAINTY","length":25,"domain":null},{"name":"NATURE","type":"esriFieldTypeString","alias":"NATURE","length":20,"domain":null},{"name":"WATERSTORAGEUSAGE","type":"esriFieldTypeString","alias":"WATERSTORAGEUSAGE","length":50,"domain":null},{"name":"SHAPE_Length","type":"esriFieldTypeDouble","alias":"SHAPE_Length","domain":null},{"name":"SHAPE_Area","type":"esriFieldTypeDouble","alias":"SHAPE_Area","domain":null}],"types":null,"relationships":[],"capabilities":"Map,Query,Data"}],"tables":[]}
+{
+  "layers": [
+    {
+      "currentVersion": 10.04,
+      "id": 0,
+      "name": "No_Labels_National_Scale_to_300K_Scale",
+      "type": "Feature Layer",
+      "description": "This is a customised layer to show the user of the web map service where the 250K data labels are not appropriate to use past between these scales (National Scale to 1:300,000 Scale).",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 300000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": [
+          {
+            "labelPlacement": null,
+            "labelExpression": "[TEXT_LABEL]",
+            "useCodedValues": true,
+            "symbol": {
+              "type": "esriTS",
+              "color": [
+                78,
+                78,
+                78,
+                255
+              ],
+              "backgroundColor": null,
+              "borderLineColor": null,
+              "verticalAlignment": "baseline",
+              "horizontalAlignment": "left",
+              "rightToLeft": false,
+              "angle": 0,
+              "xoffset": 0,
+              "yoffset": 0,
+              "font": {
+                "family": "Arial",
+                "size": 14,
+                "style": "normal",
+                "weight": "bold",
+                "decoration": "none"
+              }
+            },
+            "minScale": 0,
+            "maxScale": 0
+          }
+        ]
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 97.90759300700006,
+        "ymin": -54.25906877199998,
+        "xmax": 167.28209572600008,
+        "ymax": 0.9835908000000586,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "TEXT_LABEL",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "TEXT_LABEL",
+          "type": "esriFieldTypeString",
+          "alias": "TEXT",
+          "length": 254,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 1,
+      "name": "No_Labels_National_Scale_to_10Million_Scale",
+      "type": "Feature Layer",
+      "description": "This is a customised layer to show the user of the web map service where the 250K data labels for Rivers and Lakes/Reservoirs are not appropriate to use between these scales (National Scale to 10 Million Scale).",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": "1.0000001E7",
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": [
+          {
+            "labelPlacement": null,
+            "labelExpression": "[TEXT_LABEL]",
+            "useCodedValues": true,
+            "symbol": {
+              "type": "esriTS",
+              "color": [
+                78,
+                78,
+                78,
+                255
+              ],
+              "backgroundColor": null,
+              "borderLineColor": null,
+              "verticalAlignment": "baseline",
+              "horizontalAlignment": "left",
+              "rightToLeft": false,
+              "angle": 0,
+              "xoffset": 0,
+              "yoffset": 0,
+              "font": {
+                "family": "Arial",
+                "size": 14,
+                "style": "normal",
+                "weight": "bold",
+                "decoration": "none"
+              }
+            },
+            "minScale": 0,
+            "maxScale": 0
+          }
+        ]
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 97.90759300700006,
+        "ymin": -54.25906877199998,
+        "xmax": 167.28209572600008,
+        "ymax": 0.9835908000000586,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "TEXT_LABEL",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "TEXT_LABEL",
+          "type": "esriFieldTypeString",
+          "alias": "TEXT",
+          "length": 254,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 2,
+      "name": "No_Data",
+      "type": "Feature Layer",
+      "description": "This is a customised layer to show the user of the web map service where the 250K data is not appropriate to use past this scale (1:70,000).",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 70000,
+      "maxScale": 0,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": [
+          {
+            "labelPlacement": null,
+            "labelExpression": "[TEXT_LABEL]",
+            "useCodedValues": true,
+            "symbol": {
+              "type": "esriTS",
+              "color": [
+                78,
+                78,
+                78,
+                255
+              ],
+              "backgroundColor": null,
+              "borderLineColor": null,
+              "verticalAlignment": "baseline",
+              "horizontalAlignment": "left",
+              "rightToLeft": false,
+              "angle": 0,
+              "xoffset": 0,
+              "yoffset": 0,
+              "font": {
+                "family": "Arial",
+                "size": 14,
+                "style": "normal",
+                "weight": "bold",
+                "decoration": "none"
+              }
+            },
+            "minScale": 0,
+            "maxScale": 0
+          }
+        ]
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 97.90759300700006,
+        "ymin": -54.25906877199998,
+        "xmax": 167.28209572600008,
+        "ymax": 0.9835908000000302,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "TEXT_LABEL",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "TEXT_LABEL",
+          "type": "esriFieldTypeString",
+          "alias": "TEXT",
+          "length": 254,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 3,
+      "name": "Offshore_Rocks_and_Wrecks_Labels",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. This layer is only for labelling. 250K Specification Description -> Offshore Rock - A rock located offshore that represents a hazard to shipping. Wreck - A disabled vessel, either submerged or visible, which is attached to, or foul of, the bottom or cast up on the shore. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "size": 4,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.11904000000004,
+        "ymin": -43.66633999999999,
+        "xmax": 153.62995,
+        "ymax": -9.063350000000014,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "RELATIONSHIP",
+          "type": "esriFieldTypeString",
+          "alias": "RELATIONSHIP",
+          "length": 12,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "SOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "SOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "UFI",
+          "type": "esriFieldTypeString",
+          "alias": "UFI",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "CREATIONDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "CREATIONDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "RETIREMENTDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "RETIREMENTDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "FEATUREWIDTH",
+          "type": "esriFieldTypeDouble",
+          "alias": "FEATUREWIDTH",
+          "domain": null
+        },
+        {
+          "name": "ORIENTATION",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "ORIENTATION",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 4,
+      "name": "Lighthouses_Labels",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. This layer is only for labelling. 250K Specification Description -> Lighthouse - A building or structure housing a light used as a navigation aid to shipping. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              0
+            ],
+            "size": 4,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.97203000000002,
+        "ymin": -43.65735999999998,
+        "xmax": 153.63570000000004,
+        "ymax": -9.140769999999975,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "SOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "SOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "UFI",
+          "type": "esriFieldTypeString",
+          "alias": "UFI",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "CREATIONDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "CREATIONDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "RETIREMENTDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "RETIREMENTDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "FEATUREWIDTH",
+          "type": "esriFieldTypeDouble",
+          "alias": "FEATUREWIDTH",
+          "domain": null
+        },
+        {
+          "name": "ORIENTATION",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "ORIENTATION",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 5,
+      "name": "Reefs_and_Shoals_Labels",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. This layer is only for labelling. 250K Specification Description -> Reef - An area of rock or coral that is exposed between mean high water and lowest tide, or just below approximate lowest tide, which is visually prominent or a hazard to shipping. Shoal - A detached area of any material the depth over which constitutes a danger to surface navigation of marine craft. The term shoal is not generally used for dangers which are composed entirely of rock or coral. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.92034999999998,
+        "ymin": -43.54730999999998,
+        "xmax": 153.54714,
+        "ymax": -8.99857000000003,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "RELATIONSHIP",
+          "type": "esriFieldTypeString",
+          "alias": "RELATIONSHIP",
+          "length": 12,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "SOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "SOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "UFI",
+          "type": "esriFieldTypeString",
+          "alias": "UFI",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "CREATIONDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "CREATIONDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "RETIREMENTDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "RETIREMENTDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 6,
+      "name": "Locks_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Lock - An enclosure in a water body with gates at both ends to raise or lower the water level to enable vessels to pass from one level to another. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Victorian Department of Environment, Land, Water and Planning and South Australia Department for Environment, Water and Natural Resources",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              0
+            ],
+            "size": 4,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 138.80938000000003,
+        "ymin": -35.94261,
+        "xmax": 144.46687999999995,
+        "ymax": -33.996730000000014,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 7,
+      "name": "Waterfalls_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Waterfall Point - A sudden descent of water over a step or ledge in the bed of a watercourse. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              0
+            ],
+            "size": 4,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 115.8425565,
+        "ymin": -43.49456650000002,
+        "xmax": 153.048539,
+        "ymax": -10.643486999999993,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 8,
+      "name": "Springs_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Springs - A place where water issues from the ground naturally. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "size": 7,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1.0001
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.13675999999998,
+        "ymin": -38.23244999999997,
+        "xmax": 147.96740999999997,
+        "ymax": -11.52388000000002,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 9,
+      "name": "Waterholes_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Waterhole - A natural depression which holds perennial water, within a non-perennial watercourse or a non-perennial lake. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "size": 6.9999,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1.0001
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.69557699999996,
+        "ymin": -43.52217000000002,
+        "xmax": 153.21927000000005,
+        "ymax": -10.171490000000006,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 10,
+      "name": "Bores_Labels",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. This layer is only for labelling. 250K Specification Description -> Bore - A small diameter hole in the ground for the purpose of obtaining subterranean water by natural flow or mechanical pumping. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              132,
+              168,
+              255
+            ],
+            "size": 6.9999,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1.4173
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.93203749999998,
+        "ymin": -38.20881000000003,
+        "xmax": 152.06205999999997,
+        "ymax": -11.051049999999975,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 11,
+      "name": "Natural_Water_Points_GnammaHoles_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Gnamma Hole - Small holes of varying shape, diameter and depth, found in hard granite outcrops and in the decomposed granite of a breakaway, which can and usually does hold water.(Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "size": 7,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1.4173
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 118.13149999999996,
+        "ymin": -31.627049999999997,
+        "xmax": 127.64131999999995,
+        "ymax": -26.031510000000026,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 12,
+      "name": "Natural_Water_Points_NativeWells_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Native Well - An isolated natural depression which holds water, not within Watercourses. The natural phenomena is sometimes improved by indigenous persons for their own water collection purposes. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "size": 7,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1.4173
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.79952000000003,
+        "ymin": -31.973419999999976,
+        "xmax": 147.03940999999998,
+        "ymax": -20.273979999999995,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 13,
+      "name": "Natural_Water_Points_Pools_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Pool - A small body of still or standing water, permanent or temporary in an isolated natural depression, not within Watercourses. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "size": 7,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1.4173
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.56568400000003,
+        "ymin": -43.248490000000004,
+        "xmax": 153.09348,
+        "ymax": -10.072709999999972,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 14,
+      "name": "Natural_Water_Points_Rockholes_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Rockhole - A hole excavated in solid rock by water action. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "size": 7,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1.4173
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.76517999999999,
+        "ymin": -33.262159999999994,
+        "xmax": 142.18583999999998,
+        "ymax": -17.009979999999985,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 15,
+      "name": "Natural_Water_Points_Soaks_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Soak - A depression holding moisture after rain, especially the damp or swamp spots around the base of granite rocks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "size": 7,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1.4173
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.07808950000003,
+        "ymin": -33.145550000000014,
+        "xmax": 142.09559000000002,
+        "ymax": -15.118119999999976,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 16,
+      "name": "Dams_and_Tanks_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Dam - An open body of water collected and stored behind a constructed barrier consisting of earth, rock, concrete and/or masonry. Generally designed to capture run-off from the surrounding landscape or rainfall. The storage of water may occur on or below ground level. Water Tank -  Water Tanks are storage containers for water, usually used for human consumption and other purposes such as irrigation, agriculture, fire suppression, agricultural farming and livestock, chemical manufacturing and food preparation. Water Tanks are constructed of various materials including plastic (polyethylene or polypropylene), fiberglass, reinforced concrete, steel (welded or bolted, carbon or stainless). Those used for human consumption are generally fully enclosed. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              0,
+              0,
+              0
+            ],
+            "size": 4,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 1
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.07836999999995,
+        "ymin": -43.14695999999998,
+        "xmax": 153.49998400000004,
+        "ymax": -9.95177000000001,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 17,
+      "name": "Dam_Walls_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Dam Wall - A barrier of earth and rock, concrete or masonry constructed to form a reservoir for water storage purposes or to raise the water level. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Culture.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSLS",
+            "style": "esriSLSSolid",
+            "color": null,
+            "width": 2
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 115.00212,
+        "ymin": -43.1877,
+        "xmax": 153.30629,
+        "ymax": -10.57169,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": {
+            "type": "codedValue",
+            "name": "dm_UpperScale25K",
+            "codedValues": [
+              {
+                "name": "25000",
+                "code": 25000
+              },
+              {
+                "name": "50000",
+                "code": 50000
+              },
+              {
+                "name": "100000",
+                "code": 100000
+              },
+              {
+                "name": "250000",
+                "code": 250000
+              },
+              {
+                "name": "1000000",
+                "code": 1000000
+              },
+              {
+                "name": "2500000",
+                "code": 2500000
+              },
+              {
+                "name": "5000000",
+                "code": 5000000
+              },
+              {
+                "name": "10000000",
+                "code": 10000000
+              },
+              {
+                "name": "0",
+                "code": 0
+              }
+            ]
+          }
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 10,
+          "domain": {
+            "type": "codedValue",
+            "name": "dm_USCertainty25K",
+            "codedValues": [
+              {
+                "name": "Definite",
+                "code": "Definite"
+              },
+              {
+                "name": "Indefinite",
+                "code": "Indefinite"
+              },
+              {
+                "name": "Undefined",
+                "code": "Undefined"
+              }
+            ]
+          }
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "FEATUREWIDTH",
+          "type": "esriFieldTypeDouble",
+          "alias": "FEATUREWIDTH",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 18,
+      "name": "Watercourse_Areas_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Watercourse Area -  A natural channel along which water may flow from time to time. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.56261099999995,
+        "ymin": -43.58997599999998,
+        "xmax": 153.62839150000002,
+        "ymax": -8.933329000000015,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 19,
+      "name": "Watercourses_Major_Rivers_Scale_10Million_to_5Million_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays between the 1:10,000,000 and 1:5,050,000 scale to avoid clutter. Refer to other Watercourses layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": "1.0E7",
+      "maxScale": 5050001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSLS",
+            "style": "esriSLSSolid",
+            "color": null,
+            "width": 1.5
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 115.76303800000005,
+        "ymin": -42.77677,
+        "xmax": 150.790599,
+        "ymax": -12.004185500000006,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "Shape",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "Enabled",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "Enabled",
+          "domain": null
+        },
+        {
+          "name": "Shape_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "Shape_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 20,
+      "name": "Watercourses_Major_Rivers_Scale_5Million_to_300000_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays between 1:5,050,000 to 1:300,000 scales to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSLS",
+            "style": "esriSLSSolid",
+            "color": null,
+            "width": 1
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.62140150000005,
+        "ymin": -43.552824499999986,
+        "xmax": 153.586911,
+        "ymax": -9.408074499999998,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "Shape",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "Enabled",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "Enabled",
+          "domain": null
+        },
+        {
+          "name": "Shape_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "Shape_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 21,
+      "name": "Watercourses_All_Rivers_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSLS",
+            "style": "esriSLSSolid",
+            "color": null,
+            "width": 1
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.37534500000004,
+        "ymin": -43.62811399999998,
+        "xmax": 153.63163999999995,
+        "ymax": -9.242297500000006,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "RELATIONSHIP",
+          "type": "esriFieldTypeString",
+          "alias": "RELATIONSHIP",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "STATUS",
+          "type": "esriFieldTypeString",
+          "alias": "STATUS",
+          "length": 18,
+          "domain": null
+        },
+        {
+          "name": "RESTRICTIONS",
+          "type": "esriFieldTypeString",
+          "alias": "RESTRICTIONS",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 22,
+      "name": "Waterbody_Lakes_Scale_10Million_to_5Million_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays between the 1:10,000,000 of 1:5,050,000 scale and a size criteria of area greater than 0.1 map units to avoid clutter. Refer to other Waterbody - Lake layers at different scales for the National Map.",
+      "definitionExpression": "\"SHAPE_Area\" > 0.1",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": "1.0E7",
+      "maxScale": 5050001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.99395000000004,
+        "ymin": -43.53222699999998,
+        "xmax": 153.59316149999995,
+        "ymax": -8.937880000000007,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 23,
+      "name": "Waterbody_Lakes_Scale_5Million_to_300000_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays between 1:5,050,000 and 1:300,001 scales and a size criteria of area greater than 0.003 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.",
+      "definitionExpression": "\"SHAPE_Area\" > 0.003",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.99395000000004,
+        "ymin": -43.53222699999998,
+        "xmax": 153.59316149999995,
+        "ymax": -8.937880000000007,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 24,
+      "name": "Waterbody_Reservoirs_Scale_10Million_to_300000_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays from 1:10,000,000 1:300,001 and a size criteria of area greater than 0.003 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.",
+      "definitionExpression": "\"SHAPE_Area\" > 0.003",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": "1.0E7",
+      "maxScale": 300001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.99600999999996,
+        "ymin": -43.19614250000001,
+        "xmax": 153.54449950000003,
+        "ymax": -12.558189500000026,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 25,
+      "name": "Waterbody_Extra_Lakes_and_Reservoirs_Labels",
+      "type": "Feature Layer",
+      "description": "Custom Dataset - These are extra waterbodies added at this scale that fall under the size criteria in Waterbody Lake and Reservoir.(Only displays polygons with area greater than 0.03 map units). This layer is only for labelling. ",
+      "definitionExpression": "\"SHAPE_Area\" < 0.003",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.47902999999997,
+        "ymin": -43.039570000000026,
+        "xmax": 153.35022999999995,
+        "ymax": -8.933329000000015,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "HYDROID",
+          "type": "esriFieldTypeInteger",
+          "alias": "HYDROID",
+          "domain": null
+        },
+        {
+          "name": "AHGFFTYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "AHGFFeatureType",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIAL",
+          "type": "esriFieldTypeString",
+          "alias": "Perenniality",
+          "length": 255,
+          "domain": null
+        },
+        {
+          "name": "NETNODEID",
+          "type": "esriFieldTypeInteger",
+          "alias": "NetworkNodeID",
+          "domain": null
+        },
+        {
+          "name": "MAPNODEID",
+          "type": "esriFieldTypeInteger",
+          "alias": "MappedNodeID",
+          "domain": null
+        },
+        {
+          "name": "WSTOREUSE",
+          "type": "esriFieldTypeString",
+          "alias": "WaterStoreUse",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "SRCFCNAME",
+          "type": "esriFieldTypeString",
+          "alias": "SourceFeatureClassName",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "SRCFTYPE",
+          "type": "esriFieldTypeString",
+          "alias": "SourceFeatureType",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "SRCTYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "SourceType",
+          "domain": null
+        },
+        {
+          "name": "SOURCEID",
+          "type": "esriFieldTypeInteger",
+          "alias": "SOURCEID",
+          "domain": null
+        },
+        {
+          "name": "FEATREL",
+          "type": "esriFieldTypeDate",
+          "alias": "FeatureReliability",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FSOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FeatureSource",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "ATTRREL",
+          "type": "esriFieldTypeDate",
+          "alias": "AttributeReliability",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRSOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "AttributeSource",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "PLANACC",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PlanimetricAccuracy",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 26,
+      "name": "Waterbody_All_Lakes_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.99395000000004,
+        "ymin": -43.53222699999998,
+        "xmax": 153.59316149999995,
+        "ymax": -8.937880000000007,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 27,
+      "name": "Waterbody_All_Reservoirs_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.99600999999996,
+        "ymin": -43.19614250000001,
+        "xmax": 153.54449950000003,
+        "ymax": -12.558189500000026,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 28,
+      "name": "Waterbody_All_Flood_Irrigation_Storage_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Flood Irrigation Storage - A body of water collected and stored behind constructed barriers, for the specific use of flooding pastures via internal irrigation systems. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 143.18679150000003,
+        "ymin": -30.01566150000002,
+        "xmax": 152.4470235,
+        "ymax": -17.072844999999973,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 29,
+      "name": "Flats_Swamps_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Swamp - Land which is so saturated with water that it is not suitable for agricultural or pastoral use and presents a barrier to free passage. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.75390100000004,
+        "ymin": -43.60268000000002,
+        "xmax": 153.61275,
+        "ymax": -8.933329000000015,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 30,
+      "name": "Flats_MarineSwamps_Labels",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. This layer is only for labelling. 250K Specification Description -> Marine Swamp - That low lying part of the backshore area of tidal waters, usually immediately behind saline coastal flat, which maintains a high salt water content, and is covered with characteristic thick grasses and reed growths. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": null,
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 118.79958999999997,
+        "ymin": -20.298429,
+        "xmax": 142.18464100000006,
+        "ymax": -10.93128999999999,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 31,
+      "name": "Offshore_Rocks_And_Wrecks",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Offshore Rock - A rock located offshore that represents a hazard to shipping. Wreck - A disabled vessel, either submerged or visible, which is attached to, or foul of, the bottom or cast up on the shore. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "FEATURETYPE",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Offshore Rock",
+              "label": "Offshore Rocks",
+              "description": "",
+              "symbol": {
+                "type": "esriPMS",
+                "url": "1d036967",
+                "imageData": "iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAahJREFUKJF1kT1IW3EUxX95fclLFL+CWGMgIIihgdTBweKWgoUMJoJQoy5S1EEcHFzsXBBKwUFsVytIUmih4EfaZHIQFbFk86NQFcQSTVI1at4/z7w4PJ7QwQN3ueeew+UcGROR7w4KhVHuLGFFwi0gAySo1GeJDeTMMxmAcLRZuVHjAosXCYTBtQKd3EjjSveXkFjq2zAEw98UJa0tC/CaLi8bbLjqbCzuXwPUC8rLdEXbSPafyKS1NwJ8AB21MiNBDwDtfhee1QNUTWdmK+vEbnkLjMlAyHRurLISfvWMq2sVh93K1FgncwvbJt1jCtzmZmLQx1kmj8/rAuBv+pLACw9Dx3nmd/ONkJRkdDJIhuD30T9sticPwWlaiYM/Wc4vNYAcdOkykAACAOupcyIhP5s7R9Q7K6mptlMqlVk5VQHLDyOlovUjdm0ccH/ey1Pxfg1/Sx3t/qdMftjgtqgDqBTL7wxBsvfKGYyFcjJxoOFT6gJSF/D10PysAAzwM7L3UFwuHvlFd/S5oktTQiqHgSYgCyS4k6aJv97/v2mApf60gAmMeRT3E5KRoCNLAYgAAAAASUVORK5CYII=",
+                "contentType": "image/png",
+                "color": null,
+                "width": 9,
+                "height": 9,
+                "angle": 0,
+                "xoffset": 0,
+                "yoffset": 0
+              }
+            },
+            {
+              "value": "Wreck",
+              "label": "Wrecks",
+              "description": "",
+              "symbol": {
+                "type": "esriPMS",
+                "url": "15b6458",
+                "imageData": "iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAcxJREFUKJF1kUFIU3Ecxz/v9bb3YuSaiaSLwgoNIa0ZBBZBgYTQtkjKTTBIUiFkGF3aoqAId+pi0bGLhxnhEBRW2yGWYoQoQhR2iGB1Wa2Zi+H+b6/3OjwWdegDv9P397l8vwo1QrPb2doawZCCqoxXQAFI4zIfMj1QrL0pAAQTLWq5khJIbcgg7KwV6KYsj6n+pwEx1//aFq7OqGq+Oi+gratOITbQyqEDDQj9F4srn4kkcw0Ca56eRCeZ8BeFfHVIQHtvs8aj6AleLn0iNrlMnUvh8rmDLN1povvem3o0KQZcU4AAwN3Rozx59hb/mf1c6T+GXjWYmlmjZY+byQt7iSRz52uCF2CnW8PjVjnu2weApjoY7DvCyO0M1wc7IJnbDRlZwaSADJZl4dnh5G+cDoVS2UB1bgMoQo+pAGngtGlavFr9SvBsmV0eFwDLazn8J5tY/1gApOd2S7rjMVp1bGr2vTc62sWNeJZTvkY2fupsbAqGLh7m0q1sBd26bwuZvlJ973RgYuFbCt413hz2IcsSkiTxY7NCJL5YWSkZYV6E1v8MV0yFVvEnOh5kC9GJhWwQaAa+A2kMOU4q9OHfpQHmwnkB49j3X34DPWWfqP0jHosAAAAASUVORK5CYII=",
+                "contentType": "image/png",
+                "color": null,
+                "width": 9,
+                "height": 9,
+                "angle": 0,
+                "xoffset": 0,
+                "yoffset": 0
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.11904000000004,
+        "ymin": -43.66633999999999,
+        "xmax": 153.62995,
+        "ymax": -9.063350000000014,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "RELATIONSHIP",
+          "type": "esriFieldTypeString",
+          "alias": "RELATIONSHIP",
+          "length": 12,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "SOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "SOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "UFI",
+          "type": "esriFieldTypeString",
+          "alias": "UFI",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "CREATIONDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "CREATIONDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "RETIREMENTDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "RETIREMENTDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "FEATUREWIDTH",
+          "type": "esriFieldTypeDouble",
+          "alias": "FEATUREWIDTH",
+          "domain": null
+        },
+        {
+          "name": "ORIENTATION",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "ORIENTATION",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 32,
+      "name": "Lighthouses",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Lighthouse - A building or structure housing a light used as a navigation aid to shipping. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriPMS",
+            "url": "ebc37da5",
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAABQAAAATCAYAAACQjC21AAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAk1JREFUOI2t0z9oE1EcB/BvmrTPLkofFYSQwQweLYSCmpRcIqHFDrqI4JJrwFaFSIkUipMdFLzlMkiIAaGmhC7BwQ6xhIAtZGiuIJQ41KEZxIZD3i2+pT3sq3jn1FpC0z+kv/F9f3zefw/OuTxn6O0F8PvcQELIayHE83MBKaU3CCHPGGMvAVgdg4qipHK5XA+AOwA+dgwyxu6l02lUq9WJSqXSGUgpHdrZ2bk0OTmJ+fn5MQAXAOyeCFJKg1NTU96RkZHrhxtqtdptSZK6+vv7MTo66qRSqfeDg4M/9nPbtv9ms9m1paUlA8DmAcg531ZV9ZWqqkPj4+OO1+t17WfhcBgAkEgkSKlUShiGAQDY2NhwKpWKC8AnAI9at7wJYJgQkl5fX384OztrDwwM9B1erSzLkGUZjuNgZWXFyOfzFMALANl2ZyiEENONRuNzNBpdyGQyZjwev+Lx/G+zLAuqqv6cm5vbBXALwNcjz7ClypzzgKZp30OhECRJOgh0XYeu69uc85s44k0ed8u93d3dxO/3w7ZtbG1tOX6/3xUIBOB2u31o8w3bgoqiTMRisS7LspyZmRmzWCxe1jRtO5lM9vl8vh5CSEQIsXqWFSaEEHvBYPCPYRgLQog3mqa9W15eHotEIhcVRXlaKBRODXoXFxev6rpumqapCCGqAMAYe1Aul5/U6/W3kiTdBeAC4JwGvA+g1Gw2HwP41ZLlGWOrnPMPlNIQ5/zLiSCldI1znmszGQA0hBDDlNJrrcGRIOe8fgy2X3uMsW+tg/8ALm/uzGg889IAAAAASUVORK5CYII=",
+            "contentType": "image/png",
+            "color": null,
+            "width": 15,
+            "height": 14,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.97203000000002,
+        "ymin": -43.65735999999998,
+        "xmax": 153.63570000000004,
+        "ymax": -9.140769999999975,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "SOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "SOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "UFI",
+          "type": "esriFieldTypeString",
+          "alias": "UFI",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "CREATIONDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "CREATIONDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "RETIREMENTDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "RETIREMENTDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "FEATUREWIDTH",
+          "type": "esriFieldTypeDouble",
+          "alias": "FEATUREWIDTH",
+          "domain": null
+        },
+        {
+          "name": "ORIENTATION",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "ORIENTATION",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 33,
+      "name": "Marine_Infrastructure_Lines",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Breakwater - A solid structure to break the force of the waves, sometimes detached from the coast, protecting a harbour or anchorage. Jetty - A structure projecting into a body of water for use as a promenade or as a platform alongside which vessels may be secured for loading and unloading passengers and cargo. Sea Wall - A solid structure usually of concrete masonry or earth, built to prevent erosion or encroachment by the sea. Wharf Line - A structure built along the shoreline to provide for the berthing (or mooring) of vessels. In large commercial ports it may be associated with warehouses and storage facilities for shipping containers. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "FEATURETYPE",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Breakwater",
+              "label": "Breakwaters",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  255,
+                  255,
+                  190,
+                  255
+                ],
+                "width": 3
+              }
+            },
+            {
+              "value": "Jetty",
+              "label": "Jetties",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  255,
+                  255,
+                  190,
+                  255
+                ],
+                "width": 3
+              }
+            },
+            {
+              "value": "Sea Wall",
+              "label": "Sea Walls",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  255,
+                  255,
+                  190,
+                  255
+                ],
+                "width": 3
+              }
+            },
+            {
+              "value": "Wharf Line",
+              "label": "Wharves",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  255,
+                  255,
+                  190,
+                  255
+                ],
+                "width": 3
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.32462999999996,
+        "ymin": -43.161,
+        "xmax": 153.59193000000005,
+        "ymax": -9.062450000000013,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": "Type",
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "SOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "SOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "UFI",
+          "type": "esriFieldTypeString",
+          "alias": "UFI",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "CREATIONDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "CREATIONDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "RETIREMENTDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "RETIREMENTDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": [
+        {
+          "id": 3,
+          "name": "Jetty",
+          "domains": {}
+        },
+        {
+          "id": 2,
+          "name": "Breakwater",
+          "domains": {}
+        },
+        {
+          "id": 4,
+          "name": "SeaWall",
+          "domains": {}
+        },
+        {
+          "id": 5,
+          "name": "WharfLine",
+          "domains": {}
+        }
+      ],
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 34,
+      "name": "Reefs_And_Shoals",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Reef - An area of rock or coral that is exposed between mean high water and lowest tide, or just below approximate lowest tide, which is visually prominent or a hazard to shipping. Shoal - A detached area of any material the depth over which constitutes a danger to surface navigation of marine craft. The term shoal is not generally used for dangers which are composed entirely of rock or coral. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "FEATURETYPE",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Reef",
+              "label": "Reefs",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  0,
+                  197,
+                  255,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": null,
+                  "width": 0.4
+                }
+              }
+            },
+            {
+              "value": "Shoal",
+              "label": "Shoals",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": null,
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": null,
+                  "width": 1.0000609919999999
+                }
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.92034999999998,
+        "ymin": -43.54730999999998,
+        "xmax": 153.54714,
+        "ymax": -8.99857000000003,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "RELATIONSHIP",
+          "type": "esriFieldTypeString",
+          "alias": "RELATIONSHIP",
+          "length": 12,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "SOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "SOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "UFI",
+          "type": "esriFieldTypeString",
+          "alias": "UFI",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "CREATIONDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "CREATIONDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "RETIREMENTDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "RETIREMENTDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 35,
+      "name": "Locks",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Lock - An enclosure in a water body with gates at both ends to raise or lower the water level to enable vessels to pass from one level to another. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Victorian Department of Environment, Land, Water and Planning and South Australia Department for Environment, Water and Natural Resources",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriPMS",
+            "url": "f2dd16b8",
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAGJJREFUKJFjYYh+tpeBgUGZgRjwi1GLhZ2BQfonA4M8URq+sTKxEKUQCaBoWBXNzcDOyoii4MLt3wz1R39i1+DjyMPAycGEooGH+wsDAy4NJDtpEGrgSnlJAxt+LpXSIEUDAHlHElohkmM3AAAAAElFTkSuQmCC",
+            "contentType": "image/png",
+            "color": null,
+            "width": 9,
+            "height": 9,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 138.80938000000003,
+        "ymin": -35.94261,
+        "xmax": 144.46687999999995,
+        "ymax": -33.996730000000014,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 36,
+      "name": "Waterfalls",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Waterfall Point - A sudden descent of water over a step or ledge in the bed of a watercourse. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriPMS",
+            "url": "ae94f8b1",
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAYAAADEUlfTAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAHtJREFUCJltyaEOgVEYANDzcTfBFE2RKALy/xzmMWwUzYxEYPMmFC/gJf4saLrAVUwwp54EJrkn8pzokEvV2NhFmZqTPLyHC1EHovA0as1yke5hjU98NW5Pq4S+/wYJV7T/5DXJtsLxJ7KKTXKIk2ke116WD7oosbCP8xso1yAds4y0NgAAAABJRU5ErkJggg==",
+            "contentType": "image/png",
+            "color": null,
+            "width": 5,
+            "height": 5,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 115.8425565,
+        "ymin": -43.49456650000002,
+        "xmax": 153.048539,
+        "ymax": -10.643486999999993,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 37,
+      "name": "Springs",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Springs - A place where water issues from the ground naturally. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              190,
+              232,
+              255,
+              255
+            ],
+            "size": 5,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.13675999999998,
+        "ymin": -38.23244999999997,
+        "xmax": 147.96740999999997,
+        "ymax": -11.52388000000002,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 38,
+      "name": "Waterholes",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Waterhole - A natural depression which holds perennial water, within a non-perennial watercourse or a non-perennial lake. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              115,
+              178,
+              255,
+              255
+            ],
+            "size": 5,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.69557699999996,
+        "ymin": -43.52217000000002,
+        "xmax": 153.21927000000005,
+        "ymax": -10.171490000000006,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 39,
+      "name": "Bores",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Bore - A small diameter hole in the ground for the purpose of obtaining subterranean water by natural flow or mechanical pumping. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "Geoscience Australia",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              0,
+              132,
+              168,
+              255
+            ],
+            "size": 5,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.93203749999998,
+        "ymin": -38.20881000000003,
+        "xmax": 152.06205999999997,
+        "ymax": -11.051049999999975,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 40,
+      "name": "Natural_Water_Points_GnammaHole",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Gnamma Hole - Small holes of varying shape, diameter and depth, found in hard granite outcrops and in the decomposed granite of a breakaway, which can and usually does hold water. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              115,
+              223,
+              255,
+              255
+            ],
+            "size": 5,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "Gnamma Holes",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 118.13149999999996,
+        "ymin": -31.627049999999997,
+        "xmax": 127.64131999999995,
+        "ymax": -26.031510000000026,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 41,
+      "name": "Natural_Water_Points_NativeWell",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Native Well - An isolated natural depression which holds water, not within Watercourses. The natural phenomena is sometimes improved by indigenous persons for their own water collection purposes. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              115,
+              223,
+              255,
+              255
+            ],
+            "size": 5,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "Native Wells",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.79952000000003,
+        "ymin": -31.973419999999976,
+        "xmax": 147.03940999999998,
+        "ymax": -20.273979999999995,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 42,
+      "name": "Natural_Water_Points_Pool",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Pool - A small body of still or standing water, permanent or temporary in an isolated natural depression, not within Watercourses. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              115,
+              223,
+              255,
+              255
+            ],
+            "size": 5,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "Pools",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.56568400000003,
+        "ymin": -43.248490000000004,
+        "xmax": 153.09348,
+        "ymax": -10.072709999999972,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 43,
+      "name": "Natural_Water_Points_Rockhole",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Rockhole - A hole excavated in solid rock by water action. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              115,
+              223,
+              255,
+              255
+            ],
+            "size": 5,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "Rockholes",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.76517999999999,
+        "ymin": -33.262159999999994,
+        "xmax": 142.18583999999998,
+        "ymax": -17.009979999999985,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 44,
+      "name": "Natural_Water_Points_Soak",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Soak - A depression holding moisture after rain, especially the damp or swamp spots around the base of granite rocks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSMS",
+            "style": "esriSMSCircle",
+            "color": [
+              115,
+              223,
+              255,
+              255
+            ],
+            "size": 5,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0,
+            "outline": {
+              "color": [
+                0,
+                0,
+                0,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "Soaks",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.07808950000003,
+        "ymin": -33.145550000000014,
+        "xmax": 142.09559000000002,
+        "ymax": -15.118119999999976,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 45,
+      "name": "Dams_and_Tanks",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Dam - An open body of water collected and stored behind a constructed barrier consisting of earth, rock, concrete and/or masonry. Generally designed to capture run-off from the surrounding landscape or rainfall. The storage of water may occur on or below ground level. Water Tank - Water Tanks are storage containers for water, usually used for human consumption and other purposes such as irrigation, agriculture, fire suppression, agricultural farming and livestock, chemical manufacturing and food preparation. Water Tanks are constructed of various materials including plastic (polyethylene or polypropylene), fiberglass, reinforced concrete, steel (welded or bolted, carbon or stainless). Those used for human consumption are generally fully enclosed. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPoint",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriPMS",
+            "url": "4113ea2d",
+            "imageData": "iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAC1JREFUCJljKXnwP53xPwMnAxJgZGA4yfKPgaGViZFBGFni7///rSwMOAAVJQC/Egm/kHbQMwAAAABJRU5ErkJggg==",
+            "contentType": "image/png",
+            "color": null,
+            "width": 4,
+            "height": 4,
+            "angle": 0,
+            "xoffset": 0,
+            "yoffset": 0
+          },
+          "label": "Dams and Tanks",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.07836999999995,
+        "ymin": -43.14695999999998,
+        "xmax": 153.49998400000004,
+        "ymax": -9.95177000000001,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 46,
+      "name": "Canal_Lines",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Canal Line - An artificial open channel which provides the supply, distribution or removal of water for irrigation purposes, or for a significant infrastructure function (such as salt interception, land reclamation, or drainage between water features for environmental management purposes). (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSLS",
+            "style": "esriSLSSolid",
+            "color": [
+              115,
+              178,
+              255,
+              255
+            ],
+            "width": 1.5
+          },
+          "label": "Canal Lines",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.35392000000002,
+        "ymin": -42.343290000000025,
+        "xmax": 153.5903475,
+        "ymax": -12.52460000000002,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "RELATIONSHIP",
+          "type": "esriFieldTypeString",
+          "alias": "RELATIONSHIP",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "STATUS",
+          "type": "esriFieldTypeString",
+          "alias": "STATUS",
+          "length": 18,
+          "domain": null
+        },
+        {
+          "name": "RESTRICTIONS",
+          "type": "esriFieldTypeString",
+          "alias": "RESTRICTIONS",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 47,
+      "name": "Dam_Walls",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Dam Wall - A barrier of earth and rock, concrete or masonry constructed to form a reservoir for water storage purposes or to raise the water level. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Culture.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSLS",
+            "style": "esriSLSSolid",
+            "color": [
+              0,
+              77,
+              168,
+              255
+            ],
+            "width": 2
+          },
+          "label": "Dam Walls",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 115.00212,
+        "ymin": -43.1877,
+        "xmax": 153.30629,
+        "ymax": -10.57169,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": {
+            "type": "codedValue",
+            "name": "dm_UpperScale25K",
+            "codedValues": [
+              {
+                "name": "25000",
+                "code": 25000
+              },
+              {
+                "name": "50000",
+                "code": 50000
+              },
+              {
+                "name": "100000",
+                "code": 100000
+              },
+              {
+                "name": "250000",
+                "code": 250000
+              },
+              {
+                "name": "1000000",
+                "code": 1000000
+              },
+              {
+                "name": "2500000",
+                "code": 2500000
+              },
+              {
+                "name": "5000000",
+                "code": 5000000
+              },
+              {
+                "name": "10000000",
+                "code": 10000000
+              },
+              {
+                "name": "0",
+                "code": 0
+              }
+            ]
+          }
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 10,
+          "domain": {
+            "type": "codedValue",
+            "name": "dm_USCertainty25K",
+            "codedValues": [
+              {
+                "name": "Definite",
+                "code": "Definite"
+              },
+              {
+                "name": "Indefinite",
+                "code": "Indefinite"
+              },
+              {
+                "name": "Undefined",
+                "code": "Undefined"
+              }
+            ]
+          }
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "FEATUREWIDTH",
+          "type": "esriFieldTypeDouble",
+          "alias": "FEATUREWIDTH",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 48,
+      "name": "Rapid_Lines",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Rapid Line - An area of broken, fast flowing water in a watercourse, where the slope of the bed increases (but without a prominent break of slope which might result in a waterfall), or where a gently dipping bar of harder rock outcrops. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSLS",
+            "style": "esriSLSSolid",
+            "color": [
+              0,
+              255,
+              197,
+              255
+            ],
+            "width": 2
+          },
+          "label": "Rapid Lines",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 131.66452000000004,
+        "ymin": -35.70256999999998,
+        "xmax": 149.13694999999996,
+        "ymax": -10.705489999999998,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "RELATIONSHIP",
+          "type": "esriFieldTypeString",
+          "alias": "RELATIONSHIP",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "STATUS",
+          "type": "esriFieldTypeString",
+          "alias": "STATUS",
+          "length": 18,
+          "domain": null
+        },
+        {
+          "name": "RESTRICTIONS",
+          "type": "esriFieldTypeString",
+          "alias": "RESTRICTIONS",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 49,
+      "name": "Spillways",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Spillway - A channel or duct formed around the side of a reservoir past the end of the dam wall, to convey flood discharge from the watercourse above the reservoir into the watercourse below the dam wall. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSLS",
+            "style": "esriSLSSolid",
+            "color": [
+              0,
+              197,
+              255,
+              255
+            ],
+            "width": 3
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 117.10128,
+        "ymin": -42.10383,
+        "xmax": 153.28249,
+        "ymax": -20.97787,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "FEATURETYPE",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 50,
+      "name": "Levees",
+      "type": "Feature Layer",
+      "description": "These data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. All features have been included from the 250K data capture. 250K Specification Description -> Levee - A low earth wall erected to restrain flood waters or to contain irrigation water. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Physiography.html)",
+      "definitionExpression": "FEATURETYPE = 'Levee'",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "FEATURETYPE",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Levee",
+              "label": "Levees",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  127,
+                  127,
+                  205,
+                  255
+                ],
+                "width": 2
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.92145000000005,
+        "ymin": -43.65649000000002,
+        "xmax": 153.46622000000002,
+        "ymax": -11.006910000000005,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "FEATURETYPE",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "SOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "SOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "UFI",
+          "type": "esriFieldTypeString",
+          "alias": "UFI",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "CREATIONDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "CREATIONDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "RETIREMENTDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "RETIREMENTDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 51,
+      "name": "Canal_Areas",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Canal Area - An artificial open channel which provides the supply, distribution or removal of water for irrigation purposes, or for a significant infrastructure function (such as salt interception, land reclamation, or drainage between water features for environmental management purposes). (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              212,
+              232,
+              247,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [
+                115,
+                178,
+                255,
+                255
+              ],
+              "width": 0.2
+            }
+          },
+          "label": "Canal Areas",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 115.70707100000004,
+        "ymin": -42.85125799999997,
+        "xmax": 148.20427600000005,
+        "ymax": -32.52941900000002,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 52,
+      "name": "Rapid_Areas",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Rapid Area - An area of broken, fast flowing water in a watercourse, where the slope of the bed increases (but without a prominent break of slope which might result in a waterfall), or where a gently dipping bar of harder rock outcrops. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              212,
+              232,
+              247,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [
+                115,
+                178,
+                255,
+                255
+              ],
+              "width": 0.2
+            }
+          },
+          "label": "Rapid Areas",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 131.03976999999998,
+        "ymin": -33.99536999999998,
+        "xmax": 149.38968999999997,
+        "ymax": -12.680119999999988,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 53,
+      "name": "Watercourse_Areas",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse Area - A natural channel along which water may flow from time to time. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "FEATURETYPE",
+          "field2": "PERENNIALITY",
+          "field3": "HIERARCHY",
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Watercourse Area, Perennial, Major",
+              "label": "Watercourse Areas, Major and Minor Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.2
+                }
+              }
+            },
+            {
+              "value": "Watercourse Area, Perennial, Minor",
+              "label": "Watercourse Areas, Major and Minor Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.2
+                }
+              }
+            },
+            {
+              "value": "Watercourse Area, Non Perennial, Major",
+              "label": "Watercourse Areas, Major and Minor Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            },
+            {
+              "value": "Watercourse Area, Non-perennial, Major",
+              "label": "Watercourse Areas, Major and Minor Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            },
+            {
+              "value": "Watercourse Area, Non-perennial, Minor",
+              "label": "Watercourse Areas, Major and Minor Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.56261099999995,
+        "ymin": -43.58997599999998,
+        "xmax": 153.62839150000002,
+        "ymax": -8.933329000000015,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 54,
+      "name": "PondageArea_AquacultureAreas",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Aquaculture Area - Shallow beds, usually segmented by constructed walls, for the use of aquaculture. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              158,
+              204,
+              222,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [
+                102,
+                153,
+                205,
+                255
+              ],
+              "width": 1
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.23868000000004,
+        "ymin": -35.87101000000001,
+        "xmax": 144.99723100000006,
+        "ymax": -12.58411000000001,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 55,
+      "name": "Pondage_Areas_Salt_Evaporators",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Salt Evaporator - A flat area, usually segmented, used for the commercial production of salt by evaporation.(Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              158,
+              204,
+              222,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [
+                102,
+                153,
+                205,
+                255
+              ],
+              "width": 1
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.31874100000005,
+        "ymin": -35.29845999999998,
+        "xmax": 139.22114,
+        "ymax": -12.360050000000001,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 56,
+      "name": "Pondage_Areas_Settling_Ponds",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Settling Pond -  Shallow beds, usually segmented by constructed walls, for the treatment of sewage or other wastes. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              158,
+              204,
+              222,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [
+                102,
+                153,
+                205,
+                255
+              ],
+              "width": 1
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.66103999999996,
+        "ymin": -41.754831000000024,
+        "xmax": 146.87972549999995,
+        "ymax": -12.191229000000021,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 57,
+      "name": "Foreshore_Flats",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Foreshore Flat - That part of the seabed or estuarine areas, between mean high water and the line of lowest astronomical tide. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Marine.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              242,
+              233,
+              219,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": null,
+              "width": 0.4
+            }
+          },
+          "label": "Foreshore Flats",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.00706000000002,
+        "ymin": -43.511829999999975,
+        "xmax": 153.57853,
+        "ymax": -9.00711,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "FEATURETYPE",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 58,
+      "name": "Waterbody_Lakes_National_Scale_to_5Million",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays between the National Scale of 1:5,050,000 scale and a size criteria of area greater than 0.1 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.",
+      "definitionExpression": "\"SHAPE_Area\" > 0.1",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 5050001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "PERENNIALITY",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Perennial",
+              "label": "Lakes, Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.2
+                }
+              }
+            },
+            {
+              "value": "Not Applicable",
+              "label": "Lakes, Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.2
+                }
+              }
+            },
+            {
+              "value": "Non-perennial",
+              "label": "Lakes, Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            },
+            {
+              "value": "Non Perennial",
+              "label": "Lakes, Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.99395000000004,
+        "ymin": -43.53222699999998,
+        "xmax": 153.59316149999995,
+        "ymax": -8.937880000000007,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 59,
+      "name": "Waterbody_Lakes_Scale_5Million_to_300000",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays between 1:5,050,000 and 1:300,001 scales and a size criteria of area greater than 0.003 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.",
+      "definitionExpression": "\"SHAPE_Area\" > 0.003",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "PERENNIALITY",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Perennial",
+              "label": "Lakes, Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.2
+                }
+              }
+            },
+            {
+              "value": "Not Applicable",
+              "label": "Lakes, Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.2
+                }
+              }
+            },
+            {
+              "value": "Non-perennial",
+              "label": "Lakes, Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            },
+            {
+              "value": "Non Perennial",
+              "label": "Lakes, Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.99395000000004,
+        "ymin": -43.53222699999998,
+        "xmax": 153.59316149999995,
+        "ymax": -8.937880000000007,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 60,
+      "name": "Waterbody_Reservoirs_National_Scale_to_300000",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Town Water Storage - A body of water collected and stored behind a constructed barrier for some specific use (with the exception of Flood Irrigation Storage). Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays from national scale to a scale of 1:300,001 and a size criteria of area greater than 0.003 map units to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.",
+      "definitionExpression": "\"SHAPE_Area\" > 0.003",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 300001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "FEATURETYPE",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Reservoir Area",
+              "label": "Reservoir Area",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.2
+                }
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.99600999999996,
+        "ymin": -43.19614250000001,
+        "xmax": 153.54449950000003,
+        "ymax": -12.558189500000026,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 61,
+      "name": "Waterbody_Extra_Lakes_and_Reservoirs",
+      "type": "Feature Layer",
+      "description": "Custom Dataset - These are extra waterbodies added at this scale that fall under the size criteria in Waterbody Lake and Reservoirs. (Only displays polygons with area greater than 0.03 map units)",
+      "definitionExpression": "\"SHAPE_Area\" < 0.003",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "AHGFFTYPE",
+          "field2": "PERENNIAL",
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "26, Perennial",
+              "label": "Lake, Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.2
+                }
+              }
+            },
+            {
+              "value": "26, Non-perennial",
+              "label": "Lake, Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            },
+            {
+              "value": "25,  ",
+              "label": "Reservoir",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.2
+                }
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.47902999999997,
+        "ymin": -43.039570000000026,
+        "xmax": 153.35022999999995,
+        "ymax": -8.933329000000015,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": null,
+      "displayField": "Name",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "HYDROID",
+          "type": "esriFieldTypeInteger",
+          "alias": "HYDROID",
+          "domain": null
+        },
+        {
+          "name": "AHGFFTYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "AHGFFeatureType",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIAL",
+          "type": "esriFieldTypeString",
+          "alias": "Perenniality",
+          "length": 255,
+          "domain": null
+        },
+        {
+          "name": "NETNODEID",
+          "type": "esriFieldTypeInteger",
+          "alias": "NetworkNodeID",
+          "domain": null
+        },
+        {
+          "name": "MAPNODEID",
+          "type": "esriFieldTypeInteger",
+          "alias": "MappedNodeID",
+          "domain": null
+        },
+        {
+          "name": "WSTOREUSE",
+          "type": "esriFieldTypeString",
+          "alias": "WaterStoreUse",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "SRCFCNAME",
+          "type": "esriFieldTypeString",
+          "alias": "SourceFeatureClassName",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "SRCFTYPE",
+          "type": "esriFieldTypeString",
+          "alias": "SourceFeatureType",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "SRCTYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "SourceType",
+          "domain": null
+        },
+        {
+          "name": "SOURCEID",
+          "type": "esriFieldTypeInteger",
+          "alias": "SOURCEID",
+          "domain": null
+        },
+        {
+          "name": "FEATREL",
+          "type": "esriFieldTypeDate",
+          "alias": "FeatureReliability",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FSOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FeatureSource",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "ATTRREL",
+          "type": "esriFieldTypeDate",
+          "alias": "AttributeReliability",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRSOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "AttributeSource",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "PLANACC",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PlanimetricAccuracy",
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 62,
+      "name": "Waterbody_All_Lakes",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Lake - A naturally occurring body of mainly static water surrounded by land. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Lake layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "PERENNIALITY",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Perennial",
+              "label": "Lakes - Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "value": "Not Applicable",
+              "label": "Lakes - Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  212,
+                  232,
+                  247,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    115,
+                    178,
+                    255,
+                    255
+                  ],
+                  "width": 0.5
+                }
+              }
+            },
+            {
+              "value": "Non-perennial",
+              "label": "Lakes - Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            },
+            {
+              "value": "Non Perennial",
+              "label": "Lakes - Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [
+                  230,
+                  242,
+                  222,
+                  255
+                ],
+                "outline": {
+                  "type": "esriSLS",
+                  "style": "esriSLSSolid",
+                  "color": [
+                    190,
+                    210,
+                    255,
+                    255
+                  ],
+                  "width": 0.4
+                }
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 112.99395000000004,
+        "ymin": -43.53222699999998,
+        "xmax": 153.59316149999995,
+        "ymax": -8.937880000000007,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 63,
+      "name": "Waterbody_All_Reservoirs",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Town Water Storage - A body of water collected and stored behind a constructed barrier for some specific use (with the exception of Flood Irrigation Storage). Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              212,
+              232,
+              247,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [
+                115,
+                178,
+                255,
+                255
+              ],
+              "width": 0.2
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 114.99600999999996,
+        "ymin": -43.19614250000001,
+        "xmax": 153.54449950000003,
+        "ymax": -12.558189500000026,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 64,
+      "name": "Waterbody_All_Flood_Irrigation_Storage",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Flood Irrigation Storage - A body of water collected and stored behind constructed barriers, for the specific use of flooding pastures via internal irrigation systems. Town Water Storage - A body of water collected and stored behind a constructed barrier for some specific use (with the exception of Flood Irrigation Storage). Town Water Storage are bodies of water primarily stored for the consumption of urban, semi urban and rural township populations. The water is treated post storage by government, or private authorities, and connected to government regulated water networks. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Waterbody - Reservoir layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              212,
+              232,
+              247,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [
+                115,
+                178,
+                255,
+                255
+              ],
+              "width": 0.2
+            }
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 143.18679150000003,
+        "ymin": -30.01566150000002,
+        "xmax": 152.4470235,
+        "ymax": -17.072844999999973,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 65,
+      "name": "Farm_Dam_Area",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Rural Water Storage - A body of water collected and stored behind a constructed barrier for some specific use. Rural Water Storage are bodies of water stored for rural farming and agricultural practices (with the exception of Flood Irrigation Storage) and/or for the consumption of the associated land owners. The water is not treated by government authorities or connected to government regulated water networks. Dam - An open body of water collected and stored behind a constructed barrier consisting of earth, rock, concrete and/or masonry. Generally designed to capture run-off from the surrounding landscape or rainfall. The storage of water may occur on or below ground level. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              158,
+              215,
+              194,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [
+                0,
+                77,
+                168,
+                255
+              ],
+              "width": 0.4
+            }
+          },
+          "label": "Farm Dam Areas",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 115.08154049999996,
+        "ymin": -38.096869500000025,
+        "xmax": 153.56586049999999,
+        "ymax": -10.57168999999999,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 66,
+      "name": "Watercourses_Major_Rivers_National_Scale_to_5Million",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays between the National Scale and 1:5,050,000 scale to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": "4.0E7",
+      "maxScale": 5050001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSLS",
+            "style": "esriSLSSolid",
+            "color": [
+              115,
+              178,
+              255,
+              255
+            ],
+            "width": 1.5
+          },
+          "label": "",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 115.76303800000005,
+        "ymin": -42.77677,
+        "xmax": 150.790599,
+        "ymax": -12.004185500000006,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "Shape",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "Enabled",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "Enabled",
+          "domain": null
+        },
+        {
+          "name": "Shape_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "Shape_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 67,
+      "name": "Watercourses_Major_Rivers_Scale_5Million_to_300000",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays between 1:5,050,000 to 1:300,000 scales to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "HIERARCHY",
+          "field2": "PERENNIALITY",
+          "field3": "FEATURETYPE",
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Major, Perennial, Watercourse",
+              "label": "Watercourse, Major Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1.5
+              }
+            },
+            {
+              "value": "Major, Perennial, Connector",
+              "label": "Watercourse, Major Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1.5
+              }
+            },
+            {
+              "value": "Major, Non Perennial, Watercourse",
+              "label": "Watercourse, Major Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1
+              }
+            },
+            {
+              "value": "Major, Non-perennial, Watercourse",
+              "label": "Watercourse, Major Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1
+              }
+            },
+            {
+              "value": "Major, Non Perennial, Connector",
+              "label": "Watercourse, Major Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1
+              }
+            },
+            {
+              "value": "Major, Non-perennial, Connector",
+              "label": "Watercourse, Major Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1
+              }
+            },
+            {
+              "value": "Minor, Non Perennial, Connector",
+              "label": "Watercourse, Major Non Perennial",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.62140150000005,
+        "ymin": -43.552824499999986,
+        "xmax": 153.586911,
+        "ymax": -9.408074499999998,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "Shape",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "PID",
+          "type": "esriFieldTypeInteger",
+          "alias": "PID",
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 10,
+          "domain": null
+        },
+        {
+          "name": "SYMBOL",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "SYMBOL",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "Enabled",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "Enabled",
+          "domain": null
+        },
+        {
+          "name": "Shape_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "Shape_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 68,
+      "name": "Watercourses_All_Rivers_Connectors",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "HIERARCHY",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Major",
+              "label": "Major Connectors",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1.5
+              }
+            },
+            {
+              "value": "Minor",
+              "label": "Minor Connectors",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1
+              }
+            },
+            {
+              "value": "Not Applicable",
+              "label": "Minor Connectors",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.45159100000001,
+        "ymin": -43.53306900000001,
+        "xmax": 153.6077815,
+        "ymax": -9.948831999999982,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "RELATIONSHIP",
+          "type": "esriFieldTypeString",
+          "alias": "RELATIONSHIP",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "STATUS",
+          "type": "esriFieldTypeString",
+          "alias": "STATUS",
+          "length": 18,
+          "domain": null
+        },
+        {
+          "name": "RESTRICTIONS",
+          "type": "esriFieldTypeString",
+          "alias": "RESTRICTIONS",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 69,
+      "name": "Watercourses_All_Rivers_Watercourse_Lines",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Watercourse - A natural channel along which water may flow from time to time. Connector - An artificial line used to connect linear Hydrographic features across a defined area feature to allow network analysis of riverine networks. Connections across area features will be defined by the visual interpretation of imagery to achieve logical water flow patterns based on subtle variations in soil, vegetation and noticeable landform slope. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Drainage.html). NOTE - This layer only displays 1:300,000 to 1:70,000 to avoid clutter at the national scale (approx 1:36,000,000). Refer to other Watercourses layers at different scales for the National Map.",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolyline",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 300000,
+      "maxScale": 70000,
+      "drawingInfo": {
+        "renderer": {
+          "type": "uniqueValue",
+          "field1": "HIERARCHY",
+          "field2": null,
+          "field3": null,
+          "fieldDelimiter": ", ",
+          "defaultSymbol": null,
+          "defaultLabel": "<all other values>",
+          "uniqueValueInfos": [
+            {
+              "value": "Major",
+              "label": "Major Watercourses",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1.5
+              }
+            },
+            {
+              "value": "Minor",
+              "label": "Minor Watercourses",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1
+              }
+            },
+            {
+              "value": "<Null>",
+              "label": "Minor Watercourses",
+              "description": "",
+              "symbol": {
+                "type": "esriSLS",
+                "style": "esriSLSSolid",
+                "color": [
+                  89,
+                  153,
+                  230,
+                  255
+                ],
+                "width": 1
+              }
+            }
+          ]
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.37534500000004,
+        "ymin": -43.62811399999998,
+        "xmax": 153.63163999999995,
+        "ymax": -9.242297500000006,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "RELATIONSHIP",
+          "type": "esriFieldTypeString",
+          "alias": "RELATIONSHIP",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "STATUS",
+          "type": "esriFieldTypeString",
+          "alias": "STATUS",
+          "length": 18,
+          "domain": null
+        },
+        {
+          "name": "RESTRICTIONS",
+          "type": "esriFieldTypeString",
+          "alias": "RESTRICTIONS",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 70,
+      "name": "Flats_Swamps",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Swamp - Land which is so saturated with water that it is not suitable for agricultural or pastoral use and presents a barrier to free passage. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              219,
+              227,
+              255,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSNull",
+              "color": [
+                110,
+                110,
+                110,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "Swamps",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.75390100000004,
+        "ymin": -43.60268000000002,
+        "xmax": 153.61275,
+        "ymax": -8.933329000000015,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 71,
+      "name": "Flats_MarineSwamps",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Marine Swamp - That low lying part of the backshore area of tidal waters, usually immediately behind saline coastal flat, which maintains a high salt water content, and is covered with characteristic thick grasses and reed growths. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "\"FEATURETYPE\" = 'Marine Swamp' OR \"FEATURETYPE\" = 'Swamp'",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              133,
+              212,
+              196,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSNull",
+              "color": [
+                110,
+                110,
+                110,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "Marine Swamps",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 118.79958999999997,
+        "ymin": -20.298429,
+        "xmax": 142.18464100000006,
+        "ymax": -10.93128999999999,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 72,
+      "name": "Flats_LandSubjectToInundation",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Land Subject to Inundation - Low lying land usually adjacent to lakes or watercourses, which is regularly covered with flood water for short periods. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              230,
+              230,
+              230,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSNull",
+              "color": null,
+              "width": 0
+            }
+          },
+          "label": "Land Subject to Inundation",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.64665000000002,
+        "ymin": -42.842738999999995,
+        "xmax": 153.42711099999997,
+        "ymax": -8.933329000000015,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    },
+    {
+      "currentVersion": 10.04,
+      "id": 73,
+      "name": "Flats_SalineCoastalFlats",
+      "type": "Feature Layer",
+      "description": "All features have been included from the AUSHYDRO data capture. 250K Specification Description -> Saline Coastal Flat - That nearly level tract of land between mean high water and the line of the highest astronomical tide. (Source - http://www.ga.gov.au/mapspecs/topographic/v6/appendixA_files/Waterbodies.html)",
+      "definitionExpression": "NOT (\"FEATURETYPE\" = 'Marine Swamp' OR \"FEATURETYPE\" = 'Swamp')",
+      "geometryType": "esriGeometryPolygon",
+      "copyrightText": "AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 70001,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [
+              196,
+              214,
+              215,
+              255
+            ],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSNull",
+              "color": [
+                110,
+                110,
+                110,
+                255
+              ],
+              "width": 0
+            }
+          },
+          "label": "Saline Coastal Flats",
+          "description": ""
+        },
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 113.00808099999995,
+        "ymin": -34.003108999999995,
+        "xmax": 153.05944999999997,
+        "ymax": -10.12682000000001,
+        "spatialReference": {
+          "wkid": 4283
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "NAME",
+      "typeIdField": null,
+      "fields": [
+        {
+          "name": "OBJECTID",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "SHAPE",
+          "type": "esriFieldTypeGeometry",
+          "alias": "SHAPE",
+          "domain": null
+        },
+        {
+          "name": "geodb_oid",
+          "type": "esriFieldTypeInteger",
+          "alias": "geodb_oid",
+          "domain": null
+        },
+        {
+          "name": "FEATURETYPE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURETYPE",
+          "length": 32,
+          "domain": null
+        },
+        {
+          "name": "TYPE",
+          "type": "esriFieldTypeInteger",
+          "alias": "TYPE",
+          "domain": null
+        },
+        {
+          "name": "NAME",
+          "type": "esriFieldTypeString",
+          "alias": "NAME",
+          "length": 60,
+          "domain": null
+        },
+        {
+          "name": "PERENNIALITY",
+          "type": "esriFieldTypeString",
+          "alias": "PERENNIALITY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "HIERARCHY",
+          "type": "esriFieldTypeString",
+          "alias": "HIERARCHY",
+          "length": 14,
+          "domain": null
+        },
+        {
+          "name": "DIMENSION",
+          "type": "esriFieldTypeDouble",
+          "alias": "DIMENSION",
+          "domain": null
+        },
+        {
+          "name": "FEATURERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "FEATURERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "FEATURESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "FEATURESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTERELIABILITY",
+          "type": "esriFieldTypeDate",
+          "alias": "ATTRIBUTERELIABILITY",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "ATTRIBUTESOURCE",
+          "type": "esriFieldTypeString",
+          "alias": "ATTRIBUTESOURCE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "PLANIMETRICACCURACY",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "PLANIMETRICACCURACY",
+          "domain": null
+        },
+        {
+          "name": "REVISED",
+          "type": "esriFieldTypeDate",
+          "alias": "REVISED",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "GAID",
+          "type": "esriFieldTypeInteger",
+          "alias": "GAID",
+          "domain": null
+        },
+        {
+          "name": "LEVEL",
+          "type": "esriFieldTypeString",
+          "alias": "LEVEL",
+          "length": 30,
+          "domain": null
+        },
+        {
+          "name": "AUSHYDRO_ID",
+          "type": "esriFieldTypeInteger",
+          "alias": "AUSHYDRO_ID",
+          "domain": null
+        },
+        {
+          "name": "DEMH",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "DEMH",
+          "domain": null
+        },
+        {
+          "name": "EDITCODE",
+          "type": "esriFieldTypeSmallInteger",
+          "alias": "EDITCODE",
+          "domain": null
+        },
+        {
+          "name": "TEXTNOTE",
+          "type": "esriFieldTypeString",
+          "alias": "TEXTNOTE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRID",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRID",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRNAME",
+          "type": "esriFieldTypeString",
+          "alias": "STKEHDRNAME",
+          "length": 250,
+          "domain": null
+        },
+        {
+          "name": "STKEHDRSUPPLYDATE",
+          "type": "esriFieldTypeDate",
+          "alias": "STKEHDRSUPPLYDATE",
+          "length": 8,
+          "domain": null
+        },
+        {
+          "name": "UPPERSCALE",
+          "type": "esriFieldTypeInteger",
+          "alias": "UPPERSCALE",
+          "domain": null
+        },
+        {
+          "name": "USCERTAINTY",
+          "type": "esriFieldTypeString",
+          "alias": "USCERTAINTY",
+          "length": 25,
+          "domain": null
+        },
+        {
+          "name": "NATURE",
+          "type": "esriFieldTypeString",
+          "alias": "NATURE",
+          "length": 20,
+          "domain": null
+        },
+        {
+          "name": "WATERSTORAGEUSAGE",
+          "type": "esriFieldTypeString",
+          "alias": "WATERSTORAGEUSAGE",
+          "length": 50,
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Length",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Length",
+          "domain": null
+        },
+        {
+          "name": "SHAPE_Area",
+          "type": "esriFieldTypeDouble",
+          "alias": "SHAPE_Area",
+          "domain": null
+        }
+      ],
+      "types": null,
+      "relationships": [],
+      "capabilities": "Map,Query,Data"
+    }
+  ],
+  "tables": []
+}

--- a/wwwroot/test/ArcGisMapServer/Dynamic_National_Map_Hydrography_and_Marine/legend.json
+++ b/wwwroot/test/ArcGisMapServer/Dynamic_National_Map_Hydrography_and_Marine/legend.json
@@ -1,1 +1,1198 @@
-{"layers":[{"layerId":0,"layerName":"No_Labels_National_Scale_to_300K_Scale","layerType":"Feature Layer","minScale":0,"maxScale":300000,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":1,"layerName":"No_Labels_National_Scale_to_10Million_Scale","layerType":"Feature Layer","minScale":0,"maxScale":1.0000001E7,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":2,"layerName":"No_Data","layerType":"Feature Layer","minScale":70000,"maxScale":0,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":3,"layerName":"Offshore_Rocks_and_Wrecks_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70000,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":4,"layerName":"Lighthouses_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":5,"layerName":"Reefs_and_Shoals_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":6,"layerName":"Locks_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":7,"layerName":"Waterfalls_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":8,"layerName":"Springs_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":9,"layerName":"Waterholes_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":10,"layerName":"Bores_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":11,"layerName":"Natural_Water_Points_GnammaHoles_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":12,"layerName":"Natural_Water_Points_NativeWells_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":13,"layerName":"Natural_Water_Points_Pools_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":14,"layerName":"Natural_Water_Points_Rockholes_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":15,"layerName":"Natural_Water_Points_Soaks_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":16,"layerName":"Dams_and_Tanks_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":17,"layerName":"Dam_Walls_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":18,"layerName":"Watercourse_Areas_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":19,"layerName":"Watercourses_Major_Rivers_Scale_10Million_to_5Million_Labels","layerType":"Feature Layer","minScale":1.0E7,"maxScale":5050001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":20,"layerName":"Watercourses_Major_Rivers_Scale_5Million_to_300000_Labels","layerType":"Feature Layer","minScale":5050000,"maxScale":300001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":21,"layerName":"Watercourses_All_Rivers_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":22,"layerName":"Waterbody_Lakes_Scale_10Million_to_5Million_Labels","layerType":"Feature Layer","minScale":1.0E7,"maxScale":5050001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":23,"layerName":"Waterbody_Lakes_Scale_5Million_to_300000_Labels","layerType":"Feature Layer","minScale":5050000,"maxScale":300001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":24,"layerName":"Waterbody_Reservoirs_Scale_10Million_to_300000_Labels","layerType":"Feature Layer","minScale":1.0E7,"maxScale":300001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":25,"layerName":"Waterbody_Extra_Lakes_and_Reservoirs_Labels","layerType":"Feature Layer","minScale":5050000,"maxScale":300001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":26,"layerName":"Waterbody_All_Lakes_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70000,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":27,"layerName":"Waterbody_All_Reservoirs_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70000,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":28,"layerName":"Waterbody_All_Flood_Irrigation_Storage_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70000,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":29,"layerName":"Flats_Swamps_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":30,"layerName":"Flats_MarineSwamps_Labels","layerType":"Feature Layer","minScale":300000,"maxScale":70001,"legend":[{"label":"","url":"b48d0a8e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":31,"layerName":"Offshore_Rocks_And_Wrecks","layerType":"Feature Layer","minScale":0,"maxScale":70000,"legend":[{"label":"Offshore Rocks","url":"71ed6289","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAC1QTFRF/v//7vD1297qxszgrrfTkZ3GaX24AE2oaX24kZ7Gr7fTxsvf3N7q7vD1////kDa1CAAAAA90Uk5TAP//////////////////5Y2epgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAGJJREFUKJHdj8sNwDAIQ5Mm/Apk/3FLKvVSmCCWuPBky27tDA1AGBXoSFt4ZfQSjuspLZ4iykzzjyAsbu5CWOSpreXKVLhE17I7u8YOVItAqBpy1Cgafruo2NX6RMKZPcfpAUhFAwcT7oyWAAAAAElFTkSuQmCC","contentType":"image/png"},{"label":"Wrecks","url":"c07facc6","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAC1QTFRF/v//7vD1297qxszgrrfTkZ3GaX24AE2oaX24kZ7Gr7fTxsvf3N7q7vD1////kDa1CAAAAA90Uk5TAP//////////////////5Y2epgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAGNJREFUKJHdj8ENwzAMA+3YFimL0f7j1gX6qjJB7nsgQbb2DsayNZ5EN3yxq6pjtsKBXtoAObkD818tBCPTt1vtk+eBgZr6KZXUgHhnhu9VF1J0p+rC84uSAg+/Wp8GmzXzOj60CwNZWfDMlwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":32,"layerName":"Lighthouses","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"b8d8bfdb","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAGNQTFRF/v//7u7u29zc29zcxsfH29zcxsfHrq+vxsfHrq+vkZKSkZKSrq+vkZGRaWlpaGhokpKSrq+vaGlp3Nzcampqx8fHZ2dnkJCQaWlpAAAAaWlpkZGRr6+vxsbG3Nzc7u7u////kfumDAAAACF0Uk5TAP//////////////////////////////////////////RvROpAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAIdJREFUKJHNj8EOwiAQBVlEsVWp1hZ5UmH//yuF6KEpcO8cyCYDE1aIHaKbhtBUHWRLWX9p9Vwsi3Q4Jq4Lu3MeJK2UwTsR+JNOoKf1Oz0++ccMtWnK4ZFFvBsSWwghqWWs/Q/MgaOtqJOPFi92la1vHpp667tKb8j3FaZCqf8yZIoiVaZd8AUW/whcl6r4ZQAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":33,"layerName":"Marine_Infrastructure_Lines","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Breakwaters","url":"1d5cf6e2","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//bGxs//++Okv33AAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAB1JREFUKJFjYBgFRAImHAAkxYgVEJLCbeAoIAoAAM2qAJV9o5r0AAAAAElFTkSuQmCC","contentType":"image/png"},{"label":"Jetties","url":"1d5cf6e2","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//bGxs//++Okv33AAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAB1JREFUKJFjYBgFRAImHAAkxYgVEJLCbeAoIAoAAM2qAJV9o5r0AAAAAElFTkSuQmCC","contentType":"image/png"},{"label":"Sea Walls","url":"1d5cf6e2","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//bGxs//++Okv33AAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAB1JREFUKJFjYBgFRAImHAAkxYgVEJLCbeAoIAoAAM2qAJV9o5r0AAAAAElFTkSuQmCC","contentType":"image/png"},{"label":"Wharves","url":"1d5cf6e2","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//bGxs//++Okv33AAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAB1JREFUKJFjYBgFRAImHAAkxYgVEJLCbeAoIAoAAM2qAJV9o5r0AAAAAElFTkSuQmCC","contentType":"image/png"}]},{"layerId":34,"layerName":"Reefs_And_Shoals","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Reefs","url":"c9533ca1","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AMX/BRHMXQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=","contentType":"image/png"},{"label":"Shoals","url":"cfcbf76a","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AG//UfmYPgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":35,"layerName":"Locks","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"c4bb557","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAABtQTFRF/v//kaLuaYTqAFvmkaLur7rxxs717vD8////BD3PXgAAAAl0Uk5TAP//////////NwKb1AAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAClJREFUKJFjYBgGgJEJDtClmJjhgDQpVhBgwSrFzgEEbAMuRYa/hhsAAKcOAejmiIC1AAAAAElFTkSuQmCC","contentType":"image/png"}]},{"layerId":36,"layerName":"Waterfalls","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"7084572b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAABVQTFRF/v//7vH/2+L/rr/+kan/aZD/AG//LY5oGgAAAAd0Uk5TAP///////6V/pvsAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAzSURBVCiRY2AY0YCRmYWZEbsMGwhglWMBS7Fgk2IFS7GSqIsJLMWE1R1MrGys2GVGAQMAMCEA1315+/IAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":37,"layerName":"Springs","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"f029cec5","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//vuj/6vtFqAAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":38,"layerName":"Waterholes","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"1219bf09","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dLP/L4zSoQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":39,"layerName":"Bores","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"af30cf1c","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AIWoAGdHDwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":40,"layerName":"Natural_Water_Points_GnammaHole","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Gnamma Holes","url":"2bebb911","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":41,"layerName":"Natural_Water_Points_NativeWell","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Native Wells","url":"2bebb911","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":42,"layerName":"Natural_Water_Points_Pool","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Pools","url":"2bebb911","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":43,"layerName":"Natural_Water_Points_Rockhole","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Rockholes","url":"2bebb911","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":44,"layerName":"Natural_Water_Points_Soak","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Soaks","url":"2bebb911","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":45,"layerName":"Dams_and_Tanks","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Dams and Tanks","url":"10d1cf0f","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAABJQTFRF/v//4fb/0vL/v+7+k+X/dOD/olKucwAAAAZ0Uk5TAP//////enng/gAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYBgFWAETCDBilWJhBQLmAZcaBQwAxsMAkyqN1e4AAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":46,"layerName":"Canal_Lines","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Canal Lines","url":"e84d482d","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dLP/L4zSoQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":47,"layerName":"Dam_Walls","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Dam Walls","url":"3e3f56b3","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AE2oA0QaSQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAWUA0YcAL/UKKAUAABEjgAxF4zWkAAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":48,"layerName":"Rapid_Lines","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Rapid Lines","url":"60fb2eeb","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AP/F5rTLlgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAWUA0YcAL/UKKAUAABEjgAxF4zWkAAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":49,"layerName":"Spillways","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"46ef20d3","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AMX/BRHMXQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVEAkYcgBZSo4AoAACGXgBhcyzLKAAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":50,"layerName":"Levees","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Levees","url":"8d052486","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//f3/OFUilOAAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAWUA0YcAL/UKKAUAABEjgAxF4zWkAAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":51,"layerName":"Canal_Areas","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Canal Areas","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":52,"layerName":"Rapid_Areas","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Rapid Areas","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":53,"layerName":"Watercourse_Areas","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Watercourse Areas, Major and Minor Perennial","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"},{"label":"Watercourse Areas, Major and Minor Non Perennial","url":"fa250d75","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":54,"layerName":"PondageArea_AquacultureAreas","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"6881f54d","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//ZprOn83fJNRuVgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":55,"layerName":"Pondage_Areas_Salt_Evaporators","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"6881f54d","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//ZprOn83fJNRuVgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":56,"layerName":"Pondage_Areas_Settling_Ponds","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"","url":"6881f54d","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//ZprOn83fJNRuVgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":57,"layerName":"Foreshore_Flats","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Foreshore Flats","url":"2b83e993","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//8uncKAdxPwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":58,"layerName":"Waterbody_Lakes_National_Scale_to_5Million","layerType":"Feature Layer","minScale":0,"maxScale":5050001,"legend":[{"label":"Lakes, Perennial","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"},{"label":"Lakes, Non Perennial","url":"fa250d75","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":59,"layerName":"Waterbody_Lakes_Scale_5Million_to_300000","layerType":"Feature Layer","minScale":5050000,"maxScale":300001,"legend":[{"label":"Lakes, Perennial","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"},{"label":"Lakes, Non Perennial","url":"fa250d75","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":60,"layerName":"Waterbody_Reservoirs_National_Scale_to_300000","layerType":"Feature Layer","minScale":0,"maxScale":300001,"legend":[{"label":"Reservoir Area","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":61,"layerName":"Waterbody_Extra_Lakes_and_Reservoirs","layerType":"Feature Layer","minScale":5050000,"maxScale":300001,"legend":[{"label":"Lake, Perennial","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"},{"label":"Lake, Non Perennial","url":"fa250d75","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"},{"label":"Reservoir","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":62,"layerName":"Waterbody_All_Lakes","layerType":"Feature Layer","minScale":300000,"maxScale":70000,"legend":[{"label":"Lakes - Perennial","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"},{"label":"Lakes - Non Perennial","url":"fa250d75","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":63,"layerName":"Waterbody_All_Reservoirs","layerType":"Feature Layer","minScale":300000,"maxScale":70000,"legend":[{"label":"","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":64,"layerName":"Waterbody_All_Flood_Irrigation_Storage","layerType":"Feature Layer","minScale":300000,"maxScale":70000,"legend":[{"label":"","url":"c3bef01b","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":65,"layerName":"Farm_Dam_Area","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Farm Dam Areas","url":"77f004d7","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//AE2on9fCDMofhQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":66,"layerName":"Watercourses_Major_Rivers_National_Scale_to_5Million","layerType":"Feature Layer","minScale":4.0E7,"maxScale":5050001,"legend":[{"label":"","url":"e84d482d","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dLP/L4zSoQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==","contentType":"image/png"}]},{"layerId":67,"layerName":"Watercourses_Major_Rivers_Scale_5Million_to_300000","layerType":"Feature Layer","minScale":5050000,"maxScale":300001,"legend":[{"label":"Watercourse, Major Perennial","url":"df18a7dd","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==","contentType":"image/png"},{"label":"Watercourse, Major Non Perennial","url":"941f62c1","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFUlEQVQokWNgGAW0BYxYwUC7angAAB+/ABeuicGgAAAAAElFTkSuQmCC","contentType":"image/png"}]},{"layerId":68,"layerName":"Watercourses_All_Rivers_Connectors","layerType":"Feature Layer","minScale":300000,"maxScale":70000,"legend":[{"label":"Major Connectors","url":"df18a7dd","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==","contentType":"image/png"},{"label":"Minor Connectors","url":"941f62c1","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFUlEQVQokWNgGAW0BYxYwUC7angAAB+/ABeuicGgAAAAAElFTkSuQmCC","contentType":"image/png"}]},{"layerId":69,"layerName":"Watercourses_All_Rivers_Watercourse_Lines","layerType":"Feature Layer","minScale":300000,"maxScale":70000,"legend":[{"label":"Major Watercourses","url":"df18a7dd","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==","contentType":"image/png"},{"label":"Minor Watercourses","url":"941f62c1","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFUlEQVQokWNgGAW0BYxYwUC7angAAB+/ABeuicGgAAAAAElFTkSuQmCC","contentType":"image/png"}]},{"layerId":70,"layerName":"Flats_Swamps","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Swamps","url":"efd36116","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//3OP/QlyDLQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":71,"layerName":"Flats_MarineSwamps","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Marine Swamps","url":"ac57748e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//htTEAnthWwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":72,"layerName":"Flats_LandSubjectToInundation","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Land Subject to Inundation","url":"5fa36f2e","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//4t3cjwshuAAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=","contentType":"image/png"}]},{"layerId":73,"layerName":"Flats_SalineCoastalFlats","layerType":"Feature Layer","minScale":0,"maxScale":70001,"legend":[{"label":"Saline Coastal Flats","url":"122ff541","imageData":"iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//xNbXx+0bqQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=","contentType":"image/png"}]}]}
+{
+  "layers": [
+    {
+      "layerId": 0,
+      "layerName": "No_Labels_National_Scale_to_300K_Scale",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 300000,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 1,
+      "layerName": "No_Labels_National_Scale_to_10Million_Scale",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": "1.0000001E7",
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 2,
+      "layerName": "No_Data",
+      "layerType": "Feature Layer",
+      "minScale": 70000,
+      "maxScale": 0,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 3,
+      "layerName": "Offshore_Rocks_and_Wrecks_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 4,
+      "layerName": "Lighthouses_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 5,
+      "layerName": "Reefs_and_Shoals_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 6,
+      "layerName": "Locks_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 7,
+      "layerName": "Waterfalls_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 8,
+      "layerName": "Springs_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 9,
+      "layerName": "Waterholes_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 10,
+      "layerName": "Bores_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 11,
+      "layerName": "Natural_Water_Points_GnammaHoles_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 12,
+      "layerName": "Natural_Water_Points_NativeWells_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 13,
+      "layerName": "Natural_Water_Points_Pools_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 14,
+      "layerName": "Natural_Water_Points_Rockholes_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 15,
+      "layerName": "Natural_Water_Points_Soaks_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 16,
+      "layerName": "Dams_and_Tanks_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 17,
+      "layerName": "Dam_Walls_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 18,
+      "layerName": "Watercourse_Areas_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 19,
+      "layerName": "Watercourses_Major_Rivers_Scale_10Million_to_5Million_Labels",
+      "layerType": "Feature Layer",
+      "minScale": "1.0E7",
+      "maxScale": 5050001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 20,
+      "layerName": "Watercourses_Major_Rivers_Scale_5Million_to_300000_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 21,
+      "layerName": "Watercourses_All_Rivers_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 22,
+      "layerName": "Waterbody_Lakes_Scale_10Million_to_5Million_Labels",
+      "layerType": "Feature Layer",
+      "minScale": "1.0E7",
+      "maxScale": 5050001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 23,
+      "layerName": "Waterbody_Lakes_Scale_5Million_to_300000_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 24,
+      "layerName": "Waterbody_Reservoirs_Scale_10Million_to_300000_Labels",
+      "layerType": "Feature Layer",
+      "minScale": "1.0E7",
+      "maxScale": 300001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 25,
+      "layerName": "Waterbody_Extra_Lakes_and_Reservoirs_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 26,
+      "layerName": "Waterbody_All_Lakes_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 27,
+      "layerName": "Waterbody_All_Reservoirs_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 28,
+      "layerName": "Waterbody_All_Flood_Irrigation_Storage_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 29,
+      "layerName": "Flats_Swamps_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 30,
+      "layerName": "Flats_MarineSwamps_Labels",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b48d0a8e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAANQTFRF/v//pgZx/wAAAAF0Uk5TAEDm2GYAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAPSURBVCiRY2AYBaNgqAIAAr4AAU6byIwAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 31,
+      "layerName": "Offshore_Rocks_And_Wrecks",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "Offshore Rocks",
+          "url": "71ed6289",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAC1QTFRF/v//7vD1297qxszgrrfTkZ3GaX24AE2oaX24kZ7Gr7fTxsvf3N7q7vD1////kDa1CAAAAA90Uk5TAP//////////////////5Y2epgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAGJJREFUKJHdj8sNwDAIQ5Mm/Apk/3FLKvVSmCCWuPBky27tDA1AGBXoSFt4ZfQSjuspLZ4iykzzjyAsbu5CWOSpreXKVLhE17I7u8YOVItAqBpy1Cgafruo2NX6RMKZPcfpAUhFAwcT7oyWAAAAAElFTkSuQmCC",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Wrecks",
+          "url": "c07facc6",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAC1QTFRF/v//7vD1297qxszgrrfTkZ3GaX24AE2oaX24kZ7Gr7fTxsvf3N7q7vD1////kDa1CAAAAA90Uk5TAP//////////////////5Y2epgAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAGNJREFUKJHdj8ENwzAMA+3YFimL0f7j1gX6qjJB7nsgQbb2DsayNZ5EN3yxq6pjtsKBXtoAObkD818tBCPTt1vtk+eBgZr6KZXUgHhnhu9VF1J0p+rC84uSAg+/Wp8GmzXzOj60CwNZWfDMlwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 32,
+      "layerName": "Lighthouses",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "b8d8bfdb",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAGNQTFRF/v//7u7u29zc29zcxsfH29zcxsfHrq+vxsfHrq+vkZKSkZKSrq+vkZGRaWlpaGhokpKSrq+vaGlp3Nzcampqx8fHZ2dnkJCQaWlpAAAAaWlpkZGRr6+vxsbG3Nzc7u7u////kfumDAAAACF0Uk5TAP//////////////////////////////////////////RvROpAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAIdJREFUKJHNj8EOwiAQBVlEsVWp1hZ5UmH//yuF6KEpcO8cyCYDE1aIHaKbhtBUHWRLWX9p9Vwsi3Q4Jq4Lu3MeJK2UwTsR+JNOoKf1Oz0++ccMtWnK4ZFFvBsSWwghqWWs/Q/MgaOtqJOPFi92la1vHpp667tKb8j3FaZCqf8yZIoiVaZd8AUW/whcl6r4ZQAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 33,
+      "layerName": "Marine_Infrastructure_Lines",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Breakwaters",
+          "url": "1d5cf6e2",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//bGxs//++Okv33AAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAB1JREFUKJFjYBgFRAImHAAkxYgVEJLCbeAoIAoAAM2qAJV9o5r0AAAAAElFTkSuQmCC",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Jetties",
+          "url": "1d5cf6e2",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//bGxs//++Okv33AAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAB1JREFUKJFjYBgFRAImHAAkxYgVEJLCbeAoIAoAAM2qAJV9o5r0AAAAAElFTkSuQmCC",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Sea Walls",
+          "url": "1d5cf6e2",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//bGxs//++Okv33AAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAB1JREFUKJFjYBgFRAImHAAkxYgVEJLCbeAoIAoAAM2qAJV9o5r0AAAAAElFTkSuQmCC",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Wharves",
+          "url": "1d5cf6e2",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//bGxs//++Okv33AAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAB1JREFUKJFjYBgFRAImHAAkxYgVEJLCbeAoIAoAAM2qAJV9o5r0AAAAAElFTkSuQmCC",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 34,
+      "layerName": "Reefs_And_Shoals",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Reefs",
+          "url": "c9533ca1",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AMX/BRHMXQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Shoals",
+          "url": "cfcbf76a",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AG//UfmYPgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 35,
+      "layerName": "Locks",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "c4bb557",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAABtQTFRF/v//kaLuaYTqAFvmkaLur7rxxs717vD8////BD3PXgAAAAl0Uk5TAP//////////NwKb1AAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAClJREFUKJFjYBgGgJEJDtClmJjhgDQpVhBgwSrFzgEEbAMuRYa/hhsAAKcOAejmiIC1AAAAAElFTkSuQmCC",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 36,
+      "layerName": "Waterfalls",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "7084572b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAABVQTFRF/v//7vH/2+L/rr/+kan/aZD/AG//LY5oGgAAAAd0Uk5TAP///////6V/pvsAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAAzSURBVCiRY2AY0YCRmYWZEbsMGwhglWMBS7Fgk2IFS7GSqIsJLMWE1R1MrGys2GVGAQMAMCEA1315+/IAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 37,
+      "layerName": "Springs",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "f029cec5",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//vuj/6vtFqAAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 38,
+      "layerName": "Waterholes",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "1219bf09",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dLP/L4zSoQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 39,
+      "layerName": "Bores",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "af30cf1c",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AIWoAGdHDwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 40,
+      "layerName": "Natural_Water_Points_GnammaHole",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Gnamma Holes",
+          "url": "2bebb911",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 41,
+      "layerName": "Natural_Water_Points_NativeWell",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Native Wells",
+          "url": "2bebb911",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 42,
+      "layerName": "Natural_Water_Points_Pool",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Pools",
+          "url": "2bebb911",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 43,
+      "layerName": "Natural_Water_Points_Rockhole",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Rockholes",
+          "url": "2bebb911",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 44,
+      "layerName": "Natural_Water_Points_Soak",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Soaks",
+          "url": "2bebb911",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dOD/vhrcNgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQokWNgGAU4ACMjI24ZHHKMjDjlyJPCYxc+F44QAAAzcwAmHBfjNwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 45,
+      "layerName": "Dams_and_Tanks",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Dams and Tanks",
+          "url": "10d1cf0f",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAABJQTFRF/v//4fb/0vL/v+7+k+X/dOD/olKucwAAAAZ0Uk5TAP//////enng/gAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYBgFWAETCDBilWJhBQLmAZcaBQwAxsMAkyqN1e4AAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 46,
+      "layerName": "Canal_Lines",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Canal Lines",
+          "url": "e84d482d",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dLP/L4zSoQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 47,
+      "layerName": "Dam_Walls",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Dam Walls",
+          "url": "3e3f56b3",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AE2oA0QaSQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAWUA0YcAL/UKKAUAABEjgAxF4zWkAAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 48,
+      "layerName": "Rapid_Lines",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Rapid Lines",
+          "url": "60fb2eeb",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AP/F5rTLlgAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAWUA0YcAL/UKKAUAABEjgAxF4zWkAAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 49,
+      "layerName": "Spillways",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "46ef20d3",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//AMX/BRHMXQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVEAkYcgBZSo4AoAACGXgBhcyzLKAAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 50,
+      "layerName": "Levees",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Levees",
+          "url": "8d052486",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//f3/OFUilOAAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAWUA0YcAL/UKKAUAABEjgAxF4zWkAAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 51,
+      "layerName": "Canal_Areas",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Canal Areas",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 52,
+      "layerName": "Rapid_Areas",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Rapid Areas",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 53,
+      "layerName": "Watercourse_Areas",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Watercourse Areas, Major and Minor Perennial",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Watercourse Areas, Major and Minor Non Perennial",
+          "url": "fa250d75",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 54,
+      "layerName": "PondageArea_AquacultureAreas",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "6881f54d",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//ZprOn83fJNRuVgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 55,
+      "layerName": "Pondage_Areas_Salt_Evaporators",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "6881f54d",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//ZprOn83fJNRuVgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 56,
+      "layerName": "Pondage_Areas_Settling_Ponds",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "",
+          "url": "6881f54d",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//ZprOn83fJNRuVgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 57,
+      "layerName": "Foreshore_Flats",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Foreshore Flats",
+          "url": "2b83e993",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//8uncKAdxPwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 58,
+      "layerName": "Waterbody_Lakes_National_Scale_to_5Million",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 5050001,
+      "legend": [
+        {
+          "label": "Lakes, Perennial",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Lakes, Non Perennial",
+          "url": "fa250d75",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 59,
+      "layerName": "Waterbody_Lakes_Scale_5Million_to_300000",
+      "layerType": "Feature Layer",
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "legend": [
+        {
+          "label": "Lakes, Perennial",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Lakes, Non Perennial",
+          "url": "fa250d75",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 60,
+      "layerName": "Waterbody_Reservoirs_National_Scale_to_300000",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 300001,
+      "legend": [
+        {
+          "label": "Reservoir Area",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 61,
+      "layerName": "Waterbody_Extra_Lakes_and_Reservoirs",
+      "layerType": "Feature Layer",
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "legend": [
+        {
+          "label": "Lake, Perennial",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Lake, Non Perennial",
+          "url": "fa250d75",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Reservoir",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 62,
+      "layerName": "Waterbody_All_Lakes",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "Lakes - Perennial",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Lakes - Non Perennial",
+          "url": "fa250d75",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//vtL/4+XainG3SQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 63,
+      "layerName": "Waterbody_All_Reservoirs",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 64,
+      "layerName": "Waterbody_All_Flood_Irrigation_Storage",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "",
+          "url": "c3bef01b",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//dLP/z9roPw4QXgAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 65,
+      "layerName": "Farm_Dam_Area",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Farm Dam Areas",
+          "url": "77f004d7",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAlQTFRF/v//AE2on9fCDMofhQAAAAN0Uk5TAP//RFDWIQAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABxJREFUKJFjYCATMGIFECkmLGBUalQKf7IhAwAAvwYDdd8LbKYAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 66,
+      "layerName": "Watercourses_Major_Rivers_National_Scale_to_5Million",
+      "layerType": "Feature Layer",
+      "minScale": "4.0E7",
+      "maxScale": 5050001,
+      "legend": [
+        {
+          "label": "",
+          "url": "e84d482d",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//dLP/L4zSoQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 67,
+      "layerName": "Watercourses_Major_Rivers_Scale_5Million_to_300000",
+      "layerType": "Feature Layer",
+      "minScale": 5050000,
+      "maxScale": 300001,
+      "legend": [
+        {
+          "label": "Watercourse, Major Perennial",
+          "url": "df18a7dd",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Watercourse, Major Non Perennial",
+          "url": "941f62c1",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFUlEQVQokWNgGAW0BYxYwUC7angAAB+/ABeuicGgAAAAAElFTkSuQmCC",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 68,
+      "layerName": "Watercourses_All_Rivers_Connectors",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "Major Connectors",
+          "url": "df18a7dd",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Minor Connectors",
+          "url": "941f62c1",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFUlEQVQokWNgGAW0BYxYwUC7angAAB+/ABeuicGgAAAAAElFTkSuQmCC",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 69,
+      "layerName": "Watercourses_All_Rivers_Watercourse_Lines",
+      "layerType": "Feature Layer",
+      "minScale": 300000,
+      "maxScale": 70000,
+      "legend": [
+        {
+          "label": "Major Watercourses",
+          "url": "df18a7dd",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFklEQVQokWNgGAVUAIxYASGpUUAhAAA/EgAtc3XmGwAAAABJRU5ErkJggg==",
+          "contentType": "image/png"
+        },
+        {
+          "label": "Minor Watercourses",
+          "url": "941f62c1",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//a5HBXiVtZwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFUlEQVQokWNgGAW0BYxYwUC7angAAB+/ABeuicGgAAAAAElFTkSuQmCC",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 70,
+      "layerName": "Flats_Swamps",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Swamps",
+          "url": "efd36116",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//3OP/QlyDLQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 71,
+      "layerName": "Flats_MarineSwamps",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Marine Swamps",
+          "url": "ac57748e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//htTEAnthWwAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 72,
+      "layerName": "Flats_LandSubjectToInundation",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Land Subject to Inundation",
+          "url": "5fa36f2e",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//4t3cjwshuAAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    },
+    {
+      "layerId": 73,
+      "layerName": "Flats_SalineCoastalFlats",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 70001,
+      "legend": [
+        {
+          "label": "Saline Coastal Flats",
+          "url": "122ff541",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAAXNSR0IB2cksfwAAAAZQTFRF/v//xNbXx+0bqQAAAAJ0Uk5TAP9bkSK1AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAFElEQVQokWNgoAFgxAJGpUalqA4AJ0wBkeEX5OEAAAAASUVORK5CYII=",
+          "contentType": "image/png"
+        }
+      ]
+    }
+  ]
+}

--- a/wwwroot/test/ArcGisMapServer/Dynamic_National_Map_Hydrography_and_Marine/mapserver.json
+++ b/wwwroot/test/ArcGisMapServer/Dynamic_National_Map_Hydrography_and_Marine/mapserver.json
@@ -1,1 +1,712 @@
-{"currentVersion":10.04,"serviceDescription":"This service has been created specifically for display in the National Map and the symbology displayed may not suit other mapping applications. The AusHydro dataset represents the Australia's surface hydrology at a national scale. It includes natural and man-made geographic features such as: watercourse areas, swamps, reservoirs, canals, etc. This product presents hydrology polygon, point and line features which topologically connect and forms a complete flow path network for the entire continent of Australia. The GEODATA 250K data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. These features include the culture, drainage, hydrography, waterbodies and marine themes. Some datasets reflects the increasing data from scale to scale. The data is sourced from Geoscience Australia 250K Topographic data and AusHydro_V_2_0 data.","mapName":"Australian Topography - Hydrography and Marine","description":"This service has been created specifically for display in the National Map and the symbology displayed may not suit other mapping applications. The AusHydro dataset represents the Australia's surface hydrology at a national scale. It includes natural and man-made geographic features such as: watercourse areas, swamps, reservoirs, canals, etc. This product presents hydrology polygon, point and line features which topologically connect and forms a complete flow path network for the entire continent of Australia. The GEODATA 250K data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. These features include the culture, drainage, hydrography, waterbodies and marine themes. Some datasets reflects the increasing data from scale to scale. The data is sourced from Geoscience Australia 250K Topographic data and AusHydro_V_2_0 data.","copyrightText":"Geoscience Australia, AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","layers":[{"id":0,"name":"No_Labels_National_Scale_to_300K_Scale","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":300000},{"id":1,"name":"No_Labels_National_Scale_to_10Million_Scale","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":1.0000001E7},{"id":2,"name":"No_Data","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":70000,"maxScale":0},{"id":3,"name":"Offshore_Rocks_and_Wrecks_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70000},{"id":4,"name":"Lighthouses_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":5,"name":"Reefs_and_Shoals_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":6,"name":"Locks_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":7,"name":"Waterfalls_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":8,"name":"Springs_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":9,"name":"Waterholes_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":10,"name":"Bores_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":11,"name":"Natural_Water_Points_GnammaHoles_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":12,"name":"Natural_Water_Points_NativeWells_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":13,"name":"Natural_Water_Points_Pools_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":14,"name":"Natural_Water_Points_Rockholes_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":15,"name":"Natural_Water_Points_Soaks_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":16,"name":"Dams_and_Tanks_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":17,"name":"Dam_Walls_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":18,"name":"Watercourse_Areas_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":19,"name":"Watercourses_Major_Rivers_Scale_10Million_to_5Million_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":1.0E7,"maxScale":5050001},{"id":20,"name":"Watercourses_Major_Rivers_Scale_5Million_to_300000_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":5050000,"maxScale":300001},{"id":21,"name":"Watercourses_All_Rivers_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":22,"name":"Waterbody_Lakes_Scale_10Million_to_5Million_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":1.0E7,"maxScale":5050001},{"id":23,"name":"Waterbody_Lakes_Scale_5Million_to_300000_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":5050000,"maxScale":300001},{"id":24,"name":"Waterbody_Reservoirs_Scale_10Million_to_300000_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":1.0E7,"maxScale":300001},{"id":25,"name":"Waterbody_Extra_Lakes_and_Reservoirs_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":5050000,"maxScale":300001},{"id":26,"name":"Waterbody_All_Lakes_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70000},{"id":27,"name":"Waterbody_All_Reservoirs_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70000},{"id":28,"name":"Waterbody_All_Flood_Irrigation_Storage_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70000},{"id":29,"name":"Flats_Swamps_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":30,"name":"Flats_MarineSwamps_Labels","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70001},{"id":31,"name":"Offshore_Rocks_And_Wrecks","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70000},{"id":32,"name":"Lighthouses","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":33,"name":"Marine_Infrastructure_Lines","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":34,"name":"Reefs_And_Shoals","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":35,"name":"Locks","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":36,"name":"Waterfalls","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":37,"name":"Springs","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":38,"name":"Waterholes","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":39,"name":"Bores","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":40,"name":"Natural_Water_Points_GnammaHole","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":41,"name":"Natural_Water_Points_NativeWell","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":42,"name":"Natural_Water_Points_Pool","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":43,"name":"Natural_Water_Points_Rockhole","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":44,"name":"Natural_Water_Points_Soak","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":45,"name":"Dams_and_Tanks","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":46,"name":"Canal_Lines","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":47,"name":"Dam_Walls","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":48,"name":"Rapid_Lines","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":49,"name":"Spillways","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":50,"name":"Levees","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":51,"name":"Canal_Areas","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":52,"name":"Rapid_Areas","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":53,"name":"Watercourse_Areas","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":54,"name":"PondageArea_AquacultureAreas","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":55,"name":"Pondage_Areas_Salt_Evaporators","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":56,"name":"Pondage_Areas_Settling_Ponds","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":57,"name":"Foreshore_Flats","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":58,"name":"Waterbody_Lakes_National_Scale_to_5Million","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":5050001},{"id":59,"name":"Waterbody_Lakes_Scale_5Million_to_300000","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":5050000,"maxScale":300001},{"id":60,"name":"Waterbody_Reservoirs_National_Scale_to_300000","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":300001},{"id":61,"name":"Waterbody_Extra_Lakes_and_Reservoirs","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":5050000,"maxScale":300001},{"id":62,"name":"Waterbody_All_Lakes","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70000},{"id":63,"name":"Waterbody_All_Reservoirs","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70000},{"id":64,"name":"Waterbody_All_Flood_Irrigation_Storage","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70000},{"id":65,"name":"Farm_Dam_Area","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":66,"name":"Watercourses_Major_Rivers_National_Scale_to_5Million","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":4.0E7,"maxScale":5050001},{"id":67,"name":"Watercourses_Major_Rivers_Scale_5Million_to_300000","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":5050000,"maxScale":300001},{"id":68,"name":"Watercourses_All_Rivers_Connectors","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70000},{"id":69,"name":"Watercourses_All_Rivers_Watercourse_Lines","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":300000,"maxScale":70000},{"id":70,"name":"Flats_Swamps","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":71,"name":"Flats_MarineSwamps","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":72,"name":"Flats_LandSubjectToInundation","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001},{"id":73,"name":"Flats_SalineCoastalFlats","parentLayerId":-1,"defaultVisibility":true,"subLayerIds":null,"minScale":0,"maxScale":70001}],"tables":[],"spatialReference":{"wkid":4283},"singleFusedMapCache":false,"initialExtent":{"xmin":86.941467666162,"ymin":-62.756553980451336,"xmax":185.25829858993814,"ymax":11.180017913661423,"spatialReference":{"wkid":4283}},"fullExtent":{"xmin":100.14442693296783,"ymin":-49.98407725285527,"xmax":169.16154003177758,"ymax":-2.3882536190571813,"spatialReference":{"wkid":4283}},"units":"esriDecimalDegrees","supportedImageFormatTypes":"PNG32,PNG24,PNG,JPG,DIB,TIFF,EMF,PS,PDF,GIF,SVG,SVGZ,BMP","documentInfo":{"Title":"Australia 250K Topographic Hydrography and Marine Layers","Author":"Geoscience Australia","Comments":"This service has been created specifically for display in the National Map and the symbology displayed may not suit other mapping applications. The AusHydro dataset represents the Australia's surface hydrology at a national scale. It includes natural and man-made geographic features such as: watercourse areas, swamps, reservoirs, canals, etc. This product presents hydrology polygon, point and line features which topologically connect and forms a complete flow path network for the entire continent of Australia. The GEODATA 250K data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. These features include the culture, drainage, hydrography, waterbodies and marine themes. Some datasets reflects the increasing data from scale to scale. The data is sourced from Geoscience Australia 250K Topographic data and AusHydro_V_2_0 data.","Subject":"Australia 250K Topographic Hydrography and Marine Layers","Category":"","Keywords":"Drainage,Hydrography,Waterbodies,Marine,Culture","Credits":"Geoscience Australia, AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )","AntialiasingMode":"None","TextAntialiasingMode":"Force"},"capabilities":"Map,Query,Data"}
+{
+  "currentVersion": 10.04,
+  "serviceDescription": "This service has been created specifically for display in the National Map and the symbology displayed may not suit other mapping applications. The AusHydro dataset represents the Australia's surface hydrology at a national scale. It includes natural and man-made geographic features such as: watercourse areas, swamps, reservoirs, canals, etc. This product presents hydrology polygon, point and line features which topologically connect and forms a complete flow path network for the entire continent of Australia. The GEODATA 250K data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. These features include the culture, drainage, hydrography, waterbodies and marine themes. Some datasets reflects the increasing data from scale to scale. The data is sourced from Geoscience Australia 250K Topographic data and AusHydro_V_2_0 data.",
+  "mapName": "Australian Topography - Hydrography and Marine",
+  "description": "This service has been created specifically for display in the National Map and the symbology displayed may not suit other mapping applications. The AusHydro dataset represents the Australia's surface hydrology at a national scale. It includes natural and man-made geographic features such as: watercourse areas, swamps, reservoirs, canals, etc. This product presents hydrology polygon, point and line features which topologically connect and forms a complete flow path network for the entire continent of Australia. The GEODATA 250K data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. These features include the culture, drainage, hydrography, waterbodies and marine themes. Some datasets reflects the increasing data from scale to scale. The data is sourced from Geoscience Australia 250K Topographic data and AusHydro_V_2_0 data.",
+  "copyrightText": "Geoscience Australia, AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+  "layers": [
+    {
+      "id": 0,
+      "name": "No_Labels_National_Scale_to_300K_Scale",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 300000
+    },
+    {
+      "id": 1,
+      "name": "No_Labels_National_Scale_to_10Million_Scale",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": "1.0000001E7"
+    },
+    {
+      "id": 2,
+      "name": "No_Data",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 70000,
+      "maxScale": 0
+    },
+    {
+      "id": 3,
+      "name": "Offshore_Rocks_and_Wrecks_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70000
+    },
+    {
+      "id": 4,
+      "name": "Lighthouses_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 5,
+      "name": "Reefs_and_Shoals_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 6,
+      "name": "Locks_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 7,
+      "name": "Waterfalls_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 8,
+      "name": "Springs_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 9,
+      "name": "Waterholes_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 10,
+      "name": "Bores_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 11,
+      "name": "Natural_Water_Points_GnammaHoles_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 12,
+      "name": "Natural_Water_Points_NativeWells_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 13,
+      "name": "Natural_Water_Points_Pools_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 14,
+      "name": "Natural_Water_Points_Rockholes_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 15,
+      "name": "Natural_Water_Points_Soaks_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 16,
+      "name": "Dams_and_Tanks_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 17,
+      "name": "Dam_Walls_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 18,
+      "name": "Watercourse_Areas_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 19,
+      "name": "Watercourses_Major_Rivers_Scale_10Million_to_5Million_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": "1.0E7",
+      "maxScale": 5050001
+    },
+    {
+      "id": 20,
+      "name": "Watercourses_Major_Rivers_Scale_5Million_to_300000_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 5050000,
+      "maxScale": 300001
+    },
+    {
+      "id": 21,
+      "name": "Watercourses_All_Rivers_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 22,
+      "name": "Waterbody_Lakes_Scale_10Million_to_5Million_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": "1.0E7",
+      "maxScale": 5050001
+    },
+    {
+      "id": 23,
+      "name": "Waterbody_Lakes_Scale_5Million_to_300000_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 5050000,
+      "maxScale": 300001
+    },
+    {
+      "id": 24,
+      "name": "Waterbody_Reservoirs_Scale_10Million_to_300000_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": "1.0E7",
+      "maxScale": 300001
+    },
+    {
+      "id": 25,
+      "name": "Waterbody_Extra_Lakes_and_Reservoirs_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 5050000,
+      "maxScale": 300001
+    },
+    {
+      "id": 26,
+      "name": "Waterbody_All_Lakes_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70000
+    },
+    {
+      "id": 27,
+      "name": "Waterbody_All_Reservoirs_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70000
+    },
+    {
+      "id": 28,
+      "name": "Waterbody_All_Flood_Irrigation_Storage_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70000
+    },
+    {
+      "id": 29,
+      "name": "Flats_Swamps_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 30,
+      "name": "Flats_MarineSwamps_Labels",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70001
+    },
+    {
+      "id": 31,
+      "name": "Offshore_Rocks_And_Wrecks",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70000
+    },
+    {
+      "id": 32,
+      "name": "Lighthouses",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 33,
+      "name": "Marine_Infrastructure_Lines",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 34,
+      "name": "Reefs_And_Shoals",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 35,
+      "name": "Locks",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 36,
+      "name": "Waterfalls",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 37,
+      "name": "Springs",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 38,
+      "name": "Waterholes",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 39,
+      "name": "Bores",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 40,
+      "name": "Natural_Water_Points_GnammaHole",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 41,
+      "name": "Natural_Water_Points_NativeWell",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 42,
+      "name": "Natural_Water_Points_Pool",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 43,
+      "name": "Natural_Water_Points_Rockhole",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 44,
+      "name": "Natural_Water_Points_Soak",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 45,
+      "name": "Dams_and_Tanks",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 46,
+      "name": "Canal_Lines",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 47,
+      "name": "Dam_Walls",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 48,
+      "name": "Rapid_Lines",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 49,
+      "name": "Spillways",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 50,
+      "name": "Levees",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 51,
+      "name": "Canal_Areas",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 52,
+      "name": "Rapid_Areas",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 53,
+      "name": "Watercourse_Areas",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 54,
+      "name": "PondageArea_AquacultureAreas",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 55,
+      "name": "Pondage_Areas_Salt_Evaporators",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 56,
+      "name": "Pondage_Areas_Settling_Ponds",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 57,
+      "name": "Foreshore_Flats",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 58,
+      "name": "Waterbody_Lakes_National_Scale_to_5Million",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 5050001
+    },
+    {
+      "id": 59,
+      "name": "Waterbody_Lakes_Scale_5Million_to_300000",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 5050000,
+      "maxScale": 300001
+    },
+    {
+      "id": 60,
+      "name": "Waterbody_Reservoirs_National_Scale_to_300000",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 300001
+    },
+    {
+      "id": 61,
+      "name": "Waterbody_Extra_Lakes_and_Reservoirs",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 5050000,
+      "maxScale": 300001
+    },
+    {
+      "id": 62,
+      "name": "Waterbody_All_Lakes",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70000
+    },
+    {
+      "id": 63,
+      "name": "Waterbody_All_Reservoirs",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70000
+    },
+    {
+      "id": 64,
+      "name": "Waterbody_All_Flood_Irrigation_Storage",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70000
+    },
+    {
+      "id": 65,
+      "name": "Farm_Dam_Area",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 66,
+      "name": "Watercourses_Major_Rivers_National_Scale_to_5Million",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": "4.0E7",
+      "maxScale": 5050001
+    },
+    {
+      "id": 67,
+      "name": "Watercourses_Major_Rivers_Scale_5Million_to_300000",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 5050000,
+      "maxScale": 300001
+    },
+    {
+      "id": 68,
+      "name": "Watercourses_All_Rivers_Connectors",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70000
+    },
+    {
+      "id": 69,
+      "name": "Watercourses_All_Rivers_Watercourse_Lines",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 300000,
+      "maxScale": 70000
+    },
+    {
+      "id": 70,
+      "name": "Flats_Swamps",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 71,
+      "name": "Flats_MarineSwamps",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 72,
+      "name": "Flats_LandSubjectToInundation",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    },
+    {
+      "id": 73,
+      "name": "Flats_SalineCoastalFlats",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 70001
+    }
+  ],
+  "tables": [],
+  "spatialReference": {
+    "wkid": 4283
+  },
+  "singleFusedMapCache": false,
+  "initialExtent": {
+    "xmin": 86.941467666162,
+    "ymin": -62.756553980451336,
+    "xmax": 185.25829858993814,
+    "ymax": 11.180017913661423,
+    "spatialReference": {
+      "wkid": 4283
+    }
+  },
+  "fullExtent": {
+    "xmin": 100.14442693296783,
+    "ymin": -49.98407725285527,
+    "xmax": 169.16154003177758,
+    "ymax": -2.3882536190571813,
+    "spatialReference": {
+      "wkid": 4283
+    }
+  },
+  "units": "esriDecimalDegrees",
+  "supportedImageFormatTypes": "PNG32,PNG24,PNG,JPG,DIB,TIFF,EMF,PS,PDF,GIF,SVG,SVGZ,BMP",
+  "documentInfo": {
+    "Title": "Australia 250K Topographic Hydrography and Marine Layers",
+    "Author": "Geoscience Australia",
+    "Comments": "This service has been created specifically for display in the National Map and the symbology displayed may not suit other mapping applications. The AusHydro dataset represents the Australia's surface hydrology at a national scale. It includes natural and man-made geographic features such as: watercourse areas, swamps, reservoirs, canals, etc. This product presents hydrology polygon, point and line features which topologically connect and forms a complete flow path network for the entire continent of Australia. The GEODATA 250K data are best suited to graphical applications. These data may vary greatly in quality depending on the method of capture and digitising specifications in place at the time of capture. These features include the culture, drainage, hydrography, waterbodies and marine themes. Some datasets reflects the increasing data from scale to scale. The data is sourced from Geoscience Australia 250K Topographic data and AusHydro_V_2_0 data.",
+    "Subject": "Australia 250K Topographic Hydrography and Marine Layers",
+    "Category": "",
+    "Keywords": "Drainage,Hydrography,Waterbodies,Marine,Culture",
+    "Credits": "Geoscience Australia, AusHydro Contributors (Geoscience Australia, NSW Department Land and Property Information, Queensland Department of National Resources and Mines, Victorian Department of Environment, Land, Water and Planning, South Australia Department for Environment, Water and Natural Resources, Tasmanian Department of Primary Industries, Parks, Water and Environment and Western Australian Land Information Authority (Landgate) )",
+    "AntialiasingMode": "None",
+    "TextAntialiasingMode": "Force"
+  },
+  "capabilities": "Map,Query,Data"
+}


### PR DESCRIPTION
Refactored the rectangle on `ArcGisMapServerCatalogItem` to return a rectangle in decimal degrees rather than a cesium rectangle which has radians.

Resolves https://github.com/TerriaJS/nsw-digital-twin/issues/245
