### PR TITLE
Mobx: enable zoomTo and splitter on CartoMapCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,7 +67,7 @@ Change Log
 * Add google analytics to mobx
 * Fixed google analytics on story panel
 * Fixed path event name undefined labelling
-* Enable `zoomTo` on `CartoMapCatalogItem`.
+* Enable zoomTo and splitter on `CartoMapCatalogItem`.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@ Change Log
 * Add google analytics to mobx
 * Fixed google analytics on story panel
 * Fixed path event name undefined labelling
+* Enable `zoomTo` on `CartoMapCatalogItem`.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/CartoMapCatalogItem.ts
+++ b/lib/Models/CartoMapCatalogItem.ts
@@ -117,6 +117,10 @@ export default class CartoMapCatalogItem
     return true;
   }
 
+  get canZoomTo() {
+    return true;
+  }
+
   @computed get mapItems() {
     if (isDefined(this.imageryProvider)) {
       return [

--- a/lib/Models/CartoMapCatalogItem.ts
+++ b/lib/Models/CartoMapCatalogItem.ts
@@ -121,6 +121,10 @@ export default class CartoMapCatalogItem
     return isDefined(this.rectangle);
   }
 
+  get supportsSplitting() {
+    return true;
+  }
+
   @computed get mapItems() {
     if (isDefined(this.imageryProvider)) {
       return [

--- a/lib/Models/CartoMapCatalogItem.ts
+++ b/lib/Models/CartoMapCatalogItem.ts
@@ -118,7 +118,7 @@ export default class CartoMapCatalogItem
   }
 
   get canZoomTo() {
-    return true;
+    return isDefined(this.rectangle);
   }
 
   @computed get mapItems() {

--- a/lib/Traits/CartoMapCatalogItemTraits.ts
+++ b/lib/Traits/CartoMapCatalogItemTraits.ts
@@ -8,9 +8,11 @@ import MappableTraits from "./MappableTraits";
 import CatalogMemberTraits from "./CatalogMemberTraits";
 import UrlTraits from "./UrlTraits";
 import LegendTraits from "./LegendTraits";
+import SplitterTraits from "./SplitterTraits";
 import { JsonObject } from "../Core/Json";
 
 export default class CartoMapCatalogItemTraits extends mixTraits(
+  SplitterTraits,
   RasterLayerTraits,
   UrlTraits,
   MappableTraits,


### PR DESCRIPTION
Test with 
```
{
"name": "NSW Combined Drought Indicator",
"url": "https://edis.carto.com/api/v1/map/named/DAILY_CDI2",
"type": "carto",
"opacity": 1,
"rectangle": { "west": 140.3, "south": -38.5, "east": 154.5, "north": -27.5 }
}
```