### PR TITLE
Enable the item only if it is currently disabled.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 ### next release
 
 * Added `GeoRssCatalogItem` for displaying GeoRSS files comming from rss2 and atom feeds.
+* Fixed a bug where catalog item returned by TerriaJsonCatalogFunction gets added to the workbench twice.
 
 ### v7.11.4
 

--- a/lib/Models/CatalogItem.js
+++ b/lib/Models/CatalogItem.js
@@ -1473,7 +1473,9 @@ function isShownChanged(catalogItem) {
   if (catalogItem.isShown) {
     // If the item is not enabled, do that first.  This way things will work even if isShown is
     // deserialized before isEnabled.
-    catalogItem.isEnabled = true;
+    if (!catalogItem.isEnabled) {
+      catalogItem.isEnabled = true;
+    }
 
     // If enabling is waiting on an async load, we need to wait on it, too.
     raiseErrorOnRejectedPromise(


### PR DESCRIPTION
This fixes an issue where the item was getting added to the workbench twice.

### What this PR does

Fixes a problem where the catalog item gets added twice to the workbench if it is already enabled.

### Checklist

-   [x] I've updated CHANGES.md with what I changed.
