### PR TITLE
Mobx: fix catalog userAddedDataGroup bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Change Log
 * Added the ability to filter location search results by an app-wide bounding box configuration parameter
 * Re-introduce UI elements for search when a catalogSearchProvider is provided
 * Hide opacity control for point-table catalog items.
+* Fixed bug where `Catalog` would sometimes end up with an undefined `userAddedDataGroup`.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/CatalogNew.ts
+++ b/lib/Models/CatalogNew.ts
@@ -1,5 +1,5 @@
 import i18next from "i18next";
-import { observable, autorun, runInAction } from "mobx";
+import { observable, autorun } from "mobx";
 import { USER_ADDED_CATEGORY_ID } from "../Core/addedByUser";
 import CatalogGroup from "./CatalogGroupNew";
 import CommonStrata from "./CommonStrata";
@@ -14,14 +14,14 @@ export default class Catalog {
 
   readonly terria: Terria;
 
-  reactToGroupChanges: () => void;
+  private _disposeCreateUserAddedGroup: () => void;
 
   constructor(terria: Terria) {
     this.terria = terria;
     this.group = new CatalogGroup("/", this.terria);
     this.terria.addModel(this.group);
 
-    this.reactToGroupChanges = autorun(() => {
+    this._disposeCreateUserAddedGroup = autorun(() => {
       // Make sure the catalog has a user added data group even if its
       // group or group members are reset.
       if (
@@ -60,6 +60,10 @@ export default class Catalog {
         this.group.add(CommonStrata.definition, userAddedDataGroup);
       }
     });
+  }
+
+  destroy() {
+    this._disposeCreateUserAddedGroup();
   }
 
   get userAddedDataGroup(): CatalogGroup {

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -736,7 +736,9 @@ export default class Terria {
       reference.setTrait(CommonStrata.definition, "magdaRecord", config);
       await reference.loadReference().then(() => {
         if (reference.target instanceof CatalogGroup) {
-          this.catalog.group = reference.target;
+          runInAction(() => {
+            this.catalog.group = <CatalogGroup>reference.target;
+          });
         }
       });
     }


### PR DESCRIPTION
Added some checks to make sure the catalog always has a userAddedDataGroup by adding the userAddedDataGroup back whenever it is accidentally removed (e.g. when setting terria.catalog.group or terria.catalog.group.members).