### PR TITLE
Mobx csv about

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ Change Log
 * Fix preview map's base map and bounding rectangle size
 * Added the ability to filter location search results by an app-wide bounding box configuration parameter
 * Re-introduce UI elements for search when a catalogSearchProvider is provided
+* Set `showInfo` to true for `CsvCatalogItem` to enable the 'About This Data' button in the workbench
+
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Change Log
 * Fix preview map's base map and bounding rectangle size
 * Added the ability to filter location search results by an app-wide bounding box configuration parameter
 * Re-introduce UI elements for search when a catalogSearchProvider is provided
-* Set `showInfo` to true for `CsvCatalogItem` to enable the 'About This Data' button in the workbench
+* Set `showInfo` to true for `CsvCatalogItem` and `GtfsCatalogItem` to enable the 'About This Data' button in the workbench
 
 
 ### Next Release

--- a/lib/Models/CsvCatalogItem.ts
+++ b/lib/Models/CsvCatalogItem.ts
@@ -42,6 +42,7 @@ export default class CsvCatalogItem extends TableMixin(
   }
 
   private _csvFile?: File;
+  readonly showsInfo = true;
 
   constructor(id: string | undefined, terria: Terria) {
     super(id, terria);

--- a/lib/Models/GtfsCatalogItem.ts
+++ b/lib/Models/GtfsCatalogItem.ts
@@ -102,6 +102,8 @@ export default class GtfsCatalogItem extends AsyncMappableMixin(
    */
   protected _dataSource: DataSource = new DataSource("billboard");
 
+  readonly showsInfo = true;
+
   protected static readonly FEATURE_INFO_TEMPLATE_FIELDS: string[] = [
     "route_short_name",
     "occupancy_status#str",


### PR DESCRIPTION
Set `showInfo` to true for `CsvCatalogItem` to enable the 'About This Data' button in the workbench

This works for both configured items as well as those added by the 'Add data' functionality

resolves #3994