### PR TITLE
Add support for classBreaks renderer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### Next release
+
+* Add support for `classBreaks` renderer to `ArcGisFeatureServerCatalogItem`.
+
 ### v7.11.2
 
 * Pass minimumLevel, in Cesium, to minNativeZoom, in Leaflet.

--- a/lib/Models/ArcGisFeatureServerCatalogItem.js
+++ b/lib/Models/ArcGisFeatureServerCatalogItem.js
@@ -244,10 +244,18 @@ function setupUniqueValRenderer(renderer) {
   return out;
 }
 
+// classMinValue is an optional key in the classBreakInfo, but classMaxValue is required
+// https://developers.arcgis.com/documentation/common-data-types/renderer-objects.htm
 function findClassBreak(value, classBreakInfos) {
   for (var i = 0; i < classBreakInfos.length; i++) {
     const classBreak = classBreakInfos[i];
-    if (value < classBreak.classMaxValue) {
+    if (!("classMinValue" in classBreak) && value <= classBreak.classMaxValue) {
+      return classBreak;
+    } else if (
+      "classMinValue" in classBreak &&
+      value <= classBreak.classMaxValue &&
+      value >= classBreak.classMinValue
+    ) {
       return classBreak;
     }
   }

--- a/lib/Models/ArcGisFeatureServerCatalogItem.js
+++ b/lib/Models/ArcGisFeatureServerCatalogItem.js
@@ -148,9 +148,22 @@ ArcGisFeatureServerCatalogItem.prototype._load = function() {
           entities.values.forEach(function(entity) {
             updateEntityWithEsriStyle(entity, renderer.symbol, that);
           });
+        } else if (renderer.type === "classBreaks") {
+          // For a 'classBreaks' renderer symbology gets applied via feature properties.
+          const field = renderer.field;
 
-          // For a 'uniqueValue' renderer symbology gets applied via feature properties.
+          entities.values.forEach(function(entity) {
+            const entityVal = entity.properties[field].getValue();
+            const classBreak = findClassBreak(
+              entityVal,
+              renderer.classBreakInfos
+            );
+            if (defined(classBreak)) {
+              updateEntityWithEsriStyle(entity, classBreak.symbol, that);
+            }
+          });
         } else if (renderer.type === "uniqueValue") {
+          // For a 'uniqueValue' renderer symbology gets applied via feature properties.
           const rendererObj = setupUniqueValRenderer(renderer);
 
           const primaryFieldForSymbology = renderer.field1;
@@ -231,6 +244,15 @@ function setupUniqueValRenderer(renderer) {
   return out;
 }
 
+function findClassBreak(value, classBreakInfos) {
+  for (var i = 0; i < classBreakInfos.length; i++) {
+    const classBreak = classBreakInfos[i];
+    if (value < classBreak.classMaxValue) {
+      return classBreak;
+    }
+  }
+}
+
 function updateEntityWithEsriStyle(entity, symbol, catalogItem) {
   function convertEsriColorToCesiumColor(esriColor) {
     return new Color.fromBytes(
@@ -280,6 +302,8 @@ function updateEntityWithEsriStyle(entity, symbol, catalogItem) {
         symbol.outline.color
       );
       entity.point.outlineWidth = symbol.outline.width;
+    } else if (symbol.outline === null) {
+      entity.point.outlineWidth = 0;
     }
   }
 


### PR DESCRIPTION
Test with this catalog item config

````
{
      "name": "Cases",
      "type": "esri-featureServer",
      "url": "https://services1.arcgis.com/0MSEUqKaxRlEPj5g/ArcGIS/rest/services/ncov_cases/FeatureServer/1",
      "useStyleInformationFromService": true
    }
````

You'll notice one point doesn't get styled, that's because it's above the max class break value. On an [ArcGIS map](https://www.arcgis.com/home/webmap/viewer.html?url=https://services1.arcgis.com/0MSEUqKaxRlEPj5g/ArcGIS/rest/services/ncov_cases/FeatureServer/1&source=sd) it doesn't display which doesn't quite seem right so in that case I'm just leaving it as the default point styling.

Also added support for `outline=null`on our point styling.