### PR TITLE
Allow parameter for imagery layer to set threshold for tile failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
   * Added a question popup on window close (if there are stories on the map so users don't lose their work).
 * Pinned `html-to-react` to version 1.3.4 to avoid IE11 incompatibility with newer version of deep dependency `entities`. See https://github.com/fb55/entities/issues/209
 * Added a `MapboxStyleCatalogItem` for showing Mapbox styles.
+* Add a `tileErrorThresholdBeforeDisabling` parameter to `ImageryLayerCatalogItem` to allow a threshold to set for allowed number of tile failures before disabling the layer.
 
 ### v7.11.4
 

--- a/lib/Models/ImageryLayerCatalogItem.js
+++ b/lib/Models/ImageryLayerCatalogItem.js
@@ -194,6 +194,14 @@ var ImageryLayerCatalogItem = function(terria) {
 
   this.leafletUpdateInterval = 100;
 
+  /**
+   * Allow a threshold to be configured for the number of tile fails
+   * before disabling the layer.
+   * @default 5
+   * @type {Number}
+   */
+  this.tileErrorThresholdBeforeDisabling = 5;
+
   // Need to track initialTimeSource so we can set it in the specs after setting intervals, and then have the current time update (via the clock property).
   knockout.track(this, [
     "_clock",
@@ -1017,9 +1025,8 @@ ImageryLayerCatalogItem.enableLayer = function(
       // Give up loading this (definitively, unexpectedly bad) tile and possibly give up on this layer entirely.
       function failTile(e) {
         ++tileFailures;
-
         if (
-          tileFailures > 5 &&
+          tileFailures > catalogItem.tileErrorThresholdBeforeDisabling &&
           defined(layer) &&
           globeOrMap.isImageryLayerShown({ layer })
         ) {

--- a/test/Models/ImageryLayerCatalogItemSpec.js
+++ b/test/Models/ImageryLayerCatalogItemSpec.js
@@ -142,7 +142,8 @@ describe("ImageryLayerCatalogItem", function() {
         error: new CesiumEvent()
       };
       catalogItem = {
-        terria: terria
+        terria: terria,
+        tileErrorThresholdBeforeDisabling: 5
       };
       imageryProvider = {
         requestImage: function(x, y, level) {


### PR DESCRIPTION
### What this PR does

Fixes #3744
More work on trying to ignore SPDY errors. I've introduced a parameter called `tileErrorThresholdBeforeDisabling` which is the number of tiles are allowed to fail before disabling the layer, by default it's 5 as per current behaviour, however to keep going despite failures simply set it something really high.

````
{
  "homeCamera": {
    "east": 45,
    "north": -38,
    "south": -35,
    "west": 20
  },
  "catalog": [
    {
      "url": "https://ows.digitalearth.africa/",
      "type": "wms",
      "name": "Sentinel",
      "isEnabled": true,
      "layers": "s2_l2a",
      "tileErrorThresholdBeforeDisabling": 100000, <--- set me very high to stop the layer from erroring
      "featureTimesProperty": "data_available_for_dates"
    }
  ]
}
````

### Checklist

-   [ ] No tests
-   [x] I've updated CHANGES.md with what I changed.
