### PR TITLE
Mobx: temporary fix for errors while loading init data models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,7 @@ Change Log
 * Updated bottom attribution styling
 * Begin styled components themeing
 * Make `clampToGround` default to true for `ArcGisFeatureServerCatalogItemTraits` to stop things from floating
+* Added a temporary fix for bug where a single model failing to load in `applyInitData` in `Terria` would cause other models in the same `initData` object to not load as well.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -680,7 +680,10 @@ export default class Terria {
             stratumId,
             models,
             replaceStratum
-          );
+          ).catch(() => {
+            // TODO: deal with shared models that can't be loaded because, e.g. because they are private
+            return Promise.resolve();
+          });
         })
       ).then(() => undefined);
     } else {

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -680,8 +680,9 @@ export default class Terria {
             stratumId,
             models,
             replaceStratum
-          ).catch(() => {
+          ).catch(e => {
             // TODO: deal with shared models that can't be loaded because, e.g. because they are private
+            console.log(e);
             return Promise.resolve();
           });
         })


### PR DESCRIPTION
A temporary fix for TerriaJS/nsw-digital-twin#249.