### PR TITLE
Allow KmlCatalogItem to be proxied

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### mobx-next-release (mobx-32)
 * Fixed a regression bug where the time filter is shown for all satellite imagery items
+* Fixed a bug where KmlCatalogItem did not use the proxy for any urls.
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 
 #### mobx-31

--- a/lib/Models/KmlCatalogItem.ts
+++ b/lib/Models/KmlCatalogItem.ts
@@ -1,14 +1,14 @@
 import i18next from "i18next";
 import { computed } from "mobx";
-
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
-import KmlDataSource from "terriajs-cesium/Source/DataSources/KmlDataSource";
 import PolygonHierarchy from "terriajs-cesium/Source/Core/PolygonHierarchy";
 import Property from "terriajs-cesium/Source/Core/Property";
+import Resource from "terriajs-cesium/Source/Core/Resource";
 import sampleTerrain from "terriajs-cesium/Source/Core/sampleTerrain";
+import KmlDataSource from "terriajs-cesium/Source/DataSources/KmlDataSource";
 import isDefined from "../Core/isDefined";
 import readXml from "../Core/readXml";
 import TerriaError from "../Core/TerriaError";
@@ -17,7 +17,7 @@ import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
 import UrlMixin from "../ModelMixins/UrlMixin";
 import KmlCatalogItemTraits from "../Traits/KmlCatalogItemTraits";
 import CreateModel from "./CreateModel";
-import Terria from "./Terria";
+import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
 
 const kmzRegex = /\.kmz$/i;
 
@@ -60,7 +60,7 @@ class KmlCatalogItem extends AsyncMappableMixin(
         })
       });
 
-    return new Promise<string | Document | Blob>((resolve, reject) => {
+    return new Promise<string | Resource | Document | Blob>(resolve => {
       if (isDefined(this.kmlString)) {
         const parser = new DOMParser();
         resolve(parser.parseFromString(this.kmlString, "text/xml"));
@@ -71,7 +71,7 @@ class KmlCatalogItem extends AsyncMappableMixin(
           resolve(readXml(this._kmlFile));
         }
       } else if (isDefined(this.url)) {
-        resolve(this.url);
+        resolve(proxyCatalogItemUrl(this, this.url));
       } else {
         throw new TerriaError({
           sender: this,


### PR DESCRIPTION
### What this PR does
Address [this issue](https://github.com/TerriaJS/nsw-digital-twin/issues/412)
Proxy the KML url before sending it to Cesium to load the datasource.

### Checklist

-   [x] No unit tests as this is a small change to a class without existing unit tests
-   [x] I've updated CHANGES.md with what I changed.