### PR TITLE
Mobx: fix feature server proxy url and token bugs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Change Log
 * Add a trait called `showShadowUi` to `Cesium3DTilesCatalogItem` which hide shadows on workbench item UI.
 * Re-added `ArcGisFeatureServerCatalogItem` and `ArcGisFeatureServerCatalogGroup`
 * Prevent TerriaMap from crashing when timeline is on and changing to 2D
+* Fixed `proxyCatalogItemUrl` so it always returns a url as a string and fixed bug causing `ArcGisFeatureServerCatalogItem` to throw an error when a token is included in the proxy url.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ Change Log
 * Add a trait called `showShadowUi` to `Cesium3DTilesCatalogItem` which hide shadows on workbench item UI.
 * Re-added `ArcGisFeatureServerCatalogItem` and `ArcGisFeatureServerCatalogGroup`
 * Prevent TerriaMap from crashing when timeline is on and changing to 2D
-* Fixed `proxyCatalogItemUrl` so it always returns a url as a string and fixed bug causing `ArcGisFeatureServerCatalogItem` to throw an error when a token is included in the proxy url.
+* Fixed bug causing `ArcGisFeatureServerCatalogItem` to throw an error when a token is included in the proxy url.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/proxyCatalogItemUrl.js
+++ b/lib/Models/proxyCatalogItemUrl.js
@@ -31,15 +31,10 @@ var proxyCatalogItemUrl = function(catalogItem, url, cacheDuration) {
     return url;
   }
 
-  const urlOrResource = corsProxy.getURL(
+  return corsProxy.getURL(
     url,
     defaultValue(catalogItem.cacheDuration, cacheDuration)
   );
-  if (urlOrResource instanceof Resource) {
-    return urlOrResource.url;
-  } else {
-    return urlOrResource;
-  }
 };
 
 module.exports = proxyCatalogItemUrl;

--- a/lib/Models/proxyCatalogItemUrl.js
+++ b/lib/Models/proxyCatalogItemUrl.js
@@ -3,7 +3,6 @@
 /*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-const Resource = require("terriajs-cesium/Source/Core/Resource").default;
 
 /**
  * Proxies a URL associated with a catalog item, if necessary.

--- a/lib/Models/proxyCatalogItemUrl.js
+++ b/lib/Models/proxyCatalogItemUrl.js
@@ -3,6 +3,7 @@
 /*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
+const Resource = require("terriajs-cesium/Source/Core/Resource").default;
 
 /**
  * Proxies a URL associated with a catalog item, if necessary.
@@ -30,10 +31,15 @@ var proxyCatalogItemUrl = function(catalogItem, url, cacheDuration) {
     return url;
   }
 
-  return corsProxy.getURL(
+  const urlOrResource = corsProxy.getURL(
     url,
     defaultValue(catalogItem.cacheDuration, cacheDuration)
   );
+  if (urlOrResource instanceof Resource) {
+    return urlOrResource.url;
+  } else {
+    return urlOrResource;
+  }
 };
 
 module.exports = proxyCatalogItemUrl;


### PR DESCRIPTION
Fixed bug causing `ArcGisFeatureServerCatalogItem` to throw an error when a token is included after its url is proxied.