### PR TITLE
Mobx: restrict location search results to a bounding box

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Fixed bug causing workbench items to be shared in the wrong order.
 * Fix bug where urls in the feature info panel weren't turned into hyperlinks
 * Fix preview map's base map and bounding rectangle size
+* Added the ability to filter location search results by an app-wide bounding box configuration parameter
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -76,6 +76,7 @@ interface ConfigParameters {
   disableMyLocation?: boolean;
   experimentalFeatures?: boolean;
   magdaReferenceHeaders?: MagdaReferenceHeaders;
+  locationSearchBoundingBox?: number[];
 }
 
 interface StartOptions {
@@ -178,7 +179,8 @@ export default class Terria {
     bingMapsKey: undefined,
     brandBarElements: undefined,
     experimentalFeatures: undefined,
-    magdaReferenceHeaders: undefined
+    magdaReferenceHeaders: undefined,
+    locationSearchBoundingBox: undefined
   };
 
   @observable

--- a/lib/ReactViews/Search/LocationSearchResults.jsx
+++ b/lib/ReactViews/Search/LocationSearchResults.jsx
@@ -8,6 +8,7 @@ import SearchResult from "./SearchResult";
 import classNames from "classnames";
 import Icon from "../Icon";
 import Styles from "./location-search-result.scss";
+import isDefined from "../../Core/isDefined";
 
 const LocationSearchResults = observer(
   createReactClass({
@@ -63,12 +64,27 @@ const LocationSearchResults = observer(
     render() {
       const search = this.props.search;
       const searchProvider = search.searchProvider;
+      const locationSearchBoundingBox = this.props.terria.configParameters
+        .locationSearchBoundingBox;
+
+      const validResults = isDefined(locationSearchBoundingBox)
+        ? search.results.filter(function(r) {
+            return (
+              r.location.longitude > locationSearchBoundingBox[0] &&
+              r.location.longitude < locationSearchBoundingBox[2] &&
+              r.location.latitude > locationSearchBoundingBox[1] &&
+              r.location.latitude < locationSearchBoundingBox[3]
+            );
+          })
+        : search.results;
+
       const results =
-        search.results.length > 5
+        validResults.length > 5
           ? this.state.isExpanded
-            ? search.results
-            : search.results.slice(0, 5)
-          : search.results;
+            ? validResults
+            : validResults.slice(0, 5)
+          : validResults;
+
       return (
         <div
           key={searchProvider.name}


### PR DESCRIPTION
This PR adds a bounding box restriction to the location search (handy for providers which don't support anything similar via API requests).

In the config.json for a TerriaMap add a `locationSearchBoundingBox` to your params in the form a bounding box In minx, miny, maxx, maxy
````
    parameters: {
        "locationSearchBoundingBox": [109, -45, 158, -8]   <---- roughly australia
    }
````
Defaults to undefined and no results are filtered
**Without Filter**
![WithoutFilter](https://user-images.githubusercontent.com/6735870/73792613-c3c2b380-47f8-11ea-8d8c-048f8a6139cf.png)


**With Filter**
![screenshot-localhost_3001-2020 02 05-09_18_47](https://user-images.githubusercontent.com/6735870/73792506-8d853400-47f8-11ea-818e-76bcb337d7ad.png)
