### PR TITLE
Fix east and west references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ Change Log
 * Prevent TerriaMap from crashing when timeline is on and changing to 2D
 * Rewrite charts using `vx` svg charting library.
 * Fixed bug causing `ArcGisFeatureServerCatalogItem` to throw an error when a token is included in the proxy url.
+* Fix a bug for zooming to `ArcGisMapServerCatalogItem` layers
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -506,9 +506,9 @@ function maximumScaleToLevel(maximumScale: number | undefined) {
 }
 
 function updateBbox(extent: Extent, rectangle: RectangleExtent) {
-  if (extent.xmin < rectangle.west) rectangle.west = extent.xmax;
+  if (extent.xmin < rectangle.west) rectangle.west = extent.xmin;
   if (extent.ymin < rectangle.south) rectangle.south = extent.ymin;
-  if (extent.xmax > rectangle.east) rectangle.east = extent.xmin;
+  if (extent.xmax > rectangle.east) rectangle.east = extent.xmax;
   if (extent.ymax > rectangle.north) rectangle.north = extent.ymax;
 }
 
@@ -545,7 +545,7 @@ function getRectangleFromLayer(
     const north = p[1];
 
     return updateBbox(
-      { xmin: east, ymin: south, xmax: west, ymax: north },
+      { xmin: west, ymin: south, xmax: east, ymax: north },
       rectangle
     );
   }


### PR DESCRIPTION
Fix east and west references in `ArcGisMapServerCatalogItem` to make zoom work properly.

https://github.com/TerriaJS/nsw-digital-twin/issues/282