### PR TITLE
Mobx: Fix style selector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ Change Log
 * Begin styled components themeing
 * Make `clampToGround` default to true for `ArcGisFeatureServerCatalogItemTraits` to stop things from floating
 * Add fix for `WebMapServiceCatalogItem` in `styleSelector` to prevent crash.
+* Revert changes to `StyleSelectorSelection` component and refactor `WebMapServiceCatalogItem` styleSelector getter.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -164,9 +164,9 @@ class GetCapabilitiesStratum extends LoadableStratum(
                 candidate => candidate.name === style
               );
         if (layerStyle !== undefined && layerStyle.legend !== undefined) {
-          result.push(
-            <StratumFromTraits<LegendTraits>>(<unknown>layerStyle.legend)
-          );
+          result.push(<StratumFromTraits<LegendTraits>>(
+            (<unknown>layerStyle.legend)
+          ));
         }
       }
     }
@@ -479,7 +479,12 @@ class WebMapServiceCatalogItem
       name: "Styles",
       id: `styles-${this.uniqueId}`,
       activeStyleId: activeStyle,
-      availableStyles: this.availableStyles[0].styles,
+      availableStyles: this.availableStyles[0].styles.map(function(s) {
+        return {
+          name: s.title,
+          id: s.name
+        };
+      }),
       chooseActiveStyle: (strata: string, newStyle: string) => {
         let newParameters = {
           styles: newStyle

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -164,9 +164,9 @@ class GetCapabilitiesStratum extends LoadableStratum(
                 candidate => candidate.name === style
               );
         if (layerStyle !== undefined && layerStyle.legend !== undefined) {
-          result.push(<StratumFromTraits<LegendTraits>>(
-            (<unknown>layerStyle.legend)
-          ));
+          result.push(
+            <StratumFromTraits<LegendTraits>>(<unknown>layerStyle.legend)
+          );
         }
       }
     }

--- a/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/StyleSelectorSection.jsx
@@ -56,8 +56,8 @@ const StyleSelectorSection = createReactClass({
           onChange={this.changeStyle.bind(this, styleSelector)}
         >
           {availableStyles.map(item => (
-            <option key={item.name} value={item.name}>
-              {item.title}
+            <option key={item.id} value={item.id}>
+              {item.name}
             </option>
           ))}
         </select>


### PR DESCRIPTION
Revert changes to `StyleSelectorSelection` component that were introduced [here](https://github.com/TerriaJS/terriajs/pull/4045/files#diff-d24289c2bee74f5d67478b6751505972) and subsequently refactor `WebMapServiceCatalogItem` styleSelector getter.