### PR TITLE
include esri-featureServer-group in magda formats

### DIFF
--- a/lib/Models/MagdaReference.ts
+++ b/lib/Models/MagdaReference.ts
@@ -96,7 +96,7 @@ export default class MagdaReference extends UrlMixin(
     createStratumInstance(MagdaDistributionFormatTraits, {
       id: "EsriFeatureServer",
       formatRegex: "ESRI MAPSERVER", // TO DO - tidy up this magda format reference
-      urlRegex: "FeatureServer$|FeatureServer\/$",
+      urlRegex: "FeatureServer$|FeatureServer/$",
       definition: {
         type: "esri-featureServer-group"
       }
@@ -104,7 +104,7 @@ export default class MagdaReference extends UrlMixin(
     createStratumInstance(MagdaDistributionFormatTraits, {
       id: "EsriFeatureServer",
       formatRegex: "ESRI MAPSERVER", // TO DO - tidy up this magda format reference
-      urlRegex: "FeatureServer\/\d",
+      urlRegex: "FeatureServer/d",
       definition: {
         type: "esri-featureServer"
       }

--- a/lib/Models/MagdaReference.ts
+++ b/lib/Models/MagdaReference.ts
@@ -95,8 +95,16 @@ export default class MagdaReference extends UrlMixin(
     }),
     createStratumInstance(MagdaDistributionFormatTraits, {
       id: "EsriFeatureServer",
-      formatRegex: "^esri rest$",
-      urlRegex: "FeatureServer",
+      formatRegex: "ESRI MAPSERVER", // TO DO - tidy up this magda format reference
+      urlRegex: "FeatureServer$|FeatureServer\/$",
+      definition: {
+        type: "esri-featureServer-group"
+      }
+    }),
+    createStratumInstance(MagdaDistributionFormatTraits, {
+      id: "EsriFeatureServer",
+      formatRegex: "ESRI MAPSERVER", // TO DO - tidy up this magda format reference
+      urlRegex: "FeatureServer\/\d",
       definition: {
         type: "esri-featureServer"
       }


### PR DESCRIPTION
This fixes up magda references to feature servers

````
{
      "type": "magda",
      "url": "https://nsw.dt.terria.io",
      "name": "NSW Water Theme - Coastline",
      "isMappable": true,
      "recordId": "ds-nsw-portal-a169b3c9a29f4d85a46aa8dbdc063333"
  }
````
Which points to this portal item
https://portal.spatial.nsw.gov.au/portal/home/item.html?id=a169b3c9a29f4d85a46aa8dbdc063333

Weirdly the portal item points to a group of services and not an individual one but that's not our problem.

There is still a TO DO around somewhere an incorrect format type is being attached to the Feature distribution but that's something on the magda end I think...

