### PR TITLE
Mobx: prevent unnecessary feature info requests when using measure tool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@ Change Log
 * Fixed google analytics on story panel
 * Fixed path event name undefined labelling
 * Added name to `MapServerStratum` in `ArcGisMapServerCatalogItem`.
+* Added `allowFeatureInfoRequests` property to `Terria` and prevent unnecessary feature info requests when creating `UserDrawing`s.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -817,10 +817,9 @@ export default class Cesium extends GlobeOrMap {
     const vectorFeatures = this.pickVectorFeatures(screenPosition);
 
     const providerCoords = this._attachProviderCoordHooks();
-    const pickRasterPromise = this.scene.imageryLayers.pickImageryLayerFeatures(
-      pickRay,
-      this.scene
-    );
+    var pickRasterPromise = this.terria.allowFeatureInfoRequests
+    ? this.scene.imageryLayers.pickImageryLayerFeatures(pickRay, this.scene)
+    : undefined;
 
     const result = this._buildPickedFeatures(
       providerCoords,

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -819,8 +819,8 @@ export default class Cesium extends GlobeOrMap {
 
     const providerCoords = this._attachProviderCoordHooks();
     var pickRasterPromise = this.terria.allowFeatureInfoRequests
-    ? this.scene.imageryLayers.pickImageryLayerFeatures(pickRay, this.scene)
-    : undefined;
+      ? this.scene.imageryLayers.pickImageryLayerFeatures(pickRay, this.scene)
+      : undefined;
 
     const result = this._buildPickedFeatures(
       providerCoords,

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -495,11 +495,13 @@ export default class Leaflet extends GlobeOrMap {
     });
 
     const imageryLayers: CesiumTileLayer[] = [];
-    this.map.eachLayer(layer => {
-      if (isImageryLayer(layer)) {
-        imageryLayers.push(layer);
-      }
-    });
+    if (this.terria.allowFeatureInfoRequests) {
+      this.map.eachLayer(layer => {
+        if (isImageryLayer(layer)) {
+          imageryLayers.push(layer);
+        }
+      });
+    }
     tileCoordinates = defaultValue(tileCoordinates, {});
 
     const pickedLocation = Cartographic.fromDegrees(latlng.lng, latlng.lat);

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -199,6 +199,9 @@ export default class Terria {
   @observable
   selectedFeature: Feature | undefined;
 
+  @observable
+  allowFeatureInfoRequests: boolean = true;
+
   /**
    * Gets or sets the stack of map interactions modes.  The mode at the top of the stack
    * (highest index) handles click interactions with the map

--- a/lib/Models/UserDrawing.ts
+++ b/lib/Models/UserDrawing.ts
@@ -158,9 +158,10 @@ export default class UserDrawing extends CreateModel(EmptyTraits) {
       }
     }
 
-    // Cancel any feature picking already in progress.
+    // Cancel any feature picking already in progress and disable feature info requests.
     runInAction(() => {
       this.terria.pickedFeatures = undefined;
+      this.terria.allowFeatureInfoRequests = false;
     });
     const that = this;
 
@@ -353,10 +354,12 @@ export default class UserDrawing extends CreateModel(EmptyTraits) {
   /**
    * User has finished or cancelled; restore initial state.
    */
-  private cleanUp() {
+  cleanUp() {
     this.terria.overlays.remove(this);
     this.pointEntities = new CustomDataSource("Points");
     this.otherEntities = new CustomDataSource("Lines and polygons");
+
+    this.terria.allowFeatureInfoRequests = true;
 
     this.inDrawMode = false;
     this.closeLoop = false;

--- a/test/Models/UserDrawingSpec.ts
+++ b/test/Models/UserDrawingSpec.ts
@@ -79,6 +79,23 @@ describe("UserDrawing", function() {
     expect(userDrawing.terria.mapInteractionModeStack.length).toEqual(1);
   });
 
+  it("disables feature info requests when in drawing mode", function() {
+    var options = { terria: terria };
+    var userDrawing = new UserDrawing(options);
+    expect(userDrawing.terria.allowFeatureInfoRequests).toEqual(true);
+    userDrawing.enterDrawMode();
+    expect(userDrawing.terria.allowFeatureInfoRequests).toEqual(false);
+  });
+
+  it("re-enables feature info requests on cleanup", function() {
+    var options = { terria: terria };
+    var userDrawing = new UserDrawing(options);
+    userDrawing.enterDrawMode();
+    expect(userDrawing.terria.allowFeatureInfoRequests).toEqual(false);
+    userDrawing.cleanUp();
+    expect(userDrawing.terria.allowFeatureInfoRequests).toEqual(true);
+  });
+
   it("ensures onPointClicked callback is called when point is picked by user", function() {
     const onPointClicked = jasmine.createSpy();
     const userDrawing = new UserDrawing({ terria, onPointClicked });


### PR DESCRIPTION
Port #3937 (except the cesium and leaflet tests) to mobx. Resolves #4049.