### PR TITLE
Upgrade to cesium 1.68 and publish v7.11.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
   include:
   - language: node_js
     node_js:
-    - '8'
+    - '10'
     script:
     - npm run prettier-check
     - pyenv shell 2.7
@@ -19,7 +19,7 @@ matrix:
     - secure: gzSiFfm+cog4Kl7kxh997UwuIIbthm5cbbwDWSJE8EnqAGuHP6XJsVnu+c1Ql+nuVidY0hCeenjdGuRMt5jSWCES6jAT1RR2j46PrCE0tLRDZIcY5m2rt9uRtAGG/Wvsk0tRdg/TPMc50f/3c4zX8iMmD4Hd1qB/G/debE6PDBE=
   - language: node_js
     node_js:
-    - '8'
+    - '10'
     install: true
     sudo: required
     services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - npm run prettier-check
     - pyenv shell 2.7
     - pip install -r doc/requirements.txt
-    - gulp lint docs release
+    - gulp lint release --continue
     - gulp test-travis
     env:
     - NODE_OPTIONS=--max_old_space_size=3072

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - npm run prettier-check
     - pyenv shell 2.7
     - pip install -r doc/requirements.txt
-    - gulp lint release --continue
+    - gulp lint docs release
     - gulp test-travis
     env:
     - NODE_OPTIONS=--max_old_space_size=3072

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,10 @@ Change Log
 ==========
 
 
-### Next release
+### v7.11.4
 
 * Add support for `classBreaks` renderer to `ArcGisFeatureServerCatalogItem`.
+* Upgraded to Cesium v1.68.
 
 ### v7.11.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@ Change Log
 * Add support for `classBreaks` renderer to `ArcGisFeatureServerCatalogItem`.
 * Upgraded to Cesium v1.68.
 * Replace `defineProperties` and `freezeObject` to `Object.defineProperties` and `Object.freeze` respectively.
-* Bumped travis build environment to node 10, and skip running gulp docs on travis.
+* Bumped travis build environment to node 10.
+* Upgraded to `generate-terriajs-schema` to v1.5.0.
 
 ### v7.11.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Change Log
 * Add support for `classBreaks` renderer to `ArcGisFeatureServerCatalogItem`.
 * Upgraded to Cesium v1.68.
 * Replace `defineProperties` and `freezeObject` to `Object.defineProperties` and `Object.freeze` respectively.
-* Bumped travis build environment to node 10.
+* Bumped travis build environment to node 10, and skip running gulp docs on travis.
 
 ### v7.11.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 
 * Add support for `classBreaks` renderer to `ArcGisFeatureServerCatalogItem`.
 * Upgraded to Cesium v1.68.
+* Replace `defineProperties` and `freezeObject` to `Object.defineProperties` and `Object.freeze` respectively.
 
 ### v7.11.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Add support for `classBreaks` renderer to `ArcGisFeatureServerCatalogItem`.
 * Upgraded to Cesium v1.68.
 * Replace `defineProperties` and `freezeObject` to `Object.defineProperties` and `Object.freeze` respectively.
+* Bumped travis build environment to node 10.
 
 ### v7.11.3
 

--- a/doc/acknowledgements/attributions.md
+++ b/doc/acknowledgements/attributions.md
@@ -1,43 +1,16 @@
-info fsevents@1.2.9: The platform "linux" is incompatible with this module.
-info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
-info fsevents@2.1.2: The platform "linux" is incompatible with this module.
+info fsevents@1.2.12: The platform "win32" is incompatible with this module.
+info "fsevents@1.2.12" is an optional dependency and failed compatibility check. Excluding it from installation.
+info fsevents@2.1.2: The platform "win32" is incompatible with this module.
 info "fsevents@2.1.2" is an optional dependency and failed compatibility check. Excluding it from installation.
 THE FOLLOWING SETS FORTH ATTRIBUTION NOTICES FOR THIRD PARTY SOFTWARE THAT MAY BE CONTAINED IN PORTIONS OF THE TERRIAJS PRODUCT.
 
 -----
 
-The following software may be included in this product: @babel/code-frame, @babel/core, @babel/generator, @babel/helper-annotate-as-pure, @babel/helper-builder-binary-assignment-operator-visitor, @babel/helper-builder-react-jsx, @babel/helper-call-delegate, @babel/helper-create-regexp-features-plugin, @babel/helper-define-map, @babel/helper-explode-assignable-expression, @babel/helper-function-name, @babel/helper-get-function-arity, @babel/helper-hoist-variables, @babel/helper-member-expression-to-functions, @babel/helper-module-imports, @babel/helper-module-transforms, @babel/helper-optimise-call-expression, @babel/helper-regex, @babel/helper-remap-async-to-generator, @babel/helper-replace-supers, @babel/helper-simple-access, @babel/helper-split-export-declaration, @babel/helper-wrap-function, @babel/helpers, @babel/highlight, @babel/plugin-proposal-async-generator-functions, @babel/plugin-proposal-dynamic-import, @babel/plugin-proposal-json-strings, @babel/plugin-proposal-object-rest-spread, @babel/plugin-proposal-optional-catch-binding, @babel/plugin-proposal-unicode-property-regex, @babel/plugin-syntax-async-generators, @babel/plugin-syntax-dynamic-import, @babel/plugin-syntax-json-strings, @babel/plugin-syntax-jsx, @babel/plugin-syntax-object-rest-spread, @babel/plugin-syntax-optional-catch-binding, @babel/plugin-syntax-top-level-await, @babel/plugin-transform-arrow-functions, @babel/plugin-transform-async-to-generator, @babel/plugin-transform-block-scoped-functions, @babel/plugin-transform-block-scoping, @babel/plugin-transform-classes, @babel/plugin-transform-computed-properties, @babel/plugin-transform-destructuring, @babel/plugin-transform-dotall-regex, @babel/plugin-transform-duplicate-keys, @babel/plugin-transform-exponentiation-operator, @babel/plugin-transform-for-of, @babel/plugin-transform-function-name, @babel/plugin-transform-literals, @babel/plugin-transform-member-expression-literals, @babel/plugin-transform-modules-amd, @babel/plugin-transform-modules-commonjs, @babel/plugin-transform-modules-systemjs, @babel/plugin-transform-modules-umd, @babel/plugin-transform-named-capturing-groups-regex, @babel/plugin-transform-new-target, @babel/plugin-transform-object-super, @babel/plugin-transform-parameters, @babel/plugin-transform-property-literals, @babel/plugin-transform-react-display-name, @babel/plugin-transform-react-jsx, @babel/plugin-transform-react-jsx-self, @babel/plugin-transform-react-jsx-source, @babel/plugin-transform-regenerator, @babel/plugin-transform-reserved-words, @babel/plugin-transform-shorthand-properties, @babel/plugin-transform-spread, @babel/plugin-transform-sticky-regex, @babel/plugin-transform-template-literals, @babel/plugin-transform-typeof-symbol, @babel/plugin-transform-unicode-regex, @babel/preset-env, @babel/preset-react, @babel/runtime, @babel/template, @babel/traverse, @babel/types. A copy of the source code may be downloaded from https://github.com/babel/babel/tree/master/packages/babel-code-frame (@babel/code-frame), https://github.com/babel/babel/tree/master/packages/babel-core (@babel/core), https://github.com/babel/babel/tree/master/packages/babel-generator (@babel/generator), https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure (@babel/helper-annotate-as-pure), https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor (@babel/helper-builder-binary-assignment-operator-visitor), https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx (@babel/helper-builder-react-jsx), https://github.com/babel/babel/tree/master/packages/babel-helper-call-delegate (@babel/helper-call-delegate), https://github.com/babel/babel (@babel/helper-create-regexp-features-plugin), https://github.com/babel/babel/tree/master/packages/babel-helper-define-map (@babel/helper-define-map), https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression (@babel/helper-explode-assignable-expression), https://github.com/babel/babel/tree/master/packages/babel-helper-function-name (@babel/helper-function-name), https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity (@babel/helper-get-function-arity), https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables (@babel/helper-hoist-variables), https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions (@babel/helper-member-expression-to-functions), https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports (@babel/helper-module-imports), https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms (@babel/helper-module-transforms), https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression (@babel/helper-optimise-call-expression), https://github.com/babel/babel/tree/master/packages/babel-helper-regex (@babel/helper-regex), https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator (@babel/helper-remap-async-to-generator), https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers (@babel/helper-replace-supers), https://github.com/babel/babel/tree/master/packages/babel-helper-simple-access (@babel/helper-simple-access), https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration (@babel/helper-split-export-declaration), https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function (@babel/helper-wrap-function), https://github.com/babel/babel/tree/master/packages/babel-helpers (@babel/helpers), https://github.com/babel/babel/tree/master/packages/babel-highlight (@babel/highlight), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions (@babel/plugin-proposal-async-generator-functions), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-dynamic-import (@babel/plugin-proposal-dynamic-import), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings (@babel/plugin-proposal-json-strings), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread (@babel/plugin-proposal-object-rest-spread), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding (@babel/plugin-proposal-optional-catch-binding), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-unicode-property-regex (@babel/plugin-proposal-unicode-property-regex), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators (@babel/plugin-syntax-async-generators), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import (@babel/plugin-syntax-dynamic-import), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings (@babel/plugin-syntax-json-strings), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx (@babel/plugin-syntax-jsx), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread (@babel/plugin-syntax-object-rest-spread), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding (@babel/plugin-syntax-optional-catch-binding), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-top-level-await (@babel/plugin-syntax-top-level-await), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions (@babel/plugin-transform-arrow-functions), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator (@babel/plugin-transform-async-to-generator), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions (@babel/plugin-transform-block-scoped-functions), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping (@babel/plugin-transform-block-scoping), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes (@babel/plugin-transform-classes), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties (@babel/plugin-transform-computed-properties), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring (@babel/plugin-transform-destructuring), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-dotall-regex (@babel/plugin-transform-dotall-regex), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys (@babel/plugin-transform-duplicate-keys), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator (@babel/plugin-transform-exponentiation-operator), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of (@babel/plugin-transform-for-of), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name (@babel/plugin-transform-function-name), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals (@babel/plugin-transform-literals), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals (@babel/plugin-transform-member-expression-literals), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd (@babel/plugin-transform-modules-amd), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs (@babel/plugin-transform-modules-commonjs), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs (@babel/plugin-transform-modules-systemjs), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd (@babel/plugin-transform-modules-umd), https://github.com/babel/babel.git (@babel/plugin-transform-named-capturing-groups-regex), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target (@babel/plugin-transform-new-target), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super (@babel/plugin-transform-object-super), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters (@babel/plugin-transform-parameters), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals (@babel/plugin-transform-property-literals), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name (@babel/plugin-transform-react-display-name), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx (@babel/plugin-transform-react-jsx), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self (@babel/plugin-transform-react-jsx-self), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source (@babel/plugin-transform-react-jsx-source), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator (@babel/plugin-transform-regenerator), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words (@babel/plugin-transform-reserved-words), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties (@babel/plugin-transform-shorthand-properties), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread (@babel/plugin-transform-spread), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex (@babel/plugin-transform-sticky-regex), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals (@babel/plugin-transform-template-literals), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol (@babel/plugin-transform-typeof-symbol), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex (@babel/plugin-transform-unicode-regex), https://github.com/babel/babel/tree/master/packages/babel-preset-env (@babel/preset-env), https://github.com/babel/babel/tree/master/packages/babel-preset-react (@babel/preset-react), https://github.com/babel/babel.git (@babel/runtime), https://github.com/babel/babel/tree/master/packages/babel-template (@babel/template), https://github.com/babel/babel/tree/master/packages/babel-traverse (@babel/traverse), https://github.com/babel/babel/tree/master/packages/babel-types (@babel/types). This software contains the following license and notice below:
+The following software may be included in this product: @babel/code-frame, @babel/compat-data, @babel/core, @babel/generator, @babel/helper-annotate-as-pure, @babel/helper-builder-binary-assignment-operator-visitor, @babel/helper-builder-react-jsx, @babel/helper-builder-react-jsx-experimental, @babel/helper-compilation-targets, @babel/helper-create-regexp-features-plugin, @babel/helper-define-map, @babel/helper-explode-assignable-expression, @babel/helper-function-name, @babel/helper-get-function-arity, @babel/helper-hoist-variables, @babel/helper-member-expression-to-functions, @babel/helper-module-imports, @babel/helper-module-transforms, @babel/helper-optimise-call-expression, @babel/helper-plugin-utils, @babel/helper-regex, @babel/helper-remap-async-to-generator, @babel/helper-replace-supers, @babel/helper-simple-access, @babel/helper-split-export-declaration, @babel/helper-validator-identifier, @babel/helper-wrap-function, @babel/helpers, @babel/highlight, @babel/plugin-proposal-async-generator-functions, @babel/plugin-proposal-dynamic-import, @babel/plugin-proposal-json-strings, @babel/plugin-proposal-nullish-coalescing-operator, @babel/plugin-proposal-numeric-separator, @babel/plugin-proposal-object-rest-spread, @babel/plugin-proposal-optional-catch-binding, @babel/plugin-proposal-optional-chaining, @babel/plugin-proposal-unicode-property-regex, @babel/plugin-syntax-async-generators, @babel/plugin-syntax-dynamic-import, @babel/plugin-syntax-json-strings, @babel/plugin-syntax-jsx, @babel/plugin-syntax-nullish-coalescing-operator, @babel/plugin-syntax-numeric-separator, @babel/plugin-syntax-object-rest-spread, @babel/plugin-syntax-optional-catch-binding, @babel/plugin-syntax-optional-chaining, @babel/plugin-syntax-top-level-await, @babel/plugin-transform-arrow-functions, @babel/plugin-transform-async-to-generator, @babel/plugin-transform-block-scoped-functions, @babel/plugin-transform-block-scoping, @babel/plugin-transform-classes, @babel/plugin-transform-computed-properties, @babel/plugin-transform-destructuring, @babel/plugin-transform-dotall-regex, @babel/plugin-transform-duplicate-keys, @babel/plugin-transform-exponentiation-operator, @babel/plugin-transform-for-of, @babel/plugin-transform-function-name, @babel/plugin-transform-literals, @babel/plugin-transform-member-expression-literals, @babel/plugin-transform-modules-amd, @babel/plugin-transform-modules-commonjs, @babel/plugin-transform-modules-systemjs, @babel/plugin-transform-modules-umd, @babel/plugin-transform-named-capturing-groups-regex, @babel/plugin-transform-new-target, @babel/plugin-transform-object-super, @babel/plugin-transform-parameters, @babel/plugin-transform-property-literals, @babel/plugin-transform-react-display-name, @babel/plugin-transform-react-jsx, @babel/plugin-transform-react-jsx-development, @babel/plugin-transform-react-jsx-self, @babel/plugin-transform-react-jsx-source, @babel/plugin-transform-regenerator, @babel/plugin-transform-reserved-words, @babel/plugin-transform-shorthand-properties, @babel/plugin-transform-spread, @babel/plugin-transform-sticky-regex, @babel/plugin-transform-template-literals, @babel/plugin-transform-typeof-symbol, @babel/plugin-transform-unicode-regex, @babel/preset-env, @babel/preset-react, @babel/runtime, @babel/runtime-corejs3, @babel/template, @babel/traverse, @babel/types. A copy of the source code may be downloaded from https://github.com/babel/babel/tree/master/packages/babel-code-frame (@babel/code-frame), https://github.com/babel/babel/tree/master/packages/babel-compat-data (@babel/compat-data), https://github.com/babel/babel/tree/master/packages/babel-core (@babel/core), https://github.com/babel/babel/tree/master/packages/babel-generator (@babel/generator), https://github.com/babel/babel/tree/master/packages/babel-helper-annotate-as-pure (@babel/helper-annotate-as-pure), https://github.com/babel/babel/tree/master/packages/babel-helper-builder-binary-assignment-operator-visitor (@babel/helper-builder-binary-assignment-operator-visitor), https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx (@babel/helper-builder-react-jsx), https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx-experimental (@babel/helper-builder-react-jsx-experimental), https://github.com/babel/babel/tree/master/packages/babel-helper-compilation-targets (@babel/helper-compilation-targets), https://github.com/babel/babel (@babel/helper-create-regexp-features-plugin), https://github.com/babel/babel/tree/master/packages/babel-helper-define-map (@babel/helper-define-map), https://github.com/babel/babel/tree/master/packages/babel-helper-explode-assignable-expression (@babel/helper-explode-assignable-expression), https://github.com/babel/babel/tree/master/packages/babel-helper-function-name (@babel/helper-function-name), https://github.com/babel/babel/tree/master/packages/babel-helper-get-function-arity (@babel/helper-get-function-arity), https://github.com/babel/babel/tree/master/packages/babel-helper-hoist-variables (@babel/helper-hoist-variables), https://github.com/babel/babel/tree/master/packages/babel-helper-member-expression-to-functions (@babel/helper-member-expression-to-functions), https://github.com/babel/babel/tree/master/packages/babel-helper-module-imports (@babel/helper-module-imports), https://github.com/babel/babel/tree/master/packages/babel-helper-module-transforms (@babel/helper-module-transforms), https://github.com/babel/babel/tree/master/packages/babel-helper-optimise-call-expression (@babel/helper-optimise-call-expression), https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils (@babel/helper-plugin-utils), https://github.com/babel/babel/tree/master/packages/babel-helper-regex (@babel/helper-regex), https://github.com/babel/babel/tree/master/packages/babel-helper-remap-async-to-generator (@babel/helper-remap-async-to-generator), https://github.com/babel/babel/tree/master/packages/babel-helper-replace-supers (@babel/helper-replace-supers), https://github.com/babel/babel/tree/master/packages/babel-helper-simple-access (@babel/helper-simple-access), https://github.com/babel/babel/tree/master/packages/babel-helper-split-export-declaration (@babel/helper-split-export-declaration), https://github.com/babel/babel/tree/master/packages/babel-helper-validator-identifier (@babel/helper-validator-identifier), https://github.com/babel/babel/tree/master/packages/babel-helper-wrap-function (@babel/helper-wrap-function), https://github.com/babel/babel/tree/master/packages/babel-helpers (@babel/helpers), https://github.com/babel/babel/tree/master/packages/babel-highlight (@babel/highlight), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions (@babel/plugin-proposal-async-generator-functions), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-dynamic-import (@babel/plugin-proposal-dynamic-import), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-json-strings (@babel/plugin-proposal-json-strings), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-nullish-coalescing-operator (@babel/plugin-proposal-nullish-coalescing-operator), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-numeric-separator (@babel/plugin-proposal-numeric-separator), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-object-rest-spread (@babel/plugin-proposal-object-rest-spread), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-catch-binding (@babel/plugin-proposal-optional-catch-binding), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-optional-chaining (@babel/plugin-proposal-optional-chaining), https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-unicode-property-regex (@babel/plugin-proposal-unicode-property-regex), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators (@babel/plugin-syntax-async-generators), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import (@babel/plugin-syntax-dynamic-import), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings (@babel/plugin-syntax-json-strings), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx (@babel/plugin-syntax-jsx), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator (@babel/plugin-syntax-nullish-coalescing-operator), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-numeric-separator (@babel/plugin-syntax-numeric-separator), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread (@babel/plugin-syntax-object-rest-spread), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding (@babel/plugin-syntax-optional-catch-binding), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining (@babel/plugin-syntax-optional-chaining), https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-top-level-await (@babel/plugin-syntax-top-level-await), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-arrow-functions (@babel/plugin-transform-arrow-functions), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-async-to-generator (@babel/plugin-transform-async-to-generator), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoped-functions (@babel/plugin-transform-block-scoped-functions), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-block-scoping (@babel/plugin-transform-block-scoping), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-classes (@babel/plugin-transform-classes), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-computed-properties (@babel/plugin-transform-computed-properties), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring (@babel/plugin-transform-destructuring), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-dotall-regex (@babel/plugin-transform-dotall-regex), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-duplicate-keys (@babel/plugin-transform-duplicate-keys), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-exponentiation-operator (@babel/plugin-transform-exponentiation-operator), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-for-of (@babel/plugin-transform-for-of), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-function-name (@babel/plugin-transform-function-name), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-literals (@babel/plugin-transform-literals), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-member-expression-literals (@babel/plugin-transform-member-expression-literals), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-amd (@babel/plugin-transform-modules-amd), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-commonjs (@babel/plugin-transform-modules-commonjs), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-systemjs (@babel/plugin-transform-modules-systemjs), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-modules-umd (@babel/plugin-transform-modules-umd), https://github.com/babel/babel.git (@babel/plugin-transform-named-capturing-groups-regex), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-new-target (@babel/plugin-transform-new-target), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-super (@babel/plugin-transform-object-super), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-parameters (@babel/plugin-transform-parameters), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-property-literals (@babel/plugin-transform-property-literals), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name (@babel/plugin-transform-react-display-name), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx (@babel/plugin-transform-react-jsx), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-development (@babel/plugin-transform-react-jsx-development), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self (@babel/plugin-transform-react-jsx-self), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source (@babel/plugin-transform-react-jsx-source), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-regenerator (@babel/plugin-transform-regenerator), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-reserved-words (@babel/plugin-transform-reserved-words), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-shorthand-properties (@babel/plugin-transform-shorthand-properties), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-spread (@babel/plugin-transform-spread), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-sticky-regex (@babel/plugin-transform-sticky-regex), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-template-literals (@babel/plugin-transform-template-literals), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-typeof-symbol (@babel/plugin-transform-typeof-symbol), https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-unicode-regex (@babel/plugin-transform-unicode-regex), https://github.com/babel/babel/tree/master/packages/babel-preset-env (@babel/preset-env), https://github.com/babel/babel/tree/master/packages/babel-preset-react (@babel/preset-react), https://github.com/babel/babel.git (@babel/runtime), https://github.com/babel/babel/tree/master/packages/babel-runtime-corejs3 (@babel/runtime-corejs3), https://github.com/babel/babel/tree/master/packages/babel-template (@babel/template), https://github.com/babel/babel/tree/master/packages/babel-traverse (@babel/traverse), https://github.com/babel/babel/tree/master/packages/babel-types (@babel/types). This software contains the following license and notice below:
 
 MIT License
 
 Copyright (c) 2014-present Sebastian McKenzie and other contributors
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: @babel/helper-plugin-utils. A copy of the source code may be downloaded from https://github.com/babel/babel/tree/master/packages/babel-helper-plugin-utils. This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2014-2018 Sebastian McKenzie <sebmck@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -149,33 +122,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
-The following software may be included in this product: @nodelib/fs.scandir, @nodelib/fs.stat, @nodelib/fs.walk, fast-glob. A copy of the source code may be downloaded from https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir (@nodelib/fs.scandir), https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat (@nodelib/fs.stat), https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk (@nodelib/fs.walk), https://github.com/mrmlnc/fast-glob.git (fast-glob). This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) Denis Malinochkin
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
-The following software may be included in this product: @opencensus/core, @opencensus/propagation-b3, @xtuc/long, ejs, spdx-correct, sumchecker, validate-npm-package-license. A copy of the source code may be downloaded from https://github.com/census-instrumentation/opencensus-node.git (@opencensus/core), https://github.com/census-instrumentation/opencensus-node.git (@opencensus/propagation-b3), https://github.com/dcodeIO/long.js.git (@xtuc/long), git://github.com/mde/ejs.git (ejs), https://github.com/jslicense/spdx-correct.js.git (spdx-correct), git+https://github.com/malept/sumchecker.git (sumchecker), https://github.com/kemitchell/validate-npm-package-license.js.git (validate-npm-package-license). This software contains the following license and notice below:
+The following software may be included in this product: @opencensus/core, @opencensus/propagation-b3, @xtuc/long, spdx-correct, sumchecker, validate-npm-package-license. A copy of the source code may be downloaded from https://github.com/census-instrumentation/opencensus-node.git (@opencensus/core), https://github.com/census-instrumentation/opencensus-node.git (@opencensus/propagation-b3), https://github.com/dcodeIO/long.js.git (@xtuc/long), https://github.com/jslicense/spdx-correct.js.git (spdx-correct), git+https://github.com/malept/sumchecker.git (sumchecker), https://github.com/kemitchell/validate-npm-package-license.js.git (validate-npm-package-license). This software contains the following license and notice below:
 
 Apache License
                            Version 2.0, January 2004
@@ -1253,7 +1200,7 @@ Apache License
 
 -----
 
-The following software may be included in this product: @pm2/js-api, detect-libc, terriajs-schema, true-case-path. A copy of the source code may be downloaded from git+https://github.com/keymetrics/km.js.git (@pm2/js-api), git://github.com/lovell/detect-libc (detect-libc), git+https://github.com/TerriaJS/terriajs-schema.git (terriajs-schema), git+https://github.com/barsh/true-case-path.git (true-case-path). This software contains the following license and notice below:
+The following software may be included in this product: @pm2/js-api, detect-libc, true-case-path. A copy of the source code may be downloaded from git+https://github.com/keymetrics/km.js.git (@pm2/js-api), git://github.com/lovell/detect-libc (detect-libc), git+https://github.com/barsh/true-case-path.git (true-case-path). This software contains the following license and notice below:
 
 Apache License
                            Version 2.0, January 2004
@@ -1459,11 +1406,37 @@ Apache License
 
 -----
 
-The following software may be included in this product: @types/estree, @types/events, @types/glob, @types/minimatch, @types/node, @types/normalize-package-data. A copy of the source code may be downloaded from https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/estree), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/events), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/glob), https://www.github.com/DefinitelyTyped/DefinitelyTyped.git (@types/minimatch), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/node), https://www.github.com/DefinitelyTyped/DefinitelyTyped.git (@types/normalize-package-data). This software contains the following license and notice below:
+The following software may be included in this product: @types/color-name, @types/events, @types/glob, @types/minimatch, @types/node, @types/normalize-package-data. A copy of the source code may be downloaded from https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/color-name), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/events), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/glob), https://www.github.com/DefinitelyTyped/DefinitelyTyped.git (@types/minimatch), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/node), https://www.github.com/DefinitelyTyped/DefinitelyTyped.git (@types/normalize-package-data). This software contains the following license and notice below:
 
 MIT License
 
     Copyright (c) Microsoft Corporation. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE
+
+-----
+
+The following software may be included in this product: @types/node. A copy of the source code may be downloaded from https://github.com/DefinitelyTyped/DefinitelyTyped.git. This software contains the following license and notice below:
+
+MIT License
+
+    Copyright (c) Microsoft Corporation.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -1820,26 +1793,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: abbrev, block-stream, chownr, color-support, fs-minipass, fs-write-stream-atomic, fstream, glob, ignore-walk, ini, isexe, json-stringify-safe, lru-cache, minimatch, mute-stream, nopt, npm-packlist, npmlog, once, osenv, pseudomap, read, rimraf, semver, tar, which, wrappy, yallist. A copy of the source code may be downloaded from http://github.com/isaacs/abbrev-js (abbrev), git://github.com/isaacs/block-stream.git (block-stream), git://github.com/isaacs/chownr.git (chownr), git+https://github.com/isaacs/color-support.git (color-support), git+https://github.com/npm/fs-minipass.git (fs-minipass), https://github.com/npm/fs-write-stream-atomic (fs-write-stream-atomic), https://github.com/npm/fstream.git (fstream), git://github.com/isaacs/node-glob.git (glob), git+https://github.com/isaacs/ignore-walk.git (ignore-walk), git://github.com/isaacs/ini.git (ini), git+https://github.com/isaacs/isexe.git (isexe), git://github.com/isaacs/json-stringify-safe (json-stringify-safe), git://github.com/isaacs/node-lru-cache.git (lru-cache), git://github.com/isaacs/minimatch.git (minimatch), git://github.com/isaacs/mute-stream (mute-stream), https://github.com/npm/nopt.git (nopt), git+https://github.com/npm/npm-packlist.git (npm-packlist), https://github.com/npm/npmlog.git (npmlog), git://github.com/isaacs/once (once), https://github.com/npm/osenv (osenv), git+https://github.com/isaacs/pseudomap.git (pseudomap), git://github.com/isaacs/read.git (read), git://github.com/isaacs/rimraf.git (rimraf), https://github.com/npm/node-semver (semver), https://github.com/npm/node-tar.git (tar), git://github.com/isaacs/node-which.git (which), https://github.com/npm/wrappy (wrappy), git+https://github.com/isaacs/yallist.git (yallist). This software contains the following license and notice below:
-
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
------
-
 The following software may be included in this product: accepts, mime-types. A copy of the source code may be downloaded from https://github.com/jshttp/accepts.git (accepts), https://github.com/jshttp/mime-types.git (mime-types). This software contains the following license and notice below:
 
 (The MIT License)
