### PR TITLE
Automate NPM publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,32 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+      - run: npx gulp lint release
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish --tag test-auto-deploy
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
   },
   "scripts": {
     "prepublish": "gulp post-npm-install",
-    "postpublish": "bash -c \"git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}\"",
     "postinstall": "gulp post-npm-install",
     "gulp": "gulp",
     "make-schema": "gulp make-schema",


### PR DESCRIPTION
### Publish to NPM automatically from GitHub Actions

Currently npm publishing is manual and requires a good internet connection. We should instead publish automatically from GitHub Actions whenever someone pushes a version tag to GitHub.

We should combine this with an automated slack message that notifies everyone (`@here`) in `#terriajs` that terriajs has been published.

E.g. an action like https://github.com/marketplace/actions/post-slack-message