### PR TITLE
Fix initialisation of terria's shareDataService

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Change Log
 * Fixed bug where `Catalog` would sometimes end up with an undefined `userAddedDataGroup`.
 * Show About Data for all items by default.
 * Fix bug that throws an error when clicking on ArcGIS Map Service features
+* Fix initialisation of `terria`'s `shareDataService`.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -347,16 +347,14 @@ export default class Terria {
       })
       .then(() => {
         this.serverConfig = new ServerConfig();
-        return this.serverConfig
-          .init(this.configParameters.serverConfigUrl)
-          .then((serverConfig: any) => {
-            return this.initCorsProxy(this.configParameters, serverConfig);
-          })
-          .then(() => this.serverConfig);
+        return this.serverConfig.init(this.configParameters.serverConfigUrl);
       })
-      .then(serverConfig => {
-        if (this.shareDataService && serverConfig) {
-          this.shareDataService.init(serverConfig);
+      .then((serverConfig: any) => {
+        return this.initCorsProxy(this.configParameters, serverConfig);
+      })
+      .then(() => {
+        if (this.shareDataService && this.serverConfig.config) {
+          this.shareDataService.init(this.serverConfig.config);
         }
         if (options.applicationUrl) {
           return this.updateApplicationUrl(options.applicationUrl);


### PR DESCRIPTION
Should fix problem where ci mobx isn't shortening share urls. I also very slightly rewrote the relevant part of terria.ts to avoid confusion with `serverConfig`, which I originally thought was `this.serverConfig` but is actually `this.serverConfig.config`.