@@ -2149,7 +2102,7 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: ansi-escapes, ansi-regex, ansi-styles, array-union, binary-extensions, callsites, camelcase, chalk, cli-cursor, del, escape-string-regexp, execa, figures, find-up, get-stdin, get-stream, globals, globby, gulp-zip, has-flag, import-fresh, import-local, internal-ip, invert-kv, is-absolute-url, is-fullwidth-code-point, is-path-cwd, is-path-in-cwd, is-path-inside, is-wsl, lcid, locate-path, make-dir, mem, mimic-fn, multimatch, onetime, open, opn, os-locale, p-is-promise, p-limit, p-locate, p-map, p-retry, p-try, parent-module, parse-json, path-exists, path-type, pify, pkg-dir, read-pkg, resolve-from, restore-cursor, run-node, slash, string-width, strip-ansi, strip-json-comments, supports-color, type-fest, wrap-ansi. A copy of the source code may be downloaded from https://github.com/sindresorhus/ansi-escapes.git (ansi-escapes), https://github.com/chalk/ansi-regex.git (ansi-regex), https://github.com/chalk/ansi-styles.git (ansi-styles), https://github.com/sindresorhus/array-union.git (array-union), https://github.com/sindresorhus/binary-extensions.git (binary-extensions), https://github.com/sindresorhus/callsites.git (callsites), https://github.com/sindresorhus/camelcase.git (camelcase), https://github.com/chalk/chalk.git (chalk), https://github.com/sindresorhus/cli-cursor.git (cli-cursor), https://github.com/sindresorhus/del.git (del), https://github.com/sindresorhus/escape-string-regexp.git (escape-string-regexp), https://github.com/sindresorhus/execa.git (execa), https://github.com/sindresorhus/figures.git (figures), https://github.com/sindresorhus/find-up.git (find-up), https://github.com/sindresorhus/get-stdin.git (get-stdin), https://github.com/sindresorhus/get-stream.git (get-stream), https://github.com/sindresorhus/globals.git (globals), https://github.com/sindresorhus/globby.git (globby), https://github.com/sindresorhus/gulp-zip.git (gulp-zip), https://github.com/sindresorhus/has-flag.git (has-flag), https://github.com/sindresorhus/import-fresh.git (import-fresh), https://github.com/sindresorhus/import-local.git (import-local), https://github.com/sindresorhus/internal-ip.git (internal-ip), https://github.com/sindresorhus/invert-kv.git (invert-kv), https://github.com/sindresorhus/is-absolute-url.git (is-absolute-url), https://github.com/sindresorhus/is-fullwidth-code-point.git (is-fullwidth-code-point), https://github.com/sindresorhus/is-path-cwd.git (is-path-cwd), https://github.com/sindresorhus/is-path-in-cwd.git (is-path-in-cwd), https://github.com/sindresorhus/is-path-inside.git (is-path-inside), https://github.com/sindresorhus/is-wsl.git (is-wsl), https://github.com/sindresorhus/lcid.git (lcid), https://github.com/sindresorhus/locate-path.git (locate-path), https://github.com/sindresorhus/make-dir.git (make-dir), https://github.com/sindresorhus/mem.git (mem), https://github.com/sindresorhus/mimic-fn.git (mimic-fn), https://github.com/sindresorhus/multimatch.git (multimatch), https://github.com/sindresorhus/onetime.git (onetime), https://github.com/sindresorhus/open.git (open), https://github.com/sindresorhus/opn.git (opn), https://github.com/sindresorhus/os-locale.git (os-locale), https://github.com/sindresorhus/p-is-promise.git (p-is-promise), https://github.com/sindresorhus/p-limit.git (p-limit), https://github.com/sindresorhus/p-locate.git (p-locate), https://github.com/sindresorhus/p-map.git (p-map), https://github.com/sindresorhus/p-retry.git (p-retry), https://github.com/sindresorhus/p-try.git (p-try), https://github.com/sindresorhus/parent-module.git (parent-module), https://github.com/sindresorhus/parse-json.git (parse-json), https://github.com/sindresorhus/path-exists.git (path-exists), https://github.com/sindresorhus/path-type.git (path-type), https://github.com/sindresorhus/pify.git (pify), https://github.com/sindresorhus/pkg-dir.git (pkg-dir), https://github.com/sindresorhus/read-pkg.git (read-pkg), https://github.com/sindresorhus/resolve-from.git (resolve-from), https://github.com/sindresorhus/restore-cursor.git (restore-cursor), https://github.com/sindresorhus/run-node.git (run-node), https://github.com/sindresorhus/slash.git (slash), https://github.com/sindresorhus/string-width.git (string-width), https://github.com/chalk/strip-ansi.git (strip-ansi), https://github.com/sindresorhus/strip-json-comments.git (strip-json-comments), https://github.com/chalk/supports-color.git (supports-color), https://github.com/sindresorhus/type-fest.git (type-fest), https://github.com/chalk/wrap-ansi.git (wrap-ansi). This software contains the following license and notice below:
+The following software may be included in this product: ansi-escapes, ansi-regex, ansi-styles, binary-extensions, callsites, camelcase, chalk, del, escape-string-regexp, execa, find-up, get-stdin, get-stream, globals, has-flag, import-fresh, import-local, internal-ip, invert-kv, is-absolute-url, is-finite, is-fullwidth-code-point, is-path-cwd, is-path-in-cwd, is-path-inside, is-wsl, lcid, leven, locate-path, make-dir, mem, mimic-fn, multimatch, opn, os-locale, p-is-promise, p-limit, p-locate, p-map, p-retry, p-try, parent-module, parse-json, path-exists, pify, pkg-dir, read-pkg, resolve-from, run-node, slash, string-width, strip-ansi, strip-json-comments, supports-color, type-fest, wrap-ansi. A copy of the source code may be downloaded from https://github.com/sindresorhus/ansi-escapes.git (ansi-escapes), https://github.com/chalk/ansi-regex.git (ansi-regex), https://github.com/chalk/ansi-styles.git (ansi-styles), https://github.com/sindresorhus/binary-extensions.git (binary-extensions), https://github.com/sindresorhus/callsites.git (callsites), https://github.com/sindresorhus/camelcase.git (camelcase), https://github.com/chalk/chalk.git (chalk), https://github.com/sindresorhus/del.git (del), https://github.com/sindresorhus/escape-string-regexp.git (escape-string-regexp), https://github.com/sindresorhus/execa.git (execa), https://github.com/sindresorhus/find-up.git (find-up), https://github.com/sindresorhus/get-stdin.git (get-stdin), https://github.com/sindresorhus/get-stream.git (get-stream), https://github.com/sindresorhus/globals.git (globals), https://github.com/sindresorhus/has-flag.git (has-flag), https://github.com/sindresorhus/import-fresh.git (import-fresh), https://github.com/sindresorhus/import-local.git (import-local), https://github.com/sindresorhus/internal-ip.git (internal-ip), https://github.com/sindresorhus/invert-kv.git (invert-kv), https://github.com/sindresorhus/is-absolute-url.git (is-absolute-url), https://github.com/sindresorhus/is-finite.git (is-finite), https://github.com/sindresorhus/is-fullwidth-code-point.git (is-fullwidth-code-point), https://github.com/sindresorhus/is-path-cwd.git (is-path-cwd), https://github.com/sindresorhus/is-path-in-cwd.git (is-path-in-cwd), https://github.com/sindresorhus/is-path-inside.git (is-path-inside), https://github.com/sindresorhus/is-wsl.git (is-wsl), https://github.com/sindresorhus/lcid.git (lcid), https://github.com/sindresorhus/leven.git (leven), https://github.com/sindresorhus/locate-path.git (locate-path), https://github.com/sindresorhus/make-dir.git (make-dir), https://github.com/sindresorhus/mem.git (mem), https://github.com/sindresorhus/mimic-fn.git (mimic-fn), https://github.com/sindresorhus/multimatch.git (multimatch), https://github.com/sindresorhus/opn.git (opn), https://github.com/sindresorhus/os-locale.git (os-locale), https://github.com/sindresorhus/p-is-promise.git (p-is-promise), https://github.com/sindresorhus/p-limit.git (p-limit), https://github.com/sindresorhus/p-locate.git (p-locate), https://github.com/sindresorhus/p-map.git (p-map), https://github.com/sindresorhus/p-retry.git (p-retry), https://github.com/sindresorhus/p-try.git (p-try), https://github.com/sindresorhus/parent-module.git (parent-module), https://github.com/sindresorhus/parse-json.git (parse-json), https://github.com/sindresorhus/path-exists.git (path-exists), https://github.com/sindresorhus/pify.git (pify), https://github.com/sindresorhus/pkg-dir.git (pkg-dir), https://github.com/sindresorhus/read-pkg.git (read-pkg), https://github.com/sindresorhus/resolve-from.git (resolve-from), https://github.com/sindresorhus/run-node.git (run-node), https://github.com/sindresorhus/slash.git (slash), https://github.com/sindresorhus/string-width.git (string-width), https://github.com/chalk/strip-ansi.git (strip-ansi), https://github.com/sindresorhus/strip-json-comments.git (strip-json-comments), https://github.com/chalk/supports-color.git (supports-color), https://github.com/sindresorhus/type-fest.git (type-fest), https://github.com/chalk/wrap-ansi.git (wrap-ansi). This software contains the following license and notice below:
 
 MIT License
 
@@ -2395,7 +2348,7 @@ Apache License
 
 -----
 
-The following software may be included in this product: ansi-regex, ansi-styles, array-differ, array-find-index, array-union, array-uniq, arrify, caller-callsite, caller-path, callsites, camelcase, camelcase-keys, chalk, cli-cursor, code-point-at, decamelize, escape-string-regexp, figures, find-up, fs-access, get-stream, globby, has-ansi, has-flag, import-fresh, indent-string, ip-regex, is-binary-path, is-finite, is-fullwidth-code-point, is-plain-obj, is-stream, is-wsl, lcid, load-json-file, locate-path, loud-rejection, map-obj, meow, npm-run-path, null-check, number-is-nan, object-assign, onetime, os-homedir, os-locale, os-tmpdir, p-defer, p-finally, p-locate, p-try, parse-json, path-exists, path-is-absolute, path-key, path-type, pify, pretty-bytes, query-string, read-pkg, read-pkg-up, redent, repeating, resolve-cwd, resolve-from, restore-cursor, shebang-regex, string-width, strip-ansi, strip-bom, strip-eof, strip-indent, strip-json-comments, supports-color, trim-newlines, wrap-ansi. A copy of the source code may be downloaded from https://github.com/chalk/ansi-regex.git (ansi-regex), https://github.com/chalk/ansi-styles.git (ansi-styles), https://github.com/sindresorhus/array-differ.git (array-differ), https://github.com/sindresorhus/array-find-index.git (array-find-index), https://github.com/sindresorhus/array-union.git (array-union), https://github.com/sindresorhus/array-uniq.git (array-uniq), https://github.com/sindresorhus/arrify.git (arrify), https://github.com/sindresorhus/caller-callsite.git (caller-callsite), https://github.com/sindresorhus/caller-path.git (caller-path), https://github.com/sindresorhus/callsites.git (callsites), https://github.com/sindresorhus/camelcase.git (camelcase), https://github.com/sindresorhus/camelcase-keys.git (camelcase-keys), https://github.com/chalk/chalk.git (chalk), https://github.com/sindresorhus/cli-cursor.git (cli-cursor), https://github.com/sindresorhus/code-point-at.git (code-point-at), https://github.com/sindresorhus/decamelize.git (decamelize), https://github.com/sindresorhus/escape-string-regexp.git (escape-string-regexp), https://github.com/sindresorhus/figures.git (figures), https://github.com/sindresorhus/find-up.git (find-up), https://github.com/sindresorhus/fs-access.git (fs-access), https://github.com/sindresorhus/get-stream.git (get-stream), https://github.com/sindresorhus/globby.git (globby), https://github.com/sindresorhus/has-ansi.git (has-ansi), https://github.com/sindresorhus/has-flag.git (has-flag), https://github.com/sindresorhus/import-fresh.git (import-fresh), https://github.com/sindresorhus/indent-string.git (indent-string), https://github.com/sindresorhus/ip-regex.git (ip-regex), https://github.com/sindresorhus/is-binary-path.git (is-binary-path), https://github.com/sindresorhus/is-finite.git (is-finite), https://github.com/sindresorhus/is-fullwidth-code-point.git (is-fullwidth-code-point), https://github.com/sindresorhus/is-plain-obj.git (is-plain-obj), https://github.com/sindresorhus/is-stream.git (is-stream), https://github.com/sindresorhus/is-wsl.git (is-wsl), https://github.com/sindresorhus/lcid.git (lcid), https://github.com/sindresorhus/load-json-file.git (load-json-file), https://github.com/sindresorhus/locate-path.git (locate-path), https://github.com/sindresorhus/loud-rejection.git (loud-rejection), https://github.com/sindresorhus/map-obj.git (map-obj), https://github.com/sindresorhus/meow.git (meow), https://github.com/sindresorhus/npm-run-path.git (npm-run-path), https://github.com/sindresorhus/null-check.git (null-check), https://github.com/sindresorhus/number-is-nan.git (number-is-nan), https://github.com/sindresorhus/object-assign.git (object-assign), https://github.com/sindresorhus/onetime.git (onetime), https://github.com/sindresorhus/os-homedir.git (os-homedir), https://github.com/sindresorhus/os-locale.git (os-locale), https://github.com/sindresorhus/os-tmpdir.git (os-tmpdir), https://github.com/sindresorhus/p-defer.git (p-defer), https://github.com/sindresorhus/p-finally.git (p-finally), https://github.com/sindresorhus/p-locate.git (p-locate), https://github.com/sindresorhus/p-try.git (p-try), https://github.com/sindresorhus/parse-json.git (parse-json), https://github.com/sindresorhus/path-exists.git (path-exists), https://github.com/sindresorhus/path-is-absolute.git (path-is-absolute), https://github.com/sindresorhus/path-key.git (path-key), https://github.com/sindresorhus/path-type.git (path-type), https://github.com/sindresorhus/pify.git (pify), https://github.com/sindresorhus/pretty-bytes.git (pretty-bytes), https://github.com/sindresorhus/query-string.git (query-string), https://github.com/sindresorhus/read-pkg.git (read-pkg), https://github.com/sindresorhus/read-pkg-up.git (read-pkg-up), https://github.com/sindresorhus/redent.git (redent), https://github.com/sindresorhus/repeating.git (repeating), https://github.com/sindresorhus/resolve-cwd.git (resolve-cwd), https://github.com/sindresorhus/resolve-from.git (resolve-from), https://github.com/sindresorhus/restore-cursor.git (restore-cursor), https://github.com/sindresorhus/shebang-regex.git (shebang-regex), https://github.com/sindresorhus/string-width.git (string-width), https://github.com/chalk/strip-ansi.git (strip-ansi), https://github.com/sindresorhus/strip-bom.git (strip-bom), https://github.com/sindresorhus/strip-eof.git (strip-eof), https://github.com/sindresorhus/strip-indent.git (strip-indent), https://github.com/sindresorhus/strip-json-comments.git (strip-json-comments), https://github.com/chalk/supports-color.git (supports-color), https://github.com/sindresorhus/trim-newlines.git (trim-newlines), https://github.com/chalk/wrap-ansi.git (wrap-ansi). This software contains the following license and notice below:
+The following software may be included in this product: ansi-regex, ansi-styles, array-differ, array-find-index, array-union, array-uniq, arrify, caller-callsite, caller-path, callsites, camelcase, camelcase-keys, chalk, cli-cursor, code-point-at, decamelize, escape-string-regexp, figures, find-up, fs-access, get-stream, globby, has-ansi, has-flag, import-fresh, indent-string, ip-regex, is-binary-path, is-fullwidth-code-point, is-plain-obj, is-stream, is-wsl, lcid, load-json-file, locate-path, loud-rejection, map-obj, meow, npm-run-path, null-check, number-is-nan, object-assign, onetime, os-homedir, os-locale, os-tmpdir, p-defer, p-finally, p-locate, p-try, parse-json, path-exists, path-is-absolute, path-key, path-type, pify, pkg-up, pretty-bytes, query-string, read-pkg, read-pkg-up, redent, repeating, resolve-cwd, resolve-from, restore-cursor, shebang-regex, string-width, strip-ansi, strip-bom, strip-eof, strip-indent, strip-json-comments, supports-color, trim-newlines, wrap-ansi. A copy of the source code may be downloaded from https://github.com/chalk/ansi-regex.git (ansi-regex), https://github.com/chalk/ansi-styles.git (ansi-styles), https://github.com/sindresorhus/array-differ.git (array-differ), https://github.com/sindresorhus/array-find-index.git (array-find-index), https://github.com/sindresorhus/array-union.git (array-union), https://github.com/sindresorhus/array-uniq.git (array-uniq), https://github.com/sindresorhus/arrify.git (arrify), https://github.com/sindresorhus/caller-callsite.git (caller-callsite), https://github.com/sindresorhus/caller-path.git (caller-path), https://github.com/sindresorhus/callsites.git (callsites), https://github.com/sindresorhus/camelcase.git (camelcase), https://github.com/sindresorhus/camelcase-keys.git (camelcase-keys), https://github.com/chalk/chalk.git (chalk), https://github.com/sindresorhus/cli-cursor.git (cli-cursor), https://github.com/sindresorhus/code-point-at.git (code-point-at), https://github.com/sindresorhus/decamelize.git (decamelize), https://github.com/sindresorhus/escape-string-regexp.git (escape-string-regexp), https://github.com/sindresorhus/figures.git (figures), https://github.com/sindresorhus/find-up.git (find-up), https://github.com/sindresorhus/fs-access.git (fs-access), https://github.com/sindresorhus/get-stream.git (get-stream), https://github.com/sindresorhus/globby.git (globby), https://github.com/sindresorhus/has-ansi.git (has-ansi), https://github.com/sindresorhus/has-flag.git (has-flag), https://github.com/sindresorhus/import-fresh.git (import-fresh), https://github.com/sindresorhus/indent-string.git (indent-string), https://github.com/sindresorhus/ip-regex.git (ip-regex), https://github.com/sindresorhus/is-binary-path.git (is-binary-path), https://github.com/sindresorhus/is-fullwidth-code-point.git (is-fullwidth-code-point), https://github.com/sindresorhus/is-plain-obj.git (is-plain-obj), https://github.com/sindresorhus/is-stream.git (is-stream), https://github.com/sindresorhus/is-wsl.git (is-wsl), https://github.com/sindresorhus/lcid.git (lcid), https://github.com/sindresorhus/load-json-file.git (load-json-file), https://github.com/sindresorhus/locate-path.git (locate-path), https://github.com/sindresorhus/loud-rejection.git (loud-rejection), https://github.com/sindresorhus/map-obj.git (map-obj), https://github.com/sindresorhus/meow.git (meow), https://github.com/sindresorhus/npm-run-path.git (npm-run-path), https://github.com/sindresorhus/null-check.git (null-check), https://github.com/sindresorhus/number-is-nan.git (number-is-nan), https://github.com/sindresorhus/object-assign.git (object-assign), https://github.com/sindresorhus/onetime.git (onetime), https://github.com/sindresorhus/os-homedir.git (os-homedir), https://github.com/sindresorhus/os-locale.git (os-locale), https://github.com/sindresorhus/os-tmpdir.git (os-tmpdir), https://github.com/sindresorhus/p-defer.git (p-defer), https://github.com/sindresorhus/p-finally.git (p-finally), https://github.com/sindresorhus/p-locate.git (p-locate), https://github.com/sindresorhus/p-try.git (p-try), https://github.com/sindresorhus/parse-json.git (parse-json), https://github.com/sindresorhus/path-exists.git (path-exists), https://github.com/sindresorhus/path-is-absolute.git (path-is-absolute), https://github.com/sindresorhus/path-key.git (path-key), https://github.com/sindresorhus/path-type.git (path-type), https://github.com/sindresorhus/pify.git (pify), https://github.com/sindresorhus/pkg-up.git (pkg-up), https://github.com/sindresorhus/pretty-bytes.git (pretty-bytes), https://github.com/sindresorhus/query-string.git (query-string), https://github.com/sindresorhus/read-pkg.git (read-pkg), https://github.com/sindresorhus/read-pkg-up.git (read-pkg-up), https://github.com/sindresorhus/redent.git (redent), https://github.com/sindresorhus/repeating.git (repeating), https://github.com/sindresorhus/resolve-cwd.git (resolve-cwd), https://github.com/sindresorhus/resolve-from.git (resolve-from), https://github.com/sindresorhus/restore-cursor.git (restore-cursor), https://github.com/sindresorhus/shebang-regex.git (shebang-regex), https://github.com/sindresorhus/string-width.git (string-width), https://github.com/chalk/strip-ansi.git (strip-ansi), https://github.com/sindresorhus/strip-bom.git (strip-bom), https://github.com/sindresorhus/strip-eof.git (strip-eof), https://github.com/sindresorhus/strip-indent.git (strip-indent), https://github.com/sindresorhus/strip-json-comments.git (strip-json-comments), https://github.com/chalk/supports-color.git (supports-color), https://github.com/sindresorhus/trim-newlines.git (trim-newlines), https://github.com/chalk/wrap-ansi.git (wrap-ansi). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -2447,35 +2400,11 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: any-promise. A copy of the source code may be downloaded from https://github.com/kevinbeaty/any-promise. This software contains the following license and notice below:
-
-Copyright (C) 2014-2016 Kevin Beaty
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------
-
 The following software may be included in this product: anymatch. A copy of the source code may be downloaded from https://github.com/micromatch/anymatch. This software contains the following license and notice below:
 
 The ISC License
 
