### PR TITLE
Fix overlaying text bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,7 @@ Change Log
 * Ensure `CesiumTileLayer.getTileUrl` returns a string.
 * Adds methods `removeModelReferences` to Terria & ViewState for unregistering and removing models from different parts of the UI.
 * Add trait to enabling hiding legends for a `CatalogMember` in the workbench.
+* Fix bug that caused contents on the video panel of the help UI to overlay the actual video
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/ReactViews/Map/Panels/HelpPanel/help-panel.scss
+++ b/lib/ReactViews/Map/Panels/HelpPanel/help-panel.scss
@@ -137,6 +137,7 @@
 
 .videoGuideWrapperFullScreen {
   position: fixed;
+  z-index: 99999;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/nsw-digital-twin/issues/355

This PR fixes the bug described in the issue where the contents in the video panel of the help UI overlays the video itself. For some reasons the z-index css property of the video div got removed (I must've accidentally removed it from the code when I was tidying up 😬). Now it's re-added, the properties of the almost-full-screen-video div follows the properties of the video guide used in `story-panel.scss`, in that it has to be the top most component z-index-wise.

### Checklist

-   [x] No unit tests exist that tests the styling (css/scss) properties of the React Components (from what I've looked through so far), but will confirm with Wing first when he's back at work
-   [x] I've updated CHANGES.md with what I changed.
