### PR TITLE
Mobx: disable opacity control for point tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Fix preview map's base map and bounding rectangle size
 * Added the ability to filter location search results by an app-wide bounding box configuration parameter
 * Re-introduce UI elements for search when a catalogSearchProvider is provided
+* Hide opacity control for point-table catalog items.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -139,6 +139,12 @@ export default function TableMixin<T extends Constructor<Model<TableTraits>>>(
       );
     }
 
+    @computed
+    get disableOpacityControl() {
+      // disable opacity control for point tables
+      return this.activeTableStyle.isPoints();
+    }
+
     /**
      * Gets the items to show on the map.
      */

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
@@ -35,7 +35,7 @@ const OpacitySection = observer(
       const { t } = this.props;
       if (
         !hasTraits(item, RasterLayerTraits, "opacity") ||
-        item.opacity === undefined
+        item.disableOpacityControl
       ) {
         return null;
       }


### PR DESCRIPTION
- Adds a flag to disable opacity controls for items with RasterLayerTraits
- Disables opacity control for point tables (it stays enabled for region mapped tables).

This reflects the behavior in `master`.