### PR TITLE
Mobx: update help button icon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Fixed a bug where KmlCatalogItem did not use the proxy for any urls.
 * Add support for `CkanCatalogGroup` and `CkanItemReference`.
 * Removed sass from Clipboard
+* Replaced lifesaver icon on the help button with a question mark button
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 
 #### mobx-31

--- a/lib/ReactViews/Map/MapNavigation.jsx
+++ b/lib/ReactViews/Map/MapNavigation.jsx
@@ -118,7 +118,7 @@ class MapNavigation extends React.Component {
               <div className={Styles.control}>
                 <MapIconButton
                   expandInPlace
-                  iconElement={() => <Icon glyph={Icon.GLYPHS.newHelp} />}
+                  iconElement={() => <Icon glyph={Icon.GLYPHS.helpThick} />}
                   onClick={() => this.props.viewState.showHelpPanel()}
                 >
                   Help


### PR DESCRIPTION
### What this PR does

Fixes #4369 

Reverted back to the old ? help icon for the help button (bottom right of the map)

### Checklist

-   [x] Very simple change, no unit tests written. All unit tests still pass though, so I haven't broken anything
-   [x] I've updated CHANGES.md with what I changed.
