### PR TITLE
Add style panel for WebMapServiceCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,7 +50,7 @@ Change Log
 * Added `pointSizeMap` to `TableStyle` to allow point size to be scaled by value
 * Added `isExperiencingIssues` to `CatalogMemberTraits`. When set to true, an alert is displayed above the catalog item description.
 * Add gyroscope guidance
-* Enable StyleSelector workbench control for `WebMapServiceCatalogItem`
+* Enable StyleSelectorSection workbench control for `WebMapServiceCatalogItem`
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@ Change Log
 * Added `pointSizeMap` to `TableStyle` to allow point size to be scaled by value
 * Added `isExperiencingIssues` to `CatalogMemberTraits`. When set to true, an alert is displayed above the catalog item description.
 * Add gyroscope guidance
+* Enable StyleSelector workbench control for `WebMapServiceCatalogItem`
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
@@ -57,7 +57,7 @@ const StyleSelectorSection = createReactClass({
         >
           {availableStyles.map(item => (
             <option key={item.name} value={item.name}>
-              {item.name}
+              {item.title}
             </option>
           ))}
         </select>

--- a/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
@@ -56,7 +56,7 @@ const StyleSelectorSection = createReactClass({
           onChange={this.changeStyle.bind(this, styleSelector)}
         >
           {availableStyles.map(item => (
-            <option key={item.id} value={item.id}>
+            <option key={item.name} value={item.name}>
               {item.name}
             </option>
           ))}


### PR DESCRIPTION
Re-adds the style selector for WebMapServiceCatalogItem. Seems to work okay with sharing.

![screenshot-localhost_3001-2020 02 20-22_48_11](https://user-images.githubusercontent.com/6735870/74931122-19bb6c00-5433-11ea-82ad-f55a7820c09c.png)
