### PR TITLE
Setup framework for error provider services

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,7 @@ Change Log
 * Provide a fallback name for an `ArcGisServerCatalogItem`
 * Ensure `CesiumTileLayer.getTileUrl` returns a string.
 * Adds methods `removeModelReferences` to Terria & ViewState for unregistering and removing models from different parts of the UI.
+* Add basic support for various error provider services, implementing support for Rollbar. 
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/RollbarErrorProvider.ts
+++ b/lib/Models/RollbarErrorProvider.ts
@@ -1,5 +1,4 @@
 import isDefined from "../Core/isDefined";
-import ErrorProvider from "./ErrorProvider";
 import Terria from "./Terria";
 import Rollbar from "rollbar";
 

--- a/lib/Models/RollbarErrorProvider.ts
+++ b/lib/Models/RollbarErrorProvider.ts
@@ -22,8 +22,8 @@ export default class RollbarErrorProvider {
     this.errorProvider = new Rollbar({
       accessToken: this.terria.configParameters.rollbarAccessToken,
       captureUncaught: true,
-      captureUnhandledRejections: true
-      // enabled: process.env.NODE_ENV === 'production'
+      captureUnhandledRejections: true,
+      enabled: process.env.NODE_ENV === 'production'
     });
   }
 }

--- a/lib/Models/RollbarErrorProvider.ts
+++ b/lib/Models/RollbarErrorProvider.ts
@@ -23,7 +23,7 @@ export default class RollbarErrorProvider {
       accessToken: this.terria.configParameters.rollbarAccessToken,
       captureUncaught: true,
       captureUnhandledRejections: true,
-      enabled: process.env.NODE_ENV === 'production'
+      enabled: process.env.NODE_ENV === "production"
     });
   }
 }

--- a/lib/Models/RollbarErrorProvider.ts
+++ b/lib/Models/RollbarErrorProvider.ts
@@ -1,0 +1,30 @@
+import isDefined from "../Core/isDefined";
+import ErrorProvider from "./ErrorProvider";
+import Terria from "./Terria";
+import Rollbar from "rollbar";
+
+interface RollbarErrorProviderOptions {
+  terria: Terria;
+}
+
+export default class RollbarErrorProvider {
+  terria: Terria;
+  errorProvider: any;
+
+  constructor(options: RollbarErrorProviderOptions) {
+    this.terria = options.terria;
+
+    if (!isDefined(this.terria.configParameters.rollbarAccessToken)) {
+      console.log(
+        "A rollbarAccessToken must be configured in the config.json to use the rollbar error provider"
+      );
+      return;
+    }
+    this.errorProvider = new Rollbar({
+      accessToken: this.terria.configParameters.rollbarAccessToken,
+      captureUncaught: true,
+      captureUnhandledRejections: true
+      // enabled: process.env.NODE_ENV === 'production'
+    });
+  }
+}

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -85,6 +85,7 @@ interface ConfigParameters {
   magdaReferenceHeaders?: MagdaReferenceHeaders;
   locationSearchBoundingBox?: number[];
   googleAnalyticsKey?: string;
+  rollbarAccessToken?: string;
 }
 
 interface StartOptions {
@@ -190,7 +191,8 @@ export default class Terria {
     experimentalFeatures: undefined,
     magdaReferenceHeaders: undefined,
     locationSearchBoundingBox: undefined,
-    googleAnalyticsKey: undefined
+    googleAnalyticsKey: undefined,
+    rollbarAccessToken: undefined
   };
 
   @observable

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -23,6 +23,7 @@ interface ViewStateOptions {
   terria: Terria;
   catalogSearchProvider: any;
   locationSearchProviders: any[];
+  errorHandlingProvider?: any;
 }
 
 /**
@@ -64,6 +65,8 @@ export default class ViewState {
   @observable helpPanelExpanded: boolean = false;
 
   @observable workbenchWithOpenControls: string | undefined = undefined;
+
+  errorProvider: any | null = null;
 
   // default value is null, because user has not made decision to show or
   // not show story
@@ -128,6 +131,9 @@ export default class ViewState {
       locationSearchProviders: options.locationSearchProviders
     });
 
+    this.errorProvider = options.errorHandlingProvider
+      ? options.errorHandlingProvider
+      : null;
     this.terria = terria;
 
     // Show errors to the user as notifications.

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "react-transition-group": "^4.3.0",
     "resolve-url-loader": "^3.0.1",
     "retry": "^0.12.0",
+    "rollbar": "^2.15.0",
     "sass-loader": "^7.1.0",
     "simple-statistics": "^7.0.1",
     "string-replace-loader": "^2.1.1",

--- a/test/ReactViewModels/ViewStateSpec.ts
+++ b/test/ReactViewModels/ViewStateSpec.ts
@@ -1,5 +1,6 @@
 import Terria from "../../lib/Models/Terria";
 import ViewState from "../../lib/ReactViewModels/ViewState";
+import RollbarErrorProvider from "../../lib/Models/RollbarErrorProvider";
 import SimpleCatalogItem from "../Helpers/SimpleCatalogItem";
 
 describe("ViewState", function() {
@@ -33,7 +34,16 @@ describe("ViewState", function() {
 
   describe("error provider", function() {
     it("creates an empty error provider by default", function() {
-      viewState.errorProvider = null;
+      expect(viewState.errorProvider).toBeNull();
+    });
+
+    it("can create an error provider with rollbar", function() {
+      terria.configParameters.rollbarAccessToken = "123";
+      viewState.errorProvider = new RollbarErrorProvider({
+        terria: viewState.terria
+      });
+      expect(viewState.errorProvider).toBeDefined();
+      expect(viewState.errorProvider.errorProvider).toBeDefined();
     });
   });
 });

--- a/test/ReactViewModels/ViewStateSpec.ts
+++ b/test/ReactViewModels/ViewStateSpec.ts
@@ -30,4 +30,10 @@ describe("ViewState", function() {
       expect(viewState.userDataPreviewedItem).toBeUndefined();
     });
   });
+
+  describe("error provider", function() {
+    it("creates an empty error provider by default", function() {
+      viewState.errorProvider = null;
+    });
+  });
 });


### PR DESCRIPTION
### What this PR does

First part of https://github.com/TerriaJS/TerriaMap/issues/430

This PR sets up some basic pieces for configuring error handling services like rollbar, or sentry etc. A user would pass down a parameter via `config.json` including the API key for the respective service.

An app will also need some configuration in TerriaMap index.js to specify which ErrorProvider they want to use. This should prevent things like the rollbar library from being bundled in the application if it's not required.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
