### PR TITLE
Set default value for `showsInfo`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 * Added the ability to filter location search results by an app-wide bounding box configuration parameter
 * Re-introduce UI elements for search when a catalogSearchProvider is provided
 * Hide opacity control for point-table catalog items.
+* Show About Data for all items by default.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/ModelMixins/CatalogMemberMixin.ts
+++ b/lib/ModelMixins/CatalogMemberMixin.ts
@@ -36,6 +36,13 @@ function CatalogMemberMixin<T extends Constructor<CatalogMember>>(Base: T) {
       return true;
     }
 
+    /**
+     * Default value for showsInfo (About Data button)
+     */
+    get showsInfo() {
+      return true;
+    }
+
     @computed
     get nameInCatalog(): string | undefined {
       return super.nameInCatalog || this.name;

--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -315,7 +315,6 @@ export default class ArcGisMapServerCatalogItem
 
   readonly supportsSplitting = true;
   readonly canZoomTo = true;
-  readonly showsInfo = true;
   readonly isMappable = true;
 
   get type() {

--- a/lib/Models/Cesium3DTilesCatalogItem.ts
+++ b/lib/Models/Cesium3DTilesCatalogItem.ts
@@ -56,8 +56,6 @@ export default class Cesium3DTilesCatalogItem
   }
 
   readonly canZoomTo = true;
-  readonly showsInfo = true;
-
   private tileset?: ObservableCesium3DTileset;
 
   get isMappable() {

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -421,7 +421,6 @@ class WebMapServiceCatalogItem
 
   static readonly type = "wms";
   readonly canZoomTo = true;
-  readonly showsInfo = true;
   readonly supportsSplitting = true;
 
   get type() {

--- a/lib/Models/WebProcessingServiceCatalogItem.ts
+++ b/lib/Models/WebProcessingServiceCatalogItem.ts
@@ -183,7 +183,6 @@ export default class WebProcessingServiceCatalogItem
     return i18next.t("models.webProcessingService.wpsResult");
   }
 
-  readonly showsInfo = true;
   readonly isMappable = true;
 
   @observable


### PR DESCRIPTION
We set a default `true` value for `showsInfo` by defining a getter in the `CatalogMemberMixin`.
This can be overridden if required, in the child class, as in ResultPendingCatalogItem.