### PR TITLE
[2227] Now it's possible to use Mustache template to define an item name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 ### next release
 
 * Added `GeoRssCatalogItem` for displaying GeoRSS files comming from rss2 and atom feeds.
+* Added Mustache template Name to the CSWCatalogGroup (itemNameTemplate) to define a child item name
 
 ### v7.11.4
 

--- a/lib/Models/CswCatalogGroup.js
+++ b/lib/Models/CswCatalogGroup.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import Mustache from "mustache";
+
 /*global require*/
 var ArcGisMapServerCatalogItem = require("./ArcGisMapServerCatalogItem");
 var CatalogGroup = require("./CatalogGroup");
@@ -53,6 +55,15 @@ var CswCatalogGroup = function(terria) {
    * @type {String}
    */
   this.getRecordsTemplate = undefined;
+
+  /**
+   * Gets or sets a template to display group item names.
+   * May be a string or an object with template, name and/or partials properties.
+   * Passed model is in the following form: {record: record, uri: uri}
+   * example: "{{record.title}} - {{uri.description}}"
+   * @type {String|Object}
+   */
+  this.itemNameTemplate = undefined;
 
   /**
    * True to allow WMS resources to be added to the catalog; otherwise, false.
@@ -709,14 +720,15 @@ function createItemForUri(catalogGroup, record, uri, downloadUrls, legendUrl) {
   });
 
   if (defined(catalogItem)) {
+    catalogItem.name = getCatalogItemName(catalogGroup, record, uri);
+
+    catalogItem.url = uri.toString();
+
     if (catalogItem instanceof WebProcessingServiceCatalogGroup) {
       // only a few things we care about here
-      catalogItem.name = record.title;
-      catalogItem.url = uri.toString();
+      return catalogItem;
     } else {
-      catalogItem.name = record.title;
       catalogItem.description = record.description;
-      catalogItem.url = uri.toString();
       catalogItem.dataCustodian = "";
 
       if (defined(record.contributor)) {
@@ -763,6 +775,24 @@ function createItemForUri(catalogGroup, record, uri, downloadUrls, legendUrl) {
   }
 
   return catalogItem;
+}
+
+function getCatalogItemName(catalogGroup, record, uri) {
+  var templateName = catalogGroup.itemNameTemplate;
+
+  if (defined(templateName)) {
+    var datamodel = { record: record, uri: uri };
+    if (typeof templateName === "string") {
+      return Mustache.render(templateName, datamodel);
+    } else if (typeof templateName === "object") {
+      return Mustache.render(
+        templateName.template,
+        datamodel,
+        templateName.partials
+      );
+    }
+  }
+  return record.title;
 }
 
 function cleanUrl(url) {

--- a/test/Models/CswCatalogGroupSpec.js
+++ b/test/Models/CswCatalogGroupSpec.js
@@ -163,4 +163,34 @@ describe("CswCatalogGroup", function() {
       .then(done)
       .otherwise(done.fail);
   });
+
+  it("honors itemNameTemplate", function(done) {
+    loadText("test/csw/ReferencesWithoutProtocol.xml")
+      .then(function(xml) {
+        jasmine.Ajax.install();
+        jasmine.Ajax.stubRequest(/.*/).andError();
+        jasmine.Ajax.stubRequest("http://gamone.whoi.edu/csw").andReturn({
+          contentType: "text/xml",
+          responseText: xml
+        });
+
+        var group = new CswCatalogGroup(terria);
+
+        group.updateFromJson({
+          name: "USGS Woods Hole pycsw",
+          type: "csw",
+          url: "http://gamone.whoi.edu/csw",
+          getRecordsTemplate:
+            '<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" outputSchema="http://www.opengis.net/cat/csw/2.0.2" outputFormat="application/xml" version="2.0.2" service="CSW" resultType="results" maxRecords="1000" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"> <csw:Query typeNames="csw:Record"> <csw:ElementSetName>full</csw:ElementSetName> <csw:Constraint version="1.1.0"> <ogc:Filter> <ogc:And> <ogc:BBOX> <ogc:PropertyName>ows:BoundingBox</ogc:PropertyName> <gml:Envelope srsName="urn:ogc:def:crs:OGC:1.3:CRS84"> <gml:lowerCorner> -158.4 20.7</gml:lowerCorner> <gml:upperCorner> -60.2 50.6</gml:upperCorner> </gml:Envelope> </ogc:BBOX> <ogc:PropertyIsLike wildCard="*" singleChar="?" escapeChar="\\"> <ogc:PropertyName>apiso:AnyText</ogc:PropertyName> <ogc:Literal>*CMG_Portal*</ogc:Literal> </ogc:PropertyIsLike> <ogc:PropertyIsLike wildCard="*" singleChar="?" escapeChar="\\"> <ogc:PropertyName>apiso:ServiceType</ogc:PropertyName> <ogc:Literal>*WMS*</ogc:Literal> </ogc:PropertyIsLike> </ogc:And> </ogc:Filter> </csw:Constraint> </csw:Query> </csw:GetRecords>',
+          itemNameTemplate: "{{record.title}} - [TYPE: {{uri.scheme}}]"
+        });
+
+        return group.load().then(function() {
+          //console.warn(group.items[0]);
+          expect(group.items[0].name).toMatch(/.+ \- \[TYPE: .+\]$/);
+        });
+      })
+      .then(done)
+      .otherwise(done.fail);
+  });
 });


### PR DESCRIPTION
…lement name
Fixes #2227

I've seen that it's very hard to define a common way to present items and usually if a record has multiple external WMS resources (this also happens in CKAN) all the resources will have the same name.
I've also noticed that we have Mustache support for the getFeatureInfo template.
What I did is simply add a new configuration node into the item properties to define a template for the itemName.

Implemented test using jasmine match()

I'm open to comments, we really need this functionnality, please.

### Checklist

-   [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [X] I've updated CHANGES.md with what I changed.
