### PR TITLE
Fixes a splitter bug where split direction is not applied to new layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Change Log
 * Added satellite imagery to help panel
 * Stop disclaimer clashing with welcome message by only loading WelcomeMessage after disclaimer is no longer visible
 * Fixes a difftool bug where left/right items loose their split direction settings when the tool is reset
+* Fixes a splitter bug where split direction is not applied to new layers.
 
 #### mobx-29
 * Fix handling of urls on `Cesium3DTilesCatalogItem` related to proxying and getting confused between Resource vs URL.

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -58,6 +58,7 @@ import Terria from "./Terria";
 import MapboxVectorTileImageryProvider from "../Map/MapboxVectorTileImageryProvider";
 import getElement from "terriajs-cesium/Source/Widgets/getElement";
 import LatLonHeight from "../Core/LatLonHeight";
+import filterOutUndefined from "../Core/filterOutUndefined";
 //import Cesium3DTilesInspector from "terriajs-cesium/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector";
 
 // Intermediary
@@ -1124,18 +1125,13 @@ export default class Cesium extends GlobeOrMap {
   }
 
   getImageryLayersForItem(item: Mappable): ImageryLayer[] {
-    const allImageryParts = item.mapItems.filter(ImageryParts.is);
-    const imageryLayers: ImageryLayer[] = [];
-
-    for (let i = 0; i < allImageryParts.length; i++) {
-      let index = this.scene.imageryLayers.indexOf(
-        this._makeImageryLayerFromParts(allImageryParts[i])
-      );
-      if (index !== -1) {
-        imageryLayers.push(<ImageryLayer>this.scene.imageryLayers.get(index));
-      }
-    }
-    return imageryLayers;
+    return filterOutUndefined(
+      item.mapItems.map(m => {
+        if (ImageryParts.is(m)) {
+          return this._createImageryLayer(m.imageryProvider) as ImageryLayer;
+        }
+      })
+    );
   }
 
   private _makeImageryLayerFromParts(parts: ImageryParts): Cesium.ImageryLayer {

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -1128,7 +1128,7 @@ export default class Cesium extends GlobeOrMap {
     return filterOutUndefined(
       item.mapItems.map(m => {
         if (ImageryParts.is(m)) {
-          return this._createImageryLayer(m.imageryProvider) as ImageryLayer;
+          return this._makeImageryLayerFromParts(m) as ImageryLayer;
         }
       })
     );

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -712,19 +712,14 @@ export default class Leaflet extends GlobeOrMap {
   }
 
   getImageryLayersForItem(item: Mappable): CesiumTileLayer[] {
-    const allImageryParts = item.mapItems.filter(ImageryParts.is);
-    const imageryLayers: CesiumTileLayer[] = [];
-    this.map.eachLayer(layer => {
-      if (isImageryLayer(layer)) {
-        const found = allImageryParts.find(
-          p => p.imageryProvider === layer.imageryProvider
-        );
-        if (found) {
-          imageryLayers.push(layer);
+    return filterOutUndefined(
+      item.mapItems.map(m => {
+        if (ImageryParts.is(m)) {
+          const layer = this._createImageryLayer(m.imageryProvider);
+          return layer instanceof CesiumTileLayer ? layer : undefined;
         }
-      }
-    });
-    return imageryLayers;
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
### What this PR does

Fixes a splitter bug where split direction is not applied to new layers

This behavior can be consistently triggered after pressing the Back button to reset the difftool. It is happening because of the order of execution of the splitter reaction & observe model layer reaction in Cesium/Leaflet models. The splitter reaction sets the split direction only for layers currently on the map. So if the splitter reaction runs before the observe model layer reaction, new layers that are not yet added to the map will not get the split direction applied to it. This fix applies the split direction to all imagery layers, not checking whether they are on the map and so removes the dependency on the order in which the reactions are run.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
