### PR TITLE
Re-assign split directions when the tool is reset.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Bumped explicit base typescript to 3.9.2
 * Lock rollbar to 2.15.2
 * Ported disclaimer to mobx with new designs
+* Fixes a difftool bug where left/right items loose their split direction settings when the tool is reset
 
 #### mobx-29
 * Fix handling of urls on `Cesium3DTilesCatalogItem` related to proxying and getting confused between Resource vs URL.

--- a/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
+++ b/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
@@ -307,6 +307,16 @@ class Main extends React.Component<MainPropsType> {
     terria.overlays.add(this.props.rightItem);
     terria.workbench.remove(this.diffItem);
     this.props.terria.showSplitter = true;
+    this.props.leftItem.setTrait(
+      CommonStrata.user,
+      "splitDirection",
+      ImagerySplitDirection.LEFT
+    );
+    this.props.rightItem.setTrait(
+      CommonStrata.user,
+      "splitDirection",
+      ImagerySplitDirection.RIGHT
+    );
   }
 
   // i want to restructure the render so that there's 2 distinct "showing diff"


### PR DESCRIPTION
### What this PR does

Partly fixes #4311

Fixes a difftool bug where left/right items loose their split direction settings when the tool is reset.

### Checklist

-   [x] I've updated CHANGES.md with what I changed.
