### PR TITLE
Lock rollbar to 2.15.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * (placeholder)
 * Updated CI clientConfig values to include new help panel default
 * Bumped explicit base typescript to 3.9.2
+* Lock rollbar to 2.15.2
 
 #### mobx-29
 * Fix handling of urls on `Cesium3DTilesCatalogItem` related to proxying and getting confused between Resource vs URL.

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "react-transition-group": "^4.3.0",
     "resolve-url-loader": "^3.0.1",
     "retry": "^0.12.0",
-    "rollbar": "^2.15.0",
+    "rollbar": "2.15.2",
     "sass-loader": "^7.1.0",
     "simple-statistics": "^7.0.1",
     "string-replace-loader": "^2.1.1",


### PR DESCRIPTION
https://github.com/TerriaJS/terriajs/issues/4303

### What this PR does

Stopgap for https://github.com/TerriaJS/terriajs/issues/4303
rollbar has updated, as usual our lib is a lib and doesn't use a package-lock.json so it's pulled in a breaking change

### Checklist

-   [x] n/a There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] n/a I've updated CHANGES.md with what I changed.
