### PR TITLE
Remove hardcoded workbench & Panel button colours

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,7 @@ Change Log
 * Overhauled location search to be a dropdown instead of list of results
 * Fixed bug causing full app crash or viewer zoom refresh when using 3D view and changing settings or changing the terrain provider.
 * Add support for styling CSVs using a region mapped or text columns.
+* Removed hardcoded workbench & Panel button colours
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/ReactViews/Map/menu-button.scss
+++ b/lib/ReactViews/Map/menu-button.scss
@@ -6,7 +6,7 @@
   border-radius: $radius-small;
   border: 0;
   svg {
-    fill: #6487ae;
+    // fill: #6487ae;
     // margin: 0 3px 0 4px;
     vertical-align: middle;
   }

--- a/lib/ReactViews/SidePanel/SidePanel.jsx
+++ b/lib/ReactViews/SidePanel/SidePanel.jsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react";
 import PropTypes from "prop-types";
 import React from "react";
 import { withTranslation, Trans } from "react-i18next";
+import { withTheme } from "styled-components";
 import Icon from "../Icon";
 import SearchBoxAndResults from "../Search/SearchBoxAndResults";
 import Workbench from "../Workbench/Workbench";
@@ -24,7 +25,7 @@ function EmptyWorkbench(props) {
           min-height: 240px;
         `}
       >
-        <Text large css={"color: #88A3C1"}>
+        <Text large color={props.theme.textLightDimmed}>
           {t("emptyWorkbench.emptyArea")}
         </Text>
       </Box>
@@ -64,7 +65,8 @@ function EmptyWorkbench(props) {
   );
 }
 EmptyWorkbench.propTypes = {
-  t: PropTypes.func.isRequired
+  t: PropTypes.func.isRequired,
+  theme: PropTypes.object.isRequired
 };
 
 const SidePanel = observer(
@@ -74,7 +76,8 @@ const SidePanel = observer(
     propTypes: {
       terria: PropTypes.object.isRequired,
       viewState: PropTypes.object.isRequired,
-      t: PropTypes.func.isRequired
+      t: PropTypes.func.isRequired,
+      theme: PropTypes.object.isRequired
     },
 
     onAddDataClicked(event) {
@@ -89,7 +92,7 @@ const SidePanel = observer(
       this.props.viewState.openUserData();
     },
     render() {
-      const { t } = this.props;
+      const { t, theme } = this.props;
       const addData = t("addData.addDataBtnText");
       const uploadText = t("models.catalog.upload");
       return (
@@ -146,7 +149,7 @@ const SidePanel = observer(
                 />
               </When>
               <Otherwise>
-                <EmptyWorkbench t={t} />
+                <EmptyWorkbench t={t} theme={theme} />
               </Otherwise>
             </Choose>
           </div>
@@ -156,4 +159,4 @@ const SidePanel = observer(
   })
 );
 
-module.exports = withTranslation()(SidePanel);
+module.exports = withTranslation()(withTheme(SidePanel));

--- a/lib/Sass/common/_variables-export.scss
+++ b/lib/Sass/common/_variables-export.scss
@@ -10,6 +10,7 @@
   colorPrimary: $color-primary;
   colorSplitter: $color-splitter;
   textLight: $text-light;
+  textLightDimmed: $text-light-dimmed;
   textDark: $text-dark;
   textDarker: $text-darker;
   dark: $dark;
@@ -19,4 +20,7 @@
   greyLighter2: $grey-lighter2;
   greyLightest: $grey-lightest;
   charcoalGrey: $charcoal-grey;
+
+  // TODO: fix, these are stopgaps & should get merged in with something else(?)
+  mapButtonColor: $map-button-color;
 }

--- a/lib/Styled/Text.jsx
+++ b/lib/Styled/Text.jsx
@@ -32,9 +32,9 @@ export const Text = styled.div`
     color: ${props.theme.textLight};
   `}
   ${props =>
-    props.textLight &&
+    props.textLightDimmed &&
     `
-    color: ${props.theme.textLight};
+    color: ${props.theme.textLightDimmed};
   `}
   ${props =>
     props.textDark &&
@@ -45,6 +45,11 @@ export const Text = styled.div`
     props.textDarker &&
     `
     color: ${props.theme.textDarker};
+  `}
+  ${props =>
+    props.color &&
+    `
+    color: ${props.color};
   `}
 
   ${props => props.fullWidth && `width: 100%;`}


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs/issues/4193

These colours are hardcoded (due to the NSW push) - now bringing them back to use theme colours
<img width="563" alt="image" src="https://user-images.githubusercontent.com/9134432/78204555-8c654000-74e5-11ea-8829-0b9ac72e73b8.png">
<img width="187" alt="image" src="https://user-images.githubusercontent.com/9134432/78204560-8ec79a00-74e5-11ea-96d0-b613f8bcafb2.png">


### Checklist

-   [x] No unit tests - only pure variable swapping
-   [x] I've updated CHANGES.md with what I changed.
