### PR TITLE
Change chartable test to check for `loadChartItems` instead of `chartItems`

### DIFF
--- a/lib/Models/Chartable.ts
+++ b/lib/Models/Chartable.ts
@@ -29,7 +29,7 @@ interface Chartable extends Model<ModelTraits> {
 
 namespace Chartable {
   export function is(model: BaseModel | Chartable): model is Chartable {
-    return "chartItems" in model;
+    return "loadChartItems" in model;
   }
 }
 


### PR DESCRIPTION
All tables define `chartItems` but they are all not chartable.