### PR TITLE
Rework handling of tileRetries count for basemaps so they don't break in safari

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 
 * Added `GeoRssCatalogItem` for displaying GeoRSS files comming from rss2 and atom feeds.
 * Bug fix: Prevent geojson files from appearing twice in the workbench when dropped with the .json extension
+* Fix for safari regarding basemap imagery tile fail count
 * Story related enhancements:
   * Added a title to story panel with ability to close story panel. 
   * Added a popup on remove all stories.

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -1118,9 +1118,16 @@ ImageryLayerCatalogItem.enableLayer = function(
             if (time) {
               key += "T" + time;
             }
-            tileRetriesByMap[key] = tileRetriesByMap[key] || 0;
+            let val = 0;
+            if (key in tileRetriesByMap) {
+              val = tileRetriesByMap[key];
+              ++val;
+              tileRetriesByMap[key] = val;
+            } else {
+              tileRetriesByMap[key] = val;
+            }
 
-            if (++tileRetriesByMap[key] > 5) {
+            if (val > 5) {
               failTile({
                 name: i18next.t("models.imageryLayer.tileErrorTitle"),
                 message: i18next.t("models.imageryLayer.tileErrorMessage", {


### PR DESCRIPTION
### What this PR does

Fixes #4366

Safari seemed to get quite confused with tracking failed tile counts, the code was perhaps slightly too optimised so this PR makes it a bit simpler.

### Checklist

-   [ ] Not very sure how I'd unit test this one
-   [x] I've updated CHANGES.md with what I changed.

