### PR TITLE
[2227] Now is't possible to use Mustache template to define an item e…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 ### next release
 
 * Added `GeoRssCatalogItem` for displaying GeoRSS files comming from rss2 and atom feeds.
+* Now is't possible to use Mustache template to define an item element name
 
 ### v7.11.4
 

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -171,6 +171,15 @@ var CatalogItem = function(terria) {
   this.featureInfoTemplate = undefined;
 
   /**
+   * Gets or sets a template to display item name.
+   * May be a string or an object with template, name and/or partials properties.
+   * Passed model is in the form: {record, uri}
+   * @example "{{record.title}} - {{uri.description}}"
+   * @type {String|Object}
+   */
+  this.itemNameTemplate = undefined;
+
+  /**
    * The maximum number of features whose information can be shown at one time in the Feature Info Panel, from this item.
    * Defaults to terria.configParameters.defaultMaximumShownFeatureInfos
    * @type {Number}

--- a/lib/Models/CswCatalogGroup.js
+++ b/lib/Models/CswCatalogGroup.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import Mustache from "mustache";
+
 /*global require*/
 var ArcGisMapServerCatalogItem = require("./ArcGisMapServerCatalogItem");
 var CatalogGroup = require("./CatalogGroup");
@@ -709,14 +711,15 @@ function createItemForUri(catalogGroup, record, uri, downloadUrls, legendUrl) {
   });
 
   if (defined(catalogItem)) {
+    catalogItem.name = getCatalogItemName(catalogGroup, record, uri);
+
+    catalogItem.url = uri.toString();
+
     if (catalogItem instanceof WebProcessingServiceCatalogGroup) {
       // only a few things we care about here
-      catalogItem.name = record.title;
-      catalogItem.url = uri.toString();
+      return catalogItem;
     } else {
-      catalogItem.name = record.title;
       catalogItem.description = record.description;
-      catalogItem.url = uri.toString();
       catalogItem.dataCustodian = "";
 
       if (defined(record.contributor)) {
@@ -763,6 +766,27 @@ function createItemForUri(catalogGroup, record, uri, downloadUrls, legendUrl) {
   }
 
   return catalogItem;
+}
+
+function getCatalogItemName(catalogGroup, record, uri) {
+  const properties = catalogGroup.itemProperties;
+
+  if (defined(properties)) {
+    const templateName = properties.itemNameTemplate;
+
+    if (defined(templateName)) {
+      if (typeof templateName === "string") {
+        return Mustache.render(templateName, { record, uri });
+      } else if (typeof templateName === "object") {
+        return Mustache.render(
+          templateName.template,
+          { record, uri },
+          templateName.partials
+        );
+      }
+    }
+  }
+  return record.title;
 }
 
 function cleanUrl(url) {


### PR DESCRIPTION
…lement name

### What this PR does

Fixes #2227 

I've seen that it's very hard to define a common way to present items and usually if a *record* has multiple external WMS resources (this also happens in CKAN) all the resources will have the same name.
I've also noticed that we have [Mustache](https://docs.terria.io/guide/connecting-to-data/customizing-data-appearance/feature-info-template/) support for the getFeatureInfo template.
What I did is simply add a new configuration node into the item properties to define a template for the itemName.

*Not sure what to do with tests* (but let's see if the patch can be accepted firts).

I'm open to comments, we really need this functionnality, please.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [X] I've updated CHANGES.md with what I changed.
