### PR TITLE
Add additional check for userstrata when computing styleSelector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,7 @@ Change Log
 * Updated bottom attribution styling
 * Begin styled components themeing
 * Make `clampToGround` default to true for `ArcGisFeatureServerCatalogItemTraits` to stop things from floating
+* Add fix for `WebMapServiceCatalogItem` in `styleSelector` to prevent crash.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -469,6 +469,7 @@ class WebMapServiceCatalogItem
     const userStrata: any = this.strata.get(CommonStrata.user);
     let activeStyle = this.availableStyles[0].styles[0].name;
     if (
+      isDefined(userStrata) &&
       isDefined(userStrata.parameters) &&
       isDefined(userStrata.parameters.styles)
     ) {


### PR DESCRIPTION
Think this was sometimes causing a crash...

````
{
      "type": "wms",
      "name": "Landsat layer",
      "url": "https://gsky.nci.org.au/ows/dea",
      "layers": "landsat5_nbar_16day"
    }
````