### PR TITLE
Mobx: Fallback name for ArcGisServerCatalogItem names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,7 @@ Change Log
 * Updated upload icon to point upwards
 * Prevent catalog item names from overflowing and pushing the collapse button off the workbench
 * Stopped analytics launch event sending bad label
+* Provide a fallback name for an `ArcGisServerCatalogItem`
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -48,6 +48,7 @@ interface MapServer {
   documentInfo?: DocumentInfo;
   description?: string;
   copyrightText?: string;
+  mapName?: string;
 }
 
 interface SpatialReference {
@@ -212,6 +213,8 @@ class MapServerStratum extends LoadableStratum(
       this._mapServer.documentInfo.Title.length > 0
     ) {
       return replaceUnderscores(this._mapServer.documentInfo.Title);
+    } else if (this._mapServer.mapName && this._mapServer.mapName.length > 0) {
+      return replaceUnderscores(this._mapServer.mapName);
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/TerriaJS/nsw-digital-twin/issues/322

Add this MapServer and notice that the name is shown as the url
https://sampleserver6.arcgisonline.com/arcgis/rest/services/911CallsHotspot/MapServer

Example in [mobx branch](http://ci.terria.io/mobx/#share=s-hdcKz6762p9UMh6HiM8HOix1Oqw)

This service doesn't have anything defined in the `documentInfo`, it does however have something in the `mapName` so we can use that instead.

