### PR TITLE
Rework handling of proxy on url for Cesium3dTilesCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -115,7 +115,7 @@ Change Log
 #### mobx-28
 * Fix SASS exports causing some build errors in certain webpack conditions
 #### mobx-29
-* (placeholder)
+* Fix handling of urls on `Cesium3DTilesCatalogItem` related to proxying and getting confused between Resource vs URL.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### mobx-29
 * (placeholder)
+* Fix handling of urls on `Cesium3DTilesCatalogItem` related to proxying and getting confused between Resource vs URL.
 * Renamed `UrlReference.createUrlReferenceFromUrlReference` to `UrlReference.createCatalogMemberFromUrlReference`
 * Moved url to catalog member mapping from `createUrlRefernceFromUrl.register` to `UrlToCatalogMemberMapping` (now in `UrlReference.ts` file) 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,10 +122,6 @@ Change Log
 * Fixed MapIconButton & FeedbackButton proptypes being defined incorrectly
 * Implement SenapsLocationsCatalogItem
 * Update papaparse and improve handling for retrieveing CSVs via chunking that have no ContentLenth header
-#### mobx-28
-* Fix SASS exports causing some build errors in certain webpack conditions
-#### mobx-29
-* Fix handling of urls on `Cesium3DTilesCatalogItem` related to proxying and getting confused between Resource vs URL.
 
 ### Next Release
 * Fix draggable workbench/story items with translation HOC

--- a/lib/Models/Cesium3DTilesCatalogItem.ts
+++ b/lib/Models/Cesium3DTilesCatalogItem.ts
@@ -98,7 +98,7 @@ export default class Cesium3DTilesCatalogItem
     }
 
     let resource = undefined;
-    if (!isDefined(this.url) && isDefined(this.ionAssetId)) {
+    if (isDefined(this.ionAssetId)) {
       resource = this.createResourceFromIonId(
         this.ionAssetId,
         this.ionAccessToken,

--- a/lib/Models/Cesium3DTilesCatalogItem.ts
+++ b/lib/Models/Cesium3DTilesCatalogItem.ts
@@ -106,10 +106,7 @@ export default class Cesium3DTilesCatalogItem
       );
     } else if (isDefined(this.url)) {
       resource = this.createResourceFromUrl(
-        proxyCatalogItemUrl(this, this.url),
-        this.ionAssetId,
-        this.ionAccessToken,
-        this.ionServer
+        proxyCatalogItemUrl(this, this.url)
       );
     }
 
@@ -171,12 +168,7 @@ export default class Cesium3DTilesCatalogItem
     return options;
   }
 
-  private createResourceFromUrl(
-    url: Resource | string,
-    ionAssetId: number | undefined,
-    ionAccessToken: string | undefined,
-    ionServer: string | undefined
-  ) {
+  private createResourceFromUrl(url: Resource | string) {
     if (!isDefined(url)) {
       return;
     }


### PR DESCRIPTION
### What this PR does

During deploying `mobx-28` to https://dev.nsw.digitaltwin.terria.io/ we found problem viewing `Cesium3DTilesCatalogItem` where things were getting confused between a url string and a resource,
eg https://dev.nsw.digitaltwin.terria.io/#share=s-zJGCLt3Wi4n8ySadVILll74YvtW

 I think the bug was introduced in #4140 due to a subtle change in where `proxyCatalogItem` was applied.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
    - Not super sure how I'd write tests for this... Not sure how specific it was/is to the NSW DT deployment where there is additional complexity around our 3D tiles proxying.
-   [x] I've updated CHANGES.md with what I changed.
