### PR TITLE
Antimeridian handling in LeafletJS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### Next release
+
+* Rework the handling of point datasets on the anti-meridian when using LeafletJS.
+
+
 ### v7.11.3
 
 * Added babel dynamic import plugin for webpack builds.

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -165,6 +165,8 @@ function cleanPolyline(entity, group, details) {
   }
 }
 
+let prevBoundsType = 0;
+
 /**
  * Updates the primitives created by this visualizer to match their
  * Entity counterpart at the given time.
@@ -178,22 +180,37 @@ LeafletGeomVisualizer.prototype.update = function(time) {
     throw new DeveloperError(i18next.t("map.leafletVisualizer.devError3"));
   }
   //>>includeEnd('debug');
+  const bounds = this._leafletScene.map.getBounds();
+  let applyLocalisedAntiMeridianFix = false;
+  let currentBoundsType = 0;
+  if (
+    bounds._southWest.lng > 140 &&
+    (bounds._northEast.lng < -140 || bounds._northEast.lng > 180)
+  ) {
+    applyLocalisedAntiMeridianFix = true;
+    currentBoundsType = 1;
+  } else if (
+    (bounds._southWest.lng > 180 || bounds._southWest.lng < -140) &&
+    bounds._northEast.lng < -140
+  ) {
+    applyLocalisedAntiMeridianFix = true;
+    currentBoundsType = 2;
+  }
 
   var entities = this._entitiesToVisualize.values;
   var entityHash = this._entityHash;
-  var lastLeafletLayer = null;
-
   for (var i = 0, len = entities.length; i < len; i++) {
     var entity = entities[i];
     var entityDetails = entityHash[entity.id];
 
     if (defined(entity._point)) {
-      lastLeafletLayer = this._updatePoint(
+      this._updatePoint(
         entity,
         time,
         entityHash,
         entityDetails,
-        lastLeafletLayer
+        applyLocalisedAntiMeridianFix === true ? bounds : null,
+        prevBoundsType !== currentBoundsType
       );
     }
     if (defined(entity._billboard)) {
@@ -209,7 +226,7 @@ LeafletGeomVisualizer.prototype.update = function(time) {
       this._updatePolygon(entity, time, entityHash, entityDetails);
     }
   }
-
+  prevBoundsType = currentBoundsType;
   return true;
 };
 
@@ -256,19 +273,28 @@ LeafletGeomVisualizer.prototype.getLatLngBounds = function() {
 
 var cartographicScratch = new Cartographic();
 
-function positionToLatLng(position, prevLayer) {
+function positionToLatLng(position, bounds) {
   var cartographic = Ellipsoid.WGS84.cartesianToCartographic(
     position,
     cartographicScratch
   );
 
   let lon = CesiumMath.toDegrees(cartographic.longitude);
-  if (prevLayer) {
-    const prevLon = prevLayer._latlng.lng;
-    if (prevLon - lon > 180) {
-      lon = lon + 360;
-    } else if (prevLon - lon < -180) {
-      lon = lon - 360;
+  if (bounds !== null) {
+    if (
+      bounds._southWest.lng > 140 &&
+      (bounds._northEast.lng < -140 || bounds._northEast.lng > 180)
+    ) {
+      if (lon < -140) {
+        lon = lon + 360;
+      }
+    } else if (
+      (bounds._southWest.lng > 180 || bounds._southWest.lng < -140) &&
+      bounds._northEast.lng < -140
+    ) {
+      if (lon > 140) {
+        lon = lon - 360;
+      }
     }
   }
 
@@ -280,7 +306,8 @@ LeafletGeomVisualizer.prototype._updatePoint = function(
   time,
   entityHash,
   entityDetails,
-  lastLeafletLayer
+  bounds,
+  boundsJustChanged
 ) {
   var featureGroup = this._featureGroup;
   var pointGraphics = entity._point;
@@ -345,7 +372,7 @@ LeafletGeomVisualizer.prototype._updatePoint = function(
     };
 
     layer = details.layer = L.circleMarker(
-      positionToLatLng(position, lastLeafletLayer),
+      positionToLatLng(position, bounds),
       pointOptions
     );
     layer.on("click", featureClicked.bind(undefined, this, entity));
@@ -361,8 +388,8 @@ LeafletGeomVisualizer.prototype._updatePoint = function(
     return layer;
   }
 
-  if (!Cartesian3.equals(position, details.lastPosition)) {
-    layer.setLatLng(positionToLatLng(position, lastLeafletLayer));
+  if (!Cartesian3.equals(position, details.lastPosition) || boundsJustChanged) {
+    layer.setLatLng(positionToLatLng(position, bounds));
     Cartesian3.clone(position, details.lastPosition);
   }
 

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -216,7 +216,13 @@ LeafletGeomVisualizer.prototype.update = function(time) {
       );
     }
     if (defined(entity._billboard)) {
-      this._updateBillboard(entity, time, entityHash, entityDetails);
+      this._updateBillboard(
+        entity,
+        time,
+        entityHash,
+        entityDetails,
+        applyLocalisedAntiMeridianFix === true ? bounds : null
+      );
     }
     if (defined(entity._label)) {
       this._updateLabel(entity, time, entityHash, entityDetails);
@@ -618,7 +624,8 @@ LeafletGeomVisualizer.prototype._updateBillboard = function(
   entity,
   time,
   entityHash,
-  entityDetails
+  entityDetails,
+  bounds
 ) {
   var markerGraphics = entity._billboard;
   var featureGroup = this._featureGroup;
@@ -645,11 +652,7 @@ LeafletGeomVisualizer.prototype._updateBillboard = function(
     return;
   }
 
-  var cart = Ellipsoid.WGS84.cartesianToCartographic(position);
-  var latlng = L.latLng(
-    CesiumMath.toDegrees(cart.latitude),
-    CesiumMath.toDegrees(cart.longitude)
-  );
+  var latlng = positionToLatLng(position, bounds);
   var image = Property.getValueOrDefault(
     markerGraphics._image,
     time,

--- a/lib/Map/LeafletVisualizer.js
+++ b/lib/Map/LeafletVisualizer.js
@@ -165,6 +165,14 @@ function cleanPolyline(entity, group, details) {
   }
 }
 
+/**
+ * A variable to store what sort of bounds our leaflet map has been looking at
+ * 0 = a normal extent
+ * 1 = zoomed in close to the east/left of anti-meridian
+ * 2 = zoomed in close to the west/right of the anti-meridian
+ * When this value changes we'll need to recompute the location of our points
+ * to help them wrap around the anti-meridian
+ */
 let prevBoundsType = 0;
 
 /**
@@ -183,16 +191,10 @@ LeafletGeomVisualizer.prototype.update = function(time) {
   const bounds = this._leafletScene.map.getBounds();
   let applyLocalisedAntiMeridianFix = false;
   let currentBoundsType = 0;
-  if (
-    bounds._southWest.lng > 140 &&
-    (bounds._northEast.lng < -140 || bounds._northEast.lng > 180)
-  ) {
+  if (isCloseToEasternAntiMeridian(bounds)) {
     applyLocalisedAntiMeridianFix = true;
     currentBoundsType = 1;
-  } else if (
-    (bounds._southWest.lng > 180 || bounds._southWest.lng < -140) &&
-    bounds._northEast.lng < -140
-  ) {
+  } else if (isCloseToWesternAntiMeridian(bounds)) {
     applyLocalisedAntiMeridianFix = true;
     currentBoundsType = 2;
   }
@@ -271,6 +273,34 @@ LeafletGeomVisualizer.prototype.getLatLngBounds = function() {
   return result;
 };
 
+/**
+ * Computes whether we're looking close to the east of the anti-meridian
+ * Our western viewing extent must be > 140 degrees
+ * @returns boolean
+ */
+function isCloseToEasternAntiMeridian(bounds) {
+  const w = bounds.getWest();
+  const e = bounds.getEast();
+  if (w > 140 && (e < -140 || e > 180)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Computes whether we're looking close to the west of the anti-meridian
+ * Our eastern viewing extent must be < -140 degrees
+ * @returns boolean
+ */
+function isCloseToWesternAntiMeridian(bounds) {
+  const w = bounds.getWest();
+  const e = bounds.getEast();
+  if ((w > 180 || w < -140) && e < -140) {
+    return true;
+  }
+  return false;
+}
+
 var cartographicScratch = new Cartographic();
 
 function positionToLatLng(position, bounds) {
@@ -281,17 +311,11 @@ function positionToLatLng(position, bounds) {
 
   let lon = CesiumMath.toDegrees(cartographic.longitude);
   if (bounds !== null) {
-    if (
-      bounds._southWest.lng > 140 &&
-      (bounds._northEast.lng < -140 || bounds._northEast.lng > 180)
-    ) {
+    if (isCloseToEasternAntiMeridian(bounds)) {
       if (lon < -140) {
         lon = lon + 360;
       }
-    } else if (
-      (bounds._southWest.lng > 180 || bounds._southWest.lng < -140) &&
-      bounds._northEast.lng < -140
-    ) {
+    } else if (isCloseToWesternAntiMeridian(bounds)) {
       if (lon > 140) {
         lon = lon - 360;
       }

--- a/lib/Map/featureDataToGeoJson.js
+++ b/lib/Map/featureDataToGeoJson.js
@@ -76,6 +76,10 @@ function getEsriGeometry(featureData, geometryType, spatialReference) {
     geometry: undefined,
     properties: featureData.attributes
   };
+  if (featureData.geometry === undefined) {
+    geoJsonFeature.geometry = null;
+    return geoJsonFeature;
+  }
   if (defined(spatialReference)) {
     geoJsonFeature.crs = esriSpatialReferenceToCrs(spatialReference);
   }

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -608,7 +608,7 @@ TerriaViewer.prototype.selectLeaflet = function() {
     maxZoom: this.maximumLeafletZoomLevel,
     zoomSnap: 1, // Change to  0.2 for incremental zoom when Chrome fixes canvas scaling gaps
     preferCanvas: true,
-    worldCopyJump: false
+    worldCopyJump: true
   }).setView([-28.5, 135], 5);
 
   map.attributionControl = L.control.attribution({


### PR DESCRIPTION
### What this PR does
Fixes https://github.com/PacificCommunity/Terria-PacificMap/issues/34

Reworks the anti-meridian handling of points in the leaflet viewer so that it only gets applied in certain circumstances. The previous logic kinda worked for small scale datasets but was flawed when dealing with points covering the globe.

Try using this Esri FeatureService for example
https://services1.arcgis.com/0MSEUqKaxRlEPj5g/ArcGIS/rest/services/ncov_cases/FeatureServer/1

In the new logic
 - we track whether we're zoomed in around the anti-meridian, if not points aren't adjusted
 - we keep track of 3 viewing modes, normal (no anti-meridian in play), left-side anti-meridian (when the map bbox northEast is 180+) and right-side anti-meridian (when the map bbox southWest is < 180)
 - if we change viewing mode (because we've zoomed or panned across the anti-meridian area) then we'll double check if our points need tweaking.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
