### PR TITLE
Mobx: Fix the story panel location button

### DIFF
--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -374,6 +374,11 @@ export default class Terria {
     this._initSourceLoader.dispose();
   }
 
+  updateFromStartData (startData: any) {
+    interpretStartData(this, startData);
+    return this.loadInitSources();
+  }
+
   updateApplicationUrl(newUrl: string) {
     const uri = new URI(newUrl);
     const hash = uri.fragment();

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -374,7 +374,7 @@ export default class Terria {
     this._initSourceLoader.dispose();
   }
 
-  updateFromStartData (startData: any) {
+  updateFromStartData(startData: any) {
     interpretStartData(this, startData);
     return this.loadInitSources();
   }

--- a/lib/ReactViews/Story/StoryPanel.jsx
+++ b/lib/ReactViews/Story/StoryPanel.jsx
@@ -117,7 +117,9 @@ const StoryPanel = observer(
 
     onCenterScene(story) {
       if (story.shareData) {
-        this.props.terria.updateFromStartData(story.shareData);
+        runInAction(() => {
+          this.props.terria.updateFromStartData(story.shareData);
+        });
       }
     },
 


### PR DESCRIPTION
Roughly from ticket
> Create a story. Play the story, then pan away, then click the location button. The map should recenter to the scene location, but nothing happens. There is a console error which hints that the feature is not fully ported.

Resolves https://github.com/TerriaJS/nsw-digital-twin/issues/247

![btn](https://user-images.githubusercontent.com/6735870/73716537-659bbf00-476b-11ea-84f7-b7f91228559f.png)

