### PR TITLE
Mobx: add pointSizeMap to TableStyle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@ Change Log
 * Added AccessControlMixin for tracking access control of a given MagdaReference
 * Add a legend title trait
 * Show private or public dataset status on data catalog UI via AccessControlMixin
+* Added `pointSizeMap` to `TableStyle` to allow point size to be scaled by value
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Map/ConstantPointSizeMap.ts
+++ b/lib/Map/ConstantPointSizeMap.ts
@@ -1,0 +1,11 @@
+import PointSizeMap from "./PointSizeMap";
+
+export default class ConstantPointSizeMap extends PointSizeMap {
+  constructor(readonly pointSize: number) {
+    super();
+  }
+
+  mapValueToPointSize(value: string | number | null | undefined): number {
+    return this.pointSize;
+  }
+}

--- a/lib/Map/PointSizeMap.ts
+++ b/lib/Map/PointSizeMap.ts
@@ -1,0 +1,5 @@
+export default abstract class PointSizeMap {
+  abstract mapValueToPointSize(
+    value: string | number | null | undefined
+  ): number;
+}

--- a/lib/Map/ScalePointSizeMap.ts
+++ b/lib/Map/ScalePointSizeMap.ts
@@ -1,0 +1,25 @@
+import PointSizeMap from "./PointSizeMap";
+
+export default class ScalePointSizeMap extends PointSizeMap {
+  constructor(
+    readonly minimum: number,
+    readonly maximum: number,
+    readonly nullSize: number,
+    readonly sizeFactor: number,
+    readonly sizeOffset: number
+  ) {
+    super();
+  }
+
+  mapValueToPointSize(value: number | null | undefined): number {
+    if (value === undefined || value === null) {
+      return this.nullSize;
+    } else if (this.maximum === this.minimum) {
+      return this.sizeOffset;
+    } else {
+      const normalizedValue =
+        (value - this.minimum) / (this.maximum - this.minimum);
+      return normalizedValue * this.sizeFactor + this.sizeOffset;
+    }
+  }
+}

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -364,6 +364,8 @@ export default function TableMixin<T extends Constructor<Model<TableTraits>>>(
 
         const colorMap = (this.activeTableStyle || this.defaultTableStyle)
           .colorMap;
+        const pointSizeMap = (this.activeTableStyle || this.defaultTableStyle)
+          .pointSizeMap;
 
         const outlineColor = Color.fromCssColorString(
           "white" //this.terria.baseMapContrastColor;
@@ -385,7 +387,7 @@ export default function TableMixin<T extends Constructor<Model<TableTraits>>>(
               position: Cartesian3.fromDegrees(longitude, latitude, 0.0),
               point: new PointGraphics({
                 color: colorMap.mapValueToColor(value),
-                pixelSize: 15,
+                pixelSize: pointSizeMap.mapValueToPointSize(value),
                 outlineWidth: 1,
                 outlineColor: outlineColor,
                 heightReference: HeightReference.CLAMP_TO_GROUND

--- a/lib/Table/TableAutomaticStylesStratum.ts
+++ b/lib/Table/TableAutomaticStylesStratum.ts
@@ -13,6 +13,7 @@ import TableChartStyleTraits, {
   TableChartLineStyleTraits
 } from "../Traits/TableChartStyleTraits";
 import TableColorStyleTraits from "../Traits/TableColorStyleTraits";
+import TablePointSizeStyleTraits from "../Traits/TablePointSizeStyleTraits";
 import TableStyleTraits from "../Traits/TableStyleTraits";
 import TableColumnType from "./TableColumnType";
 import TableStyle from "./TableStyle";
@@ -95,6 +96,9 @@ export default class TableAutomaticStylesStratum extends LoadableStratum(
         color: createStratumInstance(TableColorStyleTraits, {
           colorColumn: column.name,
           legend: this._createLegendForColorStyle(i)
+        }),
+        pointSize: createStratumInstance(TablePointSizeStyleTraits, {
+          pointSizeColumn: column.name
         })
       })
     );

--- a/lib/Table/TableStyle.ts
+++ b/lib/Table/TableStyle.ts
@@ -5,8 +5,10 @@ import ColorMap from "../Map/ColorMap";
 import ConstantColorMap from "../Map/ConstantColorMap";
 import DiscreteColorMap from "../Map/DiscreteColorMap";
 import EnumColorMap from "../Map/EnumColorMap";
+import PointSizeMap from "../Map/PointSizeMap";
+import ConstantPointSizeMap from "../Map/ConstantPointSizeMap";
+import ScalePointSizeMap from "../Map/ScalePointSizeMap";
 import createCombinedModel from "../Models/createCombinedModel";
-import FlattenedFromTraits from "../Models/FlattenedFromTraits";
 import Model from "../Models/Model";
 import ModelPropertiesFromTraits from "../Models/ModelPropertiesFromTraits";
 import TableChartStyleTraits from "../Traits/TableChartStyleTraits";
@@ -19,6 +21,7 @@ import TableTraits from "../Traits/TableTraits";
 import ColorPalette from "./ColorPalette";
 import TableColumn from "./TableColumn";
 import TableColumnType from "./TableColumnType";
+import isDefined from "../Core/isDefined";
 
 const defaultColor = "yellow";
 
@@ -348,6 +351,30 @@ export default class TableStyle {
           : Color.fromCssColorString(defaultColor);
       return new ConstantColorMap(color);
     }
+  }
+
+  @computed
+  get pointSizeMap(): PointSizeMap {
+    const pointSizeColumn = this.pointSizeColumn;
+    const pointSizeTraits = this.pointSizeTraits;
+
+    if (pointSizeColumn && pointSizeColumn.type === TableColumnType.scalar) {
+      const maximum = pointSizeColumn.valuesAsNumbers.maximum;
+      const minimum = pointSizeColumn.valuesAsNumbers.minimum;
+
+      if (isDefined(maximum) && isDefined(minimum) && maximum !== minimum) {
+        return new ScalePointSizeMap(
+          minimum,
+          maximum,
+          pointSizeTraits.nullSize,
+          pointSizeTraits.sizeFactor,
+          pointSizeTraits.sizeOffset
+        );
+      }
+    }
+
+    // can't scale point size by values in this column, so use same point size for every value
+    return new ConstantPointSizeMap(pointSizeTraits.sizeOffset);
   }
 
   private resolveColumn(name: string | undefined): TableColumn | undefined {

--- a/lib/Traits/TablePointSizeStyleTraits.ts
+++ b/lib/Traits/TablePointSizeStyleTraits.ts
@@ -15,7 +15,7 @@ export default class TablePointSizeStyleTraits extends ModelTraits {
       "The point size, in pixels, to use when the column has no value.",
     type: "number"
   })
-  nullSize: number = 5;
+  nullSize: number = 7;
 
   @primitiveTrait({
     name: "Size Factor",
@@ -27,7 +27,7 @@ export default class TablePointSizeStyleTraits extends ModelTraits {
       "the highest.",
     type: "number"
   })
-  sizeFactor: number = 5;
+  sizeFactor: number = 14;
 
   @primitiveTrait({
     name: "Size Offset",
@@ -39,5 +39,5 @@ export default class TablePointSizeStyleTraits extends ModelTraits {
       "the highest.",
     type: "number"
   })
-  sizeOffset: number = 5;
+  sizeOffset: number = 7;
 }


### PR DESCRIPTION
Allow point sizes to be scaled by value, e.g.

<img width="524" alt="image" src="https://user-images.githubusercontent.com/40459355/74812174-177be380-5347-11ea-8757-04a832970050.png">
