### PR TITLE
fixed Cesium3DTilesCatalogItem to work with ionAssetIds

### DIFF
--- a/lib/Models/Cesium3DTilesCatalogItem.ts
+++ b/lib/Models/Cesium3DTilesCatalogItem.ts
@@ -92,12 +92,8 @@ export default class Cesium3DTilesCatalogItem
   }
 
   private loadTileset() {
-    if (!isDefined(this.url)) {
-      return;
-    }
-
     const tileset = this.createNewTileset(
-      proxyCatalogItemUrl(this, this.url),
+      this.url,
       this.ionAssetId,
       this.ionAccessToken,
       this.ionServer,
@@ -147,7 +143,7 @@ export default class Cesium3DTilesCatalogItem
   }
 
   private createNewTileset(
-    url: Resource | string,
+    url: Resource | string | undefined,
     ionAssetId: number | undefined,
     ionAccessToken: string | undefined,
     ionServer: string | undefined,
@@ -172,7 +168,7 @@ export default class Cesium3DTilesCatalogItem
       if (url instanceof Resource) {
         resource = url;
       } else {
-        resource = new Resource({ url });
+        resource = new Resource({ url: proxyCatalogItemUrl(this, url) });
       }
     }
 


### PR DESCRIPTION
### Fix Cesium3DTilesCatalogItem `ionAssetIds`

You could only create catalog items with the `url` property, but not the `ionAssetIds`. Whereas you should be able to create one with either property.

For example:

```json
{
  "name": "Test",
  "type": "3d-tiles",
  "ionAssetId": 1234,
}
```

```json
{
  "name": "Brisbane 3D city model (aero3Dpro)",
  "type": "3d-tiles",
  "url": "https://sample.aero3dpro.com.au/BrisbaneCBD/Scene/recon_h_3DTiles.json",
  "options": {
    "maximumScreenSpaceError": 1,
    "maximumNumberOfLoadedTiles": 1000
  },
  "rectangle": [
    153.01,
    -27.484,
    153.034,
    -27.46
  ]
}
```