### PR TITLE
Improve naming of Url to CatalogItem

### DIFF
--- a/lib/Models/UrlReference.ts
+++ b/lib/Models/UrlReference.ts
@@ -40,7 +40,7 @@ export default class UrlReference extends UrlMixin(
       return Promise.resolve(undefined);
     }
 
-    const target = UrlReference.createUrlReferenceFromUrlReference(
+    const target = UrlReference.createCatalogMemberFromUrlReference(
       this,
       this.uniqueId,
       this.url,
@@ -51,7 +51,7 @@ export default class UrlReference extends UrlMixin(
     return Promise.resolve(target);
   }
 
-  private static createUrlReferenceFromUrlReference(
+  private static createCatalogMemberFromUrlReference(
     sourceReference: BaseModel,
     id: string,
     url: string,
@@ -68,7 +68,7 @@ export default class UrlReference extends UrlMixin(
       (mapping[index].matcher && !mapping[index].matcher(url)) ||
       (mapping[index].requiresLoad && !allowLoad)
     ) {
-      return UrlReference.createUrlReferenceFromUrlReference(
+      return UrlReference.createCatalogMemberFromUrlReference(
         sourceReference,
         id,
         url,
@@ -85,7 +85,7 @@ export default class UrlReference extends UrlMixin(
       );
 
       if (item === undefined) {
-        return UrlReference.createUrlReferenceFromUrlReference(
+        return UrlReference.createCatalogMemberFromUrlReference(
           sourceReference,
           id,
           url,
@@ -105,7 +105,7 @@ export default class UrlReference extends UrlMixin(
           .loadMetadata()
           .then(() => item)
           .catch(e => {
-            return UrlReference.createUrlReferenceFromUrlReference(
+            return UrlReference.createCatalogMemberFromUrlReference(
               sourceReference,
               id,
               url,

--- a/lib/Models/createUrlReferenceFromUrl.ts
+++ b/lib/Models/createUrlReferenceFromUrl.ts
@@ -36,24 +36,3 @@ export default function createUrlReferenceFromUrl(
     }
   });
 }
-
-type Matcher = (input: string) => boolean;
-interface MappingEntry {
-  matcher: Matcher;
-  type: string;
-  requiresLoad: boolean;
-}
-
-export const mapping: MappingEntry[] = [];
-
-createUrlReferenceFromUrl.register = function(
-  matcher: Matcher,
-  type: string,
-  requiresLoad?: boolean
-) {
-  mapping.push({
-    matcher,
-    type,
-    requiresLoad: Boolean(requiresLoad)
-  });
-};

--- a/lib/Models/registerCatalogMembers.ts
+++ b/lib/Models/registerCatalogMembers.ts
@@ -7,7 +7,6 @@ import CatalogGroup from "./CatalogGroupNew";
 import CatalogMemberFactory from "./CatalogMemberFactory";
 import Cesium3DTilesCatalogItem from "./Cesium3DTilesCatalogItem";
 import CesiumTerrainCatalogItem from "./CesiumTerrainCatalogItem";
-import createUrlReferenceFromUrl from "./createUrlReferenceFromUrl";
 import CsvCatalogItem from "./CsvCatalogItem";
 import CzmlCatalogItem from "./CzmlCatalogItem";
 import GeoJsonCatalogItem from "./GeoJsonCatalogItem";
@@ -20,7 +19,7 @@ import OpenStreetMapCatalogItem from "./OpenStreetMapCatalogItem";
 import SenapsLocationsCatalogItem from "./SenapsLocationsCatalogItem";
 import WebMapServiceCatalogGroup from "./WebMapServiceCatalogGroup";
 import WebMapServiceCatalogItem from "./WebMapServiceCatalogItem";
-import UrlReference from "./UrlReference";
+import UrlReference, { UrlToCatalogMemberMapping } from "./UrlReference";
 import WebProcessingServiceCatalogFunction from "./WebProcessingServiceCatalogFunction";
 import WebProcessingServiceCatalogItem from "./WebProcessingServiceCatalogItem";
 import CompositeCatalogItem from "./CompositeCatalogItem";
@@ -98,103 +97,103 @@ export default function registerCatalogMembers() {
     CompositeCatalogItem
   );
 
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesExtension("csv"),
     CsvCatalogItem.type
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesExtension("czm"),
     CzmlCatalogItem.type
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesExtension("czml"),
     CzmlCatalogItem.type
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesExtension("geojson"),
     GeoJsonCatalogItem.type
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesExtension("json"),
     GeoJsonCatalogItem.type
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesExtension("kml"),
     KmlCatalogItem.type
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesExtension("kmz"),
     KmlCatalogItem.type
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesExtension("topojson"),
     GeoJsonCatalogItem.type
   );
 
   // These items work by trying to match a URL, then loading the data. If it fails, they move on.
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/wms/i),
     WebMapServiceCatalogGroup.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/arcgis\/rest\/.*\/MapServer\/\d+\b/i),
     ArcGisMapServerCatalogItem.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/arcgis\/rest\/.*\/FeatureServer\/\d+\b/i),
     ArcGisFeatureServerCatalogItem.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/arcgis\/rest\/.*\/FeatureServer(\/.*)?$/i),
     ArcGisFeatureServerCatalogGroup.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/arcgis\/rest\/.*\/\d+\b/i),
     ArcGisMapServerCatalogItem.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/rest\/.*\/MapServer\/\d+\b/i),
     ArcGisMapServerCatalogItem.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/rest\/.*\/FeatureServer\/\d+\b/i),
     ArcGisFeatureServerCatalogItem.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/rest\/.*\/FeatureServer(\/.*)?$/i),
     ArcGisFeatureServerCatalogGroup.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     matchesUrl(/\/rest\/.*\/\d+\b/i),
     ArcGisMapServerCatalogItem.type,
     true
   );
 
   // These don't even try to match a URL, they're just total fallbacks. We really, really want something to work.
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     s => true,
     WebMapServiceCatalogGroup.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     s => true,
     ArcGisMapServerCatalogItem.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     s => true,
     ArcGisFeatureServerCatalogItem.type,
     true
   );
-  createUrlReferenceFromUrl.register(
+  UrlToCatalogMemberMapping.register(
     s => true,
     ArcGisFeatureServerCatalogGroup.type,
     true

--- a/lib/Sass/exports/_variables-export.scss.d.ts
+++ b/lib/Sass/exports/_variables-export.scss.d.ts
@@ -18,7 +18,6 @@ interface CssExports {
   'radiusLarge': string;
   'ringWidth': string;
   'sm': string;
-  'spacing': string;
   'textBlack': string;
   'textDark': string;
   'textDarker': string;

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -10,7 +10,9 @@ import openGroup from "../../lib/Models/openGroup";
 import { BaseModel } from "../../lib/Models/Model";
 import { runInAction } from "mobx";
 import ImagerySplitDirection from "terriajs-cesium/Source/Scene/ImagerySplitDirection";
-import UrlReference from "../../lib/Models/UrlReference";
+import UrlReference, {
+  UrlToCatalogMemberMapping
+} from "../../lib/Models/UrlReference";
 import createUrlReferenceFromUrl from "../../lib/Models/createUrlReferenceFromUrl";
 import SimpleCatalogItem from "../Helpers/SimpleCatalogItem";
 import PickedFeatures from "../../lib/Map/PickedFeatures";
@@ -47,7 +49,7 @@ describe("Terria", function() {
       );
       CatalogMemberFactory.register(UrlReference.type, UrlReference);
 
-      createUrlReferenceFromUrl.register(
+      UrlToCatalogMemberMapping.register(
         s => true,
         WebMapServiceCatalogItem.type,
         true

--- a/test/Models/createCatalogItemFromUrlSpec.ts
+++ b/test/Models/createCatalogItemFromUrlSpec.ts
@@ -4,7 +4,9 @@ import WebMapServiceCatalogGroup from "../../lib/Models/WebMapServiceCatalogGrou
 import GeoJsonCatalogItem from "../../lib/Models/GeoJsonCatalogItem";
 import CatalogMemberFactory from "../../lib/Models/CatalogMemberFactory";
 import { matchesExtension } from "../../lib/Models/registerCatalogMembers";
-import UrlReference from "../../lib/Models/UrlReference";
+import UrlReference, {
+  UrlToCatalogMemberMapping
+} from "../../lib/Models/UrlReference";
 import CsvCatalogItem from "../../lib/Models/CsvCatalogItem";
 import ViewState from "../../lib/ReactViewModels/ViewState";
 import createCatalogItemFromFileOrUrl from "../../lib/Models/createCatalogItemFromFileOrUrl";
@@ -25,18 +27,18 @@ describe("createUrlReferenceFromUrl", function() {
     CatalogMemberFactory.register(CsvCatalogItem.type, CsvCatalogItem);
     CatalogMemberFactory.register(UrlReference.type, UrlReference);
 
-    createUrlReferenceFromUrl.register(
+    UrlToCatalogMemberMapping.register(
       s => true,
       WebMapServiceCatalogGroup.type,
       true
     );
 
-    createUrlReferenceFromUrl.register(
+    UrlToCatalogMemberMapping.register(
       matchesExtension("geojson"),
       GeoJsonCatalogItem.type
     );
 
-    createUrlReferenceFromUrl.register(
+    UrlToCatalogMemberMapping.register(
       matchesExtension("csv"),
       CsvCatalogItem.type
     );


### PR DESCRIPTION
### What this PR does

I renamed `createCatalogItemFromUrlReference` to `createUrlReferenceFromUrlReference` in https://github.com/TerriaJS/terriajs/pull/4139

I am sorry.

I have now renamed `createUrlReferenceFromUrlReference` to `createCatalogMemberFromUrlReference`

I have also moved the mapping from url to catalog item type from `createUrlReferenceFromUrl` file to `UrlReference` and I have called it `UrlToCatalogMemberMapping`