### PR TITLE
Customize 3d tiles color blending and highlight color

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,7 @@ Change Log
 * Ensure `CesiumTileLayer.getTileUrl` returns a string.
 * Adds methods `removeModelReferences` to Terria & ViewState for unregistering and removing models from different parts of the UI.
 * Add trait to enabling hiding legends for a `CatalogMember` in the workbench.
+* Add traits to customize color blending and highlight color for `Cesium3DTilesCatalogItem`
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/Cesium3DTilesCatalogItem.ts
+++ b/lib/Models/Cesium3DTilesCatalogItem.ts
@@ -6,6 +6,7 @@ import Resource from "terriajs-cesium/Source/Core/Resource";
 import Cesium3DTileFeature from "terriajs-cesium/Source/Scene/Cesium3DTileFeature";
 import Cesium3DTileset from "terriajs-cesium/Source/Scene/Cesium3DTileset";
 import Cesium3DTileStyle from "terriajs-cesium/Source/Scene/Cesium3DTileStyle";
+import Cesium3DTileColorBlendMode from "terriajs-cesium/Source/Scene/Cesium3DTileColorBlendMode";
 import ShadowMode from "terriajs-cesium/Source/Scene/ShadowMode";
 import isDefined from "../Core/isDefined";
 import makeRealPromise from "../Core/makeRealPromise";
@@ -104,7 +105,7 @@ export default class Cesium3DTilesCatalogItem
       this.optionsObj
     );
 
-    if (isDefined(tileset) && !tileset.destroyed) {
+    if (tileset && !tileset.destroyed) {
       this.tileset = tileset;
     }
   }
@@ -121,6 +122,12 @@ export default class Cesium3DTilesCatalogItem
     this.tileset.style = toJS(this.cesiumTileStyle);
     this.tileset.shadows = this.cesiumShadows;
     this.tileset.show = this.show;
+
+    const key = this.colorBlendMode as keyof typeof Cesium3DTileColorBlendMode;
+    const colorBlendMode = Cesium3DTileColorBlendMode[key];
+    if (colorBlendMode !== undefined)
+      this.tileset.colorBlendMode = colorBlendMode;
+    this.tileset.colorBlendAmount = this.colorBlendAmount;
 
     // default is 16 (baseMaximumScreenSpaceError @ 2)
     // we want to reduce to 8 for higher levels of quality

--- a/lib/ThirdParty/terriajs-cesium/index.d.ts
+++ b/lib/ThirdParty/terriajs-cesium/index.d.ts
@@ -1352,6 +1352,7 @@ declare module "terriajs-cesium/Source/Scene/Cesium3DTileset" {
     readyPromise: Promise<Cesium3DTileset>;
     extras: any;
     colorBlendMode: Cesium3DTileColorBlendMode;
+    colorBlendAmount: number;
 
     constructor(options: {
       url: string | IonResource | Cesium.Resource;

--- a/lib/Traits/Cesium3DCatalogItemTraits.ts
+++ b/lib/Traits/Cesium3DCatalogItemTraits.ts
@@ -159,4 +159,28 @@ export default class Cesium3DTilesCatalogItemTraits extends mixTraits(
     description: "The filters to apply to this catalog item."
   })
   filters?: FilterTraits[];
+
+  @primitiveTrait({
+    name: "Color blend mode",
+    type: "string",
+    description:
+      "The color blend mode decides how per-feature color is blended with color defined in the tileset. Acceptable values are HIGHLIGHT, MIX & REPLACE as defined in the cesium documentation - https://cesium.com/docs/cesiumjs-ref-doc/Cesium3DTileColorBlendMode.html"
+  })
+  colorBlendMode = "MIX";
+
+  @primitiveTrait({
+    name: "Color blend amount",
+    type: "number",
+    description:
+      "When the colorBlendMode is MIX this value is used to interpolate between source color and feature color. A value of 0.0 results in the source color while a value of 1.0 results in the feature color, with any value in-between resulting in a mix of the source color and feature color."
+  })
+  colorBlendAmount = 0.5;
+
+  @primitiveTrait({
+    name: "Highlight color",
+    type: "string",
+    description:
+      "The color used to highlight a feature when it is picked. If not set, this defaults to `Terria.baseMapContrastColor`"
+  })
+  highlightColor?: string;
 }

--- a/test/Models/Cesium3DTilesCatalogItemSpec.ts
+++ b/test/Models/Cesium3DTilesCatalogItemSpec.ts
@@ -4,6 +4,7 @@ import IonResource from "terriajs-cesium/Source/Core/IonResource";
 import Cesium3DTileFeature from "terriajs-cesium/Source/Scene/Cesium3DTileFeature";
 import Cesium3DTileset from "terriajs-cesium/Source/Scene/Cesium3DTileset";
 import Cesium3DTileStyle from "terriajs-cesium/Source/Scene/Cesium3DTileStyle";
+import Cesium3DTileColorBlendMode from "terriajs-cesium/Source/Scene/Cesium3DTileColorBlendMode";
 import ShadowMode from "terriajs-cesium/Source/Scene/ShadowMode";
 import Cesium3DTilesCatalogItem from "../../lib/Models/Cesium3DTilesCatalogItem";
 import createStratumInstance from "../../lib/Models/createStratumInstance";
@@ -173,6 +174,27 @@ describe("Cesium3DTilesCatalogItemSpec", function() {
           it("sets `show`", function() {
             runInAction(() => item.setTrait("definition", "show", false));
             expect(item.mapItems[0].show).toBe(false);
+          });
+
+          it("sets the shadow mode", function() {
+            runInAction(() => item.setTrait("definition", "shadows", "cast"));
+            expect(item.mapItems[0].shadows).toBe(ShadowMode.CAST_ONLY);
+          });
+
+          it("sets the color blend mode", function() {
+            runInAction(() => {
+              item.setTrait("definition", "colorBlendMode", "REPLACE");
+              expect(item.mapItems[0].colorBlendMode).toBe(
+                Cesium3DTileColorBlendMode.REPLACE
+              );
+            });
+          });
+
+          it("sets the color blend amount", function() {
+            runInAction(() => {
+              item.setTrait("user", "colorBlendAmount", 0.42);
+              expect(item.mapItems[0].colorBlendAmount).toBe(0.42);
+            });
           });
 
           it("sets the shadow mode", function() {


### PR DESCRIPTION
### What this PR does

This PR adds new traits to customize 3d tiles color blending and feature highlight color. The new traits are: `colorBlendMode`, `colorBlendAmount` & `highlightColor`.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
