### PR TITLE
Set `pointer-events: none` on select icon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### mobx-next-release (mobx-33)
+* Updated generic select so icon doesn't block click
 * Re-added loading bar for leaflet & cesium viewers
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 

--- a/lib/Styled/Select.tsx
+++ b/lib/Styled/Select.tsx
@@ -64,6 +64,7 @@ const StyledSelect = styled.select<SelectProps>`
 const ArrowPositioning = styled.div`
   ${props => props.theme.verticalAlign("absolute")}
   right: 10px;
+  pointer-events: none;
 `;
 
 interface SelectProps {


### PR DESCRIPTION
Icon in generic select were blocking click events. 

### Checklist

-   [x] There is nothing to test
-   [x] I've updated CHANGES.md with what I changed.
