### PR TITLE
Mobx remove model references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,7 @@ Change Log
 * Stopped analytics launch event sending bad label
 * Provide a fallback name for an `ArcGisServerCatalogItem`
 * Ensure `CesiumTileLayer.getTileUrl` returns a string.
+* Adds methods `removeModelReferences` to Terria & ViewState for unregistering and removing models from different parts of the UI.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Map/PickedFeatures.ts
+++ b/lib/Map/PickedFeatures.ts
@@ -1,6 +1,9 @@
+import { observable } from "mobx";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Entity from "terriajs-cesium/Source/DataSources/Entity";
-import { observable } from "mobx";
+import Feature from "../Models/Feature";
+import Mappable, { ImageryParts } from "../Models/Mappable";
+import { BaseModel } from "../Models/Model";
 
 export type ProviderCoords = { x: number; y: number; level: number };
 export type ProviderCoordsMap = { [url: string]: ProviderCoords };
@@ -39,4 +42,33 @@ export default class PickedFeatures {
   @observable error: string | undefined;
 
   providerCoords: ProviderCoordsMap | undefined;
+}
+
+export function featureBelongsToCatalogItem(
+  feature: Feature,
+  catalogItem: BaseModel
+) {
+  if (feature._catalogItem === catalogItem) return true;
+
+  if (!Mappable.is(catalogItem)) return;
+
+  const dataSource = feature.entityCollection?.owner;
+  const imageryProvider = feature.imageryLayer?.imageryProvider;
+
+  // Test whether the catalog item has a matching dataSource or an imageryProvider
+  const match = catalogItem.mapItems.some(mapItem => {
+    if (dataSource && mapItem === dataSource) {
+      return true;
+    }
+    if (
+      imageryProvider &&
+      ImageryParts.is(mapItem) &&
+      mapItem.imageryProvider === imageryProvider
+    ) {
+      return true;
+    }
+    return false;
+  });
+
+  return match;
 }

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -339,12 +339,13 @@ export default class Terria {
    * Remove references to a model from Terria.
    */
   @action
-  removeModelFromTerria(model: BaseModel) {
-    if (this.pickedFeatures) {
+  removeModelReferences(model: BaseModel) {
+    const pickedFeatures = this.pickedFeatures;
+    if (pickedFeatures) {
       // Remove picked features that belong to the catalog item
-      this.pickedFeatures.features.forEach((feature, i) => {
+      pickedFeatures.features.forEach((feature, i) => {
         if (featureBelongsToCatalogItem(<Feature>feature, model)) {
-          this.pickedFeatures?.features.splice(i, 1);
+          pickedFeatures?.features.splice(i, 1);
         }
       });
     }

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -291,7 +291,7 @@ export default class ViewState {
    * Removes references of a model from viewState
    */
   @action
-  removeModelFromViews(model: BaseModel) {
+  removeModelReferences(model: BaseModel) {
     if (this.previewedItem === model) this.previewedItem = undefined;
     if (this.userDataPreviewedItem === model)
       this.userDataPreviewedItem = undefined;

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -287,6 +287,16 @@ export default class ViewState {
     this.mobileView = viewName;
   }
 
+  /**
+   * Removes references of a model from viewState
+   */
+  @action
+  removeModelFromViews(model: BaseModel) {
+    if (this.previewedItem === model) this.previewedItem = undefined;
+    if (this.userDataPreviewedItem === model)
+      this.userDataPreviewedItem = undefined;
+  }
+
   getNextNotification() {
     return this.notifications.length && this.notifications[0];
   }

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -4,13 +4,13 @@ import defined from "terriajs-cesium/Source/Core/defined";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
 import FeatureInfoCatalogItem from "./FeatureInfoCatalogItem";
+import { featureBelongsToCatalogItem } from "../../Map/PickedFeatures.ts";
 import DragWrapper from "../DragWrapper";
 import Loader from "../Loader";
 import React from "react";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import Entity from "terriajs-cesium/Source/DataSources/Entity";
-import i18next from "i18next";
 import { withTranslation } from "react-i18next";
 import Icon from "../Icon";
 import {
@@ -21,7 +21,7 @@ import {
 } from "../../Models/LocationMarkerUtils";
 import prettifyCoordinates from "../../Map/prettifyCoordinates";
 import raiseErrorToUser from "../../Models/raiseErrorToUser";
-
+import i18next from "i18next";
 import Styles from "./feature-info-panel.scss";
 import classNames from "classnames";
 import { observer, disposeOnUnmount } from "mobx-react";
@@ -449,71 +449,24 @@ function getFeaturesGroupedByCatalogItems(terria) {
   return { catalogItems, featureCatalogItemPairs };
 }
 
-/**
- * Figures out what the catalog item for a feature is.
- *
- * @param workbench {@link Workbench} to look in the items for.
- * @param feature Feature to match
- * @returns {CatalogItem}
- */
 function determineCatalogItem(workbench, feature) {
-  if (!defined(workbench)) {
-    // So that specs do not need to define a workbench.
-    return undefined;
+  // If the feature is a marker return a fake item
+  if (feature.entityCollection && feature.entityCollection.owner) {
+    const dataSource = feature.entityCollection.owner;
+    if (dataSource.name === LOCATION_MARKER_DATA_SOURCE_NAME) {
+      return {
+        name: i18next.t("featureInfo.locationMarker")
+      };
+    }
   }
 
   if (feature._catalogItem) {
     return feature._catalogItem;
   }
 
-  // "Data sources" (eg. czml, geojson, kml, csv) have an entity collection defined on the entity
-  // (and therefore the feature).
-  // Then match up the data source on the feature with a now-viewing item's data source.
-  //
-  // Gpx, Ogr, WebFeatureServiceCatalogItem, ArcGisFeatureServerCatalogItem, WebProcessingServiceCatalogItem
-  // all have a this._geoJsonItem, which we also need to check.
-  let result;
-  let i;
-  let item;
-  if (
-    defined(feature.entityCollection) &&
-    defined(feature.entityCollection.owner)
-  ) {
-    const dataSource = feature.entityCollection.owner;
-
-    if (dataSource.name === LOCATION_MARKER_DATA_SOURCE_NAME) {
-      return {
-        name: i18next.t("featureInfo.locationMarker")
-      };
-    }
-
-    for (i = workbench.items.length - 1; i >= 0; i--) {
-      item = workbench.items[i];
-      if (item.mapItems.some(mapItem => mapItem === dataSource)) {
-        result = item;
-        break;
-      }
-    }
-    return result;
-  }
-
-  // If there is no data source, but there is an imagery layer (eg. ArcGIS),
-  // we can match up the imagery layer on the feature with a now-viewing item.
-  if (defined(feature.imageryLayer)) {
-    const imageryLayer = feature.imageryLayer;
-    for (i = workbench.items.length - 1; i >= 0; i--) {
-      const item = workbench.items[i];
-      if (
-        item.mapItems.some(
-          mapItem => mapItem.imageryProvider === imageryLayer.imageryProvider
-        )
-      ) {
-        result = workbench.items[i];
-        break;
-      }
-    }
-    return result;
-  }
+  return workbench.items.find(item =>
+    featureBelongsToCatalogItem(feature, item)
+  );
 }
 
 /**

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -101,12 +101,12 @@ class DataPreviewMap extends React.Component {
     /**
      * @param {HTMLElement | null} container
      */
-    this.containerRef = container => {
+    this.containerRef = action(container => {
       this.previewViewer.attached && this.previewViewer.detach();
       if (container !== null) {
         this.initPreview(container);
       }
-    };
+    });
     this.previewViewer = new TerriaViewer(
       this.props.terria,
       computed(() => {

--- a/test/Helpers/SimpleCatalogItem.ts
+++ b/test/Helpers/SimpleCatalogItem.ts
@@ -1,0 +1,7 @@
+import CreateModel from "../../lib/Models/CreateModel";
+import { MapItem } from "../../lib/Models/Mappable";
+import UrlTraits from "../../lib/Traits/UrlTraits";
+
+export default class SimpleCatalogItem extends CreateModel(UrlTraits) {
+  mapItems: MapItem[] = [];
+}

--- a/test/Map/PickedFeaturesSpec.ts
+++ b/test/Map/PickedFeaturesSpec.ts
@@ -2,19 +2,13 @@ import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSourc
 import ImageryLayer from "terriajs-cesium/Source/Scene/ImageryLayer";
 import WebMapServiceImageryProvider from "terriajs-cesium/Source/Scene/WebMapServiceImageryProvider";
 import { featureBelongsToCatalogItem } from "../../lib/Map/PickedFeatures";
-import CreateModel from "../../lib/Models/CreateModel";
 import Feature from "../../lib/Models/Feature";
-import { MapItem } from "../../lib/Models/Mappable";
 import Terria from "../../lib/Models/Terria";
-import UrlTraits from "../../lib/Traits/UrlTraits";
-
-class TestCatalogItem extends CreateModel(UrlTraits) {
-  mapItems: MapItem[] = [];
-}
+import SimpleCatalogItem from "../Helpers/SimpleCatalogItem";
 
 describe("featureBelongsToCatalogItem", function() {
   it("returns true if the `_catalogItem` property matches", function() {
-    const item = new TestCatalogItem(undefined, new Terria());
+    const item = new SimpleCatalogItem(undefined, new Terria());
     const feature = new Feature({});
     expect(featureBelongsToCatalogItem(feature, item)).toBe(false);
     feature._catalogItem = item;
@@ -22,7 +16,7 @@ describe("featureBelongsToCatalogItem", function() {
   });
 
   it("returns true if mapItems has the dataSource that owns the feature", function() {
-    const item = new TestCatalogItem(undefined, new Terria());
+    const item = new SimpleCatalogItem(undefined, new Terria());
     const feature = new Feature({});
     const dataSource = new CustomDataSource("testData");
     dataSource.entities.add(feature);
@@ -32,7 +26,7 @@ describe("featureBelongsToCatalogItem", function() {
   });
 
   it("returns true if mapItems has a matching imagery provider", function() {
-    const item = new TestCatalogItem(undefined, new Terria());
+    const item = new SimpleCatalogItem(undefined, new Terria());
     const feature = new Feature({});
     const imageryProvider = new WebMapServiceImageryProvider({
       url: "test",

--- a/test/Map/PickedFeaturesSpec.ts
+++ b/test/Map/PickedFeaturesSpec.ts
@@ -1,0 +1,46 @@
+import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSource";
+import ImageryLayer from "terriajs-cesium/Source/Scene/ImageryLayer";
+import WebMapServiceImageryProvider from "terriajs-cesium/Source/Scene/WebMapServiceImageryProvider";
+import { featureBelongsToCatalogItem } from "../../lib/Map/PickedFeatures";
+import CreateModel from "../../lib/Models/CreateModel";
+import Feature from "../../lib/Models/Feature";
+import { MapItem } from "../../lib/Models/Mappable";
+import Terria from "../../lib/Models/Terria";
+import UrlTraits from "../../lib/Traits/UrlTraits";
+
+class TestCatalogItem extends CreateModel(UrlTraits) {
+  mapItems: MapItem[] = [];
+}
+
+describe("featureBelongsToCatalogItem", function() {
+  it("returns true if the `_catalogItem` property matches", function() {
+    const item = new TestCatalogItem(undefined, new Terria());
+    const feature = new Feature({});
+    expect(featureBelongsToCatalogItem(feature, item)).toBe(false);
+    feature._catalogItem = item;
+    expect(featureBelongsToCatalogItem(feature, item)).toBe(true);
+  });
+
+  it("returns true if mapItems has the dataSource that owns the feature", function() {
+    const item = new TestCatalogItem(undefined, new Terria());
+    const feature = new Feature({});
+    const dataSource = new CustomDataSource("testData");
+    dataSource.entities.add(feature);
+    expect(featureBelongsToCatalogItem(feature, item)).toBe(false);
+    item.mapItems = [dataSource];
+    expect(featureBelongsToCatalogItem(feature, item)).toBe(true);
+  });
+
+  it("returns true if mapItems has a matching imagery provider", function() {
+    const item = new TestCatalogItem(undefined, new Terria());
+    const feature = new Feature({});
+    const imageryProvider = new WebMapServiceImageryProvider({
+      url: "test",
+      layers: "test"
+    });
+    feature.imageryLayer = new ImageryLayer(imageryProvider);
+    expect(featureBelongsToCatalogItem(feature, item)).toBe(false);
+    item.mapItems = [{ imageryProvider }];
+    expect(featureBelongsToCatalogItem(feature, item)).toBe(true);
+  });
+});

--- a/test/Map/PickedFeaturesSpec.ts
+++ b/test/Map/PickedFeaturesSpec.ts
@@ -34,7 +34,7 @@ describe("featureBelongsToCatalogItem", function() {
     });
     feature.imageryLayer = new ImageryLayer(imageryProvider);
     expect(featureBelongsToCatalogItem(feature, item)).toBe(false);
-    item.mapItems = [{ imageryProvider }];
+    item.mapItems = [{ imageryProvider, alpha: 0, show: false }];
     expect(featureBelongsToCatalogItem(feature, item)).toBe(true);
   });
 });

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -12,6 +12,9 @@ import { runInAction } from "mobx";
 import ImagerySplitDirection from "terriajs-cesium/Source/Scene/ImagerySplitDirection";
 import UrlReference from "../../lib/Models/UrlReference";
 import createCatalogItemFromUrl from "../../lib/Models/createCatalogItemFromUrl";
+import SimpleCatalogItem from "../Helpers/SimpleCatalogItem";
+import PickedFeatures from "../../lib/Map/PickedFeatures";
+import Feature from "../../lib/Models/Feature";
 
 describe("Terria", function() {
   let terria: Terria;
@@ -218,6 +221,34 @@ describe("Terria", function() {
       .catch(error => {
         done.fail();
       });
+  });
+
+  describe("removeModelReferences", function() {
+    let model: SimpleCatalogItem;
+    beforeEach(function() {
+      model = new SimpleCatalogItem("testId", terria);
+      terria.addModel(model);
+    });
+
+    it("removes the model from workbench", function() {
+      terria.workbench.add(model);
+      terria.removeModelReferences(model);
+      expect(terria.workbench).not.toContain(model);
+    });
+
+    it("it removes picked features that contain the model", function() {
+      terria.pickedFeatures = new PickedFeatures();
+      const feature = new Feature({});
+      feature._catalogItem = model;
+      terria.pickedFeatures.features.push(feature);
+      terria.removeModelReferences(model);
+      expect(terria.pickedFeatures.features.length).toBe(0);
+    });
+
+    it("unregisters the model from Terria", function() {
+      terria.removeModelReferences(model);
+      expect(terria.getModelById(BaseModel, "testId")).toBeUndefined();
+    });
   });
 
   //   it("tells us there's a time enabled WMS with `checkNowViewingForTimeWms()`", function(done) {

--- a/test/ReactViewModels/ViewStateSpec.ts
+++ b/test/ReactViewModels/ViewStateSpec.ts
@@ -11,7 +11,7 @@ describe("ViewState", function() {
     viewState = new ViewState({
       terria,
       catalogSearchProvider: undefined,
-      locationSearchProviders: undefined
+      locationSearchProviders: []
     });
   });
 

--- a/test/ReactViewModels/ViewStateSpec.ts
+++ b/test/ReactViewModels/ViewStateSpec.ts
@@ -1,0 +1,33 @@
+import Terria from "../../lib/Models/Terria";
+import ViewState from "../../lib/ReactViewModels/ViewState";
+import SimpleCatalogItem from "../Helpers/SimpleCatalogItem";
+
+describe("ViewState", function() {
+  let terria: Terria;
+  let viewState: ViewState;
+
+  beforeEach(function() {
+    terria = new Terria();
+    viewState = new ViewState({
+      terria,
+      catalogSearchProvider: undefined,
+      locationSearchProviders: undefined
+    });
+  });
+
+  describe("removeModelReferences", function() {
+    it("unsets the previewedItem if it matches the model", function() {
+      const item = new SimpleCatalogItem("testId", terria);
+      viewState.previewedItem = item;
+      viewState.removeModelReferences(item);
+      expect(viewState.previewedItem).toBeUndefined();
+    });
+
+    it("unsets the userDataPreviewedItem if it matches the model", function() {
+      const item = new SimpleCatalogItem("testId", terria);
+      viewState.userDataPreviewedItem = item;
+      viewState.removeModelReferences(item);
+      expect(viewState.userDataPreviewedItem).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
### What this PR does

- Adds methods to remove references of a model from Terria & ViewState.
- Refactors code for testing whether a `Feature` belongs to a catalog item. 

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
