### PR TITLE
Mobx - Prevent StoryPanel from reloading data references when navigating story

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@ Change Log
 * Added a temporary fix for bug where a single model failing to load in `applyInitData` in `Terria` would cause other models in the same `initData` object to not load as well.
 * Change gyroscope focus/hover behaviour to move buttons on hover
 * Stop showing previewed item when catalog is closed
+* Prevent `StoryPanel.jsx` from reloading magda references on move through story.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -205,9 +205,9 @@ export default class Cesium extends GlobeOrMap {
         );
       }
       if (expandLink) {
-        let attributionToAboutPage = document.createElement('div');
+        let attributionToAboutPage = document.createElement("div");
         attributionToAboutPage.innerHTML = `<a href="about.html#data-attribution" target="_blank" rel="noopener noreferrer">Data attribution</a>`;
-        let disclaimerToAboutPage = document.createElement('div');
+        let disclaimerToAboutPage = document.createElement("div");
         disclaimerToAboutPage.innerHTML = `<a href="about.html#disclaimer" target="_blank" rel="noopener noreferrer">Disclaimer</a>`;
 
         logoContainer.parentNode.insertBefore(

--- a/lib/ReactViews/Story/StoryPanel.jsx
+++ b/lib/ReactViews/Story/StoryPanel.jsx
@@ -17,7 +17,7 @@ export function activateStory(story, terria) {
       return story.shareData.initSources.map(initSource =>
         terria.applyInitData({
           initData: initSource,
-          replaceStratum: true
+          replaceStratum: false
         })
       );
     }


### PR DESCRIPTION
Prevent over-excessive reloading of data & magda references when navigating through stories.