### PR TITLE
Stop automatically including all "@ types" packages in compilation

### DIFF
--- a/lib/ThirdParty/terriajs-cesium/index.d.ts
+++ b/lib/ThirdParty/terriajs-cesium/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="cesium" />
+
 // Generated from the intersection of:
 // - properties available on Cesium object
 // - files in Source/**/*

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
         "esModuleInterop": true,
         "allowSyntheticDefaultImports": true,
         "outDir": "ts-out",
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "types": []
     },
     "include": [
         "./lib/**/*",


### PR DESCRIPTION
Fixes `tsc --noEmit` (which was broken due to pulling in `@types/react-native` from styled-components and browser library types)

Also paves the way for https://github.com/TerriaJS/TerriaMap/issues/437 by fixing many/all of the errors that show up there.

See https://www.typescriptlang.org/v2/tsconfig#types
