### PR TITLE
Changes for invoking MyData without using the ExplorerWindow component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Bug fix for `DatePicker` in `BottomDock` causing app crash
 * Made changes to the video modals: close button has been added, pressing escape now closes the component and some basic unit tests created
 * Updated the video modal for _Data Stories: Getting Started_ to use the new `VideoGuide` component
+* Tweaked MyData/AddData tabs to make it possible to invoke them without using the `ExplorerWindow` component and also customize the extensions listed in the dropdown.
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 
 #### mobx-34

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,6 @@ Change Log
 * Made changes to the video modals: close button has been added, pressing escape now closes the component and some basic unit tests created
 * Updated the video modal for _Data Stories: Getting Started_ to use the new `VideoGuide` component
 * Tweaked MyData/AddData tabs to make it possible to invoke them without using the `ExplorerWindow` component and also customize the extensions listed in the dropdown.
-* (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
-
-#### mobx-34
 * Fix the timeline stack handling for when there are multiple time-enabled layers
 * Ported timeseries tables.
 * Extended the support for styles for ESRI ArcGis Feature Server. Line styles are supported for lines and polygon outlines in both Cesium and Leaflet viewer. #4405

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -561,6 +561,7 @@
       "gpx": "GPX",
       "json": "JSON",
       "carto": "Carto",
+      "gltf": "GLTF",
       "other": "Other (use conversion service)"
     },
     "printWindow": {

--- a/lib/Models/addUserCatalogMember.ts
+++ b/lib/Models/addUserCatalogMember.ts
@@ -17,7 +17,6 @@ import getDereferencedIfExists from "../Core/getDereferencedIfExists";
 interface AddUserCatalogMemberOptions {
   enable?: boolean;
   open?: boolean;
-  zoomTo?: boolean;
 }
 
 /**
@@ -68,12 +67,6 @@ export default function addUserCatalogMember(
         ) {
           terria.workbench.add(dereferenced);
         }
-      }
-
-      if (defaultValue(options.zoomTo, true) && Mappable.is(dereferenced)) {
-        dereferenced
-          .loadMapItems()
-          .then(() => terria.currentViewer.zoomTo(dereferenced, 1));
       }
 
       return newCatalogItem;

--- a/lib/ReactViews/ExplorerWindow/ModalPopup.jsx
+++ b/lib/ReactViews/ExplorerWindow/ModalPopup.jsx
@@ -87,7 +87,7 @@ const ModalPopup = createReactClass({
   },
 
   componentWillUnmount() {
-    window.removeEventListener("keydown", this.escKeyListener, false);
+    window.removeEventListener("keydown", this.escKeyListener, true);
   },
 
   render() {

--- a/lib/ReactViews/ExplorerWindow/Tabs.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs.jsx
@@ -11,6 +11,7 @@ import { withTranslation } from "react-i18next";
 import Styles from "./tabs.scss";
 import { observer } from "mobx-react";
 import { runInAction } from "mobx";
+import Mappable from "../../Models/Mappable";
 
 const Tabs = observer(
   createReactClass({
@@ -21,6 +22,17 @@ const Tabs = observer(
       viewState: PropTypes.object.isRequired,
       tabs: PropTypes.array,
       t: PropTypes.func.isRequired
+    },
+
+    onFileAddFinished(files) {
+      const file = files.find(f => Mappable.is(f));
+      if (file) {
+        file
+          .loadMapItems()
+          .then(() => this.props.terria.currentViewer.zoomTo(file, 1));
+        this.props.viewState.viewCatalogMember(file);
+      }
+      this.props.viewState.myDataIsUploadView = false;
     },
 
     getTabs() {
@@ -38,6 +50,7 @@ const Tabs = observer(
           <MyDataTab
             terria={this.props.terria}
             viewState={this.props.viewState}
+            onFileAddFinished={files => this.onFileAddFinished(files)}
           />
         )
       };

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -33,6 +33,7 @@ const AddData = createReactClass({
     activeTab: PropTypes.string,
     localDataTypes: PropTypes.arrayOf(PropTypes.object),
     remoteDataTypes: PropTypes.arrayOf(PropTypes.object),
+    onFileAddFinished: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired
   },
 

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -113,13 +113,15 @@ const AddData = createReactClass({
       }
     }
     addUserCatalogMember(this.props.terria, promise).then(addedItem => {
+      if (addedItem && !(addedItem instanceof TerriaError)) {
+        this.onFileAddFinished([addedItem]);
+      }
+      // FIXME: Setting state here might result in a react warning if the
+      // component unmounts before the promise finishes
       this.setState({
         isLoading: false
       });
       this.props.resetTab();
-      if (addedItem && !(addedItem instanceof TerriaError)) {
-        this.onFileAddFinished([addedItem]);
-      }
     });
   },
 

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -76,7 +76,7 @@ const AddData = createReactClass({
       this.state.localDataType
     ).then(addedCatalogItems => {
       if (addedCatalogItems && addedCatalogItems.length > 0) {
-        this.onFileAddFinished(addedCatalogItems);
+        this.props.onFileAddFinished(addedCatalogItems);
       }
       this.setState({
         isLoading: false
@@ -114,7 +114,7 @@ const AddData = createReactClass({
     }
     addUserCatalogMember(this.props.terria, promise).then(addedItem => {
       if (addedItem && !(addedItem instanceof TerriaError)) {
-        this.onFileAddFinished([addedItem]);
+        this.props.onFileAddFinished([addedItem]);
       }
       // FIXME: Setting state here might result in a react warning if the
       // component unmounts before the promise finishes
@@ -123,10 +123,6 @@ const AddData = createReactClass({
       });
       this.props.resetTab();
     });
-  },
-
-  onFileAddFinished(files) {
-    this.props.onFileAddFinished(files);
   },
 
   onRemoteUrlChange(event) {

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -17,8 +17,8 @@ import TerriaError from "../../../../Core/TerriaError";
 import addUserFiles from "../../../../Models/addUserFiles";
 
 // Local and remote data have different dataType options
-const remoteDataType = getDataType().remoteDataType;
-const localDataType = getDataType().localDataType;
+const defaultRemoteDataTypes = getDataType().remoteDataType;
+const defaultLocalDataTypes = getDataType().localDataType;
 
 /**
  * Add data panel in modal window -> My data tab
@@ -31,13 +31,22 @@ const AddData = createReactClass({
     viewState: PropTypes.object,
     resetTab: PropTypes.func,
     activeTab: PropTypes.string,
+    localDataTypes: PropTypes.arrayOf(PropTypes.object),
+    remoteDataTypes: PropTypes.arrayOf(PropTypes.object),
     t: PropTypes.func.isRequired
+  },
+
+  getDefaultProps() {
+    return {
+      remoteDataTypes: defaultRemoteDataTypes,
+      localDataTypes: defaultLocalDataTypes
+    };
   },
 
   getInitialState() {
     return {
-      localDataType: localDataType[0], // By default select the first item (auto)
-      remoteDataType: remoteDataType[0],
+      localDataType: this.props.localDataTypes[0], // By default select the first item (auto)
+      remoteDataType: this.props.remoteDataTypes[0],
       remoteUrl: "", // By default there's no remote url
       isLoading: false
     };
@@ -66,7 +75,7 @@ const AddData = createReactClass({
       this.state.localDataType
     ).then(addedCatalogItems => {
       if (addedCatalogItems && addedCatalogItems.length > 0) {
-        this.onFileAddFinished(addedCatalogItems[0]);
+        this.onFileAddFinished(addedCatalogItems);
       }
       this.setState({
         isLoading: false
@@ -103,19 +112,18 @@ const AddData = createReactClass({
       }
     }
     addUserCatalogMember(this.props.terria, promise).then(addedItem => {
-      if (addedItem && !(addedItem instanceof TerriaError)) {
-        this.onFileAddFinished(addedItem);
-      }
       this.setState({
         isLoading: false
       });
       this.props.resetTab();
+      if (addedItem && !(addedItem instanceof TerriaError)) {
+        this.onFileAddFinished([addedItem]);
+      }
     });
   },
 
-  onFileAddFinished(fileToSelect) {
-    this.props.viewState.myDataIsUploadView = false;
-    this.props.viewState.viewCatalogMember(fileToSelect);
+  onFileAddFinished(files) {
+    this.props.onFileAddFinished(files);
   },
 
   onRemoteUrlChange(event) {
@@ -133,7 +141,10 @@ const AddData = createReactClass({
       icon: <Icon glyph={Icon.GLYPHS.opened} />
     };
 
-    const dataTypes = localDataType.reduce(function(result, currentDataType) {
+    const dataTypes = this.props.localDataTypes.reduce(function(
+      result,
+      currentDataType
+    ) {
       if (currentDataType.extensions) {
         return result.concat(
           currentDataType.extensions.map(extension => "." + extension)
@@ -141,7 +152,8 @@ const AddData = createReactClass({
       } else {
         return result;
       }
-    }, []);
+    },
+    []);
 
     return (
       <div className={Styles.tabPanels}>
@@ -154,7 +166,7 @@ const AddData = createReactClass({
               </Trans>
             </label>
             <Dropdown
-              options={localDataType}
+              options={this.props.localDataTypes}
               selected={this.state.localDataType}
               selectOption={this.selectLocalOption}
               matchWidth={true}
@@ -181,7 +193,7 @@ const AddData = createReactClass({
               </Trans>
             </label>
             <Dropdown
-              options={remoteDataType}
+              options={this.props.remoteDataTypes}
               selected={this.state.remoteDataType}
               selectOption={this.selectRemoteOption}
               matchWidth={true}

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -21,6 +21,9 @@ const MyDataTab = observer(
     propTypes: {
       terria: PropTypes.object,
       viewState: PropTypes.object,
+      localDataTypes: PropTypes.arrayOf(PropTypes.object),
+      remoteDataTypes: PropTypes.arrayOf(PropTypes.object),
+      onFileAddFinished: PropTypes.func.isRequired,
       t: PropTypes.func.isRequired
     },
 
@@ -133,6 +136,9 @@ const MyDataTab = observer(
                 viewState={this.props.viewState}
                 activeTab={this.state.activeTab}
                 resetTab={this.resetTab}
+                localDataTypes={this.props.localDataTypes}
+                remoteDataTypes={this.props.remoteDataTypes}
+                onFileAddFinished={this.props.onFileAddFinished}
               />
             </If>
             <If condition={showTwoColumn}>

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
@@ -186,8 +186,7 @@ const ViewingControls = observer(
 
         // Add it to terria.catalog, which is required so the new item can be shared.
         addUserCatalogMember(terria, splitRef, {
-          open: false,
-          zoomTo: false
+          open: false
         });
       });
     },


### PR DESCRIPTION
### What this PR does

As of now it is not possible to open the upload data modal without showing the other tabs like the catalog explorer. In some tools we want the user to upload some data and the upload modal should not show other tabs. This PR makes it possible to open the upload data modal independent of the `ExplorerWindow` component.

List of changes:
     * Makes it possible to invoke MyData tab from a component different from ExplorerWindow
     * The extensions shown in the AddData dropdown are now customizable
     * Receive a callback when files are uploaded


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
