### PR TITLE
Mobx fix timefilter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### MobX Development
 
 #### mobx-next-release (mobx-32)
-* Fixing a regression bug were the time filter is shown for all satellite imagery items
+* Fixing a regression bug where the time filter is shown for all satellite imagery items
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 
 #### mobx-31

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### mobx-next-release (mobx-32)
+* Fixing a regression bug were the time filter is shown for all satellite imagery items
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 
 #### mobx-31

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### MobX Development
 
 #### mobx-next-release (mobx-32)
-* Fixing a regression bug where the time filter is shown for all satellite imagery items
+* Fixed a regression bug where the time filter is shown for all satellite imagery items
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 
 #### mobx-31

--- a/lib/ModelMixins/DiffableMixin.ts
+++ b/lib/ModelMixins/DiffableMixin.ts
@@ -41,7 +41,7 @@ function DiffableMixin<T extends Constructor<MixinModel>>(Base: T) {
     get canFilterTimeByFeature() {
       // Hides the SatelliteImageryTimeFilterSection for the item if it is
       // currently showing difference image
-      return this.isShowingDiff ? false : true;
+      return super.canFilterTimeByFeature && !this.isShowingDiff;
     }
   }
 

--- a/test/ModelMixins/DiffableMixinSpec.ts
+++ b/test/ModelMixins/DiffableMixinSpec.ts
@@ -27,7 +27,7 @@ describe("DiffableMixin", function() {
     );
 
     it(
-      "returns the inherited value",
+      "otherwise returns the inherited value",
       action(function() {
         const testItem = new TestCatalogItem("test", new Terria());
         testItem.setTrait(CommonStrata.user, "isShowingDiff", false);

--- a/test/ModelMixins/DiffableMixinSpec.ts
+++ b/test/ModelMixins/DiffableMixinSpec.ts
@@ -20,7 +20,7 @@ describe("DiffableMixin", function() {
     it(
       "returns false if the item is showing diff",
       action(function() {
-        const testItem = new TestCatalogItem("test", new Terria());
+        const testItem = new TestDiffableItem("test", new Terria());
         testItem.setTrait(CommonStrata.user, "isShowingDiff", true);
         expect(testItem.canFilterTimeByFeature).toBe(false);
       })
@@ -29,7 +29,7 @@ describe("DiffableMixin", function() {
     it(
       "otherwise returns the inherited value",
       action(function() {
-        const testItem = new TestCatalogItem("test", new Terria());
+        const testItem = new TestDiffableItem("test", new Terria());
         testItem.setTrait(CommonStrata.user, "isShowingDiff", false);
         testItem.setTrait(CommonStrata.user, "timeFilterPropertyName", "foo");
         expect(testItem.canFilterTimeByFeature).toBe(true);
@@ -44,7 +44,7 @@ describe("DiffableMixin", function() {
   });
 });
 
-class TestCatalogItem extends DiffableMixin(
+class TestDiffableItem extends DiffableMixin(
   TimeFilterMixin(
     CreateModel(
       mixTraits(

--- a/test/ModelMixins/DiffableMixinSpec.ts
+++ b/test/ModelMixins/DiffableMixinSpec.ts
@@ -1,0 +1,88 @@
+import { computed, action } from "mobx";
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import DiffableMixin from "../../lib/ModelMixins/DiffableMixin";
+import TimeFilterMixin from "../../lib/ModelMixins/TimeFilterMixin";
+import CommonStrata from "../../lib/Models/CommonStrata";
+import CreateModel from "../../lib/Models/CreateModel";
+import SelectableStyle from "../../lib/Models/SelectableStyle";
+import Terria from "../../lib/Models/Terria";
+import CatalogMemberTraits from "../../lib/Traits/CatalogMemberTraits";
+import DiffableTraits from "../../lib/Traits/DiffableTraits";
+import DiscretelyTimeVaryingTraits from "../../lib/Traits/DiscretelyTimeVaryingTraits";
+import MappableTraits from "../../lib/Traits/MappableTraits";
+import mixTraits from "../../lib/Traits/mixTraits";
+import ShowableTraits from "../../lib/Traits/ShowableTraits";
+import SplitterTraits from "../../lib/Traits/SplitterTraits";
+import TimeFilterTraits from "../../lib/Traits/TimeFilterTraits";
+
+describe("DiffableMixin", function() {
+  describe("canFilterTimeByFeature", function() {
+    it(
+      "returns false if the item is showing diff",
+      action(function() {
+        const testItem = new TestCatalogItem("test", new Terria());
+        testItem.setTrait(CommonStrata.user, "isShowingDiff", true);
+        expect(testItem.canFilterTimeByFeature).toBe(false);
+      })
+    );
+
+    it(
+      "returns the inherited value",
+      action(function() {
+        const testItem = new TestCatalogItem("test", new Terria());
+        testItem.setTrait(CommonStrata.user, "isShowingDiff", false);
+        testItem.setTrait(CommonStrata.user, "timeFilterPropertyName", "foo");
+        expect(testItem.canFilterTimeByFeature).toBe(true);
+        testItem.setTrait(
+          CommonStrata.user,
+          "timeFilterPropertyName",
+          undefined
+        );
+        expect(testItem.canFilterTimeByFeature).toBe(false);
+      })
+    );
+  });
+});
+
+class TestCatalogItem extends DiffableMixin(
+  TimeFilterMixin(
+    CreateModel(
+      mixTraits(
+        DiffableTraits,
+        ShowableTraits,
+        CatalogMemberTraits,
+        SplitterTraits,
+        TimeFilterTraits,
+        DiscretelyTimeVaryingTraits,
+        MappableTraits
+      )
+    )
+  )
+) {
+  styleSelector: SelectableStyle | undefined = undefined;
+
+  get discreteTimes() {
+    return undefined;
+  }
+
+  showDiffImage(
+    firstDate: JulianDate,
+    secondDate: JulianDate,
+    diffStyleId: string
+  ) {}
+
+  clearDiffImage() {}
+
+  getLegendUrlForDiffStyle(
+    diffStyleId: string,
+    firstDate: JulianDate,
+    secondDate: JulianDate
+  ) {
+    return "test-legend-url";
+  }
+
+  @computed
+  get mapItems() {
+    return [];
+  }
+}

--- a/test/ModelMixins/TimeFilterMixinSpec.ts
+++ b/test/ModelMixins/TimeFilterMixinSpec.ts
@@ -1,0 +1,49 @@
+import { action, computed } from "mobx";
+import TimeFilterMixin from "../../lib/ModelMixins/TimeFilterMixin";
+import CommonStrata from "../../lib/Models/CommonStrata";
+import CreateModel from "../../lib/Models/CreateModel";
+import Terria from "../../lib/Models/Terria";
+import DiscretelyTimeVaryingTraits from "../../lib/Traits/DiscretelyTimeVaryingTraits";
+import MappableTraits from "../../lib/Traits/MappableTraits";
+import mixTraits from "../../lib/Traits/mixTraits";
+import TimeFilterTraits from "../../lib/Traits/TimeFilterTraits";
+
+class TestCatalogItem extends TimeFilterMixin(
+  CreateModel(
+    mixTraits(TimeFilterTraits, DiscretelyTimeVaryingTraits, MappableTraits)
+  )
+) {
+  get discreteTimes() {
+    return undefined;
+  }
+
+  @computed
+  get mapItems() {
+    return [];
+  }
+}
+
+describe("TimeFilterMixin", function() {
+  describe("canFilterTimeByFeature", function() {
+    it(
+      "returns false if timeFilterPropertyName is not set",
+      action(function() {
+        const testItem = new TestCatalogItem("test", new Terria());
+        expect(testItem.canFilterTimeByFeature).toBe(false);
+      })
+    );
+
+    it(
+      "returns true if timeFilterPropertyName is set",
+      action(function() {
+        const testItem = new TestCatalogItem("test", new Terria());
+        testItem.setTrait(
+          CommonStrata.user,
+          "timeFilterPropertyName",
+          "filter-dates"
+        );
+        expect(testItem.canFilterTimeByFeature).toBe(true);
+      })
+    );
+  });
+});

--- a/test/ModelMixins/TimeFilterMixinSpec.ts
+++ b/test/ModelMixins/TimeFilterMixinSpec.ts
@@ -8,7 +8,32 @@ import MappableTraits from "../../lib/Traits/MappableTraits";
 import mixTraits from "../../lib/Traits/mixTraits";
 import TimeFilterTraits from "../../lib/Traits/TimeFilterTraits";
 
-class TestCatalogItem extends TimeFilterMixin(
+describe("TimeFilterMixin", function() {
+  describe("canFilterTimeByFeature", function() {
+    it(
+      "returns false if timeFilterPropertyName is not set",
+      action(function() {
+        const testItem = new TestTimeFilterableItem("test", new Terria());
+        expect(testItem.canFilterTimeByFeature).toBe(false);
+      })
+    );
+
+    it(
+      "returns true if timeFilterPropertyName is set",
+      action(function() {
+        const testItem = new TestTimeFilterableItem("test", new Terria());
+        testItem.setTrait(
+          CommonStrata.user,
+          "timeFilterPropertyName",
+          "filter-dates"
+        );
+        expect(testItem.canFilterTimeByFeature).toBe(true);
+      })
+    );
+  });
+});
+
+class TestTimeFilterableItem extends TimeFilterMixin(
   CreateModel(
     mixTraits(TimeFilterTraits, DiscretelyTimeVaryingTraits, MappableTraits)
   )
@@ -22,28 +47,3 @@ class TestCatalogItem extends TimeFilterMixin(
     return [];
   }
 }
-
-describe("TimeFilterMixin", function() {
-  describe("canFilterTimeByFeature", function() {
-    it(
-      "returns false if timeFilterPropertyName is not set",
-      action(function() {
-        const testItem = new TestCatalogItem("test", new Terria());
-        expect(testItem.canFilterTimeByFeature).toBe(false);
-      })
-    );
-
-    it(
-      "returns true if timeFilterPropertyName is set",
-      action(function() {
-        const testItem = new TestCatalogItem("test", new Terria());
-        testItem.setTrait(
-          CommonStrata.user,
-          "timeFilterPropertyName",
-          "filter-dates"
-        );
-        expect(testItem.canFilterTimeByFeature).toBe(true);
-      })
-    );
-  });
-});


### PR DESCRIPTION
### What this PR does

Fixes a bug which causes time filter to show for all satellite imagery layers

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
