### PR TITLE
Mobx: Default esri-featureServer items to clamping to ground.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,7 @@ Change Log
 * Moved excess workbench viewing controls into menu
 * Updated bottom attribution styling
 * Begin styled components themeing
+* Make `clampToGround` default to true for `ArcGisFeatureServerCatalogItemTraits` to stop things from floating
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Traits/ArcGisFeatureServerCatalogItemTraits.ts
+++ b/lib/Traits/ArcGisFeatureServerCatalogItemTraits.ts
@@ -19,7 +19,7 @@ export default class ArcGisFeatureServerCatalogItemTraits extends mixTraits(
     description:
       "Whether the features in this service should be clamped to the terrain surface."
   })
-  clampToGround: boolean = false;
+  clampToGround: boolean = true;
 
   @primitiveTrait({
     type: "boolean",


### PR DESCRIPTION
````
{
      "type": "esri-featureServer",
      "name": "disputed boundaries",
      "url": "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/Disputed_Boundary_Lines/FeatureServer/0",
    }
````

**With the clamp**
![ClampToGound](https://user-images.githubusercontent.com/6735870/74987998-b7915400-5490-11ea-9bbc-518ee7ab4615.png)


**Without clamp**
![WithoutClamp](https://user-images.githubusercontent.com/6735870/74988068-ee676a00-5490-11ea-8c8c-f5189785ebe3.png)
