### PR TITLE
Fix diffable & discretelytimevarying mixin methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### mobx-next-release (mobx-32)
 * Fixed a regression bug where the time filter is shown for all satellite imagery items
+* Fixed a bug where WMS items caused type errors in newer babel and typescript builds, due to mixed mixin methods on DiffableMixin & DiscretelyTimeVaryingMixin
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 
 #### mobx-31

--- a/lib/ModelMixins/DiffableMixin.ts
+++ b/lib/ModelMixins/DiffableMixin.ts
@@ -17,7 +17,7 @@ type MixinModel = Model<
 
 function DiffableMixin<T extends Constructor<MixinModel>>(Base: T) {
   abstract class DiffableMixin extends Base {
-    abstract styleSelector: SelectableStyle | undefined;
+    abstract get styleSelector(): SelectableStyle | undefined;
 
     get hasDiffableMixin() {
       return true;

--- a/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
+++ b/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
@@ -24,7 +24,7 @@ function DiscretelyTimeVaryingMixin<
 >(Base: T) {
   abstract class DiscretelyTimeVaryingMixin extends Base
     implements TimeVarying {
-    abstract discreteTimes:
+    abstract get discreteTimes():
       | { time: string; tag: string | undefined }[]
       | undefined;
 


### PR DESCRIPTION
### What this PR does

* Fixes a bug where WMS items caused type errors in newer babel and typescript builds, due to mixed mixin methods on DiffableMixin & DiscretelyTimeVaryingMixin

### Checklist
-   [x] unit tests n/a - tried to do this but it would involve different tsconfig options which would break a bunch of other bits of terria.
-   [x] I've updated CHANGES.md with what I changed.
