### PR TITLE
Fix incorrect headings in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,18 +3,17 @@ Change Log
 
 ### MobX Development
 
-#### mobx-next-release (mobx-35)
+#### mobx-next-release (mobx-34)
 * Bug fix for `DatePicker` in `BottomDock` causing app crash
 * Made changes to the video modals: close button has been added, pressing escape now closes the component and some basic unit tests created
 * Updated the video modal for _Data Stories: Getting Started_ to use the new `VideoGuide` component
 * Fix the timeline stack handling for when there are multiple time-enabled layers
 * Ported timeseries tables.
-* (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
-
-#### mobx-34
 * Extended the support for styles for ESRI ArcGis Feature Server. Line styles are supported for lines and polygon outlines in both Cesium and Leaflet viewer. #4405
 * Fix polygon outline style bug.
 * Add a unit test for polygon outline style.
+* (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
+
 
 #### mobx-33
 * Updated generic select so icon doesn't block click


### PR DESCRIPTION
There has not yet been a mobx-34 release on npm but new changes have been added to mobx-35. This fixes that.