### PR TITLE
Lock moment to 2.24.0 until 2.25 issue resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mobx": "^4.15.4",
     "mobx-react": "^6.2.2",
     "mobx-utils": "^5.4.1",
-    "moment": "^2.21.0",
+    "moment": "2.24.0",
     "mustache": "^2.2.1",
     "mutationobserver-shim": "^0.3.1",
     "node-fetch": "^2.1.1",


### PR DESCRIPTION
### What this PR does

Fixes CI

Given CI will nuke TerriaMap's package lock, terriajs auto upgrades dependencies depending on package json defined versions. (This will never change as package-lock.json from TerriaMap will never sync up with a given branch)