-Copyright (c) 2019 Elan Shanker, Paul Miller (https://paulmillr.com)
+Copyright (c) 2014 Elan Shanker
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
@@ -2495,7 +2424,7 @@ The following software may be included in this product: anymatch. A copy of the 
 
 The ISC License
 
-Copyright (c) 2014 Elan Shanker
+Copyright (c) 2019 Elan Shanker, Paul Miller (https://paulmillr.com)
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above
@@ -2609,7 +2538,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: archy, buffer-equal, concat-map, ent, fast-json-stable-stringify, is-typedarray, json-stable-stringify-without-jsonify, minimist, path-browserify, resolve, safe-regex, semver-compare, text-table, tty-browserify, wordwrap. A copy of the source code may be downloaded from http://github.com/substack/node-archy.git (archy), git://github.com/substack/node-buffer-equal.git (buffer-equal), git://github.com/substack/node-concat-map.git (concat-map), https://github.com/substack/node-ent.git (ent), git://github.com/epoberezkin/fast-json-stable-stringify.git (fast-json-stable-stringify), git://github.com/hughsk/is-typedarray.git (is-typedarray), git://github.com/samn/json-stable-stringify.git (json-stable-stringify-without-jsonify), git://github.com/substack/minimist.git (minimist), git://github.com/substack/path-browserify.git (path-browserify), git://github.com/substack/node-resolve.git (resolve), git://github.com/substack/safe-regex.git (safe-regex), git://github.com/substack/semver-compare.git (semver-compare), git://github.com/substack/text-table.git (text-table), git://github.com/substack/tty-browserify.git (tty-browserify), git://github.com/substack/node-wordwrap.git (wordwrap). This software contains the following license and notice below:
+The following software may be included in this product: archy, buffer-equal, concat-map, ent, is-typedarray, json-stable-stringify-without-jsonify, minimist, path-browserify, safe-regex, semver-compare, text-table, tty-browserify, wordwrap. A copy of the source code may be downloaded from http://github.com/substack/node-archy.git (archy), git://github.com/substack/node-buffer-equal.git (buffer-equal), git://github.com/substack/node-concat-map.git (concat-map), https://github.com/substack/node-ent.git (ent), git://github.com/hughsk/is-typedarray.git (is-typedarray), git://github.com/samn/json-stable-stringify.git (json-stable-stringify-without-jsonify), git://github.com/substack/minimist.git (minimist), git://github.com/substack/path-browserify.git (path-browserify), git://github.com/substack/safe-regex.git (safe-regex), git://github.com/substack/semver-compare.git (semver-compare), git://github.com/substack/text-table.git (text-table), git://github.com/substack/tty-browserify.git (tty-browserify), git://github.com/substack/node-wordwrap.git (wordwrap). This software contains the following license and notice below:
 
 This software is released under the MIT license:
 
@@ -2824,11 +2753,11 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: array-back, collect-all, config-master, sort-array, stream-via, wordwrapjs. A copy of the source code may be downloaded from https://github.com/75lb/array-back.git (array-back), https://github.com/75lb/collect-all.git (collect-all), https://github.com/75lb/config-master (config-master), https://github.com/75lb/sort-array.git (sort-array), https://github.com/75lb/stream-via.git (stream-via), https://github.com/75lb/wordwrapjs.git (wordwrapjs). This software contains the following license and notice below:
+The following software may be included in this product: array-back, find-replace, home-path, table-layout, walk-back. A copy of the source code may be downloaded from https://github.com/75lb/array-back.git (array-back), https://github.com/75lb/find-replace.git (find-replace), https://github.com/75lb/home-path (home-path), https://github.com/75lb/table-layout.git (table-layout), https://github.com/75lb/walk-back.git (walk-back). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
-Copyright (c) 2015-17 Lloyd Brookes <75pound@gmail.com>
+Copyright (c) 2015-19 Lloyd Brookes <75pound@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -2850,11 +2779,11 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: array-back, find-replace, home-path, table-layout, walk-back. A copy of the source code may be downloaded from https://github.com/75lb/array-back.git (array-back), https://github.com/75lb/find-replace.git (find-replace), https://github.com/75lb/home-path (home-path), https://github.com/75lb/table-layout.git (table-layout), https://github.com/75lb/walk-back.git (walk-back). This software contains the following license and notice below:
+The following software may be included in this product: array-back, collect-all, config-master, sort-array, stream-via, wordwrapjs. A copy of the source code may be downloaded from https://github.com/75lb/array-back.git (array-back), https://github.com/75lb/collect-all.git (collect-all), https://github.com/75lb/config-master (config-master), https://github.com/75lb/sort-array.git (sort-array), https://github.com/75lb/stream-via.git (stream-via), https://github.com/75lb/wordwrapjs.git (wordwrapjs). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
-Copyright (c) 2015-19 Lloyd Brookes <75pound@gmail.com>
+Copyright (c) 2015-17 Lloyd Brookes <75pound@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -2928,7 +2857,7 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: array-includes, define-properties, es-abstract. A copy of the source code may be downloaded from git://github.com/ljharb/array-includes.git (array-includes), git://github.com/ljharb/define-properties.git (define-properties), git://github.com/ljharb/es-abstract.git (es-abstract). This software contains the following license and notice below:
+The following software may be included in this product: array-includes, define-properties, es-abstract. A copy of the source code may be downloaded from git://github.com/es-shims/array-includes.git (array-includes), git://github.com/ljharb/define-properties.git (define-properties), git://github.com/ljharb/es-abstract.git (es-abstract). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -3054,7 +2983,7 @@ THE SOFTWARE
 
 -----
 
-The following software may be included in this product: assert, readable-stream, util. A copy of the source code may be downloaded from git://github.com/browserify/commonjs-assert.git (assert), git://github.com/nodejs/readable-stream (readable-stream), git://github.com/defunctzombie/node-util (util). This software contains the following license and notice below:
+The following software may be included in this product: assert, readable-stream, util. A copy of the source code may be downloaded from git://github.com/defunctzombie/commonjs-assert.git (assert), git://github.com/nodejs/readable-stream (readable-stream), git://github.com/defunctzombie/node-util (util). This software contains the following license and notice below:
 
 Copyright Joyent, Inc. and other Node contributors. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -3102,7 +3031,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: astral-regex, dir-glob. A copy of the source code may be downloaded from https://github.com/kevva/astral-regex.git (astral-regex), https://github.com/kevva/dir-glob.git (dir-glob). This software contains the following license and notice below:
+The following software may be included in this product: astral-regex. A copy of the source code may be downloaded from https://github.com/kevva/astral-regex.git. This software contains the following license and notice below:
 
 MIT License
 
@@ -3119,30 +3048,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 The following software may be included in this product: async. A copy of the source code may be downloaded from https://github.com/caolan/async.git. This software contains the following license and notice below:
 
 Copyright (c) 2010-2018 Caolan McMahon
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------
-
-The following software may be included in this product: async. A copy of the source code may be downloaded from https://github.com/caolan/async.git. This software contains the following license and notice below:
-
-Copyright (c) 2010-2014 Caolan McMahon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -4246,31 +4151,30 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----
 
-The following software may be included in this product: binaryextensions, textextensions. A copy of the source code may be downloaded from https://github.com/bevry/binaryextensions.git (binaryextensions), https://github.com/bevry/textextensions.git (textextensions). This software contains the following license and notice below:
+The following software may be included in this product: bindings. A copy of the source code may be downloaded from git://github.com/TooTallNate/node-bindings.git. This software contains the following license and notice below:
 
-<!-- LICENSEFILE/ -->
+(The MIT License)
 
-<h1>License</h1>
+Copyright (c) 2012 Nathan Rajlich &lt;nathan@tootallnate.net&gt;
 
-Unless stated otherwise all works are:
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-<ul><li>Copyright &copy; 2013+ <a href="http://bevry.me">Bevry Pty Ltd</a></li></ul>
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-and licensed under:
-
-<ul><li><a href="http://spdx.org/licenses/MIT.html">MIT License</a></li></ul>
-
-<h2>MIT License</h2>
-
-<pre>
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-
-<!-- /LICENSEFILE -->
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
@@ -4279,7 +4183,7 @@ The following software may be included in this product: bl. A copy of the source
 The MIT License (MIT)
 =====================
 
-Copyright (c) 2013-2018 bl contributors
+Copyright (c) 2013-2016 bl contributors
 ----------------------------------
 
 *bl contributors listed at <https://github.com/rvagg/bl#contributors>*
@@ -4297,7 +4201,7 @@ The following software may be included in this product: bl. A copy of the source
 The MIT License (MIT)
 =====================
 
-Copyright (c) 2013-2016 bl contributors
+Copyright (c) 2013-2019 bl contributors
 ----------------------------------
 
 *bl contributors listed at <https://github.com/rvagg/bl#contributors>*
@@ -4358,6 +4262,26 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-----
+
+The following software may be included in this product: block-stream, chownr, color-support, fs-minipass, fs-write-stream-atomic, fstream, ignore-walk, ini, isexe, json-stringify-safe, lru-cache, minimatch, mute-stream, nopt, npm-packlist, npmlog, once, osenv, pseudomap, read, rimraf, semver, tar, which, wrappy, yallist. A copy of the source code may be downloaded from git://github.com/isaacs/block-stream.git (block-stream), git://github.com/isaacs/chownr.git (chownr), git+https://github.com/isaacs/color-support.git (color-support), git+https://github.com/npm/fs-minipass.git (fs-minipass), https://github.com/npm/fs-write-stream-atomic (fs-write-stream-atomic), https://github.com/npm/fstream.git (fstream), git+https://github.com/isaacs/ignore-walk.git (ignore-walk), git://github.com/isaacs/ini.git (ini), git+https://github.com/isaacs/isexe.git (isexe), git://github.com/isaacs/json-stringify-safe (json-stringify-safe), git://github.com/isaacs/node-lru-cache.git (lru-cache), git://github.com/isaacs/minimatch.git (minimatch), git://github.com/isaacs/mute-stream (mute-stream), https://github.com/npm/nopt.git (nopt), git+https://github.com/npm/npm-packlist.git (npm-packlist), https://github.com/npm/npmlog.git (npmlog), git://github.com/isaacs/once (once), https://github.com/npm/osenv (osenv), git+https://github.com/isaacs/pseudomap.git (pseudomap), git://github.com/isaacs/read.git (read), git://github.com/isaacs/rimraf.git (rimraf), https://github.com/npm/node-semver (semver), https://github.com/npm/node-tar.git (tar), git://github.com/isaacs/node-which.git (which), https://github.com/npm/wrappy (wrappy), git+https://github.com/isaacs/yallist.git (yallist). This software contains the following license and notice below:
+
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----
 
@@ -4719,7 +4643,7 @@ The following software may be included in this product: browserslist. A copy of 
 
 The MIT License (MIT)
 
-Copyright 2014 Andrey Sitnik <andrey@sitnik.ru>
+Copyright 2014 Andrey Sitnik <andrey@sitnik.ru> and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -4867,7 +4791,7 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: builtin-status-codes, stream-to-promise. A copy of the source code may be downloaded from https://github.com/bendrucker/builtin-status-codes.git (builtin-status-codes), git://github.com/bendrucker/stream-to-promise.git (stream-to-promise). This software contains the following license and notice below:
+The following software may be included in this product: builtin-status-codes. A copy of the source code may be downloaded from https://github.com/bendrucker/builtin-status-codes.git. This software contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -4921,7 +4845,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: cacache, figgy-pudding, ssri. A copy of the source code may be downloaded from https://github.com/npm/cacache (cacache), https://github.com/zkat/figgy-pudding (figgy-pudding), https://github.com/zkat/ssri (ssri). This software contains the following license and notice below:
+The following software may be included in this product: cacache, figgy-pudding, ssri. A copy of the source code may be downloaded from https://github.com/npm/cacache (cacache), https://github.com/npm/figgy-pudding (figgy-pudding), https://github.com/zkat/ssri (ssri). This software contains the following license and notice below:
 
 ISC License
 
@@ -5672,6 +5596,32 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----
 
+The following software may be included in this product: clipboard. A copy of the source code may be downloaded from https://github.com/zenorocha/clipboard.js.git. This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) Zeno Rocha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
 The following software may be included in this product: cliui. A copy of the source code may be downloaded from http://github.com/yargs/cliui.git. This software contains the following license and notice below:
 
 Copyright (c) 2015, Contributors
@@ -5844,7 +5794,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: color-name. A copy of the source code may be downloaded from git@github.com:dfcreative/color-name.git. This software contains the following license and notice below:
+The following software may be included in this product: color-name. A copy of the source code may be downloaded from git@github.com:colorjs/color-name.git. This software contains the following license and notice below:
 
 The MIT License (MIT)
 Copyright (c) 2015 Dmitry Ivanov
@@ -6476,9 +6426,33 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: core-js, core-js-compat. A copy of the source code may be downloaded from https://github.com/zloirock/core-js.git (core-js), https://github.com/zloirock/core-js.git (core-js-compat). This software contains the following license and notice below:
+The following software may be included in this product: core-js. A copy of the source code may be downloaded from https://github.com/zloirock/core-js.git. This software contains the following license and notice below:
 
 Copyright (c) 2014-2019 Denis Pushkarev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: core-js-compat, core-js-pure. A copy of the source code may be downloaded from https://github.com/zloirock/core-js.git (core-js-compat), https://github.com/zloirock/core-js.git (core-js-pure). This software contains the following license and notice below:
+
+Copyright (c) 2014-2020 Denis Pushkarev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -6846,7 +6820,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
-The following software may be included in this product: css-select, css-what, domelementtype, domhandler, domutils, entities, nth-check. A copy of the source code may be downloaded from git://github.com/fb55/css-select.git (css-select), https://github.com/fb55/css-what (css-what), git://github.com/fb55/domelementtype.git (domelementtype), git://github.com/fb55/DomHandler.git (domhandler), git://github.com/fb55/domutils.git (domutils), git://github.com/fb55/entities.git (entities), https://github.com/fb55/nth-check (nth-check). This software contains the following license and notice below:
+The following software may be included in this product: css-select, css-what, domelementtype, domhandler, domutils, entities, nth-check. A copy of the source code may be downloaded from git://github.com/fb55/css-select.git (css-select), https://github.com/fb55/css-what (css-what), git://github.com/fb55/domelementtype.git (domelementtype), git://github.com/fb55/DomHandler.git (domhandler), git://github.com/FB55/domutils.git (domutils), git://github.com/fb55/entities.git (entities), https://github.com/fb55/nth-check (nth-check). This software contains the following license and notice below:
 
 Copyright (c) Felix Böhm
 All rights reserved.
@@ -7627,7 +7601,34 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: destroy, ee-first, mime-db, stream-to-array, temp-path. A copy of the source code may be downloaded from https://github.com/stream-utils/destroy.git (destroy), https://github.com/jonathanong/ee-first.git (ee-first), https://github.com/jshttp/mime-db.git (mime-db), https://github.com/stream-utils/stream-to-array.git (stream-to-array), https://github.com/fs-utils/temp-path.git (temp-path). This software contains the following license and notice below:
+The following software may be included in this product: depd. A copy of the source code may be downloaded from https://github.com/dougwilson/nodejs-depd.git. This software contains the following license and notice below:
+
+(The MIT License)
+
+Copyright (c) 2014-2018 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: destroy, ee-first, mime-db, temp-path. A copy of the source code may be downloaded from https://github.com/stream-utils/destroy.git (destroy), https://github.com/jonathanong/ee-first.git (ee-first), https://github.com/jshttp/mime-db.git (mime-db), https://github.com/fs-utils/temp-path.git (temp-path). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -8064,7 +8065,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: dom-helpers. A copy of the source code may be downloaded from git+https://github.com/jquense/dom-helpers.git. This software contains the following license and notice below:
+The following software may be included in this product: dom-helpers. A copy of the source code may be downloaded from git+https://github.com/react-bootstrap/dom-helpers.git. This software contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -8594,45 +8595,6 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: edge-launcher. This software contains the following license and notice below:
-
-Copyright (c) Microsoft Corporation
-All rights reserved. 
-MIT License
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: editions. A copy of the source code may be downloaded from https://github.com/bevry/editions.git. This software contains the following license and notice below:
-
-<!-- LICENSEFILE/ -->
-
-<h1>License</h1>
-
-Unless stated otherwise all works are:
-
-<ul><li>Copyright &copy; 2016+ <a href="http://bevry.me">Bevry Pty Ltd</a></li></ul>
-
-and licensed under:
-
-<ul><li><a href="http://spdx.org/licenses/MIT.html">MIT License</a></li></ul>
-
-<h2>MIT License</h2>
-
-<pre>
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-
-<!-- /LICENSEFILE -->
-
------
-
 The following software may be included in this product: electron. A copy of the source code may be downloaded from https://github.com/electron/electron. This software contains the following license and notice below:
 
 Copyright (c) 2013-2018 GitHub Inc.
@@ -8833,36 +8795,7 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: error-stack-parser, stackframe, tweetnacl. A copy of the source code may be downloaded from git://github.com/stacktracejs/error-stack-parser.git (error-stack-parser), git://github.com/stacktracejs/stackframe.git (stackframe), https://github.com/dchest/tweetnacl-js.git (tweetnacl). This software contains the following license and notice below:
-
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org>
-
------
-
-The following software may be included in this product: es-to-primitive, is-callable, is-date-object, is-symbol, object.entries, object.getownpropertydescriptors, object.values, string.prototype.trimleft, string.prototype.trimright. A copy of the source code may be downloaded from git://github.com/ljharb/es-to-primitive.git (es-to-primitive), git://github.com/ljharb/is-callable.git (is-callable), git://github.com/ljharb/is-date-object.git (is-date-object), git://github.com/inspect-js/is-symbol.git (is-symbol), git://github.com/es-shims/Object.entries.git (object.entries), git://github.com/ljharb/object.getownpropertydescriptors.git (object.getownpropertydescriptors), git://github.com/es-shims/Object.values.git (object.values), git://github.com/es-shims/String.prototype.trimLeft.git (string.prototype.trimleft), git://github.com/es-shims/String.prototype.trimRight.git (string.prototype.trimright). This software contains the following license and notice below:
+The following software may be included in this product: es-to-primitive, is-callable, is-date-object, is-string, is-symbol, object.entries, object.getownpropertydescriptors, object.values, string.prototype.matchall, string.prototype.trimleft, string.prototype.trimright. A copy of the source code may be downloaded from git://github.com/ljharb/es-to-primitive.git (es-to-primitive), git://github.com/ljharb/is-callable.git (is-callable), git://github.com/ljharb/is-date-object.git (is-date-object), git://github.com/ljharb/is-string.git (is-string), git://github.com/inspect-js/is-symbol.git (is-symbol), git://github.com/es-shims/Object.entries.git (object.entries), git://github.com/es-shims/object.getownpropertydescriptors.git (object.getownpropertydescriptors), git://github.com/es-shims/Object.values.git (object.values), git+https://github.com/ljharb/String.prototype.matchAll.git (string.prototype.matchall), git://github.com/es-shims/String.prototype.trimLeft.git (string.prototype.trimleft), git://github.com/es-shims/String.prototype.trimRight.git (string.prototype.trimright). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -9052,54 +8985,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
------
-
-The following software may be included in this product: eslint-plugin-eslint-plugin. A copy of the source code may be downloaded from git+https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-=====================
-
-Copyright © 2016 Teddy Katz
-
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the “Software”), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: eslint-plugin-html. A copy of the source code may be downloaded from https://github.com/BenoitZugmeyer/eslint-plugin-html. This software contains the following license and notice below:
-
-Copyright (c) 2016, Benoît Zugmeyer
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----
 
@@ -9388,34 +9273,6 @@ Apache License
 
 -----
 
-The following software may be included in this product: esm. A copy of the source code may be downloaded from https://github.com/standard-things/esm.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright esm contributors
-
-Based on reify, copyright Ben Newman <https://github.com/benjamn/reify>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
 The following software may be included in this product: espree. A copy of the source code may be downloaded from https://github.com/eslint/espree.git. This software contains the following license and notice below:
 
 Espree
@@ -9495,7 +9352,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
-The following software may be included in this product: esquery. A copy of the source code may be downloaded from https://github.com/jrfeenst/esquery.git. This software contains the following license and notice below:
+The following software may be included in this product: esquery. A copy of the source code may be downloaded from https://github.com/estools/esquery.git. This software contains the following license and notice below:
 
 Copyright (c) 2013, Joel Feenstra
 All rights reserved.
@@ -9763,11 +9620,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: extend-shallow, parse-filepath. A copy of the source code may be downloaded from https://github.com/jonschlinkert/extend-shallow.git (extend-shallow), https://github.com/jonschlinkert/parse-filepath.git (parse-filepath). This software contains the following license and notice below:
+The following software may be included in this product: extend-shallow, mixin-deep. A copy of the source code may be downloaded from https://github.com/jonschlinkert/extend-shallow.git (extend-shallow), https://github.com/jonschlinkert/mixin-deep.git (mixin-deep). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
-Copyright (c) 2014-2015, Jon Schlinkert.
+Copyright (c) 2014-2015, 2017, Jon Schlinkert.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9789,11 +9646,11 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: extend-shallow, mixin-deep. A copy of the source code may be downloaded from https://github.com/jonschlinkert/extend-shallow.git (extend-shallow), https://github.com/jonschlinkert/mixin-deep.git (mixin-deep). This software contains the following license and notice below:
+The following software may be included in this product: extend-shallow, parse-filepath. A copy of the source code may be downloaded from https://github.com/jonschlinkert/extend-shallow.git (extend-shallow), https://github.com/jonschlinkert/parse-filepath.git (parse-filepath). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
-Copyright (c) 2014-2015, 2017, Jon Schlinkert.
+Copyright (c) 2014-2015, Jon Schlinkert.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9919,6 +9776,32 @@ SOFTWARE.
 
 -----
 
+The following software may be included in this product: fast-json-stable-stringify. A copy of the source code may be downloaded from git://github.com/epoberezkin/fast-json-stable-stringify.git. This software contains the following license and notice below:
+
+This software is released under the MIT license:
+
+Copyright (c) 2017 Evgeny Poberezkin
+Copyright (c) 2013 James Halliday
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
 The following software may be included in this product: fast-levenshtein. A copy of the source code may be downloaded from https://github.com/hiddentao/fast-levenshtein.git. This software contains the following license and notice below:
 
 (MIT License)
@@ -9945,24 +9828,6 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: fastq. A copy of the source code may be downloaded from git+https://github.com/mcollina/fastq.git. This software contains the following license and notice below:
-
-Copyright (c) 2015, Matteo Collina <matteo.collina@gmail.com>
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 -----
 
@@ -10152,7 +10017,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: fill-range, is-number, micromatch. A copy of the source code may be downloaded from https://github.com/jonschlinkert/fill-range.git (fill-range), https://github.com/jonschlinkert/is-number.git (is-number), https://github.com/micromatch/micromatch.git (micromatch). This software contains the following license and notice below:
+The following software may be included in this product: fill-range, is-number. A copy of the source code may be downloaded from https://github.com/jonschlinkert/fill-range.git (fill-range), https://github.com/jonschlinkert/is-number.git (is-number). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -10364,15 +10229,29 @@ Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
 
 -----
 
-The following software may be included in this product: formidable. A copy of the source code may be downloaded from git://github.com/felixge/node-formidable.git. This software contains the following license and notice below:
+The following software may be included in this product: formidable. A copy of the source code may be downloaded from https://github.com/node-formidable/formidable.git. This software contains the following license and notice below:
 
-Copyright (C) 2011 Felix Geisendörfer
+The MIT License (MIT)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2011-present Felix Geisendörfer, and contributors.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 -----
 
@@ -10664,6 +10543,18 @@ THE SOFTWARE.
 
 -----
 
+The following software may be included in this product: gensync. This software contains the following license and notice below:
+
+Copyright 2018 Logan Smyth <loganfsmyth@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
 The following software may be included in this product: get-caller-file. A copy of the source code may be downloaded from git+https://github.com/stefanpenner/get-caller-file.git. This software contains the following license and notice below:
 
 ISC License (ISC)
@@ -10841,32 +10732,6 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: global-modules, global-prefix, repeat-element, shallow-clone, to-regex-range, use. A copy of the source code may be downloaded from https://github.com/jonschlinkert/global-modules.git (global-modules), https://github.com/jonschlinkert/global-prefix.git (global-prefix), https://github.com/jonschlinkert/repeat-element.git (repeat-element), https://github.com/jonschlinkert/shallow-clone.git (shallow-clone), https://github.com/micromatch/to-regex-range.git (to-regex-range), https://github.com/jonschlinkert/use.git (use). This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2015-present, Jon Schlinkert.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------
-
 The following software may be included in this product: globule. A copy of the source code may be downloaded from git://github.com/cowboy/node-globule.git. This software contains the following license and notice below:
 
 Copyright (c) 2018 "Cowboy" Ben Alman
@@ -10891,21 +10756,6 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: glsl-tokenizer. A copy of the source code may be downloaded from git://github.com/gl-modules/glsl-tokenizer.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-=====================
-
-Copyright (c) 2014 [Chris Dickinson](http://github.com/chrisdickinson)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
@@ -10981,118 +10831,6 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: gulp-clean-css. A copy of the source code may be downloaded from https://github.com/scniro/gulp-clean-css.git. This software contains the following license and notice below:
-
-Copyright (c) 2019 scniro <scniro@outlook.com>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: gulp-rename. A copy of the source code may be downloaded from git://github.com/hparra/gulp-rename.git. This software contains the following license and notice below:
-
-Copyright 2013 Hector Guillermo Parra Alvarez
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: gulp-replace. A copy of the source code may be downloaded from git://github.com/lazd/gulp-replace.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2013 Larry Davis
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: gulp-tap. A copy of the source code may be downloaded from https://github.com/geejs/gulp-tap. This software contains the following license and notice below:
-
-Copyright 2014 Mario Gutierrez
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: gulp-uglify. A copy of the source code may be downloaded from https://github.com/terinjokes/gulp-uglify.git. This software contains the following license and notice below:
-
-Copyright (c) 2013-2017 Terin Stock <terinjokes@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
 The following software may be included in this product: gulplog. A copy of the source code may be downloaded from https://github.com/gulpjs/gulplog.git. This software contains the following license and notice below:
 
 The MIT License (MIT)
@@ -11147,7 +10885,7 @@ THE SOFTWARE.
 
 The following software may be included in this product: handlebars. A copy of the source code may be downloaded from https://github.com/wycats/handlebars.js.git. This software contains the following license and notice below:
 
-Copyright (C) 2011-2017 by Yehuda Katz
+Copyright (C) 2011-2019 by Yehuda Katz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -11223,32 +10961,6 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: has-gulplog. A copy of the source code may be downloaded from https://github.com/gulpjs/has-gulplog.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2015 gulp
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 -----
 
@@ -12043,6 +11755,32 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
+The following software may be included in this product: internal-slot, side-channel. A copy of the source code may be downloaded from git+https://github.com/ljharb/internal-slot.git (internal-slot), git+https://github.com/ljharb/side-channel.git (side-channel). This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2019 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
 The following software may be included in this product: interpret. A copy of the source code may be downloaded from https://github.com/gulpjs/interpret.git. This software contains the following license and notice below:
 
 Copyright (c) 2014-2018 Tyler Kellen <tyler@sleekcode.net>, Blaine Bublitz <blaine.bublitz@gmail.com>, and Eric Schoffstall <yo@contra.io>
@@ -12171,7 +11909,7 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: is-arguments, is-regex, object-is. A copy of the source code may be downloaded from git://github.com/ljharb/is-arguments.git (is-arguments), git://github.com/ljharb/is-regex.git (is-regex), git://github.com/ljharb/object-is.git (object-is). This software contains the following license and notice below:
+The following software may be included in this product: is-arguments, is-regex, object-is. A copy of the source code may be downloaded from git://github.com/ljharb/is-arguments.git (is-arguments), git://github.com/ljharb/is-regex.git (is-regex), git://github.com/es-shims/object-is.git (object-is). This software contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -12381,148 +12119,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----
 
-The following software may be included in this product: istanbul. A copy of the source code may be downloaded from git://github.com/gotwarlost/istanbul.git. This software contains the following license and notice below:
-
-Copyright 2012 Yahoo! Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the Yahoo! Inc. nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------
-
-The following software may be included in this product: istanbul-lib-coverage, istanbul-lib-instrument, istanbul-lib-report, istanbul-reports. A copy of the source code may be downloaded from git@github.com:istanbuljs/istanbuljs.git (istanbul-lib-coverage), git@github.com:istanbuljs/istanbuljs.git (istanbul-lib-instrument), git@github.com:istanbuljs/istanbuljs.git (istanbul-lib-report), git@github.com:istanbuljs/istanbuljs (istanbul-reports). This software contains the following license and notice below:
-
-Copyright 2012-2015 Yahoo! Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the Yahoo! Inc. nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------
-
-The following software may be included in this product: istanbul-lib-source-maps. A copy of the source code may be downloaded from git+ssh://git@github.com/istanbuljs/istanbuljs.git. This software contains the following license and notice below:
-
-Copyright 2015 Yahoo! Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the Yahoo! Inc. nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
------
-
-The following software may be included in this product: istextorbinary. A copy of the source code may be downloaded from https://github.com/bevry/istextorbinary.git. This software contains the following license and notice below:
-
-<!-- LICENSEFILE/ -->
-
-<h1>License</h1>
-
-Unless stated otherwise all works are:
-
-<ul><li>Copyright &copy; 2012+ <a href="http://bevry.me">Bevry Pty Ltd</a></li>
-<li>Copyright &copy; 2011 <a href="http://balupton.com">Benjamin Lupton</a></li></ul>
-
-and licensed under:
-
-<ul><li><a href="http://spdx.org/licenses/MIT.html">MIT License</a></li></ul>
-
-<h2>MIT License</h2>
-
-<pre>
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-
-<!-- /LICENSEFILE -->
-
------
-
-The following software may be included in this product: jest-worker, react, react-dom, react-is, react-test-renderer, scheduler. A copy of the source code may be downloaded from https://github.com/facebook/jest.git (jest-worker), https://github.com/facebook/react.git (react), https://github.com/facebook/react.git (react-dom), https://github.com/facebook/react.git (react-is), https://github.com/facebook/react.git (react-test-renderer), https://github.com/facebook/react.git (scheduler). This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) Facebook, Inc. and its affiliates.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
 The following software may be included in this product: jmespath. A copy of the source code may be downloaded from git://github.com/jmespath/jmespath.js. This software contains the following license and notice below:
 
 Copyright 2014 James Saryerwinnie
@@ -12596,32 +12192,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
------
-
-The following software may be included in this product: js-levenshtein. A copy of the source code may be downloaded from https://github.com/gustf/js-levenshtein.git. This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2017 Gustaf Andersson
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 -----
 
@@ -13116,14 +12686,14 @@ third-party archives.
 NOTICE
 
 js2xmlparser  
-Copyright (C) 2016-2019 Michael Kourlas
+Copyright (C) 2016-2020 Michael Kourlas
 
 ## Apache License, version 2.0 ##
 
 The following components are provided under the [Apache License, version 2.0](https://www.apache.org/licenses/LICENSE-2.0):
 
 xmlcreate  
-Copyright (C) 2016-2019 Michael Kourlas
+Copyright (C) 2016-2020 Michael Kourlas
 
 -----
 
@@ -13428,6 +12998,32 @@ SOFTWARE.
 
 -----
 
+The following software may be included in this product: json5. A copy of the source code may be downloaded from https://github.com/aseemk/json5.git. This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2012-2016 Aseem Kishore, and [others](https://github.com/aseemk/json5/contributors).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
 The following software may be included in this product: json5. A copy of the source code may be downloaded from git+https://github.com/json5/json5.git. This software contains the following license and notice below:
 
 MIT License
@@ -13456,32 +13052,6 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: json5. A copy of the source code may be downloaded from https://github.com/aseemk/json5.git. This software contains the following license and notice below:
-
-MIT License
-
-Copyright (c) 2012-2016 Aseem Kishore, and [others](https://github.com/aseemk/json5/contributors).
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
 The following software may be included in this product: jsonfile. A copy of the source code may be downloaded from git@github.com:jprichardson/node-jsonfile.git. This software contains the following license and notice below:
 
 (The MIT License)
@@ -13499,32 +13069,6 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
 OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: jsonschema. A copy of the source code may be downloaded from git://github.com/tdegrunt/jsonschema.git. This software contains the following license and notice below:
-
-jsonschema is licensed under MIT license.
-
-Copyright (C) 2012-2015 Tom de Grunt <tom@degrunt.nl>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 -----
 
@@ -13592,36 +13136,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: karma-browserstack-launcher, karma-chrome-launcher, karma-coverage, karma-edge-launcher, karma-firefox-launcher, karma-ie-launcher, karma-jasmine, karma-opera-launcher, karma-sauce-launcher. A copy of the source code may be downloaded from git://github.com/karma-runner/karma-browserstack-launcher.git (karma-browserstack-launcher), git://github.com/karma-runner/karma-chrome-launcher.git (karma-chrome-launcher), git://github.com/karma-runner/karma-coverage.git (karma-coverage), https://github.com/karma-runner/karma-edge-launcher.git (karma-edge-launcher), git://github.com/karma-runner/karma-firefox-launcher.git (karma-firefox-launcher), git://github.com/karma-runner/karma-ie-launcher.git (karma-ie-launcher), git://github.com/karma-runner/karma-jasmine.git (karma-jasmine), git://github.com/karma-runner/karma-opera-launcher.git (karma-opera-launcher), git://github.com/karma-runner/karma-sauce-launcher.git (karma-sauce-launcher). This software contains the following license and notice below:
+The following software may be included in this product: karma-browserstack-launcher, karma-chrome-launcher, karma-firefox-launcher, karma-ie-launcher, karma-jasmine, karma-opera-launcher, karma-sauce-launcher. A copy of the source code may be downloaded from git://github.com/karma-runner/karma-browserstack-launcher.git (karma-browserstack-launcher), git://github.com/karma-runner/karma-chrome-launcher.git (karma-chrome-launcher), git://github.com/karma-runner/karma-firefox-launcher.git (karma-firefox-launcher), git://github.com/karma-runner/karma-ie-launcher.git (karma-ie-launcher), git://github.com/karma-runner/karma-jasmine.git (karma-jasmine), git://github.com/karma-runner/karma-opera-launcher.git (karma-opera-launcher), git://github.com/karma-runner/karma-sauce-launcher.git (karma-sauce-launcher). This software contains the following license and notice below:
 
 The MIT License
 
 Copyright (C) 2011-2013 Google, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: karma-coverage-istanbul-instrumenter. A copy of the source code may be downloaded from git+https://github.com/monounity/karma-coverage-istanbul-instrumenter.git. This software contains the following license and notice below:
-
-The MIT License
-
-Copyright (C) 2019 Erik Barke, Monounity.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -13813,6 +13332,32 @@ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRU
 HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+The following software may be included in this product: levenary. A copy of the source code may be downloaded from https://github.com/tanhauhau/levenary.git. This software contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Tan Li Hau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 -----
 
@@ -14188,46 +13733,6 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: magic-string. A copy of the source code may be downloaded from https://github.com/rich-harris/magic-string. This software contains the following license and notice below:
-
-Copyright 2018 Rich Harris
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: make-error. A copy of the source code may be downloaded from git://github.com/JsCommunity/make-error.git. This software contains the following license and notice below:
-
-Copyright 2014 Julien Fontanet
-
-Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
------
-
-The following software may be included in this product: make-error-cause. A copy of the source code may be downloaded from git://github.com/blakeembrey/make-error-cause.git. This software contains the following license and notice below:
-
-Copyright 2015 Blake Embrey
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
------
-
 The following software may be included in this product: map-age-cleaner. A copy of the source code may be downloaded from https://github.com/SamVerschueren/map-age-cleaner.git. This software contains the following license and notice below:
 
 MIT License
@@ -14474,58 +13979,6 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: merge-stream. A copy of the source code may be downloaded from https://github.com/grncdr/merge-stream.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) Stephen Sugden <me@stephensugden.com> (stephensugden.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------
-
-The following software may be included in this product: merge2. A copy of the source code may be downloaded from git@github.com:teambition/merge2.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2014-2019 Teambition
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
 The following software may be included in this product: methods. A copy of the source code may be downloaded from https://github.com/jshttp/methods.git. This software contains the following license and notice below:
 
 (The MIT License)
@@ -14691,7 +14144,33 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: mkdirp, mkdirp2, optimist, yargs. A copy of the source code may be downloaded from https://github.com/substack/node-mkdirp.git (mkdirp), https://github.com/75lb/mkdirp2 (mkdirp2), http://github.com/substack/node-optimist.git (optimist), http://github.com/chevex/yargs.git (yargs). This software contains the following license and notice below:
+The following software may be included in this product: mkdirp. A copy of the source code may be downloaded from https://github.com/isaacs/node-mkdirp.git. This software contains the following license and notice below:
+
+Copyright James Halliday (mail@substack.net) and Isaac Z. Schlueter (i@izs.me)
+
+This project is free software released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: mkdirp, mkdirp2, optimist, yargs. A copy of the source code may be downloaded from https://github.com/substack/node-mkdirp.git (mkdirp), https://github.com/75lb/mkdirp2 (mkdirp2), http://github.com/substack/node-optimist.git (optimist), http://github.com/bcoe/yargs.git (yargs). This software contains the following license and notice below:
 
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -15692,6 +15171,26 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
+The following software may be included in this product: npm-normalize-package-bin. A copy of the source code may be downloaded from git+https://github.com/npm/npm-normalize-package-bin. This software contains the following license and notice below:
+
+The ISC License
+
+Copyright (c) npm, Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+-----
+
 The following software may be included in this product: nssocket. A copy of the source code may be downloaded from http://github.com/foreverjs/nssocket.git. This software contains the following license and notice below:
 
 Copyright (C) 2011 Charlie Robbins, Paolo Fragomeni, & the Contributors.
@@ -16059,7 +15558,7 @@ The following software may be included in this product: pako. A copy of the sour
 
 (The MIT License)
 
-Copyright (C) 2014-2016 by Vitaly Puzrin
+Copyright (C) 2014-2017 by Vitaly Puzrin and Andrei Tuputcyn
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -16085,7 +15584,7 @@ The following software may be included in this product: pako. A copy of the sour
 
 (The MIT License)
 
-Copyright (C) 2014-2017 by Vitaly Puzrin and Andrei Tuputcyn
+Copyright (C) 2014-2016 by Vitaly Puzrin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -17342,7 +16841,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
-The following software may be included in this product: proj4. A copy of the source code may be downloaded from git://github.com/proj4js/proj4js.git. This software contains the following license and notice below:
+The following software may be included in this product: proj4, wkt-parser. A copy of the source code may be downloaded from git://github.com/proj4js/proj4js.git (proj4), git+https://github.com/proj4js/wkt-parser.git (wkt-parser). This software contains the following license and notice below:
 
 ## Proj4js -- Javascript reprojection library. 
  
@@ -17421,6 +16920,31 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: proxy-from-env. A copy of the source code may be downloaded from https://github.com/Rob--W/proxy-from-env.git. This software contains the following license and notice below:
+
+The MIT License
+
+Copyright (C) 2016-2018 Rob Wu <rob@robwu.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
@@ -17702,7 +17226,7 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: rc-slider, rc-tooltip, rc-trigger, rc-util. A copy of the source code may be downloaded from git@github.com:react-component/slider.git (rc-slider), git@github.com:react-component/tooltip.git (rc-tooltip), https://github.com/react-component/trigger.git (rc-trigger), git@github.com:react-component/util.git (rc-util). This software contains the following license and notice below:
+The following software may be included in this product: rc-slider, rc-tooltip, rc-trigger. A copy of the source code may be downloaded from git@github.com:react-component/slider.git (rc-slider), git@github.com:react-component/tooltip.git (rc-tooltip), https://github.com/react-component/trigger.git (rc-trigger). This software contains the following license and notice below:
 
 The MIT License (MIT)
 Copyright (c) 2015-present Alipay.com, https://www.alipay.com/
@@ -17724,6 +17248,59 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: rc-util. A copy of the source code may be downloaded from git@github.com:react-component/util.git. This software contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2014-present yiminghe
+Copyright (c) 2015-present Alipay.com, https://www.alipay.com/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: react, react-dom, react-is, react-test-renderer, scheduler. A copy of the source code may be downloaded from https://github.com/facebook/react.git (react), https://github.com/facebook/react.git (react-dom), https://github.com/facebook/react.git (react-is), https://github.com/facebook/react.git (react-test-renderer), https://github.com/facebook/react.git (scheduler). This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 -----
 
@@ -17882,11 +17459,11 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: react-swipeable. A copy of the source code may be downloaded from http://github.com/dogfessional/react-swipeable.git. This software contains the following license and notice below:
+The following software may be included in this product: react-swipeable. A copy of the source code may be downloaded from https://github.com/FormidableLabs/react-swipeable.git. This software contains the following license and notice below:
 
 The MIT License (MIT)
 
-Copyright (C) 2014-present Dogfessional
+Copyright (C) 2014-present Formidable
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -17997,31 +17574,6 @@ IN THE SOFTWARE.
 
 The following software may be included in this product: readdirp. A copy of the source code may be downloaded from git://github.com/paulmillr/readdirp.git. This software contains the following license and notice below:
 
-This software is released under the MIT license:
-
-Copyright (c) 2012-2015 Thorsten Lorenz
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: readdirp. A copy of the source code may be downloaded from git://github.com/paulmillr/readdirp.git. This software contains the following license and notice below:
-
 MIT License
 
 Copyright (c) 2012-2019 Thorsten Lorenz, Paul Miller (https://paulmillr.com)
@@ -18043,6 +17595,31 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-----
+
+The following software may be included in this product: readdirp. A copy of the source code may be downloaded from git://github.com/paulmillr/readdirp.git. This software contains the following license and notice below:
+
+This software is released under the MIT license:
+
+Copyright (c) 2012-2015 Thorsten Lorenz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
@@ -18070,32 +17647,6 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: redbox-react. A copy of the source code may be downloaded from git+https://github.com/commissure/redbox-react.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2015 David Pfahler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 -----
 
@@ -18341,6 +17892,32 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
+The following software may be included in this product: repeat-element, shallow-clone, to-regex-range, use. A copy of the source code may be downloaded from https://github.com/jonschlinkert/repeat-element.git (repeat-element), https://github.com/jonschlinkert/shallow-clone.git (shallow-clone), https://github.com/micromatch/to-regex-range.git (to-regex-range), https://github.com/jonschlinkert/use.git (use). This software contains the following license and notice below:
+
+The MIT License (MIT)
+
+Copyright (c) 2015-present, Jon Schlinkert.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----
+
 The following software may be included in this product: replace-ext. A copy of the source code may be downloaded from https://github.com/gulpjs/replace-ext.git. This software contains the following license and notice below:
 
 The MIT License (MIT)
@@ -18364,36 +17941,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
------
-
-The following software may be included in this product: replacestream. A copy of the source code may be downloaded from https://github.com/eugeneware/replacestream.git. This software contains the following license and notice below:
-
-Copyright (c) 2014, Eugene Ware
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. Neither the name of Eugene Ware nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY EUGENE WARE ''AS IS'' AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL EUGENE WARE BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
@@ -18664,32 +18211,6 @@ Felix Geisendörfer (felix@debuggable.com)
 
 -----
 
-The following software may be included in this product: reusify. A copy of the source code may be downloaded from git+https://github.com/mcollina/reusify.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Matteo Collina
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
 The following software may be included in this product: rfdc. A copy of the source code may be downloaded from git+https://github.com/davidmarkclements/rfdc.git. This software contains the following license and notice below:
 
 Copyright 2019 "David Mark Clements <david.mark.clements@gmail.com>"
@@ -18736,640 +18257,6 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: rollup. A copy of the source code may be downloaded from https://github.com/rollup/rollup.git. This software contains the following license and notice below:
-
-# Rollup core license
-Rollup is released under the MIT license:
-
-The MIT License (MIT)
-
-Copyright (c) 2017 [these people](https://github.com/rollup/rollup/graphs/contributors)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-# Licenses of bundled dependencies
-The published Rollup artifact additionally contains code with the following licenses:
-MIT, ISC, Apache-2.0
-
-# Bundled dependencies:
-## acorn-export-ns-from
-License: MIT
-By: Adrian Heine
-Repository: https://github.com/acornjs/acorn-export-ns-from
-
-> Copyright (C) 2017-2018 by Adrian Heine
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## acorn-import-meta
-License: MIT
-By: Adrian Heine
-Repository: https://github.com/adrianheine/acorn-import-meta
-
-> Copyright (C) 2017-2018 by Adrian Heine
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## acorn-walk
-License: MIT
-By: Marijn Haverbeke, Ingvar Stepanyan, Adrian Heine
-Repository: https://github.com/acornjs/acorn.git
-
-> Copyright (C) 2012-2018 by various contributors (see AUTHORS)
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## braces
-License: MIT
-By: Jon Schlinkert, Brian Woodward, Elan Shanker, Eugene Sharygin, hemanth.hm
-Repository: micromatch/braces
-
-> The MIT License (MIT)
-> 
-> Copyright (c) 2014-2018, Jon Schlinkert.
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## date-time
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/date-time
-
----------------------------------------
-
-## fill-range
-License: MIT
-By: Jon Schlinkert, Edo Rivai, Paul Miller, Rouven Weßling
-Repository: jonschlinkert/fill-range
-
-> The MIT License (MIT)
-> 
-> Copyright (c) 2014-present, Jon Schlinkert.
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## hash.js
-License: MIT
-By: Fedor Indutny
-Repository: git@github.com:indutny/hash.js
-
----------------------------------------
-
-## inherits
-License: ISC
-Repository: git://github.com/isaacs/inherits
-
-> The ISC License
-> 
-> Copyright (c) Isaac Z. Schlueter
-> 
-> Permission to use, copy, modify, and/or distribute this software for any
-> purpose with or without fee is hereby granted, provided that the above
-> copyright notice and this permission notice appear in all copies.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-> REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-> FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-> INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-> LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-> OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-> PERFORMANCE OF THIS SOFTWARE.
-
----------------------------------------
-
-## is-number
-License: MIT
-By: Jon Schlinkert, Olsten Larck, Rouven Weßling
-Repository: jonschlinkert/is-number
-
-> The MIT License (MIT)
-> 
-> Copyright (c) 2014-present, Jon Schlinkert.
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## is-reference
-License: MIT
-By: Rich Harris
-Repository: git+https://github.com/Rich-Harris/is-reference.git
-
----------------------------------------
-
-## locate-character
-License: MIT
-By: Rich Harris
-Repository: Rich-Harris/locate-character
-
----------------------------------------
-
-## magic-string
-License: MIT
-By: Rich Harris
-Repository: https://github.com/rich-harris/magic-string
-
-> Copyright 2018 Rich Harris
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
-## micromatch
-License: MIT
-By: Jon Schlinkert, Amila Welihinda, Bogdan Chadkin, Brian Woodward, Devon Govett, Elan Shanker, Fabrício Matté, Martin Kolárik, Olsten Larck, Paul Miller, Tom Byrer, Tyler Akins, Peter Bright
-Repository: micromatch/micromatch
-
-> The MIT License (MIT)
-> 
-> Copyright (c) 2014-present, Jon Schlinkert.
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## minimalistic-assert
-License: ISC
-Repository: https://github.com/calvinmetcalf/minimalistic-assert.git
-
-> Copyright 2015 Calvin Metcalf
-> 
-> Permission to use, copy, modify, and/or distribute this software for any purpose
-> with or without fee is hereby granted, provided that the above copyright notice
-> and this permission notice appear in all copies.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-> REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-> FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-> INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-> LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
-> OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-> PERFORMANCE OF THIS SOFTWARE.
-
----------------------------------------
-
-## minimist
-License: MIT
-By: James Halliday
-Repository: git://github.com/substack/minimist.git
-
-> This software is released under the MIT license:
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy of
-> this software and associated documentation files (the "Software"), to deal in
-> the Software without restriction, including without limitation the rights to
-> use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-> the Software, and to permit persons to whom the Software is furnished to do so,
-> subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-> FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-> COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-> IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-> CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
-## parse-ms
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/parse-ms
-
----------------------------------------
-
-## picomatch
-License: MIT
-By: Jon Schlinkert
-Repository: micromatch/picomatch
-
-> The MIT License (MIT)
-> 
-> Copyright (c) 2017-present, Jon Schlinkert.
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## pretty-bytes
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/pretty-bytes
-
----------------------------------------
-
-## pretty-ms
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/pretty-ms
-
----------------------------------------
-
-## require-relative
-License: MIT
-By: Valerio Proietti
-Repository: git://github.com/kamicane/require-relative.git
-
----------------------------------------
-
-## rollup-pluginutils
-License: MIT
-By: Rich Harris
-Repository: rollup/rollup-pluginutils
-
----------------------------------------
-
-## signal-exit
-License: ISC
-By: Ben Coe
-Repository: https://github.com/tapjs/signal-exit.git
-
-> The ISC License
-> 
-> Copyright (c) 2015, Contributors
-> 
-> Permission to use, copy, modify, and/or distribute this software
-> for any purpose with or without fee is hereby granted, provided
-> that the above copyright notice and this permission notice
-> appear in all copies.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-> WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
-> OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE
-> LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
-> OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
-> WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
-> ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----------------------------------------
-
-## sourcemap-codec
-License: MIT
-By: Rich Harris
-Repository: https://github.com/Rich-Harris/sourcemap-codec
-
-> The MIT License
-> 
-> Copyright (c) 2015 Rich Harris
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## time-zone
-License: MIT
-By: Sindre Sorhus
-Repository: sindresorhus/time-zone
-
----------------------------------------
-
-## to-regex-range
-License: MIT
-By: Jon Schlinkert, Rouven Weßling
-Repository: micromatch/to-regex-range
-
-> The MIT License (MIT)
-> 
-> Copyright (c) 2015-present, Jon Schlinkert.
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
-## tslib
-License: Apache-2.0
-By: Microsoft Corp.
-Repository: https://github.com/Microsoft/tslib.git
-
-> Apache License
-> 
-> Version 2.0, January 2004
-> 
-> http://www.apache.org/licenses/ 
-> 
-> TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-> 
-> 1. Definitions.
-> 
-> "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
-> 
-> "Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
-> 
-> "Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-> 
-> "You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
-> 
-> "Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
-> 
-> "Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
-> 
-> "Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
-> 
-> "Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
-> 
-> "Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
-> 
-> "Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
-> 
-> 2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
-> 
-> 3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
-> 
-> 4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
-> 
-> You must give any other recipients of the Work or Derivative Works a copy of this License; and
-> 
-> You must cause any modified files to carry prominent notices stating that You changed the files; and
-> 
-> You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-> 
-> If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-> 
-> 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
-> 
-> 6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
-> 
-> 7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
-> 
-> 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
-> 
-> 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
-> 
-> END OF TERMS AND CONDITIONS
-
----------------------------------------
-
-## turbocolor
-License: MIT
-By: Jorge Bucaran
-Repository: jorgebucaran/turbocolor
-
-> Copyright © 2015-present [Jorge Bucaran](https://github.com/jorgebucaran)
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
------
-
-The following software may be included in this product: rollup-plugin-external-globals. A copy of the source code may be downloaded from https://github.com/eight04/rollup-plugin-external-globals.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) 2018 eight
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
------
-
-The following software may be included in this product: rollup-plugin-uglify. A copy of the source code may be downloaded from git+https://github.com/TrySound/rollup-plugin-uglify.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright 2016 Bogdan Chadkin <trysound@yandex.ru>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
 The following software may be included in this product: run-async. A copy of the source code may be downloaded from https://github.com/SBoudrias/run-async.git. This software contains the following license and notice below:
 
 The MIT License (MIT)
@@ -19393,31 +18280,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
------
-
-The following software may be included in this product: run-parallel. A copy of the source code may be downloaded from git://github.com/feross/run-parallel.git. This software contains the following license and notice below:
-
-The MIT License (MIT)
-
-Copyright (c) Feross Aboukhadijeh
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
@@ -19653,7 +18515,7 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: sass-loader, webpack-cli. A copy of the source code may be downloaded from https://github.com/webpack-contrib/sass-loader.git (sass-loader), https://github.com/webpack/webpack-cli.git (webpack-cli). This software contains the following license and notice below:
+The following software may be included in this product: sass-loader. A copy of the source code may be downloaded from https://github.com/webpack-contrib/sass-loader.git. This software contains the following license and notice below:
 
 Copyright JS Foundation and other contributors
 
@@ -20459,7 +19321,8 @@ The following software may be included in this product: source-map-resolve. A co
 
 The MIT License (MIT)
 
-Copyright (c) 2014, 2015, 2016, 2017 Simon Lydell
+Copyright (c) 2014, 2015, 2016, 2017, 2018, 2019 Simon Lydell
+Copyright (c) 2019 ZHAO Jinxiang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -20530,64 +19393,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
------
-
-The following software may be included in this product: sourcemap-codec. A copy of the source code may be downloaded from https://github.com/Rich-Harris/sourcemap-codec. This software contains the following license and notice below:
-
-The MIT License
-
-Copyright (c) 2015 Rich Harris
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
------
-
-The following software may be included in this product: sourcemapped-stacktrace. A copy of the source code may be downloaded from http://github.com/novocaine/sourcemapped-stacktrace. This software contains the following license and notice below:
-
-Copyright (c) 2016, James Salter
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of sourcemapped-stacktrace nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
@@ -20932,6 +19737,32 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
+The following software may be included in this product: string.prototype.trimend, string.prototype.trimstart. A copy of the source code may be downloaded from git://github.com/es-shims/String.prototype.trimEnd.git (string.prototype.trimend), git://github.com/es-shims/String.prototype.trimStart.git (string.prototype.trimstart). This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2017 Khaled Al-Ansari
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
 The following software may be included in this product: sver-compat. A copy of the source code may be downloaded from git+ssh://git@github.com/phated/sver-compat.git. This software contains the following license and notice below:
 
 MIT License
@@ -21045,215 +19876,9 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: terriajs. A copy of the source code may be downloaded from http://github.com/TerriaJS/terriajs. This software contains the following license and notice below:
-
-Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2012-2018 CSIRO's Data61 and Contributors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
------
-
 The following software may be included in this product: terriajs-cesium. A copy of the source code may be downloaded from https://github.com/TerriaJS/cesium.git. This software contains the following license and notice below:
 
-Copyright 2011-2019 CesiumJS Contributors
+Copyright 2011-2020 CesiumJS Contributors
 
                                  Apache License
                            Version 2.0, January 2004
@@ -21443,7 +20068,7 @@ Copyright 2011-2019 CesiumJS Contributors
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2011-2018 CesiumJS Contributors
+   Copyright 2011-2020 CesiumJS Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -21457,9 +20082,9 @@ Copyright 2011-2019 CesiumJS Contributors
    See the License for the specific language governing permissions and
    limitations under the License.
 
-Patents 9153063 9865085
+Patents US9153063B2 US9865085B1 US10592242
 
-Patents pending 15/829,786 62/701,099 62/837,358 62/837,381
+Patents pending US15/829,786 US62/837,358 US62/837,381
 
 Third-Party Code
 ================
@@ -22106,1000 +20731,7 @@ http://dojotoolkit.org/
 
 http://codemirror.net/
 
-> Copyright (C) 2014 by Marijn Haverbeke <marijnh@gmail.com> and others
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
->
-> Please note that some subdirectories of the CodeMirror distribution include their own LICENSE files, and are released under different licences.
-
-### clipboard.js
-
-https://clipboardjs.com/
-
-> The MIT License (MIT)
-> Copyright © 2018 Zeno Rocha <hi@zenorocha.com>
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### JSHint
-
-http://www.jshint.com/
-
-> JSHint, by JSHint Community.
->
-> Licensed under the same slightly modified MIT license that JSLint is. It stops evil-doers everywhere.
->
-> JSHint is a derivative work of JSLint:
->
-> Copyright (c) 2002 Douglas Crockford (www.JSLint.com)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> The Software shall be used for Good, not Evil.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. JSHint was forked from the 2010-12-16 edition of JSLint.
-
-### bitmap-sdf
-
-https://github.com/dy/bitmap-sdf
-
-> (c) 2017 Dima Yv. MIT License
->
-> Development supported by plot.ly.
-
-### Public domain data from Natural Earth
-
-Free vector and raster map data @ naturalearthdata.com
-
-Terms of use: http://www.naturalearthdata.com/about/terms-of-use/
-
-### Data from JHT's Planetary Pixel Emporium
-
-Copyright (c) by James Hastings-Trew
-
-http://planetpixelemporium.com/
-
-Copyright Information:  http://planetpixelemporium.com/planets.html
-
-### Sky box images from NASA
-
-http://maps.jpl.nasa.gov/stars.html
-
-http://svs.gsfc.nasa.gov/vis/a000000/a003500/a003572/
-
-Terms of use: http://www.nasa.gov/audience/formedia/features/MP_Photo_Guidelines.html
-
-### Some vector icons from (or inspired by) Raphaël JS
-
-http://raphaeljs.com/icons/
-
-http://raphaeljs.com/license.html
-
-### Mouse and gesture vector icons made by Freepik from Flaticon.com
-
-Creative Commons Attribution 3.0
-https://web.archive.org/web/20140419110558/http://www.flaticon.com/terms-of-use
-
-### Maki icon set from Mapbox
-
-https://www.mapbox.com/maki/
-
-https://github.com/mapbox/maki
-
-### Big Buck Bunny trailer
-
-Creative Commons Attribution 3.0
-(c) copyright 2008, Blender Foundation
-www.bigbuckbunny.org
-
-### population909500.json ###
-
-https://github.com/dataarts/webgl-globe
-
-> Copyright 2011 Google Data Arts Team
->
-> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
->
->     http://www.apache.org/licenses/LICENSE-2.0
->
-> Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
-### Wooden Watch Tower ###
-
-Creative Commons Attribution 3.0
-(c) copyright 2012, Dennis Haupt
-http://www.blendswap.com/blends/view/61653
-
-### GitHub logo
-
-https://github.com/logos
-
-### Font Awesome Icon
-
-Font Awesome by Dave Gandy - http://fontawesome.io
-
-### GraphemeSplitter
-
-https://github.com/orling/grapheme-splitter
-
-> The MIT License (MIT)
->
-> Copyright (c) 2015 Orlin Georgiev
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: terriajs-cesium. A copy of the source code may be downloaded from https://github.com/TerriaJS/cesium.git. This software contains the following license and notice below:
-
-Copyright 2011-2019 CesiumJS Contributors
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2011-2018 CesiumJS Contributors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-Patents US9153063B2 US9865085B1
-
-Patents pending US15/829,786 US16/516,997 US62/837,358 US62/837,381
-
-Third-Party Code
-================
-
-CesiumJS includes the following third-party code.
-
-### Sean O'Neil
-
-http://sponeil.net/
-
-> Copyright (c) 2000-2005, Sean O'Neil (s_p_oneil@hotmail.com)
->
-> All rights reserved.
->
-> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
->
-> * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-> * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-> * Neither the name of the project nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
->
-> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-###  Grauw Uri utilities
-
-http://hg.grauw.nl/grauw-lib
-
-> Laurens Holst (http://www.grauw.nl/)
->
-> Copyright 2012 Laurens Holst
->
-> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
->
-> http://www.apache.org/licenses/LICENSE-2.0
->
-> Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-
-### when.js
-
-https://github.com/cujojs/when
-
->  Licensed under the MIT License at:
->  http://www.opensource.org/licenses/mit-license.php
->
->  MIT License (c) copyright B Cavalier &amp; J Hann
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### zip.js
-
-https://github.com/gildas-lormeau/zip.js
-
->  Copyright (c) 2013 Gildas Lormeau. All rights reserved.
->
->  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
->
->  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
->
->  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
->
->  3. The names of the authors may not be used to endorse or promote products derived from this software without specific prior written permission.
->
->  THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL JCRAFT, INC. OR ANY CONTRIBUTORS TO THIS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### Autolinker.js
-
-https://github.com/gregjacobs/Autolinker.js
-
-The MIT License (MIT)
-
-> Copyright (c) 2015 Gregory Jacobs (http://greg-jacobs.com)
-
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
->THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### tween.js
-
-https://github.com/sole/tween.js
-
-> Copyright (c) 2010-2012 Tween.js authors.
->
-> Easing equations Copyright (c) 2001 Robert Penner http://robertpenner.com/easing/
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### php.js
-
-https://github.com/kvz/phpjs
-
-> php.js is copyright 2013 Kevin van Zonneveld.
->
-> Portions copyright Brett Zamir (http://brett-zamir.me), Kevin van Zonneveld (http://kevin.vanzonneveld.net), Onno Marsman, Theriault, Michael White (http://getsprink.com), Waldo Malqui Silva, Paulo Freitas, Jack, Jonas Raoni Soares Silva (http://www.jsfromhell.com), Philip Peterson, Legaev Andrey, Ates Goral (http://magnetiq.com), Alex, Ratheous, Martijn Wieringa, Rafa? Kukawski (http://blog.kukawski.pl), lmeyrick (https://sourceforge.net/projects/bcmath-js/), Nate, Philippe Baumann, Enrique Gonzalez, Webtoolkit.info (http://www.webtoolkit.info/), Carlos R. L. Rodrigues (http://www.jsfromhell.com), Ash Searle (http://hexmen.com/blog/), Jani Hartikainen, travc, Ole Vrijenhoek, Erkekjetter, Michael Grier, Rafa? Kukawski (http://kukawski.pl), Johnny Mast (http://www.phpvrouwen.nl), T.Wild, d3x, http://stackoverflow.com/questions/57803/how-to-convert-decimal-to-hex-in-javascript, Rafa? Kukawski (http://blog.kukawski.pl/), stag019, pilus, WebDevHobo (http://webdevhobo.blogspot.com/), marrtins, GeekFG (http://geekf  blogspot.com), Andrea Giammarchi (http://webreflection.blogspot.com), Arpad Ray (mailto:arpad@php.net), gorthaur, Paul Smith, Tim de Koning (http://www.kingsquare.nl), Joris, Oleg Eremeev, Steve Hilder, majak, gettimeofday, KELAN, Josh Fraser (http://onlineaspect.com/2007/06/08/auto-detect-a-time-zone-with-javascript/), Marc Palau, Martin (http://www.erlenwiese.de/), Breaking Par Consulting Inc (http://www.breakingpar.com/bkp/home.nsf/0/87256B280015193F87256CFB006C45F7), Chris, Mirek Slugen, saulius, Alfonso Jimenez (http://www.alfonsojimenez.com), Diplom@t (http://difane.com/), felix, Mailfaker (http://www.weedem.fr/), Tyler Akins (http://rumkin.com), Caio Ariede (http://caioariede.com), Robin, Kankrelune (http://www.webfaktory.info/), Karol Kowalski, Imgen Tata (http://www.myipdf.com/), mdsjack (http://www.mdsjack.bo.it), Dreamer, Felix Geisendoerfer (http://www.debuggable.com/felix), Lars Fischer, AJ, David, Aman Gupta, Michael White, Public Domain (http://www.json.org/json2.js), Steven Levithan (http://b  g.stevenlevithan.com), Sakimori, Pellentesque Malesuada, Thunder.m, Dj (http://phpjs.org/functions/htmlentities:425#comment_134018), Steve Clay, David James, Francois, class_exists, nobbler, T. Wild, Itsacon (http://www.itsacon.net/), date, Ole Vrijenhoek (http://www.nervous.nl/), Fox, Raphael (Ao RUDLER), Marco, noname, Mateusz "loonquawl" Zalega, Frank Forte, Arno, ger, mktime, john (http://www.jd-tech.net), Nick Kolosov (http://sammy.ru), marc andreu, Scott Cariss, Douglas Crockford (http://javascript.crockford.com), madipta, Slawomir Kaniecki, ReverseSyntax, Nathan, Alex Wilson, kenneth, Bayron Guevara, Adam Wallner (http://web2.bitbaro.hu/), paulo kuong, jmweb, Lincoln Ramsay, djmix, Pyerre, Jon Hohle, Thiago Mata (http://thiagomata.blog.com), lmeyrick (https://sourceforge.net/projects/bcmath-js/this.), Linuxworld, duncan, Gilbert, Sanjoy Roy, Shingo, sankai, Oskar Larsson H?gfeldt (http://oskar-lh.name/), Denny Wardhana, 0m3r, Everlasto, Subhasis Deb, josh, jd, Pier Paolo Ramon (http://www.mastersoup.c  /), P, merabi, Soren Hansen, Eugene Bulkin (http://doubleaw.com/), Der Simon (http://innerdom.sourceforge.net/), echo is bad, Ozh, XoraX (http://www.xorax.info), EdorFaus, JB, J A R, Marc Jansen, Francesco, LH, Stoyan Kyosev (http://www.svest.org/), nord_ua, omid (http://phpjs.org/functions/380:380#comment_137122), Brad Touesnard, MeEtc (http://yass.meetcweb.com), Peter-Paul Koch (http://www.quirksmode.org/js/beat.html), Olivier Louvignes (http://mg-crea.com/), T0bsn, Tim Wiel, Bryan Elliott, Jalal Berrami, Martin, JT, David Randall, Thomas Beaucourt (http://www.webapp.fr), taith, vlado houba, Pierre-Luc Paour, Kristof Coomans (SCK-CEN Belgian Nucleair Research Centre), Martin Pool, Kirk Strobeck, Rick Waldron, Brant Messenger (http://www.brantmessenger.com/), Devan Penner-Woelk, Saulo Vallory, Wagner B. Soares, Artur Tchernychev, Valentina De Rosa, Jason Wong (http://carrot.org/), Christoph, Daniel Esteban, strftime, Mick@el, rezna, Simon Willison (http://simonwillison.net), Anton Ongson, Gabriel Paderni, M rco van Oort, penutbutterjelly, Philipp Lenssen, Bjorn Roesbeke (http://www.bjornroesbeke.be/), Bug?, Eric Nagel, Tomasz Wesolowski, Evertjan Garretsen, Bobby Drake, Blues (http://tech.bluesmoon.info/), Luke Godfrey, Pul, uestla, Alan C, Ulrich, Rafal Kukawski, Yves Sucaet, sowberry, Norman "zEh" Fuchs, hitwork, Zahlii, johnrembo, Nick Callen, Steven Levithan (stevenlevithan.com), ejsanders, Scott Baker, Brian Tafoya (http://www.premasolutions.com/), Philippe Jausions (http://pear.php.net/user/jausions), Aidan Lister (http://aidanlister.com/), Rob, e-mike, HKM, ChaosNo1, metjay, strcasecmp, strcmp, Taras Bogach, jpfle, Alexander Ermolaev (http://snippets.dzone.com/user/AlexanderErmolaev), DxGx, kilops, Orlando, dptr1988, Le Torbi, James (http://www.james-bell.co.uk/), Pedro Tainha (http://www.pedrotainha.com), James, Arnout Kazemier (http://www.3rd-Eden.com), Chris McMacken, gabriel paderni, Yannoo, FGFEmperor, baris ozdil, Tod Gentille, Greg Frazier, jakes, 3D-GRAF, Allan Jensen (http://www.winternet.no), Ho ard Yeend, Benjamin Lupton, davook, daniel airton wermann (http://wermann.com.br), Atli T??r, Maximusya, Ryan W Tenney (http://ryan.10e.us), Alexander M Beedie, fearphage (http://http/my.opera.com/fearphage/), Nathan Sepulveda, Victor, Matteo, Billy, stensi, Cord, Manish, T.J. Leahy, Riddler (http://www.frontierwebdev.com/), Rafa? Kukawski, FremyCompany, Matt Bradley, Tim de Koning, Luis Salazar (http://www.freaky-media.com/), Diogo Resende, Rival, Andrej Pavlovic, Garagoth, Le Torbi (http://www.letorbi.de/), Dino, Josep Sanz (http://www.ws3.es/), rem, Russell Walker (http://www.nbill.co.uk/), Jamie Beck (http://www.terabit.ca/), setcookie, Michael, YUI Library: http://developer.yahoo.com/yui/docs/YAHOO.util.DateLocale.html, Blues at http://hacks.bluesmoon.info/strftime/strftime.js, Ben (http://benblume.co.uk/), DtTvB (http://dt.in.th/2008-09-16.string-length-in-bytes.html), Andreas, William, meo, incidence, Cagri Ekin, Amirouche, Amir Habibi (http://www.residence-mixte.com/), Luke Smith (http://lucassmith.na  ), Kheang Hok Chin (http://www.distantia.ca/), Jay Klehr, Lorenzo Pisani, Tony, Yen-Wei Liu, Greenseed, mk.keck, Leslie Hoare, dude, booeyOH, Ben Bryan
->
-> Licensed under the MIT (MIT-LICENSE.txt) license.
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL KEVIN VAN ZONNEVELD BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OROTHER DEALINGS IN THE SOFTWARE.
-
-### fontmetrics.js
-
-https://github.com/Pomax/fontmetrics.js
-
-> Copyright (C) 2011 by Mike "Pomax" Kamermans
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### almond
-
-https://github.com/jrburke/almond
-
-> Copyright (c) 2010-2011, The Dojo Foundation
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### RequireJS
-
-https://github.com/jrburke/requirejs
-
-> Copyright (c) 2010-2015, The Dojo Foundation
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### Knockout
-
-http://knockoutjs.com/
-
-> (c) The Knockout.js team - http://knockoutjs.com/
-> License: MIT (http://www.opensource.org/licenses/mit-license.php)
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### Knockout ES5 plugin
-
-https://github.com/SteveSanderson/knockout-es5
-
-> Copyright (c) Steve Sanderson
-> MIT license
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### topojson
-
-https://github.com/mbostock/topojson
-
-> Copyright (c) 2012, Michael Bostock
-> All rights reserved.
->
-> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
->
-> * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
->
-> * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
->
-> * The name Michael Bostock may not be used to endorse or promote products derived from this software without specific prior written permission.
->
-> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MICHAEL BOSTOCK BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### mersenne-twister.js
-
-https://gist.github.com/banksean/300494
-
-> Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-> All rights reserved.
->
-> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
->
-> 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
->
-> 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
->
-> 3. The names of its contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
->
-> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### NVIDIA GameWorks Graphics Samples
-
-https://github.com/NVIDIAGameWorks/GraphicsSamples
-
-> Copyright 2016 NVIDIA Corporation
->
-> BY DOWNLOADING THE SOFTWARE AND OTHER AVAILABLE MATERIALS, YOU  ("DEVELOPER") AGREE TO BE BOUND BY THE FOLLOWING TERMS AND CONDITIONS
->
-> The materials available for download to Developers may include software in both sample source ("Source Code") and object code ("Object Code") versions, documentation ("Documentation"), certain art work ("Art Assets") and other materials (collectively, these materials referred to herein as "Materials").  Except as expressly indicated herein, all terms and conditions of this Agreement apply to all of the Materials.
->
-> Except as expressly set forth herein, NVIDIA owns all of the Materials and makes them available to Developer only under the terms and conditions set forth in this Agreement.
->
-> License:  Subject to the terms of this Agreement, NVIDIA hereby grants to Developer a royalty-free, non-exclusive license to possess and to use the Materials.  The following terms apply to the specified type of Material:
->
-> Source Code:  Developer shall have the right to modify and create derivative works with the Source Code.  Developer shall own any derivative works ("Derivatives") it creates to the Source Code, provided that Developer uses the Materials in accordance with the terms of this Agreement.  Developer may distribute the Derivatives, provided that all NVIDIA copyright notices and trademarks are used properly and the Derivatives include the following statement: "This software contains source code provided by NVIDIA Corporation."
->
-> Object Code:  Developer agrees not to disassemble, decompile or reverse engineer the Object Code versions of any of the Materials.  Developer acknowledges that certain of the Materials provided in Object Code version may contain third party components that may be subject to restrictions, and expressly agrees not to attempt to modify or distribute such Materials without first receiving consent from NVIDIA.
->
-> Art Assets:  Developer shall have the right to modify and create Derivatives of the Art Assets, but may not distribute any of the Art Assets or Derivatives created therefrom without NVIDIA's prior written consent.
->
-> Government End Users: If you are acquiring the Software on behalf of any unit or agency of the United States Government, the following provisions apply. The Government agrees the Software and documentation were developed at private expense and are provided with "RESTRICTED RIGHTS". Use, duplication, or disclosure by the Government is subject to restrictions as set forth in DFARS 227.7202-1(a) and 227.7202-3(a) (1995), DFARS 252.227-7013(c)(1)(ii) (Oct 1988), FAR 12.212(a)(1995), FAR 52.227-19, (June 1987) or FAR 52.227-14(ALT III) (June 1987),as amended from time to time. In the event that this License, or any part thereof, is deemed inconsistent with the minimum rights identified in the Restricted Rights provisions, the minimum rights shall prevail.
-> No Other License. No rights or licenses are granted by NVIDIA under this License, expressly or by implication, with respect to any proprietary information or patent, copyright, trade secret or other intellectual property right owned or controlled by NVIDIA, except as expressly provided in this License.
-> Term:  This License is effective until terminated.  NVIDIA may terminate this Agreement (and with it, all of Developer's right to the Materials) immediately upon written notice (which may include email) to Developer, with or without cause.
->
-> Support:  NVIDIA has no obligation to support or to continue providing or updating any of the Materials.
->
-> No Warranty:  THE SOFTWARE AND ANY OTHER MATERIALS PROVIDED BY NVIDIA TO DEVELOPER HEREUNDER ARE PROVIDED "AS IS."  NVIDIA DISCLAIMS ALL WARRANTIES, EXPRESS, IMPLIED OR STATUTORY, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
->
-> LIMITATION OF LIABILITY:  NVIDIA SHALL NOT BE LIABLE TO DEVELOPER, DEVELOPER'S CUSTOMERS, OR ANY OTHER PERSON OR ENTITY CLAIMING THROUGH OR UNDER DEVELOPER FOR ANY LOSS OF PROFITS, INCOME, SAVINGS, OR ANY OTHER CONSEQUENTIAL, INCIDENTAL, SPECIAL, PUNITIVE, DIRECT OR INDIRECT DAMAGES (WHETHER IN AN ACTION IN CONTRACT, TORT OR BASED ON A WARRANTY), EVEN IF NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  THESE LIMITATIONS SHALL APPLY NOTWITHSTANDING ANY FAILURE OF THE ESSENTIAL PURPOSE OF ANY LIMITED REMEDY.  IN NO EVENT SHALL NVIDIA'S AGGREGATE LIABILITY TO DEVELOPER OR ANY OTHER PERSON OR ENTITY CLAIMING THROUGH OR UNDER DEVELOPER EXCEED THE AMOUNT OF MONEY ACTUALLY PAID BY DEVELOPER TO NVIDIA FOR THE SOFTWARE OR ANY OTHER MATERIALS.
-
-### NoSleep.js
-
-https://github.com/richtr/NoSleep.js
-
-> NoSleep.js v0.5.0 - git.io/vfn01
-> Rich Tibbett
-> MIT license
-
-### jsep
-
-https://github.com/soney/jsep
-
-> Copyright (c) 2013 Stephen Oney, http://jsep.from.so/
->
-> Permission is hereby granted, free of charge, to any person obtaining
-> a copy of this software and associated documentation files (the
-> "Software"), to deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify, merge, publish,
-> distribute, sublicense, and/or sell copies of the Software, and to
-> permit persons to whom the Software is furnished to do so, subject to
-> the following conditions:
->
-> The above copyright notice and this permission notice shall be
-> included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### earcut
-
-https://github.com/mapbox/earcut
-
->Copyright (c) 2016, Mapbox
->
->Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
->
->THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
-
-### kdbush
-
-https://github.com/mourner/kdbush
-
-> Copyright (c) 2016, Vladimir Agafonkin
->
->Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
->
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
-
-### rbush
-
-https://github.com/mourner/rbush
-
-> MIT License
-
-> Copyright (c) 2016 Vladimir Agafonkin
-
->Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
->
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
->
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-### quickselect
-
-https://github.com/mourner/quickselect
-
-> ISC License
-
-> Copyright (c) 2018, Vladimir Agafonkin
-
->Permission to use, copy, modify, and/or distribute this software for any purpose
-with or without fee is hereby granted, provided that the above copyright notice
-and this permission notice appear in all copies.
->
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
-THIS SOFTWARE.
-
-### crunch
-
-https://github.com/BinomialLLC/crunch
-
->crunch/crnlib uses the ZLIB license:
->http://opensource.org/licenses/Zlib
->
->Copyright (c) 2010-2016 Richard Geldreich, Jr. and Binomial LLC
->
->This software is provided 'as-is', without any express or implied
-warranty.  In no event will the authors be held liable for any damages
-arising from the use of this software.
->
->Permission is granted to anyone to use this software for any purpose,
-including commercial applications, and to alter it and redistribute it
-freely, subject to the following restrictions:
->
->1. The origin of this software must not be misrepresented; you must not
-claim that you wrote the original software. If you use this software
-in a product, an acknowledgment in the product documentation would be
-appreciated but is not required.
->
->2. Altered source versions must be plainly marked as such, and must not be
-misrepresented as being the original software.
->
->3. This notice may not be removed or altered from any source distribution.
-
-### crunch_lib.cpp
-
-https://github.com/Apress/html5-game-dev-insights/blob/master/jones_ch21/crunch_webgl/crunch_js/crunch_lib.cpp
-
->Copyright (c) 2013, Evan Parker, Brandon Jones. All rights reserved.
->
->Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
->
->  * Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
->  * Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
->
->THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
-
-### texture-tester
-
-https://github.com/toji/texture-tester
-
->Copyright (c) 2014, Brandon Jones. All rights reserved.
->
->Redistribution and use in source and binary forms, with or without modification,
->are permitted provided that the following conditions are met:
->
->* Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
->* Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials provided with the distribution.
->
->THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### pako
-
-https://github.com/nodeca/pako
-
->(The MIT License)
->
->Copyright (C) 2014-2017 by Vitaly Puzrin and Andrei Tuputcyn
->
->Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
->
->The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
->
->THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-### protobuf
-
-https://github.com/dcodeIO/ProtoBuf.js
-
->Copyright (c) 2016, Daniel Wirtz  All rights reserved.
->
->Redistribution and use in source and binary forms, with or without
->modification, are permitted provided that the following conditions are
->met:
->
->* Redistributions of source code must retain the above copyright
->  notice, this list of conditions and the following disclaimer.
->* Redistributions in binary form must reproduce the above copyright
->  notice, this list of conditions and the following disclaimer in the
->  documentation and/or other materials provided with the distribution.
->* Neither the name of its author, nor the names of its contributors
->  may be used to endorse or promote products derived from this software
->  without specific prior written permission.
->
->THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
->"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
->LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
->A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
->OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
->SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
->LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
->DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
->THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
->(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
->OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### gltf-WebGL-PBR
-
-https://github.com/KhronosGroup/glTF-WebGL-PBR
-
->The MIT License
->
->Copyright (c) 2016-2017 Mohamad Moneimne and Contributors
->
->Permission is hereby granted, free of charge, to any person obtaining
->a copy of this software and associated documentation files (the "Software"),
->to deal in the Software without restriction, including without limitation the
->rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
->sell copies of the Software, and to permit persons to whom the Software is
->furnished to do so, subject to the following conditions:
->
->The above copyright notice and this permission notice shall be included in
->all copies or substantial portions of the Software.
->
->THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
->INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
->PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
->HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
->CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
->OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### ShaderFastLibs
-
-https://github.com/michaldrobot/ShaderFastLibs
-
-> The MIT License (MIT)
->
-> Copyright (c) <2014> <Michal Drobot>
->
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### Draco
-
-https://github.com/google/draco
-
->Licensed under the Apache License, Version 2.0 (the "License"); you may not
->use this file except in compliance with the License. You may obtain a copy of
->the License at
->
-><http://www.apache.org/licenses/LICENSE-2.0>
->
->Unless required by applicable law or agreed to in writing, software
->distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
->WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
->License for the specific language governing permissions and limitations under
->the License.
-
-### DOMPUrify
-
-https://github.com/cure53/DOMPurify
-
->DOMPurify
->Copyright 2015 Mario Heiderich
->
->DOMPurify is free software; you can redistribute it and/or modify it under the
->terms of either:
->
->a) the Apache License Version 2.0, or
->b) the Mozilla Public License Version 2.0
->
->Licensed under the Apache License, Version 2.0 (the "License");
->you may not use this file except in compliance with the License.
->You may obtain a copy of the License at
->
->    http://www.apache.org/licenses/LICENSE-2.0
->
->    Unless required by applicable law or agreed to in writing, software
->    distributed under the License is distributed on an "AS IS" BASIS,
->    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
->    See the License for the specific language governing permissions and
->    limitations under the License.
-
-### LERC
-
-http://github.com/Esri/lerc/
-
->Copyright 2015 Esri
->
->Licensed under the Apache License, Version 2.0 (the "License");
->you may not use this file except in compliance with the License.
->You may obtain a copy of the License at
->
->    http://www.apache.org/licenses/LICENSE-2.0
->
->    Unless required by applicable law or agreed to in writing, software
->    distributed under the License is distributed on an "AS IS" BASIS,
->    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
->    See the License for the specific language governing permissions and
->    limitations under the License.
->
->A copy of the license and additional notices are located with the
->source distribution at:
->
->http://github.com/Esri/lerc/
-
-Tests
-=====
-
-The CesiumJS tests use the following third-party libraries and data.
-
-### Jasmine
-
-http://jasmine.github.io/
-
-Copyright (c) 2008-2014 Pivotal Labs
-
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
->
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-CesiumJS Documentation
-====================
-
-The CesiumJS documentation files include the following third-party content.
-
-### Source Sans Pro (Font)
-
-Source® Sans Pro, Adobe's first open source typeface family, was designed by Paul D. Hunt. It is a sans serif typeface intended to work well in user interfaces.
-
-[SIL Open Font License, 1.1](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL) ([text](http://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=OFL_plaintext&filename=OFL.txt))
-
-
-Example Applications
-====================
-
-The CesiumJS example applications include the following third-party libraries and data.
-
-### Dojo Toolkit
-
-http://dojotoolkit.org/
-
-> Copyright (c) 2005-2015, The Dojo Foundation
->
-> All rights reserved.
->
-> Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
->
->   * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
->   * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
->   * Neither the name of the Dojo Foundation nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
->
-> THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### CodeMirror
-
-http://codemirror.net/
-
-> Copyright (C) 2014 by Marijn Haverbeke <marijnh@gmail.com> and others
+> Copyright (C) 2017 by Marijn Haverbeke <marijnh@gmail.com> and others
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 >
@@ -23617,7 +21249,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 -----
 
-The following software may be included in this product: traverse. A copy of the source code may be downloaded from git://github.com/substack/js-traverse.git. This software contains the following license and notice below:
+The following software may be included in this product: traverse. A copy of the source code may be downloaded from http://github.com/substack/js-traverse.git. This software contains the following license and notice below:
 
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -23716,6 +21348,35 @@ This code is released into the "public domain" by its author(s).  Anybody may us
 
 If you find a bug or make an improvement, it would be courteous to let the author know, but it is not compulsory.
 */
+
+-----
+
+The following software may be included in this product: tweetnacl. A copy of the source code may be downloaded from https://github.com/dchest/tweetnacl-js.git. This software contains the following license and notice below:
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
 
 -----
 
@@ -23918,7 +21579,7 @@ SUCH DAMAGE.
 
 The following software may be included in this product: underscore. A copy of the source code may be downloaded from git://github.com/jashkenas/underscore.git. This software contains the following license and notice below:
 
-Copyright (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative
+Copyright (c) 2009-2020 Jeremy Ashkenas, DocumentCloud and Investigative
 Reporters & Editors
 
 Permission is hereby granted, free of charge, to any person
@@ -23946,7 +21607,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 The following software may be included in this product: underscore. A copy of the source code may be downloaded from git://github.com/jashkenas/underscore.git. This software contains the following license and notice below:
 
-Copyright (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative
+Copyright (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative
 Reporters & Editors
 
 Permission is hereby granted, free of charge, to any person
@@ -24319,7 +21980,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: uuid. A copy of the source code may be downloaded from https://github.com/kelektiv/node-uuid.git. This software contains the following license and notice below:
+The following software may be included in this product: uuid. A copy of the source code may be downloaded from https://github.com/uuidjs/uuid.git. This software contains the following license and notice below:
 
 The MIT License (MIT)
 
@@ -24764,212 +22425,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------
-
-The following software may be included in this product: workspace-aggregator-e92b2bb1-333a-4562-8660-734ed8beb642. A copy of the source code may be downloaded from http://github.com/TerriaJS/TerriaMap. This software contains the following license and notice below:
-
-Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2012-2019 CSIRO's Data61 and Contributors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
 
 -----
 
@@ -25455,11 +22910,11 @@ third-party archives.
 NOTICE
 
 xmlcreate  
-Copyright (C) 2016-2019 Michael Kourlas
+Copyright (C) 2016-2020 Michael Kourlas
 
 -----
 
-The following software may be included in this product: xmldom. A copy of the source code may be downloaded from git://github.com/jindw/xmldom.git. This software contains the following license and notice below:
+The following software may be included in this product: xmldom. A copy of the source code may be downloaded from git://github.com/xmldom/xmldom.git. This software contains the following license and notice below:
 
 You can choose any one of those:
 
@@ -25496,6 +22951,32 @@ Copyright (c) 2010 passive.ly LLC
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: xregexp. A copy of the source code may be downloaded from https://github.com/slevithan/xregexp.git. This software contains the following license and notice below:
+
+The MIT License
+
+Copyright (c) 2007-present Steven Levithan <http://xregexp.com/>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 -----
 
@@ -25593,7 +23074,7 @@ THE SOFTWARE.
 
 -----
 
-The following software may be included in this product: yauzl, yazl. A copy of the source code may be downloaded from https://github.com/thejoshwolfe/yauzl.git (yauzl), https://github.com/thejoshwolfe/yazl.git (yazl). This software contains the following license and notice below:
+The following software may be included in this product: yauzl. A copy of the source code may be downloaded from https://github.com/thejoshwolfe/yauzl.git. This software contains the following license and notice below:
 
 The MIT License (MIT)
 

--- a/lib/Core/loadJsonp.js
+++ b/lib/Core/loadJsonp.js
@@ -1,5 +1,3 @@
-const defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 const Resource = require("terriajs-cesium/Source/Core/Resource").default;
 
 function loadJsonp(urlOrResource, callbackParameterName) {
@@ -7,7 +5,7 @@ function loadJsonp(urlOrResource, callbackParameterName) {
   return resource.fetchJsonp(callbackParameterName);
 }
 
-defineProperties(loadJsonp, {
+Object.defineProperties(loadJsonp, {
   loadAndExecuteScript: {
     get: function() {
       return Resource._Implementations.loadAndExecuteScript;

--- a/lib/Core/loadWithXhr.js
+++ b/lib/Core/loadWithXhr.js
@@ -1,7 +1,5 @@
 const defaultValue = require("terriajs-cesium/Source/Core/defaultValue")
   .default;
-const defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 const Resource = require("terriajs-cesium/Source/Core/Resource").default;
 
 function loadWithXhr(options) {
@@ -16,7 +14,7 @@ function loadWithXhr(options) {
   });
 }
 
-defineProperties(loadWithXhr, {
+Object.defineProperties(loadWithXhr, {
   load: {
     get: function() {
       return Resource._Implementations.loadWithXhr;

--- a/lib/Map/AbsCode.js
+++ b/lib/Map/AbsCode.js
@@ -2,8 +2,6 @@
 
 /*global require*/
 
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
@@ -77,7 +75,7 @@ var AbsCode = function(code, name, concept) {
 
 inherit(Concept, AbsCode);
 
-defineProperties(AbsCode.prototype, {
+Object.defineProperties(AbsCode.prototype, {
   /**
    * Gets a value indicating whether this item has child items.
    * @type {Boolean}

--- a/lib/Map/AbsConcept.js
+++ b/lib/Map/AbsConcept.js
@@ -6,8 +6,6 @@ naturalSort.insensitive = true;
 
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 
 var AbsCode = require("./AbsCode");
@@ -90,7 +88,7 @@ var AbsConcept = function(options) {
 
 inherit(Concept, AbsConcept);
 
-defineProperties(AbsConcept.prototype, {
+Object.defineProperties(AbsConcept.prototype, {
   /**
    * Gets a value indicating whether this item has child items.
    * @type {Boolean}

--- a/lib/Map/CesiumSelectionIndicator.js
+++ b/lib/Map/CesiumSelectionIndicator.js
@@ -4,8 +4,6 @@ import i18next from "i18next";
 /*global require*/
 var Cartesian2 = require("terriajs-cesium/Source/Core/Cartesian2").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var EasingFunction = require("terriajs-cesium/Source/Core/EasingFunction")
@@ -257,7 +255,7 @@ CesiumSelectionIndicator.prototype.animateDepart = function() {
   });
 };
 
-defineProperties(CesiumSelectionIndicator.prototype, {
+Object.defineProperties(CesiumSelectionIndicator.prototype, {
   /**
    * Gets the HTML element containing the selection indicator.
    * @memberof CesiumSelectionIndicator.prototype

--- a/lib/Map/Concept.js
+++ b/lib/Map/Concept.js
@@ -2,8 +2,6 @@
 
 /*global require*/
 
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 
 /**
@@ -70,7 +68,7 @@ var Concept = function(name) {
   knockout.track(this, ["name", "isSelectable", "isVisible", "color"]);
 };
 
-defineProperties(Concept.prototype, {
+Object.defineProperties(Concept.prototype, {
   /**
    * Gets a value indicating whether this item has child items.
    * If your subclass can return true, it must also define isOpen & items properties, and a toggleOpen function.

--- a/lib/Map/LeafletDataSourceDisplay.js
+++ b/lib/Map/LeafletDataSourceDisplay.js
@@ -9,8 +9,6 @@ const CustomDataSource = require("terriajs-cesium/Source/DataSources/CustomDataS
 const defaultValue = require("terriajs-cesium/Source/Core/defaultValue")
   .default;
 const defined = require("terriajs-cesium/Source/Core/defined").default;
-const defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 const destroyObject = require("terriajs-cesium/Source/Core/destroyObject")
   .default;
 const EventHelper = require("terriajs-cesium/Source/Core/EventHelper").default;
@@ -94,7 +92,7 @@ LeafletDataSourceDisplay.defaultVisualizersCallback = function(
   return [];
 };
 
-defineProperties(LeafletDataSourceDisplay.prototype, {
+Object.defineProperties(LeafletDataSourceDisplay.prototype, {
   /**
    * Gets the scene associated with this display.
    * @memberof LeafletDataSourceDisplay.prototype

--- a/lib/Map/Legend.js
+++ b/lib/Map/Legend.js
@@ -2,8 +2,6 @@
 "use strict";
 
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var LegendUrl = require("./LegendUrl");
 
@@ -127,7 +125,7 @@ var Legend = function(props) {
   this._svg = undefined;
 };
 
-defineProperties(Legend.prototype, {
+Object.defineProperties(Legend.prototype, {
   computedItemHeight: {
     get: function() {
       return defaultValue(

--- a/lib/Map/MapboxVectorTileImageryProvider.js
+++ b/lib/Map/MapboxVectorTileImageryProvider.js
@@ -16,8 +16,6 @@ var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var URITemplate = require("urijs/src/URITemplate");
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;
 var Cartesian2 = require("terriajs-cesium/Source/Core/Cartesian2").default;
 var BoundingRectangle = require("terriajs-cesium/Source/Core/BoundingRectangle")
@@ -91,7 +89,7 @@ var MapboxVectorTileImageryProvider = function(options) {
   this._ready = true;
 };
 
-defineProperties(MapboxVectorTileImageryProvider.prototype, {
+Object.defineProperties(MapboxVectorTileImageryProvider.prototype, {
   url: {
     get: function() {
       return this._uriTemplate.expression;

--- a/lib/Map/TableColumn.js
+++ b/lib/Map/TableColumn.js
@@ -3,8 +3,6 @@
 
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 var destroyObject = require("terriajs-cesium/Source/Core/destroyObject")
   .default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
@@ -219,7 +217,7 @@ function updateForType(tableColumn) {
   }
 }
 
-defineProperties(TableColumn.prototype, {
+Object.defineProperties(TableColumn.prototype, {
   /**
    * Gets or sets the type of this column.
    * @memberOf TableColumn.prototype

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -9,8 +9,6 @@ var DataSourceClock = require("terriajs-cesium/Source/DataSources/DataSourceCloc
   .default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 var destroyObject = require("terriajs-cesium/Source/Core/destroyObject")
   .default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
@@ -117,7 +115,7 @@ var TableStructure = function(name, options) {
 };
 inherit(DisplayVariablesConcept, TableStructure);
 
-defineProperties(TableStructure.prototype, {
+Object.defineProperties(TableStructure.prototype, {
   /**
    * Gets or sets the columns for this structure.
    * @memberOf TableStructure.prototype

--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -239,6 +239,7 @@ Object.defineProperties(TableStructure.prototype, {
           valueOrFirstValue(nameIdOrIndex)
         );
       }
+      return undefined;
     }
   },
 
@@ -251,7 +252,7 @@ Object.defineProperties(TableStructure.prototype, {
     get: function() {
       var activeTimeColumn = this.activeTimeColumn;
       if (!defined(this.activeTimeColumn)) {
-        return;
+        return undefined;
       }
       return activeTimeColumn._timeIntervals;
     }
@@ -266,7 +267,7 @@ Object.defineProperties(TableStructure.prototype, {
     get: function() {
       var activeTimeColumn = this.activeTimeColumn;
       if (!defined(this.activeTimeColumn)) {
-        return;
+        return undefined;
       }
       return activeTimeColumn.finishJulianDates;
     }
@@ -282,7 +283,7 @@ Object.defineProperties(TableStructure.prototype, {
     get: function() {
       var activeTimeColumn = this.activeTimeColumn;
       if (!defined(this.activeTimeColumn)) {
-        return;
+        return undefined;
       }
       return activeTimeColumn._clock;
     }

--- a/lib/Models/AbsIttCatalogGroup.js
+++ b/lib/Models/AbsIttCatalogGroup.js
@@ -5,9 +5,7 @@ var URI = require("urijs");
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 var objectToQuery = require("terriajs-cesium/Source/Core/objectToQuery")
@@ -114,7 +112,7 @@ var AbsIttCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, AbsIttCatalogGroup);
 
-defineProperties(AbsIttCatalogGroup.prototype, {
+Object.defineProperties(AbsIttCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf AbsIttCatalogGroup.prototype
@@ -162,7 +160,7 @@ AbsIttCatalogGroup.defaultSerializers = clone(CatalogGroup.defaultSerializers);
 AbsIttCatalogGroup.defaultSerializers.items =
   CatalogGroup.enabledShareableItemsSerializer;
 
-freezeObject(AbsIttCatalogGroup.defaultSerializers);
+Object.freeze(AbsIttCatalogGroup.defaultSerializers);
 
 AbsIttCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url, this.blacklist, this.whitelist];

--- a/lib/Models/AbsIttCatalogItem.js
+++ b/lib/Models/AbsIttCatalogItem.js
@@ -6,11 +6,10 @@ var URI = require("urijs");
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 var loadText = require("../Core/loadText");
@@ -273,7 +272,7 @@ var AbsIttCatalogItem = function(terria, url) {
 
 inherit(TableCatalogItem, AbsIttCatalogItem);
 
-defineProperties(AbsIttCatalogItem.prototype, {
+Object.defineProperties(AbsIttCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf AbsIttCatalogItem.prototype
@@ -334,7 +333,7 @@ AbsIttCatalogItem.defaultPropertiesForSharing.push("filter");
 AbsIttCatalogItem.defaultPropertiesForSharing.push("regionConcept");
 AbsIttCatalogItem.defaultPropertiesForSharing.push("regionTypeConcept");
 AbsIttCatalogItem.defaultPropertiesForSharing.push("displayPercent");
-freezeObject(AbsIttCatalogItem.defaultPropertiesForSharing);
+Object.freeze(AbsIttCatalogItem.defaultPropertiesForSharing);
 
 AbsIttCatalogItem.defaultSerializers = clone(
   TableCatalogItem.defaultSerializers
@@ -350,7 +349,7 @@ AbsIttCatalogItem.defaultSerializers.filter = function(item, json) {
   }, []);
 };
 
-freezeObject(AbsIttCatalogItem.defaultSerializers);
+Object.freeze(AbsIttCatalogItem.defaultSerializers);
 
 //Just the items that would influence the load from the abs server or the file
 AbsIttCatalogItem.prototype._getValuesThatInfluenceLoad = function() {

--- a/lib/Models/ArcGisCatalogGroup.js
+++ b/lib/Models/ArcGisCatalogGroup.js
@@ -5,9 +5,7 @@ var URI = require("urijs");
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 
@@ -66,7 +64,7 @@ var ArcGisCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, ArcGisCatalogGroup);
 
-defineProperties(ArcGisCatalogGroup.prototype, {
+Object.defineProperties(ArcGisCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf ArcGisCatalogGroup.prototype
@@ -121,7 +119,7 @@ ArcGisCatalogGroup.defaultSerializers.isLoading = function(
   options
 ) {};
 
-freezeObject(ArcGisCatalogGroup.defaultSerializers);
+Object.freeze(ArcGisCatalogGroup.defaultSerializers);
 
 ArcGisCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url, this.blacklist];

--- a/lib/Models/ArcGisFeatureServerCatalogGroup.js
+++ b/lib/Models/ArcGisFeatureServerCatalogGroup.js
@@ -5,9 +5,7 @@ var URI = require("urijs");
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
@@ -66,7 +64,7 @@ var ArcGisFeatureServerCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, ArcGisFeatureServerCatalogGroup);
 
-defineProperties(ArcGisFeatureServerCatalogGroup.prototype, {
+Object.defineProperties(ArcGisFeatureServerCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf ArcGisFeatureServerCatalogGroup.prototype
@@ -123,7 +121,7 @@ ArcGisFeatureServerCatalogGroup.defaultSerializers.isLoading = function(
   options
 ) {};
 
-freezeObject(ArcGisFeatureServerCatalogGroup.defaultSerializers);
+Object.freeze(ArcGisFeatureServerCatalogGroup.defaultSerializers);
 
 ArcGisFeatureServerCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url, this.blacklist];

--- a/lib/Models/ArcGisFeatureServerCatalogItem.js
+++ b/lib/Models/ArcGisFeatureServerCatalogItem.js
@@ -4,8 +4,7 @@
 var URI = require("urijs");
 
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var Color = require("terriajs-cesium/Source/Core/Color").default;
 const HeightReference = require("terriajs-cesium/Source/Scene/HeightReference")
   .default;
@@ -58,7 +57,7 @@ var ArcGisFeatureServerCatalogItem = function(terria) {
 
 inherit(CatalogItem, ArcGisFeatureServerCatalogItem);
 
-defineProperties(ArcGisFeatureServerCatalogItem.prototype, {
+Object.defineProperties(ArcGisFeatureServerCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf ArcGisFeatureServerCatalogItem.prototype

--- a/lib/Models/ArcGisMapServerCatalogGroup.js
+++ b/lib/Models/ArcGisMapServerCatalogGroup.js
@@ -5,9 +5,7 @@ var URI = require("urijs");
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
@@ -66,7 +64,7 @@ var ArcGisMapServerCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, ArcGisMapServerCatalogGroup);
 
-defineProperties(ArcGisMapServerCatalogGroup.prototype, {
+Object.defineProperties(ArcGisMapServerCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf ArcGisMapServerCatalogGroup.prototype
@@ -123,7 +121,7 @@ ArcGisMapServerCatalogGroup.defaultSerializers.isLoading = function(
   options
 ) {};
 
-freezeObject(ArcGisMapServerCatalogGroup.defaultSerializers);
+Object.freeze(ArcGisMapServerCatalogGroup.defaultSerializers);
 
 ArcGisMapServerCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url, this.blacklist];

--- a/lib/Models/ArcGisMapServerCatalogItem.js
+++ b/lib/Models/ArcGisMapServerCatalogItem.js
@@ -6,8 +6,7 @@ var ArcGisMapServerImageryProvider = require("terriajs-cesium/Source/Scene/ArcGi
   .default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var Ellipsoid = require("terriajs-cesium/Source/Core/Ellipsoid").default;
 var getToken = require("./getToken");
 var ImageryLayerCatalogItem = require("./ImageryLayerCatalogItem");
@@ -171,7 +170,7 @@ var ArcGisMapServerCatalogItem = function(terria) {
 
 inherit(ImageryLayerCatalogItem, ArcGisMapServerCatalogItem);
 
-defineProperties(ArcGisMapServerCatalogItem.prototype, {
+Object.defineProperties(ArcGisMapServerCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf ArcGisMapServerCatalogItem.prototype

--- a/lib/Models/BingMapsCatalogItem.js
+++ b/lib/Models/BingMapsCatalogItem.js
@@ -7,8 +7,7 @@ var BingMapsImageryProvider = require("terriajs-cesium/Source/Scene/BingMapsImag
 var BingMapsStyle = require("terriajs-cesium/Source/Scene/BingMapsStyle")
   .default;
 var Credit = require("terriajs-cesium/Source/Core/Credit").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 
 var ImageryLayerCatalogItem = require("./ImageryLayerCatalogItem");
@@ -45,7 +44,7 @@ var BingMapsCatalogItem = function(terria) {
 
 inherit(ImageryLayerCatalogItem, BingMapsCatalogItem);
 
-defineProperties(BingMapsCatalogItem.prototype, {
+Object.defineProperties(BingMapsCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf BingMapsCatalogItem.prototype

--- a/lib/Models/BooleanParameter.js
+++ b/lib/Models/BooleanParameter.js
@@ -1,8 +1,7 @@
 "use strict";
 
 /*global require*/
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
 
@@ -35,7 +34,7 @@ var BooleanParameter = function(options) {
 
 inherit(FunctionParameter, BooleanParameter);
 
-defineProperties(BooleanParameter.prototype, {
+Object.defineProperties(BooleanParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof BooleanParameter.prototype

--- a/lib/Models/BooleanParameterGroup.js
+++ b/lib/Models/BooleanParameterGroup.js
@@ -1,8 +1,7 @@
 "use strict";
 
 /*global require*/
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var BooleanParameter = require("./BooleanParameter");
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
@@ -159,7 +158,7 @@ BooleanParameterGroup.prototype.getValue = function() {
   return param_values.filter(item => item !== undefined);
 };
 
-defineProperties(BooleanParameterGroup.prototype, {
+Object.defineProperties(BooleanParameterGroup.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof BooleanParameterGroup.prototype

--- a/lib/Models/CameraView.js
+++ b/lib/Models/CameraView.js
@@ -5,8 +5,7 @@ var Cartesian3 = require("terriajs-cesium/Source/Core/Cartesian3").default;
 var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;
 var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var Ellipsoid = require("terriajs-cesium/Source/Core/Ellipsoid").default;
@@ -45,7 +44,7 @@ var CameraView = function(rectangle, position, direction, up) {
   this._up = up;
 };
 
-defineProperties(CameraView.prototype, {
+Object.defineProperties(CameraView.prototype, {
   /**
    * Gets the rectangular extent of the view.  If {@link CameraView#position}, {@link CameraView#direction},
    * and {@link CameraView#up} are specified, this property will be ignored for viewers that support those parameters

--- a/lib/Models/CartoMapCatalogItem.js
+++ b/lib/Models/CartoMapCatalogItem.js
@@ -3,8 +3,6 @@
 /*global require*/
 
 const defined = require("terriajs-cesium/Source/Core/defined").default;
-const defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 const inherit = require("../Core/inherit");
 const knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 const proxyCatalogItemUrl = require("./proxyCatalogItemUrl");
@@ -57,7 +55,7 @@ function CartoMapCatalogItem(terria) {
 
 inherit(UrlTemplateCatalogItem, CartoMapCatalogItem);
 
-defineProperties(CartoMapCatalogItem.prototype, {
+Object.defineProperties(CartoMapCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf CartoMapCatalogItem.prototype

--- a/lib/Models/Catalog.js
+++ b/lib/Models/Catalog.js
@@ -3,8 +3,7 @@
 /*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
@@ -75,7 +74,7 @@ var Catalog = function(terria) {
   });
 };
 
-defineProperties(Catalog.prototype, {
+Object.defineProperties(Catalog.prototype, {
   /**
    * Gets the Terria instance.
    * @memberOf Catalog.prototype

--- a/lib/Models/CatalogFunction.js
+++ b/lib/Models/CatalogFunction.js
@@ -7,11 +7,10 @@ var CatalogMember = require("./CatalogMember");
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var createCatalogMemberFromType = require("./createCatalogMemberFromType");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var inherit = require("../Core/inherit");
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var runLater = require("../Core/runLater");
@@ -53,7 +52,7 @@ var CatalogFunction = function(terria) {
 
 inherit(CatalogMember, CatalogFunction);
 
-defineProperties(CatalogFunction.prototype, {
+Object.defineProperties(CatalogFunction.prototype, {
   /**
    * Gets a value indicating whether this catalog member can show information.  If so, an info icon will be shown next to the item
    * in the data catalog.
@@ -147,7 +146,7 @@ CatalogFunction.defaultUpdaters.contextItem = function(
   return itemObject.updateFromJson(itemJson, options);
 };
 
-freezeObject(CatalogFunction.defaultUpdaters);
+Object.freeze(CatalogFunction.defaultUpdaters);
 
 CatalogFunction.defaultSerializers = clone(CatalogMember.defaultSerializers);
 
@@ -162,7 +161,7 @@ CatalogFunction.defaultSerializers.contextItem = function(
   }
 };
 
-freezeObject(CatalogFunction.defaultSerializers);
+Object.freeze(CatalogFunction.defaultSerializers);
 
 CatalogFunction.defaultPropertiesForSharing = clone(
   CatalogMember.defaultPropertiesForSharing

--- a/lib/Models/CatalogGroup.js
+++ b/lib/Models/CatalogGroup.js
@@ -5,9 +5,7 @@
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var RuntimeError = require("terriajs-cesium/Source/Core/RuntimeError").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
@@ -128,7 +126,7 @@ var CatalogGroup = function(terria) {
 
 inherit(CatalogMember, CatalogGroup);
 
-defineProperties(CatalogGroup.prototype, {
+Object.defineProperties(CatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf CatalogGroup.prototype
@@ -228,7 +226,7 @@ CatalogGroup.defaultUpdaters.isLoading = function(
   propertyName
 ) {};
 
-freezeObject(CatalogGroup.defaultUpdaters);
+Object.freeze(CatalogGroup.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
@@ -293,7 +291,7 @@ CatalogGroup.defaultSerializers.isLoading = function(
   options
 ) {};
 
-freezeObject(CatalogGroup.defaultSerializers);
+Object.freeze(CatalogGroup.defaultSerializers);
 
 /**
  * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
@@ -306,7 +304,7 @@ CatalogGroup.defaultPropertiesForSharing = clone(
 CatalogGroup.defaultPropertiesForSharing.push("items");
 CatalogGroup.defaultPropertiesForSharing.push("isOpen");
 
-freezeObject(CatalogGroup.defaultPropertiesForSharing);
+Object.freeze(CatalogGroup.defaultPropertiesForSharing);
 
 CatalogGroup.prototype._setupItemListeners = function() {
   var itemsChangeListeners = {
@@ -483,7 +481,7 @@ CatalogGroup.prototype._load = function() {
   return when();
 };
 
-var emptyArray = freezeObject([]);
+var emptyArray = Object.freeze([]);
 
 /**
  * When implemented in a derived class, gets an array containing the current value of all properties that

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -8,11 +8,10 @@ var clone = require("terriajs-cesium/Source/Core/clone").default;
 var createCatalogMemberFromType = require("./createCatalogMemberFromType");
 var Credit = require("terriajs-cesium/Source/Core/Credit").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var inherit = require("../Core/inherit");
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
@@ -487,7 +486,7 @@ var CatalogItem = function(terria) {
 
 inherit(CatalogMember, CatalogItem);
 
-defineProperties(CatalogItem.prototype, {
+Object.defineProperties(CatalogItem.prototype, {
   /**
    * Gets a value indicating whether this data item, when enabled, can be reordered with respect to other data items.
    * Data items that cannot be reordered are typically displayed above reorderable data items.
@@ -623,7 +622,7 @@ CatalogItem.defaultMetadata.serviceErrorMessage = i18next.t(
   "models.catalog.serviceErrorMessage"
 );
 
-freezeObject(CatalogItem.defaultMetadata);
+Object.freeze(CatalogItem.defaultMetadata);
 
 /**
  * Gets or sets the set of default updater functions to use in {@link CatalogMember#updateFromJson}.  Types derived from this type
@@ -750,7 +749,7 @@ CatalogItem.defaultUpdaters.discreteTime = function(
   // Do not update .currentTime as it is a view of .clock.currentTime.
 };
 
-freezeObject(CatalogItem.defaultUpdaters);
+Object.freeze(CatalogItem.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
@@ -868,7 +867,7 @@ CatalogItem.defaultSerializers.clampedDiscreteTime = function(
   // Do not serialise .clampedDiscreteTime as it is a view of .clock.currentTime.
 };
 
-freezeObject(CatalogItem.defaultSerializers);
+Object.freeze(CatalogItem.defaultSerializers);
 
 /**
  * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
@@ -885,7 +884,7 @@ CatalogItem.defaultPropertiesForSharing.push("nowViewingIndex");
 CatalogItem.defaultPropertiesForSharing.push("nowViewingCatalogItem");
 CatalogItem.defaultPropertiesForSharing.push("useOwnClock");
 
-freezeObject(CatalogItem.defaultPropertiesForSharing);
+Object.freeze(CatalogItem.defaultPropertiesForSharing);
 
 /**
  * Loads this catalog item, if it's not already loaded.  It is safe to
@@ -943,7 +942,7 @@ CatalogItem.prototype._load = function() {
   return when();
 };
 
-var emptyArray = freezeObject([]);
+var emptyArray = Object.freeze([]);
 
 /**
  * When implemented in a derived class, gets an array containing the current value of all properties that

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -4,11 +4,10 @@
 
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var serializeToJson = require("../Core/serializeToJson");
@@ -246,7 +245,7 @@ var CatalogMember = function(terria) {
 
 var descriptionRegex = /description/i;
 
-defineProperties(CatalogMember.prototype, {
+Object.defineProperties(CatalogMember.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf CatalogMember.prototype
@@ -471,7 +470,7 @@ CatalogMember.defaultUpdaters = {
   }
 };
 
-freezeObject(CatalogMember.defaultUpdaters);
+Object.freeze(CatalogMember.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
@@ -482,7 +481,7 @@ CatalogMember.defaultSerializers = {
   nameSortKey: function() {}
 };
 
-freezeObject(CatalogMember.defaultSerializers);
+Object.freeze(CatalogMember.defaultSerializers);
 
 /**
  * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogMember}-derived object
@@ -491,7 +490,7 @@ freezeObject(CatalogMember.defaultSerializers);
  */
 CatalogMember.defaultPropertiesForSharing = ["name"];
 
-freezeObject(CatalogMember.defaultPropertiesForSharing);
+Object.freeze(CatalogMember.defaultPropertiesForSharing);
 
 /**
  * Updates the catalog member from a JSON object-literal description of it.

--- a/lib/Models/Cesium3DTilesCatalogItem.js
+++ b/lib/Models/Cesium3DTilesCatalogItem.js
@@ -7,8 +7,7 @@ var Cesium3DTileset = require("terriajs-cesium/Source/Scene/Cesium3DTileset")
   .default;
 var combine = require("terriajs-cesium/Source/Core/combine").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var inherit = require("../Core/inherit");
 var IonResource = require("terriajs-cesium/Source/Core/IonResource").default;
 var proxyCatalogItemUrl = require("./proxyCatalogItemUrl");
@@ -64,7 +63,7 @@ var Cesium3DTilesCatalogItem = function(terria) {
 
 inherit(CatalogItem, Cesium3DTilesCatalogItem);
 
-defineProperties(Cesium3DTilesCatalogItem.prototype, {
+Object.defineProperties(Cesium3DTilesCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf CesiumTerrainCatalogItem.prototype

--- a/lib/Models/CesiumTerrainCatalogItem.js
+++ b/lib/Models/CesiumTerrainCatalogItem.js
@@ -5,8 +5,7 @@
 var CesiumTerrainProvider = require("terriajs-cesium/Source/Core/CesiumTerrainProvider")
   .default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var IonResource = require("terriajs-cesium/Source/Core/IonResource").default;
 var raiseErrorToUser = require("./raiseErrorToUser");
 
@@ -52,7 +51,7 @@ var CesiumTerrainCatalogItem = function(terria) {
 
 inherit(TerrainCatalogItem, CesiumTerrainCatalogItem);
 
-defineProperties(CesiumTerrainCatalogItem.prototype, {
+Object.defineProperties(CesiumTerrainCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf CesiumTerrainCatalogItem.prototype

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -5,10 +5,9 @@ var URI = require("urijs");
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var formatError = require("terriajs-cesium/Source/Core/formatError").default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 var loadText = require("../Core/loadText");
@@ -280,7 +279,7 @@ var CkanCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, CkanCatalogGroup);
 
-defineProperties(CkanCatalogGroup.prototype, {
+Object.defineProperties(CkanCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf CkanCatalogGroup.prototype
@@ -364,7 +363,7 @@ CkanCatalogGroup.defaultUpdaters.czmlResourceFormat = createRegexDeserializer(
   "czmlResourceFormat"
 );
 
-freezeObject(CkanCatalogGroup.defaultUpdaters);
+Object.freeze(CkanCatalogGroup.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
@@ -401,7 +400,7 @@ CkanCatalogGroup.defaultSerializers.czmlResourceFormat = createRegexSerializer(
   "czmlResourceFormat"
 );
 
-freezeObject(CkanCatalogGroup.defaultSerializers);
+Object.freeze(CkanCatalogGroup.defaultSerializers);
 
 CkanCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [

--- a/lib/Models/CkanCatalogItem.js
+++ b/lib/Models/CkanCatalogItem.js
@@ -10,9 +10,7 @@ var createRegexSerializer = require("./createRegexSerializer");
 var CsvCatalogItem = require("./CsvCatalogItem");
 var CzmlCatalogItem = require("./CzmlCatalogItem");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var GeoJsonCatalogItem = require("./GeoJsonCatalogItem");
 var inherit = require("../Core/inherit");
 var KmlCatalogItem = require("./KmlCatalogItem");
@@ -183,7 +181,7 @@ function CkanCatalogItem(terria) {
 
 inherit(CatalogItem, CkanCatalogItem);
 
-defineProperties(CkanCatalogItem.prototype, {
+Object.defineProperties(CkanCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf CkanCatalogItem.prototype
@@ -284,7 +282,7 @@ CkanCatalogItem.defaultUpdaters.czmlResourceFormat = createRegexDeserializer(
   "czmlResourceFormat"
 );
 
-freezeObject(CkanCatalogItem.defaultUpdaters);
+Object.freeze(CkanCatalogItem.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
@@ -318,7 +316,7 @@ CkanCatalogItem.defaultSerializers.czmlResourceFormat = createRegexSerializer(
   "czmlResourceFormat"
 );
 
-freezeObject(CkanCatalogItem.defaultSerializers);
+Object.freeze(CkanCatalogItem.defaultSerializers);
 
 /**
  * Creates a catalog item from a CKAN resource.

--- a/lib/Models/CompositeCatalogItem.js
+++ b/lib/Models/CompositeCatalogItem.js
@@ -4,9 +4,7 @@
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var RuntimeError = require("terriajs-cesium/Source/Core/RuntimeError").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
@@ -62,7 +60,7 @@ var CompositeCatalogItem = function(terria, items) {
 
 inherit(CatalogItem, CompositeCatalogItem);
 
-defineProperties(CompositeCatalogItem.prototype, {
+Object.defineProperties(CompositeCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf CompositeCatalogItem.prototype
@@ -191,7 +189,7 @@ CompositeCatalogItem.defaultUpdaters.isLoading = function(
   propertyName
 ) {};
 
-freezeObject(CompositeCatalogItem.defaultUpdaters);
+Object.freeze(CompositeCatalogItem.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
@@ -223,7 +221,7 @@ CompositeCatalogItem.defaultSerializers.isLoading = function(
   options
 ) {};
 
-freezeObject(CompositeCatalogItem.defaultSerializers);
+Object.freeze(CompositeCatalogItem.defaultSerializers);
 
 /**
  * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
@@ -235,7 +233,7 @@ CompositeCatalogItem.defaultPropertiesForSharing = clone(
 );
 CompositeCatalogItem.defaultPropertiesForSharing.push("items");
 
-freezeObject(CompositeCatalogItem.defaultPropertiesForSharing);
+Object.freeze(CompositeCatalogItem.defaultPropertiesForSharing);
 
 //
 

--- a/lib/Models/CsvCatalogItem.js
+++ b/lib/Models/CsvCatalogItem.js
@@ -4,11 +4,10 @@
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var Resource = require("terriajs-cesium/Source/Core/Resource").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
 
@@ -81,7 +80,7 @@ var CsvCatalogItem = function(terria, url, options) {
 
 inherit(TableCatalogItem, CsvCatalogItem);
 
-defineProperties(CsvCatalogItem.prototype, {
+Object.defineProperties(CsvCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf CsvCatalogItem.prototype
@@ -152,7 +151,7 @@ CsvCatalogItem.defaultUpdaters.sourceCatalogItem = function() {
   // TODO: For now, don't update from JSON. Better to do it via an id?
 };
 
-freezeObject(CsvCatalogItem.defaultUpdaters);
+Object.freeze(CsvCatalogItem.defaultUpdaters);
 
 CsvCatalogItem.defaultSerializers = clone(TableCatalogItem.defaultSerializers);
 
@@ -160,7 +159,7 @@ CsvCatalogItem.defaultSerializers.sourceCatalogItem = function() {
   // TODO: For now, don't serialize. Can we do it via an id?
 };
 
-freezeObject(CsvCatalogItem.defaultSerializers);
+Object.freeze(CsvCatalogItem.defaultSerializers);
 
 CsvCatalogItem.defaultPropertiesForSharing = clone(
   TableCatalogItem.defaultPropertiesForSharing
@@ -170,7 +169,7 @@ CsvCatalogItem.defaultPropertiesForSharing.push("dataUrl");
 CsvCatalogItem.defaultPropertiesForSharing.push("sourceCatalogItemId");
 CsvCatalogItem.defaultPropertiesForSharing.push("regenerationOptions");
 
-freezeObject(CsvCatalogItem.defaultPropertiesForSharing);
+Object.freeze(CsvCatalogItem.defaultPropertiesForSharing);
 
 /**
  * Loads the TableStructure from a csv file.

--- a/lib/Models/CswCatalogGroup.js
+++ b/lib/Models/CswCatalogGroup.js
@@ -7,10 +7,9 @@ var clone = require("terriajs-cesium/Source/Core/clone").default;
 var CsvCatalogItem = require("./CsvCatalogItem");
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var formatError = require("terriajs-cesium/Source/Core/formatError").default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var GeoJsonCatalogItem = require("./GeoJsonCatalogItem");
 var inherit = require("../Core/inherit");
 var KmlCatalogItem = require("./KmlCatalogItem");
@@ -169,7 +168,7 @@ CswCatalogGroup.wpsGetRecordsTemplate = require("./CswGetRecordsWPSTemplate.xml"
 
 inherit(CatalogGroup, CswCatalogGroup);
 
-defineProperties(CswCatalogGroup.prototype, {
+Object.defineProperties(CswCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf CswCatalogGroup.prototype
@@ -256,7 +255,7 @@ CswCatalogGroup.defaultUpdaters.wpsResourceFormat = regexDeserializer(
   "wpsResourceFormat"
 );
 
-freezeObject(CswCatalogGroup.defaultUpdaters);
+Object.freeze(CswCatalogGroup.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
@@ -296,7 +295,7 @@ CswCatalogGroup.defaultSerializers.wpsResourceFormat = regexSerializer(
   "wpsResourceFormat"
 );
 
-freezeObject(CswCatalogGroup.defaultSerializers);
+Object.freeze(CswCatalogGroup.defaultSerializers);
 
 CswCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [

--- a/lib/Models/CzmlCatalogItem.js
+++ b/lib/Models/CzmlCatalogItem.js
@@ -3,8 +3,7 @@
 /*global require*/
 
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
 
@@ -54,7 +53,7 @@ var CzmlCatalogItem = function(terria, url) {
 
 inherit(DataSourceCatalogItem, CzmlCatalogItem);
 
-defineProperties(CzmlCatalogItem.prototype, {
+Object.defineProperties(CzmlCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf CzmlCatalogItem.prototype

--- a/lib/Models/DataSourceCatalogItem.js
+++ b/lib/Models/DataSourceCatalogItem.js
@@ -2,8 +2,7 @@
 
 /*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
@@ -27,7 +26,7 @@ var DataSourceCatalogItem = function(terria) {
 
 inherit(CatalogItem, DataSourceCatalogItem);
 
-defineProperties(DataSourceCatalogItem.prototype, {
+Object.defineProperties(DataSourceCatalogItem.prototype, {
   /**
    * Returns true if we can zoom to this item. Depends on observable properties, and so updates once loaded.
    * @memberOf DataSourceCatalogItem.prototype

--- a/lib/Models/DateTimeParameter.js
+++ b/lib/Models/DateTimeParameter.js
@@ -1,8 +1,7 @@
 "use strict";
 
 /*global require*/
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
 
@@ -26,7 +25,7 @@ var DateTimeParameter = function(options) {
 
 inherit(FunctionParameter, DateTimeParameter);
 
-defineProperties(DateTimeParameter.prototype, {
+Object.defineProperties(DateTimeParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof DateTimeParameter.prototype

--- a/lib/Models/EnumerationParameter.js
+++ b/lib/Models/EnumerationParameter.js
@@ -4,8 +4,7 @@
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
 
@@ -41,7 +40,7 @@ var EnumerationParameter = function(options) {
 
 inherit(FunctionParameter, EnumerationParameter);
 
-defineProperties(EnumerationParameter.prototype, {
+Object.defineProperties(EnumerationParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof EnumerationParameter.prototype

--- a/lib/Models/FunctionParameter.js
+++ b/lib/Models/FunctionParameter.js
@@ -4,8 +4,7 @@
 var arraysAreEqual = require("../Core/arraysAreEqual");
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
@@ -139,7 +138,7 @@ FunctionParameter.defaultValueSetter = function(value) {
   this._value = value;
 };
 
-defineProperties(FunctionParameter.prototype, {
+Object.defineProperties(FunctionParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof FunctionParameter.prototype

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -7,8 +7,7 @@ var Color = require("terriajs-cesium/Source/Core/Color").default;
 var ColorMaterialProperty = require("terriajs-cesium/Source/DataSources/ColorMaterialProperty")
   .default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var Entity = require("terriajs-cesium/Source/DataSources/Entity").default;
@@ -112,7 +111,7 @@ var GeoJsonCatalogItem = function(terria, url) {
 
 inherit(DataSourceCatalogItem, GeoJsonCatalogItem);
 
-defineProperties(GeoJsonCatalogItem.prototype, {
+Object.defineProperties(GeoJsonCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf GeoJsonCatalogItem.prototype

--- a/lib/Models/GeoJsonParameter.js
+++ b/lib/Models/GeoJsonParameter.js
@@ -1,8 +1,7 @@
 "use strict";
 
 /*global require*/
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
@@ -33,7 +32,7 @@ var GeoJsonParameter = function(options) {
 
 inherit(FunctionParameter, GeoJsonParameter);
 
-defineProperties(GeoJsonParameter.prototype, {
+Object.defineProperties(GeoJsonParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof GeoJsonParameter.prototype

--- a/lib/Models/GltfCatalogItem.js
+++ b/lib/Models/GltfCatalogItem.js
@@ -6,11 +6,7 @@ const Cartesian3 = require("terriajs-cesium/Source/Core/Cartesian3").default;
 const CatalogItem = require("./CatalogItem");
 const clone = require("terriajs-cesium/Source/Core/clone").default;
 const defined = require("terriajs-cesium/Source/Core/defined").default;
-const defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 const Feature = require("./Feature");
-const freezeObject = require("terriajs-cesium/Source/Core/freezeObject")
-  .default;
 const inherit = require("../Core/inherit");
 const knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 const Metadata = require("./Metadata");
@@ -162,7 +158,7 @@ function GltfCatalogItem(terria, url) {
 
 inherit(CatalogItem, GltfCatalogItem);
 
-defineProperties(GltfCatalogItem.prototype, {
+Object.defineProperties(GltfCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf GltfCatalogItem.prototype
@@ -249,7 +245,7 @@ defineProperties(GltfCatalogItem.prototype, {
  */
 GltfCatalogItem.defaultUpdaters = clone(CatalogItem.defaultUpdaters);
 
-freezeObject(GltfCatalogItem.defaultUpdaters);
+Object.freeze(GltfCatalogItem.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
@@ -258,7 +254,7 @@ freezeObject(GltfCatalogItem.defaultUpdaters);
  */
 GltfCatalogItem.defaultSerializers = clone(CatalogItem.defaultSerializers);
 
-freezeObject(GltfCatalogItem.defaultSerializers);
+Object.freeze(GltfCatalogItem.defaultSerializers);
 
 GltfCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url];

--- a/lib/Models/GoogleUrlShortener.js
+++ b/lib/Models/GoogleUrlShortener.js
@@ -3,8 +3,7 @@
 /*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var loadJson = require("../Core/loadJson");
@@ -26,7 +25,7 @@ var GoogleUrlShortener = function(options) {
   );
 };
 
-defineProperties(GoogleUrlShortener.prototype, {
+Object.defineProperties(GoogleUrlShortener.prototype, {
   isUsable: {
     get: function() {
       var key = this.terria.configParameters.googleUrlShortenerKey;

--- a/lib/Models/GpxCatalogItem.js
+++ b/lib/Models/GpxCatalogItem.js
@@ -4,8 +4,7 @@
 var toGeoJSON = require("@mapbox/togeojson");
 
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
 
@@ -57,7 +56,7 @@ var GpxCatalogItem = function(terria, url) {
 
 inherit(CatalogItem, GpxCatalogItem);
 
-defineProperties(GpxCatalogItem.prototype, {
+Object.defineProperties(GpxCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf GpxCatalogItem.prototype

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -8,13 +8,12 @@ var DataSourceClock = require("terriajs-cesium/Source/DataSources/DataSourceCloc
   .default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var Ellipsoid = require("terriajs-cesium/Source/Core/Ellipsoid").default;
 var formatError = require("terriajs-cesium/Source/Core/formatError").default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var ImagerySplitDirection = require("terriajs-cesium/Source/Scene/ImagerySplitDirection")
   .default;
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
@@ -338,7 +337,7 @@ var ImageryLayerCatalogItem = function(terria) {
 
 inherit(CatalogItem, ImageryLayerCatalogItem);
 
-defineProperties(ImageryLayerCatalogItem.prototype, {
+Object.defineProperties(ImageryLayerCatalogItem.prototype, {
   /**
    * Gets a value indicating whether this {@link ImageryLayerCatalogItem} supports the {@link ImageryLayerCatalogItem#intervals}
    * property for configuring time-dynamic imagery.
@@ -588,7 +587,7 @@ ImageryLayerCatalogItem.defaultUpdaters.intervalFilterFeature = function(
   }
 };
 
-freezeObject(ImageryLayerCatalogItem.defaultUpdaters);
+Object.freeze(ImageryLayerCatalogItem.defaultUpdaters);
 
 ImageryLayerCatalogItem.defaultSerializers = clone(
   CatalogItem.defaultSerializers
@@ -666,7 +665,7 @@ ImageryLayerCatalogItem.defaultSerializers.intervalFilterFeature = function(
   }
 };
 
-freezeObject(ImageryLayerCatalogItem.defaultSerializers);
+Object.freeze(ImageryLayerCatalogItem.defaultSerializers);
 
 /**
  * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
@@ -685,7 +684,7 @@ ImageryLayerCatalogItem.defaultPropertiesForSharing.push(
 );
 ImageryLayerCatalogItem.defaultPropertiesForSharing.push("showOnChart");
 
-freezeObject(ImageryLayerCatalogItem.defaultPropertiesForSharing);
+Object.freeze(ImageryLayerCatalogItem.defaultPropertiesForSharing);
 
 /**
  * Creates the {@link ImageryProvider} for this catalog item.

--- a/lib/Models/IonImageryCatalogItem.js
+++ b/lib/Models/IonImageryCatalogItem.js
@@ -4,8 +4,7 @@
 
 var IonImageryProvider = require("terriajs-cesium/Source/Scene/IonImageryProvider")
   .default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var ImageryLayerCatalogItem = require("./ImageryLayerCatalogItem");
 var inherit = require("../Core/inherit");
 var i18next = require("i18next").default;
@@ -45,7 +44,7 @@ var IonImageryCatalogItem = function(terria) {
 
 inherit(ImageryLayerCatalogItem, IonImageryCatalogItem);
 
-defineProperties(IonImageryCatalogItem.prototype, {
+Object.defineProperties(IonImageryCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf UrlTemplateCatalogItem.prototype

--- a/lib/Models/KmlCatalogItem.js
+++ b/lib/Models/KmlCatalogItem.js
@@ -3,8 +3,7 @@
 /*global require,Document*/
 
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var Ellipsoid = require("terriajs-cesium/Source/Core/Ellipsoid").default;
 //var KmlDataSource = require('terriajs-cesium/Source/DataSources/KmlDataSource');
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
@@ -60,7 +59,7 @@ var KmlCatalogItem = function(terria, url) {
 
 inherit(DataSourceCatalogItem, KmlCatalogItem);
 
-defineProperties(KmlCatalogItem.prototype, {
+Object.defineProperties(KmlCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf KmlCatalogItem.prototype

--- a/lib/Models/LineParameter.js
+++ b/lib/Models/LineParameter.js
@@ -1,8 +1,7 @@
 "use strict";
 
 /*global require*/
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
@@ -28,7 +27,7 @@ var LineParameter = function(options) {
 
 inherit(FunctionParameter, LineParameter);
 
-defineProperties(LineParameter.prototype, {
+Object.defineProperties(LineParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof LineParameter.prototype

--- a/lib/Models/MagdaCatalogItem.js
+++ b/lib/Models/MagdaCatalogItem.js
@@ -10,9 +10,7 @@ var createRegexSerializer = require("terriajs/lib/Models/createRegexSerializer")
 var CsvCatalogItem = require("terriajs/lib/Models/CsvCatalogItem");
 var CzmlCatalogItem = require("terriajs/lib/Models/CzmlCatalogItem");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var GeoJsonCatalogItem = require("terriajs/lib/Models/GeoJsonCatalogItem");
 var inherit = require("terriajs/lib/Core/inherit");
 var KmlCatalogItem = require("terriajs/lib/Models/KmlCatalogItem");
@@ -184,7 +182,7 @@ function MagdaCatalogItem(terria) {
 
 inherit(CatalogItem, MagdaCatalogItem);
 
-defineProperties(MagdaCatalogItem.prototype, {
+Object.defineProperties(MagdaCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf MagdaCatalogItem.prototype
@@ -287,7 +285,7 @@ MagdaCatalogItem.defaultUpdaters.czmlDistributionFormat = createRegexDeserialize
   "czmlDistributionFormat"
 );
 
-freezeObject(MagdaCatalogItem.defaultUpdaters);
+Object.freeze(MagdaCatalogItem.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type
@@ -321,7 +319,7 @@ MagdaCatalogItem.defaultSerializers.czmlDistributionFormat = createRegexSerializ
   "czmlDistributionFormat"
 );
 
-freezeObject(MagdaCatalogItem.defaultSerializers);
+Object.freeze(MagdaCatalogItem.defaultSerializers);
 
 /**
  * Creates a catalog item from a MAGDA distribution.

--- a/lib/Models/MapboxMapCatalogItem.js
+++ b/lib/Models/MapboxMapCatalogItem.js
@@ -5,8 +5,7 @@ var URI = require("urijs");
 
 var MapboxImageryProvider = require("terriajs-cesium/Source/Scene/MapboxImageryProvider")
   .default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var ImageryLayerCatalogItem = require("./ImageryLayerCatalogItem");
@@ -51,7 +50,7 @@ var MapboxCatalogItem = function(terria) {
 
 inherit(ImageryLayerCatalogItem, MapboxCatalogItem);
 
-defineProperties(MapboxCatalogItem.prototype, {
+Object.defineProperties(MapboxCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf MapboxCatalogItem.prototype

--- a/lib/Models/MapboxVectorTileCatalogItem.js
+++ b/lib/Models/MapboxVectorTileCatalogItem.js
@@ -1,8 +1,6 @@
 const MapboxVectorTileImageryProvider = require("../Map/MapboxVectorTileImageryProvider");
 const clone = require("terriajs-cesium/Source/Core/clone").default;
 const defined = require("terriajs-cesium/Source/Core/defined").default;
-const defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 const ImageryLayerFeatureInfo = require("terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo")
   .default;
 const ImageryLayerCatalogItem = require("./ImageryLayerCatalogItem");
@@ -113,7 +111,7 @@ const MapboxVectorTileCatalogItem = function(terria) {
 
 inherit(ImageryLayerCatalogItem, MapboxVectorTileCatalogItem);
 
-defineProperties(MapboxVectorTileCatalogItem.prototype, {
+Object.defineProperties(MapboxVectorTileCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf MapboxVectorTileCatalogItem.prototype

--- a/lib/Models/MetadataItem.js
+++ b/lib/Models/MetadataItem.js
@@ -2,8 +2,6 @@
 
 /*global require*/
 
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 
 /**
@@ -41,7 +39,7 @@ var MetadataItem = function(name, value) {
   knockout.track(this, ["name", "value", "items", "isOpen"]);
 };
 
-defineProperties(MetadataItem.prototype, {
+Object.defineProperties(MetadataItem.prototype, {
   /**
    * Gets a value indicating whether this item has child items.
    * @type {Boolean}

--- a/lib/Models/NowViewing.js
+++ b/lib/Models/NowViewing.js
@@ -4,8 +4,7 @@
 var CesiumEvent = require("terriajs-cesium/Source/Core/Event").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var EventHelper = require("terriajs-cesium/Source/Core/EventHelper").default;
@@ -48,7 +47,7 @@ var NowViewing = function(terria) {
   );
 };
 
-defineProperties(NowViewing.prototype, {
+Object.defineProperties(NowViewing.prototype, {
   /**
    * Gets the Terria instance.
    * @memberOf NowViewing.prototype

--- a/lib/Models/OgrCatalogItem.js
+++ b/lib/Models/OgrCatalogItem.js
@@ -3,8 +3,7 @@
 /*global require*/
 
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadWithXhr = require("../Core/loadWithXhr");
 var Uri = require("terriajs-cesium/Source/ThirdParty/Uri").default;
@@ -54,7 +53,7 @@ var OgrCatalogItem = function(terria, url) {
 
 inherit(CatalogItem, OgrCatalogItem);
 
-defineProperties(OgrCatalogItem.prototype, {
+Object.defineProperties(OgrCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf OgrCatalogItem.prototype

--- a/lib/Models/OpenStreetMapCatalogItem.js
+++ b/lib/Models/OpenStreetMapCatalogItem.js
@@ -5,8 +5,7 @@ var URI = require("urijs");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var UrlTemplateImageryProvider = require("terriajs-cesium/Source/Scene/UrlTemplateImageryProvider")
   .default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var ImageryLayerCatalogItem = require("./ImageryLayerCatalogItem");
 var inherit = require("../Core/inherit");
@@ -60,7 +59,7 @@ var OpenStreetMapCatalogItem = function(terria) {
 
 inherit(ImageryLayerCatalogItem, OpenStreetMapCatalogItem);
 
-defineProperties(OpenStreetMapCatalogItem.prototype, {
+Object.defineProperties(OpenStreetMapCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf OpenStreetMapCatalogItem.prototype

--- a/lib/Models/PlacesLikeMeCatalogFunction.js
+++ b/lib/Models/PlacesLikeMeCatalogFunction.js
@@ -4,8 +4,7 @@
 var CatalogFunction = require("./CatalogFunction");
 var CsvCatalogItem = require("./CsvCatalogItem");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var extendLoad = require("./extendLoad");
 var inherit = require("../Core/inherit");
 var invokeTerriaAnalyticsService = require("./invokeTerriaAnalyticsService");
@@ -70,7 +69,7 @@ var PlacesLikeMeCatalogfunction = function(terria) {
 
 inherit(CatalogFunction, PlacesLikeMeCatalogfunction);
 
-defineProperties(PlacesLikeMeCatalogfunction.prototype, {
+Object.defineProperties(PlacesLikeMeCatalogfunction.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf PlacesLikeMeCatalogfunction.prototype

--- a/lib/Models/PointParameter.js
+++ b/lib/Models/PointParameter.js
@@ -3,8 +3,7 @@
 /*global require*/
 var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
@@ -29,7 +28,7 @@ var PointParameter = function(options) {
 
 inherit(FunctionParameter, PointParameter);
 
-defineProperties(PointParameter.prototype, {
+Object.defineProperties(PointParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof DateTimeParameter.prototype

--- a/lib/Models/PolygonParameter.js
+++ b/lib/Models/PolygonParameter.js
@@ -1,8 +1,7 @@
 "use strict";
 
 /*global require*/
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
@@ -28,7 +27,7 @@ var PolygonParameter = function(options) {
 
 inherit(FunctionParameter, PolygonParameter);
 
-defineProperties(PolygonParameter.prototype, {
+Object.defineProperties(PolygonParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof PolygonParameter.prototype

--- a/lib/Models/RectangleParameter.js
+++ b/lib/Models/RectangleParameter.js
@@ -4,8 +4,7 @@
 var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
 var Reproject = require("../Map/Reproject");
@@ -35,7 +34,7 @@ var RectangleParameter = function(options) {
 
 inherit(FunctionParameter, RectangleParameter);
 
-defineProperties(RectangleParameter.prototype, {
+Object.defineProperties(RectangleParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof DateTimeParameter.prototype

--- a/lib/Models/RegionDataParameter.js
+++ b/lib/Models/RegionDataParameter.js
@@ -3,8 +3,7 @@
 /*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var FunctionParameter = require("./FunctionParameter");
@@ -44,7 +43,7 @@ var RegionDataParameter = function(options) {
 
 inherit(FunctionParameter, RegionDataParameter);
 
-defineProperties(RegionDataParameter.prototype, {
+Object.defineProperties(RegionDataParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof RegionDataParameter.prototype

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -115,6 +115,7 @@ Object.defineProperties(RegionMapping.prototype, {
       if (defined(this._tableStructure)) {
         return this._tableStructure.clock;
       }
+      return undefined;
     }
   },
   /**

--- a/lib/Models/RegionMapping.js
+++ b/lib/Models/RegionMapping.js
@@ -7,8 +7,7 @@ var CesiumEvent = require("terriajs-cesium/Source/Core/Event").default;
 var combine = require("terriajs-cesium/Source/Core/combine").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var destroyObject = require("terriajs-cesium/Source/Core/destroyObject")
   .default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
@@ -104,7 +103,7 @@ var RegionMapping = function(catalogItem, tableStructure, tableStyle) {
     }, this);
 };
 
-defineProperties(RegionMapping.prototype, {
+Object.defineProperties(RegionMapping.prototype, {
   /**
    * Gets the clock settings defined by the loaded data.  If
    * only static data exists, this value is undefined.

--- a/lib/Models/RegionParameter.js
+++ b/lib/Models/RegionParameter.js
@@ -87,6 +87,7 @@ Object.defineProperties(RegionParameter.prototype, {
       if (this._regionProvider instanceof RegionTypeParameter) {
         return this._regionProvider;
       }
+      return undefined;
     }
   }
 });

--- a/lib/Models/RegionParameter.js
+++ b/lib/Models/RegionParameter.js
@@ -2,8 +2,7 @@
 
 /*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var FunctionParameter = require("./FunctionParameter");
@@ -37,7 +36,7 @@ var RegionParameter = function(options) {
 
 inherit(FunctionParameter, RegionParameter);
 
-defineProperties(RegionParameter.prototype, {
+Object.defineProperties(RegionParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof RegionParameter.prototype

--- a/lib/Models/RegionTypeParameter.js
+++ b/lib/Models/RegionTypeParameter.js
@@ -2,8 +2,7 @@
 
 /*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var overrideProperty = require("../Core/overrideProperty");
 
@@ -102,7 +101,7 @@ RegionTypeParameter.resolveRegionProvider = function(
 
 inherit(FunctionParameter, RegionTypeParameter);
 
-defineProperties(RegionTypeParameter.prototype, {
+Object.defineProperties(RegionTypeParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof RegionTypeParameter.prototype

--- a/lib/Models/ResultPendingCatalogItem.js
+++ b/lib/Models/ResultPendingCatalogItem.js
@@ -2,8 +2,7 @@
 
 /*global require*/
 var CatalogItem = require("./CatalogItem");
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var inherit = require("../Core/inherit");
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var i18next = require("i18next").default;
@@ -28,7 +27,7 @@ var ResultPendingCatalogItem = function(terria) {
 
 inherit(CatalogItem, ResultPendingCatalogItem);
 
-defineProperties(ResultPendingCatalogItem.prototype, {
+Object.defineProperties(ResultPendingCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf ResultPendingCatalogItem.prototype

--- a/lib/Models/SdmxJsonCatalogItem.js
+++ b/lib/Models/SdmxJsonCatalogItem.js
@@ -9,11 +9,10 @@ naturalSort.insensitive = true;
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var deprecationWarning = require("terriajs-cesium/Source/Core/deprecationWarning")
   .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 var loadSdmxStructureJson = require("../Core/loadSdmxStructureJson");
@@ -385,7 +384,7 @@ var SdmxJsonCatalogItem = function(terria, url) {
 
 inherit(TableCatalogItem, SdmxJsonCatalogItem);
 
-defineProperties(SdmxJsonCatalogItem.prototype, {
+Object.defineProperties(SdmxJsonCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf SdmxJsonCatalogItem.prototype
@@ -468,7 +467,7 @@ SdmxJsonCatalogItem.defaultPropertiesForSharing = clone(
 );
 SdmxJsonCatalogItem.defaultPropertiesForSharing.push("selectedInitially");
 SdmxJsonCatalogItem.defaultPropertiesForSharing.push("displayPercent");
-freezeObject(SdmxJsonCatalogItem.defaultPropertiesForSharing);
+Object.freeze(SdmxJsonCatalogItem.defaultPropertiesForSharing);
 
 SdmxJsonCatalogItem.defaultSerializers = clone(
   TableCatalogItem.defaultSerializers
@@ -499,7 +498,7 @@ SdmxJsonCatalogItem.defaultSerializers.url = function(item, json) {
   // Put the original URL back in as the url when serializing.
   json.url = item.originalUrl;
 };
-freezeObject(SdmxJsonCatalogItem.defaultSerializers);
+Object.freeze(SdmxJsonCatalogItem.defaultSerializers);
 
 // Just the items that would influence the load from the server or the file
 SdmxJsonCatalogItem.prototype._getValuesThatInfluenceLoad = function() {

--- a/lib/Models/SelectAPolygonParameter.js
+++ b/lib/Models/SelectAPolygonParameter.js
@@ -1,8 +1,7 @@
 "use strict";
 
 /*global require*/
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
@@ -27,7 +26,7 @@ var SelectAPolygonParameter = function(options) {
 
 inherit(FunctionParameter, SelectAPolygonParameter);
 
-defineProperties(SelectAPolygonParameter.prototype, {
+Object.defineProperties(SelectAPolygonParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof SelectAPolygonParameter.prototype

--- a/lib/Models/SensorObservationServiceCatalogItem.js
+++ b/lib/Models/SensorObservationServiceCatalogItem.js
@@ -7,11 +7,10 @@ var Mustache = require("mustache");
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadWithXhr = require("../Core/loadWithXhr");
@@ -306,7 +305,7 @@ SensorObservationServiceCatalogItem.defaultRequestTemplate = require("./SensorOb
 
 inherit(TableCatalogItem, SensorObservationServiceCatalogItem);
 
-defineProperties(SensorObservationServiceCatalogItem.prototype, {
+Object.defineProperties(SensorObservationServiceCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf SensorObservationServiceCatalogItem.prototype
@@ -384,7 +383,7 @@ SensorObservationServiceCatalogItem.defaultPropertiesForSharing.push(
 SensorObservationServiceCatalogItem.defaultPropertiesForSharing.push(
   "initialObservablePropertyIndex"
 );
-freezeObject(SensorObservationServiceCatalogItem.defaultPropertiesForSharing);
+Object.freeze(SensorObservationServiceCatalogItem.defaultPropertiesForSharing);
 
 SensorObservationServiceCatalogItem.defaultSerializers = clone(
   TableCatalogItem.defaultSerializers
@@ -392,7 +391,7 @@ SensorObservationServiceCatalogItem.defaultSerializers = clone(
 SensorObservationServiceCatalogItem.defaultSerializers.activeConcepts = function() {
   // Don't serialize.
 };
-freezeObject(SensorObservationServiceCatalogItem.defaultSerializers);
+Object.freeze(SensorObservationServiceCatalogItem.defaultSerializers);
 
 // Just the items that would influence the load from the abs server or the file
 SensorObservationServiceCatalogItem.prototype._getValuesThatInfluenceLoad = function() {

--- a/lib/Models/SensorObservationServiceCatalogItem.js
+++ b/lib/Models/SensorObservationServiceCatalogItem.js
@@ -365,6 +365,7 @@ Object.defineProperties(SensorObservationServiceCatalogItem.prototype, {
       } else if (defined(this._dataSource)) {
         return this._dataSource;
       }
+      return undefined;
     }
   }
 });

--- a/lib/Models/ShareDataService.js
+++ b/lib/Models/ShareDataService.js
@@ -4,8 +4,7 @@
 var i18next = require("i18next").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 var loadJson = require("../Core/loadJson");
@@ -24,7 +23,7 @@ var ShareDataService = function(options) {
   this._isUsable = undefined;
 };
 
-defineProperties(ShareDataService.prototype, {
+Object.defineProperties(ShareDataService.prototype, {
   isUsable: {
     get: function() {
       return this._isUsable;

--- a/lib/Models/SocrataCatalogGroup.js
+++ b/lib/Models/SocrataCatalogGroup.js
@@ -4,10 +4,9 @@
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var formatError = require("terriajs-cesium/Source/Core/formatError").default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 var proxyCatalogItemUrl = require("./proxyCatalogItemUrl");
@@ -68,7 +67,7 @@ var SocrataCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, SocrataCatalogGroup);
 
-defineProperties(SocrataCatalogGroup.prototype, {
+Object.defineProperties(SocrataCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf SocrataCatalogGroup.prototype
@@ -127,7 +126,7 @@ defineProperties(SocrataCatalogGroup.prototype, {
  */
 SocrataCatalogGroup.defaultUpdaters = clone(CatalogGroup.defaultUpdaters);
 
-freezeObject(SocrataCatalogGroup.defaultUpdaters);
+Object.freeze(SocrataCatalogGroup.defaultUpdaters);
 
 /**
  * Gets or sets the set of default serializer functions to use in {@link CatalogMember#serializeToJson}.  Types derived from this type

--- a/lib/Models/SpatialDetailingCatalogFunction.js
+++ b/lib/Models/SpatialDetailingCatalogFunction.js
@@ -4,8 +4,7 @@
 var BooleanParameter = require("./BooleanParameter");
 var CatalogFunction = require("./CatalogFunction");
 var CsvCatalogItem = require("./CsvCatalogItem");
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var inherit = require("../Core/inherit");
 var invokeTerriaAnalyticsService = require("./invokeTerriaAnalyticsService");
 var RegionDataParameter = require("./RegionDataParameter");
@@ -89,7 +88,7 @@ var SpatialDetailingCatalogFunction = function(terria) {
 
 inherit(CatalogFunction, SpatialDetailingCatalogFunction);
 
-defineProperties(SpatialDetailingCatalogFunction.prototype, {
+Object.defineProperties(SpatialDetailingCatalogFunction.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf SpatialDetailingCatalogFunction.prototype

--- a/lib/Models/StringParameter.js
+++ b/lib/Models/StringParameter.js
@@ -1,8 +1,7 @@
 "use strict";
 
 /*global require*/
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var FunctionParameter = require("./FunctionParameter");
 var inherit = require("../Core/inherit");
 
@@ -28,7 +27,7 @@ var StringParameter = function(options) {
 
 inherit(FunctionParameter, StringParameter);
 
-defineProperties(StringParameter.prototype, {
+Object.defineProperties(StringParameter.prototype, {
   /**
    * Gets the type of this parameter.
    * @memberof StringParameter.prototype

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -4,11 +4,10 @@
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var ImagerySplitDirection = require("terriajs-cesium/Source/Scene/ImagerySplitDirection")
   .default;
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
@@ -366,7 +365,7 @@ function addMarginToRectangle(rect, marginFraction) {
   return rect;
 }
 
-defineProperties(TableCatalogItem.prototype, {
+Object.defineProperties(TableCatalogItem.prototype, {
   /**
    * Gets the active time column, if it exists.
    * @memberOf TableCatalogItem.prototype
@@ -595,7 +594,7 @@ TableCatalogItem.defaultUpdaters.intervals = function() {
   // Don't update from JSON.
 };
 
-freezeObject(TableCatalogItem.defaultUpdaters);
+Object.freeze(TableCatalogItem.defaultUpdaters);
 
 TableCatalogItem.defaultSerializers = clone(CatalogItem.defaultSerializers);
 
@@ -679,7 +678,7 @@ TableCatalogItem.defaultSerializers.intervals = function() {
   // Don't serialize.
 };
 
-freezeObject(TableCatalogItem.defaultSerializers);
+Object.freeze(TableCatalogItem.defaultSerializers);
 
 /**
  * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
@@ -694,7 +693,7 @@ TableCatalogItem.defaultPropertiesForSharing.push("opacity");
 TableCatalogItem.defaultPropertiesForSharing.push("tableStyle");
 TableCatalogItem.defaultPropertiesForSharing.push("splitDirection");
 TableCatalogItem.defaultPropertiesForSharing.push("url");
-freezeObject(TableCatalogItem.defaultPropertiesForSharing);
+Object.freeze(TableCatalogItem.defaultPropertiesForSharing);
 
 TableCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url, this.data];

--- a/lib/Models/TableCatalogItem.js
+++ b/lib/Models/TableCatalogItem.js
@@ -395,6 +395,7 @@ Object.defineProperties(TableCatalogItem.prototype, {
           this._tableStructure.columnsByType[VarType.SCALAR][0]
         );
       }
+      return undefined;
     }
   },
 

--- a/lib/Models/TableColumnStyle.js
+++ b/lib/Models/TableColumnStyle.js
@@ -3,7 +3,6 @@
 /*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
 
 var ColorMap = require("../Map/ColorMap");
 var serializeToJson = require("../Core/serializeToJson");
@@ -247,7 +246,7 @@ TableColumnStyle.prototype.updaters = {
     });
   }
 };
-freezeObject(TableColumnStyle.prototype.updaters);
+Object.freeze(TableColumnStyle.prototype.updaters);
 
 TableColumnStyle.prototype.serializers = {
   colorMap: function(tableColumnStyle, json, propertyName) {
@@ -257,7 +256,7 @@ TableColumnStyle.prototype.serializers = {
     }
   }
 };
-freezeObject(TableColumnStyle.prototype.serializers);
+Object.freeze(TableColumnStyle.prototype.serializers);
 
 TableColumnStyle.prototype.updateFromJson = function(json, options) {
   return updateFromJson(this, json, options);

--- a/lib/Models/TableDataSource.js
+++ b/lib/Models/TableDataSource.js
@@ -9,8 +9,7 @@ var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;
 var Color = require("terriajs-cesium/Source/Core/Color").default;
 var createGuid = require("terriajs-cesium/Source/Core/createGuid").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var destroyObject = require("terriajs-cesium/Source/Core/destroyObject")
   .default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
@@ -115,7 +114,7 @@ var TableDataSource = function(
     .subscribe(changedActiveItems.bind(null, this), this);
 };
 
-defineProperties(TableDataSource.prototype, {
+Object.defineProperties(TableDataSource.prototype, {
   /**
    * Gets a human-readable name for this instance.
    * @memberof TableDataSource.prototype

--- a/lib/Models/TableDataSource.js
+++ b/lib/Models/TableDataSource.js
@@ -136,6 +136,7 @@ Object.defineProperties(TableDataSource.prototype, {
       if (defined(this._tableStructure)) {
         return this._tableStructure.clock;
       }
+      return undefined;
     }
   },
   /**

--- a/lib/Models/TableStyle.js
+++ b/lib/Models/TableStyle.js
@@ -4,7 +4,7 @@
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
 
 var inherit = require("../Core/inherit");
@@ -102,7 +102,7 @@ TableStyle.prototype.updaters["columns"] = function(
   propertyName
 ) {};
 
-freezeObject(TableStyle.prototype.updaters);
+Object.freeze(TableStyle.prototype.updaters);
 
 function objectToTableColumnStyle(json, promises, options) {
   if (defined(json.columns)) {

--- a/lib/Models/TerrainCatalogItem.js
+++ b/lib/Models/TerrainCatalogItem.js
@@ -3,8 +3,7 @@
 /*global require*/
 var i18next = require("i18next").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 
@@ -31,7 +30,7 @@ var TerrainCatalogItem = function(terria) {
 
 inherit(CatalogItem, TerrainCatalogItem);
 
-defineProperties(TerrainCatalogItem.prototype, {
+Object.defineProperties(TerrainCatalogItem.prototype, {
   /**
    * Gets the terrain provider object associated with this data source.
    * This property is undefined if the data source is not enabled.

--- a/lib/Models/TerriaJsonCatalogFunction.js
+++ b/lib/Models/TerriaJsonCatalogFunction.js
@@ -6,9 +6,7 @@ var CatalogGroup = require("./CatalogGroup");
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var createParameterFromType = require("./createParameterFromType");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var inherit = require("../Core/inherit");
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var proxyCatalogItemUrl = require("./proxyCatalogItemUrl");
@@ -242,7 +240,7 @@ function TerriaJsonCatalogFunction(terria) {
 
 inherit(CatalogFunction, TerriaJsonCatalogFunction);
 
-defineProperties(TerriaJsonCatalogFunction.prototype, {
+Object.defineProperties(TerriaJsonCatalogFunction.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf TerriaJSONCatalogFunction.prototype
@@ -342,7 +340,7 @@ TerriaJsonCatalogFunction.defaultUpdaters.inputs = function(
   });
 };
 
-freezeObject(TerriaJsonCatalogFunction.defaultUpdaters);
+Object.freeze(TerriaJsonCatalogFunction.defaultUpdaters);
 
 TerriaJsonCatalogFunction.defaultSerializers = clone(
   CatalogFunction.defaultSerializers
@@ -363,7 +361,7 @@ TerriaJsonCatalogFunction.defaultSerializers.inputs = function(
   );
 };
 
-freezeObject(TerriaJsonCatalogFunction.defaultSerializers);
+Object.freeze(TerriaJsonCatalogFunction.defaultSerializers);
 
 TerriaJsonCatalogFunction.defaultPropertiesForSharing = clone(
   CatalogFunction.defaultPropertiesForSharing

--- a/lib/Models/UrlTemplateCatalogItem.js
+++ b/lib/Models/UrlTemplateCatalogItem.js
@@ -4,8 +4,7 @@
 var i18next = require("i18next").default;
 var UrlTemplateImageryProvider = require("terriajs-cesium/Source/Scene/UrlTemplateImageryProvider")
   .default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var ImageryLayerCatalogItem = require("./ImageryLayerCatalogItem");
 var inherit = require("../Core/inherit");
@@ -69,7 +68,7 @@ var UrlTemplateCatalogItem = function(terria) {
 
 inherit(ImageryLayerCatalogItem, UrlTemplateCatalogItem);
 
-defineProperties(UrlTemplateCatalogItem.prototype, {
+Object.defineProperties(UrlTemplateCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf UrlTemplateCatalogItem.prototype

--- a/lib/Models/WebFeatureServiceCatalogGroup.js
+++ b/lib/Models/WebFeatureServiceCatalogGroup.js
@@ -5,9 +5,7 @@ var URI = require("urijs");
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadXML = require("../Core/loadXML");
 var Rectangle = require("terriajs-cesium/Source/Core/Rectangle").default;
@@ -60,7 +58,7 @@ var WebFeatureServiceCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, WebFeatureServiceCatalogGroup);
 
-defineProperties(WebFeatureServiceCatalogGroup.prototype, {
+Object.defineProperties(WebFeatureServiceCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf WebFeatureServiceCatalogGroup.prototype
@@ -117,7 +115,7 @@ WebFeatureServiceCatalogGroup.defaultSerializers.isLoading = function(
   options
 ) {};
 
-freezeObject(WebFeatureServiceCatalogGroup.defaultSerializers);
+Object.freeze(WebFeatureServiceCatalogGroup.defaultSerializers);
 
 WebFeatureServiceCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url, this.blacklist];

--- a/lib/Models/WebFeatureServiceCatalogItem.js
+++ b/lib/Models/WebFeatureServiceCatalogItem.js
@@ -6,9 +6,7 @@ var combine = require("terriajs-cesium/Source/Core/combine").default;
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 var loadXML = require("../Core/loadXML");
@@ -151,7 +149,7 @@ var WebFeatureServiceCatalogItem = function(terria) {
 
 inherit(CatalogItem, WebFeatureServiceCatalogItem);
 
-defineProperties(WebFeatureServiceCatalogItem.prototype, {
+Object.defineProperties(WebFeatureServiceCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf WebFeatureServiceCatalogItem.prototype
@@ -218,7 +216,7 @@ defineProperties(WebFeatureServiceCatalogItem.prototype, {
 WebFeatureServiceCatalogItem.defaultUpdaters = clone(
   CatalogItem.defaultUpdaters
 );
-freezeObject(WebFeatureServiceCatalogItem.defaultUpdaters);
+Object.freeze(WebFeatureServiceCatalogItem.defaultUpdaters);
 
 WebFeatureServiceCatalogItem.defaultSerializers = clone(
   CatalogItem.defaultSerializers
@@ -246,7 +244,7 @@ WebFeatureServiceCatalogItem.defaultSerializers.metadataUrl = function(
 ) {
   json.metadataUrl = wfsItem._metadataUrl;
 };
-freezeObject(WebFeatureServiceCatalogItem.defaultSerializers);
+Object.freeze(WebFeatureServiceCatalogItem.defaultSerializers);
 
 WebFeatureServiceCatalogItem.prototype._getValuesThatInfluenceLoad = function() {
   return [

--- a/lib/Models/WebMapServiceCatalogGroup.js
+++ b/lib/Models/WebMapServiceCatalogGroup.js
@@ -5,9 +5,7 @@ var URI = require("urijs");
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadXML = require("../Core/loadXML");
 
@@ -97,7 +95,7 @@ var WebMapServiceCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, WebMapServiceCatalogGroup);
 
-defineProperties(WebMapServiceCatalogGroup.prototype, {
+Object.defineProperties(WebMapServiceCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf WebMapServiceCatalogGroup.prototype
@@ -154,7 +152,7 @@ WebMapServiceCatalogGroup.defaultSerializers.isLoading = function(
   options
 ) {};
 
-freezeObject(WebMapServiceCatalogGroup.defaultSerializers);
+Object.freeze(WebMapServiceCatalogGroup.defaultSerializers);
 
 WebMapServiceCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url, this.blacklist, this.titleField];

--- a/lib/Models/WebMapServiceCatalogItem.js
+++ b/lib/Models/WebMapServiceCatalogItem.js
@@ -9,10 +9,9 @@ var clone = require("terriajs-cesium/Source/Core/clone").default;
 var combine = require("terriajs-cesium/Source/Core/combine").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var Ellipsoid = require("terriajs-cesium/Source/Core/Ellipsoid").default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var GeographicTilingScheme = require("terriajs-cesium/Source/Core/GeographicTilingScheme")
   .default;
 var GetFeatureInfoFormat = require("terriajs-cesium/Source/Scene/GetFeatureInfoFormat")
@@ -429,7 +428,7 @@ var WebMapServiceCatalogItem = function(terria) {
 
 inherit(ImageryLayerCatalogItem, WebMapServiceCatalogItem);
 
-defineProperties(WebMapServiceCatalogItem.prototype, {
+Object.defineProperties(WebMapServiceCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf WebMapServiceCatalogItem.prototype
@@ -571,7 +570,7 @@ WebMapServiceCatalogItem.defaultUpdaters.getFeatureInfoFormats = function(
   wmsItem.getFeatureInfoFormats = formats;
 };
 
-freezeObject(WebMapServiceCatalogItem.defaultUpdaters);
+Object.freeze(WebMapServiceCatalogItem.defaultUpdaters);
 
 WebMapServiceCatalogItem.defaultSerializers = clone(
   ImageryLayerCatalogItem.defaultSerializers
@@ -610,7 +609,7 @@ WebMapServiceCatalogItem.defaultSerializers.intervals = function() {};
 WebMapServiceCatalogItem.defaultSerializers.description = function() {};
 WebMapServiceCatalogItem.defaultSerializers.info = function() {};
 
-freezeObject(WebMapServiceCatalogItem.defaultSerializers);
+Object.freeze(WebMapServiceCatalogItem.defaultSerializers);
 
 /**
  * Gets or sets the default set of properties that are serialized when serializing a {@link CatalogItem}-derived object
@@ -625,7 +624,7 @@ WebMapServiceCatalogItem.defaultPropertiesForSharing.push("colorScaleMinimum");
 WebMapServiceCatalogItem.defaultPropertiesForSharing.push("colorScaleMaximum");
 WebMapServiceCatalogItem.defaultPropertiesForSharing.push("dimensions");
 
-freezeObject(WebMapServiceCatalogItem.defaultPropertiesForSharing);
+Object.freeze(WebMapServiceCatalogItem.defaultPropertiesForSharing);
 
 /**
  * The collection of strings that indicate an Abstract property should be ignored.  If these strings occur anywhere

--- a/lib/Models/WebMapTileServiceCatalogGroup.js
+++ b/lib/Models/WebMapTileServiceCatalogGroup.js
@@ -6,9 +6,7 @@ var i18next = require("i18next").default;
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadXML = require("../Core/loadXML");
 
@@ -85,7 +83,7 @@ var WebMapTileServiceCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, WebMapTileServiceCatalogGroup);
 
-defineProperties(WebMapTileServiceCatalogGroup.prototype, {
+Object.defineProperties(WebMapTileServiceCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf WebMapTileServiceCatalogGroup.prototype
@@ -142,7 +140,7 @@ WebMapTileServiceCatalogGroup.defaultSerializers.isLoading = function(
   options
 ) {};
 
-freezeObject(WebMapTileServiceCatalogGroup.defaultSerializers);
+Object.freeze(WebMapTileServiceCatalogGroup.defaultSerializers);
 
 WebMapTileServiceCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url, this.blacklist, this.titleField];

--- a/lib/Models/WebMapTileServiceCatalogItem.js
+++ b/lib/Models/WebMapTileServiceCatalogItem.js
@@ -7,9 +7,7 @@ var i18next = require("i18next").default;
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var GeographicTilingScheme = require("terriajs-cesium/Source/Core/GeographicTilingScheme")
   .default;
 var GetFeatureInfoFormat = require("terriajs-cesium/Source/Scene/GetFeatureInfoFormat")
@@ -184,7 +182,7 @@ var WebMapTileServiceCatalogItem = function(terria) {
 
 inherit(ImageryLayerCatalogItem, WebMapTileServiceCatalogItem);
 
-defineProperties(WebMapTileServiceCatalogItem.prototype, {
+Object.defineProperties(WebMapTileServiceCatalogItem.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf WebMapTileServiceCatalogItem.prototype
@@ -296,7 +294,7 @@ WebMapTileServiceCatalogItem.defaultUpdaters.getFeatureInfoFormats = function(
   wmtsItem.getFeatureInfoFormats = formats;
 };
 
-freezeObject(WebMapTileServiceCatalogItem.defaultUpdaters);
+Object.freeze(WebMapTileServiceCatalogItem.defaultUpdaters);
 
 WebMapTileServiceCatalogItem.defaultSerializers = clone(
   ImageryLayerCatalogItem.defaultSerializers
@@ -344,7 +342,7 @@ WebMapTileServiceCatalogItem.defaultSerializers.tilingScheme = function(
     json.tilingScheme = wmtsItem.tilingScheme;
   }
 };
-freezeObject(WebMapTileServiceCatalogItem.defaultSerializers);
+Object.freeze(WebMapTileServiceCatalogItem.defaultSerializers);
 
 /**
  * The collection of strings that indicate an Abstract property should be ignored.  If these strings occur anywhere

--- a/lib/Models/WebProcessingServiceCatalogFunction.js
+++ b/lib/Models/WebProcessingServiceCatalogFunction.js
@@ -10,8 +10,7 @@ var CatalogFunction = require("./CatalogFunction");
 var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
 var DateTimeParameter = require("./DateTimeParameter");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var EnumerationParameter = require("./EnumerationParameter");
 var StringParameter = require("./StringParameter");
 var inherit = require("../Core/inherit");
@@ -79,7 +78,7 @@ function WebProcessingServiceCatalogFunction(terria) {
 
 inherit(CatalogFunction, WebProcessingServiceCatalogFunction);
 
-defineProperties(WebProcessingServiceCatalogFunction.prototype, {
+Object.defineProperties(WebProcessingServiceCatalogFunction.prototype, {
   /**
    * Gets the type of data item represented by this instance.
    * @memberOf WebProcessingServiceCatalogFunction.prototype

--- a/lib/Models/WebProcessingServiceCatalogGroup.js
+++ b/lib/Models/WebProcessingServiceCatalogGroup.js
@@ -4,9 +4,7 @@
 var CatalogGroup = require("./CatalogGroup");
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var inherit = require("../Core/inherit");
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadXML = require("../Core/loadXML");
@@ -54,7 +52,7 @@ function WebProcessingServiceCatalogGroup(terria) {
 
 inherit(CatalogGroup, WebProcessingServiceCatalogGroup);
 
-defineProperties(WebProcessingServiceCatalogGroup.prototype, {
+Object.defineProperties(WebProcessingServiceCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf WebProcessingServiceCatalogGroup.prototype
@@ -112,7 +110,7 @@ WebProcessingServiceCatalogGroup.defaultSerializers.isLoading = function(
   propertyName,
   options
 ) {};
-freezeObject(WebProcessingServiceCatalogGroup.defaultSerializers);
+Object.freeze(WebProcessingServiceCatalogGroup.defaultSerializers);
 
 WebProcessingServiceCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [this.url, this.itemProperties];

--- a/lib/Models/WebProcessingServiceCatalogItem.js
+++ b/lib/Models/WebProcessingServiceCatalogItem.js
@@ -4,8 +4,7 @@
 var CatalogItem = require("./CatalogItem");
 var createGuid = require("terriajs-cesium/Source/Core/createGuid").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 var GeoJsonCatalogItem = require("./GeoJsonCatalogItem");
 var inherit = require("../Core/inherit");
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
@@ -64,7 +63,7 @@ function WebProcessingServiceCatalogItem(terria) {
 
 inherit(CatalogItem, WebProcessingServiceCatalogItem);
 
-defineProperties(WebProcessingServiceCatalogItem.prototype, {
+Object.defineProperties(WebProcessingServiceCatalogItem.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf WebProcessingServiceCatalogItem.prototype

--- a/lib/Models/WfsFeaturesCatalogGroup.js
+++ b/lib/Models/WfsFeaturesCatalogGroup.js
@@ -6,9 +6,7 @@ var i18next = require("i18next").default;
 
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
-var freezeObject = require("terriajs-cesium/Source/Core/freezeObject").default;
+
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var loadJson = require("../Core/loadJson");
 
@@ -103,7 +101,7 @@ var WfsFeaturesCatalogGroup = function(terria) {
 
 inherit(CatalogGroup, WfsFeaturesCatalogGroup);
 
-defineProperties(WfsFeaturesCatalogGroup.prototype, {
+Object.defineProperties(WfsFeaturesCatalogGroup.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf WfsFeaturesCatalogGroup.prototype
@@ -160,7 +158,7 @@ WfsFeaturesCatalogGroup.defaultSerializers.isLoading = function(
   options
 ) {};
 
-freezeObject(WfsFeaturesCatalogGroup.defaultSerializers);
+Object.freeze(WfsFeaturesCatalogGroup.defaultSerializers);
 
 WfsFeaturesCatalogGroup.prototype._getValuesThatInfluenceLoad = function() {
   return [

--- a/lib/Models/WhyAmISpecialCatalogFunction.js
+++ b/lib/Models/WhyAmISpecialCatalogFunction.js
@@ -3,8 +3,7 @@
 /*global require*/
 var CatalogFunction = require("./CatalogFunction");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
-var defineProperties = require("terriajs-cesium/Source/Core/defineProperties")
-  .default;
+
 // var extendLoad = require('./extendLoad');
 var GeoJsonCatalogItem = require("./GeoJsonCatalogItem");
 var inherit = require("../Core/inherit");
@@ -70,7 +69,7 @@ var WhyAmISpecialCatalogFunction = function(terria) {
 
 inherit(CatalogFunction, WhyAmISpecialCatalogFunction);
 
-defineProperties(WhyAmISpecialCatalogFunction.prototype, {
+Object.defineProperties(WhyAmISpecialCatalogFunction.prototype, {
   /**
    * Gets the type of data member represented by this instance.
    * @memberOf WhyAmISpecialCatalogFunction.prototype

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "eslint-plugin-jsx-control-statements": "^2.2.1",
     "eslint-plugin-react": "^7.12.4",
     "fs-extra": "^7.0.1",
-    "generate-terriajs-schema": "^1.4.0",
+    "generate-terriajs-schema": "^1.5.0",
     "glob-all": "^3.0.1",
     "husky": "^2.2.0",
     "jasmine-core": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "string-replace-webpack-plugin": "^0.1.3",
     "style-loader": "^0.23.1",
     "svg-sprite-loader": "4.1.3",
-    "terriajs-cesium": "1.66.0",
+    "terriajs-cesium": "1.68.0",
     "terriajs-html2canvas": "1.0.0-alpha.12-terriajs-1",
     "urijs": "^1.18.12",
     "url-loader": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "7.11.3",
+  "version": "7.11.4",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### What this PR does

Partially addresses https://github.com/TerriaJS/terriajs/issues/4198

* Upgraded the version of `terriajs-cesium` on `package.json` to 1.68. 
* Because of this upgrade, had to replace all of `defineProperties` and `freezeObject` that was previously dependent on Cesium's functions to use built in `Object` functions instead, to accommodate the change
* From this change, getters are made to return something within the `Object.defineProperties` function to fix lint errors
* Travis builds apparently need v10+ now, so bumped node version on travis to v10 now
* Also removed running `docs` on `gulp` to fix errors (current gulp command copied from mobx branch)

### Checklist

-   [x] I've updated CHANGES.md with what I changed.
