### PR TITLE
Fix urijs typings version to 1.19.1 until we do a permanent fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/react": "^16.8.18",
     "@types/react-dom": "^16.9.1",
     "@types/styled-components": "^4.4.3",
-    "@types/urijs": "^1.19.1",
+    "@types/urijs": "1.19.1",
     "@vx/axis": "^0.0.193-alpha.2",
     "@vx/clip-path": "^0.0.193-alpha.2",
     "@vx/event": "^0.0.193-alpha.2",


### PR DESCRIPTION
Fix urijs typings version to 1.19.1 for now so that CI builds pass.

Issue to upgrade typings: https://github.com/TerriaJS/terriajs/issues/4116