### PR TITLE
Make expanded SOS chart item shareable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### mobx-next-release (mobx-32)
+* Made expanded SOS chart item shareable.
 * Fixed a regression bug where the time filter is shown for all satellite imagery items
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 

--- a/lib/Models/SensorObservationServiceCatalogItem.ts
+++ b/lib/Models/SensorObservationServiceCatalogItem.ts
@@ -31,6 +31,7 @@ import StratumOrder from "./StratumOrder";
 import Terria from "./Terria";
 import TableColumnTraits from "../Traits/TableColumnTraits";
 import CommonStrata from "./CommonStrata";
+import { BaseModel } from "./Model";
 
 interface GetFeatureOfInterestResponse {
   featureMember?: FeatureMember[] | FeatureMember;
@@ -313,13 +314,12 @@ export default class SensorObservationServiceCatalogItem extends TableMixin(
   static readonly type = "sos";
   static defaultRequestTemplate = require("./SensorObservationServiceRequestTemplate.xml");
 
-  constructor(id: string | undefined, terria: Terria) {
-    super(id, terria);
-    this.initializeAutomaticStyleStratum();
-  }
-
-  @action
-  initializeAutomaticStyleStratum() {
+  constructor(
+    id: string | undefined,
+    terria: Terria,
+    sourceReference?: BaseModel
+  ) {
+    super(id, terria, sourceReference);
     this.strata.set(
       automaticTableStylesStratumName,
       new SosAutomaticStylesStratum(this)

--- a/lib/Models/SensorObservationServiceCatalogItem.ts
+++ b/lib/Models/SensorObservationServiceCatalogItem.ts
@@ -89,6 +89,12 @@ class SosAutomaticStylesStratum extends TableAutomaticStylesStratum {
     super(catalogItem);
   }
 
+  duplicateLoadableStratum(
+    newModel: SensorObservationServiceCatalogItem
+  ): this {
+    return new SosAutomaticStylesStratum(newModel) as this;
+  }
+
   @computed
   get styles(): StratumFromTraits<TableStyleTraits>[] {
     return this.catalogItem.procedures.map(p => {
@@ -312,6 +318,7 @@ export default class SensorObservationServiceCatalogItem extends TableMixin(
     this.initializeAutomaticStyleStratum();
   }
 
+  @action
   initializeAutomaticStyleStratum() {
     this.strata.set(
       automaticTableStylesStratumName,

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import { runInAction } from "mobx";
+import { action, observable, runInAction } from "mobx";
+import { observer } from "mobx-react";
 import PropTypes from "prop-types";
 import React from "react";
 import { withTranslation } from "react-i18next";
@@ -9,10 +10,14 @@ import Dropdown from "../../Generic/Dropdown";
 import Styles from "./chart-expand-and-download-buttons.scss";
 import Icon from "../../Icon";
 import defined from "terriajs-cesium/Source/Core/defined";
+import filterOutUndefined from "../../../Core/filterOutUndefined";
 
+@observer
 class ChartExpandAndDownloadButtons extends React.Component {
+  @observable sourceItems = [];
+
   static propTypes = {
-    sourceItems: PropTypes.array.isRequired,
+    sourceItems: PropTypes.array.isRequired, // Array of items or Promise returning item
     sourceNames: PropTypes.array,
     canDownload: PropTypes.bool,
     downloads: PropTypes.array,
@@ -21,24 +26,38 @@ class ChartExpandAndDownloadButtons extends React.Component {
     t: PropTypes.func.isRequired
   };
 
+  @action
   expandButton = () => {
-    expandItem(this.props, this.props.sourceItems.length - 1);
+    expandItem(
+      this.sourceItems,
+      this.sourceItems.length - 1,
+      this.props.terria
+    );
   };
 
+  @action
   expandDropdown = (selected, sourceIndex) => {
-    expandItem(this.props, sourceIndex);
+    expandItem(this.sourceItems, sourceIndex, this.props.terria);
   };
+
+  componentDidMount() {
+    Promise.all(
+      this.props.sourceItems.map(sourceItem => Promise.resolve(sourceItem))
+    ).then(
+      action(results => {
+        this.sourceItems = filterOutUndefined(results);
+      })
+    );
+  }
 
   render() {
-    if (this.props.sourceItems.length === 0) {
+    if (this.sourceItems.length === 0) {
       return null;
     }
 
     // The downloads and download names default to the sources and source names if not defined.
     const downloads = runInAction(() => {
-      return (
-        this.props.downloads || this.props.sourceItems.map(item => item.url)
-      );
+      return this.props.downloads || this.sourceItems.map(item => item.url);
     });
     const downloadNames = this.props.downloadNames || this.props.sourceNames;
     let downloadButton;
@@ -130,13 +149,12 @@ class ChartExpandAndDownloadButtons extends React.Component {
  * We also remove any existing sourceItems from workbench so that only one
  * source is shown at any time.
  */
-function expandItem(props, sourceIndex) {
-  const terria = props.terria;
+function expandItem(sourceItems, sourceIndex, terria) {
   const workbench = terria.workbench;
-  const sourceItem = props.sourceItems[sourceIndex];
+  const sourceItem = sourceItems[sourceIndex];
 
   // remove any source item that is already in the workbench
-  props.sourceItems.forEach(sourceItem => {
+  sourceItems.forEach(sourceItem => {
     workbench.items.forEach(workbenchItem => {
       if (sourceItem.uniqueId === workbenchItem.uniqueId) {
         workbench.remove(workbenchItem);

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -41,7 +41,7 @@ class ChartExpandAndDownloadButtons extends React.Component {
     expandItem(this.sourceItems, sourceIndex, this.props.terria);
   };
 
-  componentDidMount() {
+  resolveSourceItems() {
     Promise.all(
       this.props.sourceItems.map(sourceItem => Promise.resolve(sourceItem))
     ).then(
@@ -49,6 +49,16 @@ class ChartExpandAndDownloadButtons extends React.Component {
         this.sourceItems = filterOutUndefined(results);
       })
     );
+  }
+
+  componentDidMount() {
+    this.resolveSourceItems();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.sourceItems !== prevProps.sourceItems) {
+      this.resolveSourceItems();
+    }
   }
 
   render() {

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -17,6 +17,7 @@ class ChartExpandAndDownloadButtons extends React.Component {
   @observable sourceItems = [];
 
   static propTypes = {
+    terria: PropTypes.object.isRequired,
     sourceItems: PropTypes.array.isRequired, // Array of items or Promise returning item
     sourceNames: PropTypes.array,
     canDownload: PropTypes.bool,

--- a/lib/ReactViews/Custom/SOSChartCustomComponent.ts
+++ b/lib/ReactViews/Custom/SOSChartCustomComponent.ts
@@ -75,7 +75,6 @@ export default class SOSChartCustomComponent extends CustomComponent {
     if (!hideButtons) {
       // Build expand/download buttons
       const downloadItem = catalogItem.duplicateModel(createGuid());
-      downloadItem.initializeAutomaticStyleStratum();
       downloadItem.setTrait(CommonStrata.user, "showAsChart", true);
       downloadItem.setTrait(
         CommonStrata.user,
@@ -102,7 +101,6 @@ export default class SOSChartCustomComponent extends CustomComponent {
 
     // Build chart item to show in the info panel
     const chartItem = catalogItem.duplicateModel(createGuid());
-    chartItem.initializeAutomaticStyleStratum();
     chartItem.setTrait(CommonStrata.user, "showAsChart", true);
     chartItem.setTrait(
       CommonStrata.user,

--- a/test/Models/SensorObservationServiceCatalogItemSpec.ts
+++ b/test/Models/SensorObservationServiceCatalogItemSpec.ts
@@ -2,6 +2,7 @@ import { runInAction } from "mobx";
 import CommonStrata from "../../lib/Models/CommonStrata";
 import SensorObservationServiceCatalogItem from "../../lib/Models/SensorObservationServiceCatalogItem";
 import Terria from "../../lib/Models/Terria";
+import SimpleCatalogItem from "../Helpers/SimpleCatalogItem";
 
 const GetFeatureOfInterestResponse = require("raw-loader!../../wwwroot/test/sos/GetFeatureOfInterestResponse.xml");
 const EmptyGetFeatureOfInterestResponse = require("raw-loader!../../wwwroot/test/sos/GetFeatureOfInterestResponse_NoMembers.xml");
@@ -59,6 +60,30 @@ describe("SensorObservationServiceCatalogItem", function() {
 
   afterEach(function() {
     jasmine.Ajax.uninstall();
+  });
+
+  describe("when constructed", function() {
+    it("correctly sets the sourceReference", function() {
+      const terria = new Terria();
+      const sourceItem = new SimpleCatalogItem(undefined, terria);
+      const sosItem = new SensorObservationServiceCatalogItem(
+        undefined,
+        terria,
+        sourceItem
+      );
+      expect(sosItem.sourceReference).toBe(sourceItem);
+    });
+
+    it("correctly initializes the automatic stratum", function() {
+      const terria = new Terria();
+      const sourceItem = new SimpleCatalogItem(undefined, terria);
+      const sosItem = new SensorObservationServiceCatalogItem(
+        undefined,
+        terria,
+        sourceItem
+      );
+      expect(sosItem.strata.get("automaticTableStyles")).toBeDefined();
+    });
   });
 
   describe("features table", function() {


### PR DESCRIPTION
### What this PR does

A user cannot share the expanded SOS chart item, this PR makes it shareable. 

Currently, when creating the expanded chart item we simply duplicate the source item and then when we create a share link we only copy the items "user" traits. This means that when restoring the chart item from a share link its URL and other definition traits will be missing and the item wont load properly. So instead of duplicating the source item, we create a reference to the source item. This process is asynchronous so we also change `ChartExpandAndDownloadButtons` component to accept a promise of items.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
