### PR TITLE
Add babel dynamic-import plugin.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### Next
+
+* Added babel dynamic import plugin for webpack builds.
+
 ### v7.11.2
 
 * Pass minimumLevel, in Cesium, to minNativeZoom, in Leaflet.

--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -85,7 +85,8 @@ function configureWebpack(terriaJSBasePath, config, devMode, hot, MiniCssExtract
             presets: ['@babel/preset-env', '@babel/preset-react'],
             plugins: [
                 'babel-plugin-jsx-control-statements',
-                '@babel/plugin-transform-modules-commonjs'
+                '@babel/plugin-transform-modules-commonjs',
+                '@babel/plugin-syntax-dynamic-import',
             ]
         }
     });

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "worker-loader": "^2.0.0"
   },
   "devDependencies": {
+    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "babel-eslint": "^10.0.1",
     "electron": "^2.0.0",
     "eslint": "^5.14.1",


### PR DESCRIPTION
### What this PR does

Enables babel dynamic import plugin in webpack build. Not having it was causing errors when building and loading downstream maps.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
      Just a build config change
-   [x] I've updated CHANGES.md with what I changed.
