### PR TITLE
Ignore invalid HTTP 200 responses for tile image requests.

### DIFF
--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -1183,17 +1183,21 @@ ImageryLayerCatalogItem.enableLayer = function(
             } else if (!defined(e.statusCode) && defined(e.target)) {
               // This is a failed image element, which means we got a 200 response but
               // could not load it as an image.
-              failTile({
-                name: i18next.t("models.imageryLayer.tileErrorTitle"),
-                message: i18next.t("models.imageryLayer.tileErrorMessageII", {
-                  url: getUrlForImageryTile(
-                    imageryProvider,
-                    tileProviderError.x,
-                    tileProviderError.y,
-                    tileProviderError.level
-                  )
-                })
-              });
+              if (catalogItem.ignoreUnknownTileErrors) {
+                tellMapToSilentlyGiveUp();
+              } else {
+                failTile({
+                  name: i18next.t("models.imageryLayer.tileErrorTitle"),
+                  message: i18next.t("models.imageryLayer.tileErrorMessageII", {
+                    url: getUrlForImageryTile(
+                      imageryProvider,
+                      tileProviderError.x,
+                      tileProviderError.y,
+                      tileProviderError.level
+                    )
+                  })
+                });
+              }
             } else if (!defined(e.statusCode)) {
               // On a modern-ish browser, this is probably a CORS problem, but can also be a
               // domain name lookup failure or a general network failure.


### PR DESCRIPTION
Fixes #3990 
Ignores image responses that are 200 OK but are actually something else (like a service error XML), instead of throwing an error.