### PR TITLE
Ensure getTileUrl always returns a string.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,7 @@ Change Log
 * Updated upload icon to point upwards
 * Prevent catalog item names from overflowing and pushing the collapse button off the workbench
 * Stopped analytics launch event sending bad label
+* Ensure `CesiumTileLayer.getTileUrl` returns a string.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Map/CesiumTileLayer.ts
+++ b/lib/Map/CesiumTileLayer.ts
@@ -193,11 +193,13 @@ export default class CesiumTileLayer extends L.TileLayer {
       return this.options.errorTileUrl;
     }
 
-    return getUrlForImageryTile(
-      this.imageryProvider,
-      tilePoint.x,
-      tilePoint.y,
-      level
+    return (
+      getUrlForImageryTile(
+        this.imageryProvider,
+        tilePoint.x,
+        tilePoint.y,
+        level
+      ) || ""
     );
   }
 

--- a/lib/Map/CesiumTileLayer.ts
+++ b/lib/Map/CesiumTileLayer.ts
@@ -187,10 +187,11 @@ export default class CesiumTileLayer extends L.TileLayer {
     return tile;
   }
 
-  getTileUrl(tilePoint: L.Coords) {
+  getTileUrl(tilePoint: L.Coords): string {
     const level = this._getLevelFromZ(tilePoint);
+    const errorTileUrl = this.options.errorTileUrl || "";
     if (level < 0) {
-      return this.options.errorTileUrl;
+      return errorTileUrl;
     }
 
     return (
@@ -199,7 +200,7 @@ export default class CesiumTileLayer extends L.TileLayer {
         tilePoint.x,
         tilePoint.y,
         level
-      ) || ""
+      ) || errorTileUrl
     );
   }
 


### PR DESCRIPTION
### What this PR does

Ensures that `getTileUrl` always returns a string to satisfy the type of parent class.

For fixing the following type errors in CI.

```
npm ERR! prepareGitDep lib/Map/CesiumTileLayer.ts(190,3): error TS2416: Property 'getTileUrl' in type 'CesiumTileLayer' is not assignable to the same property in base type 'TileLayer'.

npm ERR! prepareGitDep   Type '(tilePoint: Coords) => string | undefined' is not assignable to type '(coords: Coords) => string'.

npm ERR! prepareGitDep     Type 'string | undefined' is not assignable to type 'string'.

npm ERR! prepareGitDep       Type 'undefined' is not assignable to type 'string'.
```

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
