### PR TITLE
Add Mapbox style catalog item

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
   * Added a popup on remove all stories.
   * Added button for sharing stories.
   * Added a question popup on window close (if there are stories on the map so users don't lose their work).
+* Added a `MapboxStyleCatalogItem` for showing Mapbox styles.
 
 ### v7.11.4
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,3 +59,4 @@ The following people have contributed to TerriaJS:
 * [NCI](http://www.nci.org.au)
    * [Edison Guo](https://github.com/edisonguo)
 * [Zoran Kokeza](https://github.com/zoran995)
+* [J. Garcia](https://github.com/ctwhome)

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -834,6 +834,9 @@
     "mapboxVectorTile": {
       "name": "Mapbox Vector Tile"
     },
+    "mapboxStyle": {
+      "name": "Mapbox Style"
+    },
     "ogr": {
       "name": "Unknown / Converted to GeoJSON",
       "dataSourceErrorMessage": "This data source does not have any details available.",

--- a/lib/Models/MapboxStyleCatalogItem.js
+++ b/lib/Models/MapboxStyleCatalogItem.js
@@ -1,0 +1,173 @@
+"use strict";
+
+/*global require*/
+var URI = require("urijs");
+
+var MapboxStyleImageryProvider = require("terriajs-cesium/Source/Scene/MapboxStyleImageryProvider")
+  .default;
+
+var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
+var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
+var ImageryLayerCatalogItem = require("./ImageryLayerCatalogItem");
+var inherit = require("../Core/inherit");
+var proxyCatalogItemUrl = require("./proxyCatalogItemUrl");
+var i18next = require("i18next").default;
+
+/**
+ * A {@link ImageryLayerCatalogItem} representing a layer from the Mapbox server.
+ *
+ * @alias MapboxMapCatalogItem
+ * @constructor
+ * @extends ImageryLayerCatalogItem
+ *
+ * @param {Terria} terria The Terria instance.
+ */
+const MapboxStyleCatalogItem = function(terria) {
+  ImageryLayerCatalogItem.call(this, terria);
+
+  /**
+   * The Mapbox server url.
+   * * @type {string}
+   */
+
+  this.url = defaultValue(this.url, "//api.mapbox.com/styles/v1/");
+
+  /**
+   * The username of the map account.
+   * [optional]
+   * @type {string}
+   */
+  this.username = "mapbox";
+
+  /**
+   * 	The Mapbox Style ID.
+   * 	@type {String}
+   */
+  this.styleId = undefined;
+
+  /**
+   * The public access token for the imagery.
+   * [optional]
+   * @type {String}
+   */
+  this.accessToken = undefined;
+
+  /**
+   * The size of the image tiles.
+   * [optional]
+   * @type {Number}
+   * @default 512
+   */
+  this.tilesize = 512;
+
+  /**
+   * Determines if tiles are rendered at a @2x scale factor.
+   * [optional]
+   * @type {Boolean}
+   */
+  this.scaleFactor = undefined;
+
+  /**
+   * 	The ellipsoid. If not specified, the WGS84 ellipsoid is used.
+   * [optional]
+   * @type {Ellipsoid}
+   */
+  this.ellipsoid = undefined;
+
+  /**
+   * The minimum level-of-detail supported by the imagery provider. Take care when specifying this that the number of tiles at the minimum level is small, such as four or less. A larger number is likely to result in rendering problems.
+   * [optional]
+   * @type {Number}
+   * @default 0
+   */
+  this.minimumLevel = 0;
+
+  /**
+   * The maximum level-of-detail supported by the imagery provider, or undefined if there is no limit.
+   * [optional]
+   * @type {Number}
+   */
+  this.maximumLevel = undefined;
+
+  /**
+   * The rectangle, in radians, covered by the image.
+   * [optional]
+   * @type {Rectangle}
+   * @default Rectangle.MAX_VALUE
+   */
+  this.rectangle = undefined;
+
+  /**
+   * A credit for the data source, which is displayed on the canvas
+   * [optional]
+   * @type {credit | String}
+   */
+  this.credit = undefined;
+
+  knockout.track(this, [
+    "styleId",
+    "accessToken",
+    "tilesize",
+    "scaleFactor",
+    "ellipsoid",
+    "minimumLevel",
+    "maximumLevel",
+    "rectangle",
+    "credit"
+  ]);
+};
+
+inherit(ImageryLayerCatalogItem, MapboxStyleCatalogItem);
+
+Object.defineProperties(MapboxStyleCatalogItem.prototype, {
+  /**
+   * Gets the type of data item represented by this instance.
+   * @memberOf MapboxStyleCatalogItem.prototype
+   * @type {String}
+   */
+  type: {
+    get: function() {
+      return "mapbox-style";
+    }
+  },
+
+  /**
+   * Gets a human-readable name for this type of data source, 'OpenStreet Map'.
+   * @memberOf MapboxStyleCatalogItem.prototype
+   * @type {String}
+   */
+  typeName: {
+    get: function() {
+      return i18next.t("models.mapboxStyle.name");
+    }
+  }
+});
+
+MapboxStyleCatalogItem.prototype._createImageryProvider = function() {
+  return new MapboxStyleImageryProvider({
+    url: cleanAndProxyUrl(this, this.url),
+    username: this.username,
+    styleId: this.styleId,
+    accessToken: this.accessToken,
+    tilesize: this.tilesize,
+    scaleFactor: this.scaleFactor,
+    ellipsoid: this.ellipsoid,
+    minimumLevel: this.minimumLevel,
+    maximumLevel: this.maximumLevel,
+    rectangle: this.rectangle,
+    credit: this.credit
+  });
+};
+
+function cleanAndProxyUrl(catalogItem, url) {
+  return proxyCatalogItemUrl(catalogItem, cleanUrl(url));
+}
+
+function cleanUrl(url) {
+  // Strip off the search portion of the URL
+  var uri = new URI(url);
+  uri.search("");
+  return uri.toString();
+}
+
+module.exports = MapboxStyleCatalogItem;

--- a/lib/Models/MapboxStyleCatalogItem.js
+++ b/lib/Models/MapboxStyleCatalogItem.js
@@ -30,7 +30,7 @@ const MapboxStyleCatalogItem = function(terria) {
    * * @type {string}
    */
 
-  this.url = defaultValue(this.url, "//api.mapbox.com/styles/v1/");
+  this.url = defaultValue(this.url, "https://api.mapbox.com/styles/v1/");
 
   /**
    * The username of the map account.

--- a/lib/Models/registerCatalogMembers.js
+++ b/lib/Models/registerCatalogMembers.js
@@ -49,6 +49,7 @@ var WebProcessingServiceCatalogFunction = require("./WebProcessingServiceCatalog
 var WfsFeaturesCatalogGroup = require("./WfsFeaturesCatalogGroup");
 var MagdaCatalogItem = require("./MagdaCatalogItem");
 var MapboxMapCatalogItem = require("./MapboxMapCatalogItem");
+var MapboxStyleCatalogItem = require("./MapboxStyleCatalogItem");
 
 var registerCatalogMembers = function() {
   createCatalogMemberFromType.register("3d-tiles", Cesium3DTilesCatalogItem);
@@ -148,6 +149,7 @@ var registerCatalogMembers = function() {
   );
   createCatalogMemberFromType.register("magda-item", MagdaCatalogItem);
   createCatalogMemberFromType.register("mapbox-map", MapboxMapCatalogItem);
+  createCatalogMemberFromType.register("mapbox-style", MapboxStyleCatalogItem);
 
   createCatalogItemFromUrl.register(matchesExtension("csv"), CsvCatalogItem);
   createCatalogItemFromUrl.register(matchesExtension("czm"), CzmlCatalogItem);


### PR DESCRIPTION
### What this PR does

Add Mapbox style catalog item

Adds the ability to load Mapbox styles from https://studio.mapbox.com

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.


Test catalog item on TerriaMap init files with:
 ```
{
      "type": "mapbox-style",
      "name": "Pirate - Mapbox Style",
      "username": "tempgeocent",
      "styleId": "cj2qe6qid003a2rmrquvqgbcx",
      "accessToken": "pk.eyJ1IjoidGVtcGdlb2NlbnQiLCJhIjoiY2l1YTNmenEyMDAwdDJ6cWZxbG55Yjg4OSJ9.QRTz4Pi3096MtXKc_QgpWQ"
    },
```