### PR TITLE
remove duplicate text from descriptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Change Log
 * Fix bug that prevented live transport data from being hidden
 * Hide opacity control for point-table catalog items.
 * Show About Data for all items by default.
+* Remove duplicate text from data catalog item presentation.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/ReactViews/Preview/DataPreviewUrl.jsx
+++ b/lib/ReactViews/Preview/DataPreviewUrl.jsx
@@ -28,32 +28,22 @@ const DataPreviewUrl = createReactClass({
         <If condition={this.props.metadataItem.type === "wms"}>
           <p>
             <Trans i18nKey="description.wms">
-              This is a
               <a
                 href="https://en.wikipedia.org/wiki/Web_Map_Service"
                 target="_blank"
                 rel="noopener noreferrer"
-              >
-                WMS service
-              </a>
-              , which generates map images on request. It can be used in GIS
-              software with this URL:
+              />
             </Trans>
           </p>
         </If>
         <If condition={this.props.metadataItem.type === "wfs"}>
           <p>
             <Trans i18nKey="description.wfs">
-              This is a
               <a
                 href="https://en.wikipedia.org/wiki/Web_Feature_Service"
                 target="_blank"
                 rel="noopener noreferrer"
-              >
-                WFS service
-              </a>
-              , which transfers raw spatial data on request. It can be used in
-              GIS software with this URL:
+              />
             </Trans>
           </p>
         </If>

--- a/lib/ReactViews/Preview/Description.jsx
+++ b/lib/ReactViews/Preview/Description.jsx
@@ -91,32 +91,22 @@ const Description = observer(
                 <When condition={catalogItem.type === "wms"}>
                   <p key="wms-description">
                     <Trans i18nKey="description.wms">
-                      This is a
                       <a
                         href="https://en.wikipedia.org/wiki/Web_Map_Service"
                         target="_blank"
                         rel="noopener noreferrer"
-                      >
-                        WMS service
-                      </a>
-                      , which generates map images on request. It can be used in
-                      GIS software with this URL:
+                      />
                     </Trans>
                   </p>
                 </When>
                 <When condition={catalogItem.type === "wfs"}>
                   <p key="wfs-description">
                     <Trans i18nKey="description.wfs">
-                      This is a{" "}
                       <a
                         href="https://en.wikipedia.org/wiki/Web_Feature_Service"
                         target="_blank"
                         rel="noopener noreferrer"
-                      >
-                        WFS service
-                      </a>
-                      , which transfers raw spatial data on request. It can be
-                      used in GIS software with this URL:
+                      />
                     </Trans>
                   </p>
                 </When>


### PR DESCRIPTION
Removes duplicate text that was probably introduced by internationalisation

resolves #4004 