### PR TITLE
Add npm publish GitHub Action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,40 @@
+name: npm-publish
+on:
+  push:
+    branches:
+      - mobx
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Check version changes
+        uses: EndBug/version-check@v1
+        id: check
+        with:
+          diff-search: true
+
+      - name: Version update detected
+        if: steps.check.outputs.changed == 'true'
+        run: 'echo "Version change found! New version: ${{ steps.check.outputs.version }} (${{ steps.check.outputs.type }})"'
+
+      - name: Set up Node.js for NPM
+        if: steps.check.outputs.changed == 'true'
+        uses: actions/setup-node@v1
+        with:
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        if: steps.check.outputs.changed == 'true'
+        run: npm install
+
+      - name: Publish package to NPM
+        if: steps.check.outputs.changed == 'true'
+        run: npm publish --tag mobx
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Install dependencies
         if: steps.check.outputs.changed == 'true'
         run: npm install
+        
+      - name: Lint and build terriajs
+        if: steps.check.outputs.changed == 'true'
+        run: npx gulp lint release
+        env:
+          NODE_OPTIONS: '--max_old_space_size=8192'
 
       - name: Publish package to NPM
         if: steps.check.outputs.changed == 'true'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         if: steps.check.outputs.changed == 'true'
         run: npm install
-        
+
       - name: Lint and build terriajs
         if: steps.check.outputs.changed == 'true'
         run: npx gulp lint release
@@ -44,3 +44,16 @@ jobs:
         run: npm publish --tag mobx
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: action-slack
+        if: always() # Pick up events even if the job fails or is canceled.
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,action,ref
+          author_name: ${{ github.workflow }}
+          mention: here
+          if_mention: always
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -57,7 +57,7 @@ jobs:
 
       # These slack success and failure message actions can be combined but it means there'll be no notification on a failed
       #  version-check (which is probably unlikely to fail). It also allows for a bit better message customisation
-      - name: action-slack-success
+      - name: Send success notification on Slack
         if: steps.check.outputs.changed == 'true'
         uses: 8398a7/action-slack@v3
         with:
@@ -70,7 +70,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 
-      - name: action-slack-failure
+      - name: Send failure or cancellation notification on Slack
         if: failure() || cancelled() # Pick up events even if the job fails or is canceled.
         uses: 8398a7/action-slack@v3
         with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -55,8 +55,23 @@ jobs:
           tagger-name: Terria Bot via GitHub Actions
           tagger-email: TerriaBot@users.noreply.github.com
 
-      - name: action-slack
-        if: always() # Pick up events even if the job fails or is canceled.
+      # These slack success and failure message actions can be combined but it means there'll be no notification on a failed
+      #  version-check (which is probably unlikely to fail). It also allows for a bit better message customisation
+      - name: action-slack-success
+        if: steps.check.outputs.changed == 'true'
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,action,ref
+          author_name: ${{ github.workflow }}
+          mention: here
+          if_mention: always
+          text: ':white_check_mark: Published v${{ steps.check.outputs.version }} to https://www.npmjs.com/package/terriajs'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+
+      - name: action-slack-failure
+        if: failure() || cancelled() # Pick up events even if the job fails or is canceled.
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,6 +45,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Tag new version
+        if: steps.check.outputs.changed == 'true'
+        uses: steve9164/annotated-tag@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag-name: ${{ steps.check.outputs.version }}
+          tag-message: ${{ steps.check.outputs.version }}
+          tagger-name: Terria Bot via GitHub Actions
+          tagger-email: TerriaBot@users.noreply.github.com
+
       - name: action-slack
         if: always() # Pick up events even if the job fails or is canceled.
         uses: 8398a7/action-slack@v3

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
   },
   "scripts": {
     "prepublish": "gulp post-npm-install",
-    "postpublish": "bash -c \"if [ -z \"$GITHUB_ACTION\" ]; then git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}; else echo 'Running in GitHub Action. Must be tagged separately'; fi \"",
+    "postpublish": "bash -c \"if [ -z \"$GITHUB_ACTION\" ]; then git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}; fi \"",
     "postinstall": "gulp post-npm-install",
     "gulp": "gulp",
     "make-schema": "gulp make-schema",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
   },
   "scripts": {
     "prepublish": "gulp post-npm-install",
-    "postpublish": "bash -c \"git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}\"",
+    "postpublish": "bash -c \"if [ -z \"$GITHUB_ACTION\" ]; then git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}; else echo 'Running in GitHub Action. Must be tagged separately'; fi \"",
     "postinstall": "gulp post-npm-install",
     "gulp": "gulp",
     "make-schema": "gulp make-schema",


### PR DESCRIPTION
Add automated NPM publishing. Requires an NPM_TOKEN in secrets.

This approach will publish an NPM package revision any time a version change commit makes it to `mobx`, and since `mobx` is protected for all users that will always be a merge commit from a reviewed PR

~Things I still want to add:~
- [x] A way to send a slack message to `#terriajs` to notify devs of a successful or failed npm publish
    * Hopefully through some github actions / slack official or third-party integration
    * Could instead make a specific slack bot to post specific things
    * Plain webhooks?

Things we might add later:
- [ ] Something that labels PRs that will cause a release with a label called something like "Release PR". And make it red
    * The version change checker supports PRs so this should be fairly easy to do, but we might have to create a custom action script for applying/removing the label 