### PR TITLE
Mobx: Prevent app crash when timeline active and switching to 2D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Fix bug where urls in the feature info panel weren't turned into hyperlinks
 * Fix preview map's base map and bounding rectangle size
 * Re-introduce UI elements for search when a catalogSearchProvider is provided
+* Prevent TerriaMap from crashing when timeline is on and changing to 2D
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/TimelineStack.ts
+++ b/lib/Models/TimelineStack.ts
@@ -2,6 +2,7 @@ import { action, computed, observable, IReactionDisposer, autorun } from "mobx";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import TimeVarying from "../ModelMixins/TimeVarying";
 import CommonStrata from "./CommonStrata";
+import isDefined from "../Core/isDefined";
 import filterOutUndefined from "../Core/filterOutUndefined";
 import ReferenceMixin from "../ModelMixins/ReferenceMixin";
 
@@ -161,7 +162,7 @@ export default class TimelineStack {
     const clock = this.clock;
     const currentTime = JulianDate.toIso8601(clock.currentTime);
     const isPaused = !clock.shouldAnimate;
-    if (this.top && this.top.startTime !== JulianDate.toIso8601(clock.startTime)) {
+    if (this.top && !isDefined(this.top.startTime)) {
       this.top.setTrait(
         stratumId,
         "startTime",
@@ -181,7 +182,10 @@ export default class TimelineStack {
       layer.setTrait(stratumId, "isPaused", isPaused);
     }
 
-    if (this.defaultTimeVarying && this.defaultTimeVarying.currentTime !== currentTime) {
+    if (
+      this.defaultTimeVarying &&
+      !isDefined(this.defaultTimeVarying.currentTime)
+    ) {
       this.defaultTimeVarying.setTrait(stratumId, "currentTime", currentTime);
       this.defaultTimeVarying.setTrait(stratumId, "isPaused", isPaused);
     }

--- a/lib/Models/TimelineStack.ts
+++ b/lib/Models/TimelineStack.ts
@@ -161,8 +161,7 @@ export default class TimelineStack {
     const clock = this.clock;
     const currentTime = JulianDate.toIso8601(clock.currentTime);
     const isPaused = !clock.shouldAnimate;
-
-    if (this.top) {
+    if (this.top && this.top.startTime !== JulianDate.toIso8601(clock.startTime)) {
       this.top.setTrait(
         stratumId,
         "startTime",
@@ -182,7 +181,7 @@ export default class TimelineStack {
       layer.setTrait(stratumId, "isPaused", isPaused);
     }
 
-    if (this.defaultTimeVarying) {
+    if (this.defaultTimeVarying && this.defaultTimeVarying.currentTime !== currentTime) {
       this.defaultTimeVarying.setTrait(stratumId, "currentTime", currentTime);
       this.defaultTimeVarying.setTrait(stratumId, "isPaused", isPaused);
     }


### PR DESCRIPTION
I'm not super sure of this fix but it works... 

Previously
- From the map menu select "Always show timeline"
- Then switch to 2d map

Resolves #3989