### PR TITLE
Mobx fix timefilter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change Log
 ### MobX Development
 
 #### mobx-next-release (mobx-31)
+* Fixes broken time filter location picker when other features are present on the map.
+* Fixes the feature info panel button to show imagery at the selected location.
 * Added `hideSource` trait to `CatalogMemberTraits`. When set to true source URL won't be visible in the explorer window.
 * Added `Title`, `ContactInformation`, `Fees` to the `CapabilitiesService` interface so they are pulled on metadata load.
 * Resolved name issue of `WebMapServiceCapabilities`. Now it returns a name resolved from `capabilities` unless it is set by user.

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.jsx
@@ -200,7 +200,7 @@ class FeatureInfoPanel extends React.Component {
 
   filterIntervalsByFeature(catalogItem, feature) {
     try {
-      catalogItem.filterIntervalsByFeature(
+      catalogItem.setTimeFilterFeature(
         feature,
         this.props.terria.pickedFeatures
       );

--- a/lib/ReactViews/Workbench/Controls/SatelliteImageryTimeFilterSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/SatelliteImageryTimeFilterSection.jsx
@@ -87,7 +87,7 @@ const SatelliteImageryTimeFilterSection = observer(
                 mapItem =>
                   mapItem.imageryProvider &&
                   mapItem.imageryProvider ===
-                    feature.imageryLayer.imageryProvider
+                    feature.imageryLayer?.imageryProvider
               ) !== undefined
             );
           })[0];


### PR DESCRIPTION
### What this PR does

Fixes two bugs in time filter:
* Fixes broken time filter location picker when other features are present on the map.
* Fixes the feature info panel button to show imagery at the selected location.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
