### PR TITLE
Tell other packages (like TerriaMap) where additional type definition…

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
         "allowSyntheticDefaultImports": true,
         "outDir": "ts-out",
         "resolveJsonModule": true,
-        "types": []
+        "typeRoots": ["./lib/ThirdParty"]
     },
     "include": [
         "./lib/**/*",


### PR DESCRIPTION
### What this PR does

Needed for https://github.com/TerriaJS/TerriaMap/pull/442 (issue https://github.com/TerriaJS/TerriaMap/issues/437)

Maintains behaviour of `"types": []` (not adding all `@types/` modules to compilation), but also lets TerriaMap find additional type definitions needed to compile TerriaJS typescript files that rely on our custom types in `lib/ThirdParty`.
