### PR TITLE
Create ShadowTraits class shared by GltfCatalogItem and Cesium3DTilesCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Extended the support for styles for ESRI ArcGis Feature Server. Line styles are supported for lines and polygon outlines in both Cesium and Leaflet viewer. #4405
 * Fix polygon outline style bug.
 * Add a unit test for polygon outline style.
+* Creates a `ShadowTraits` class that is shared by `GltfCatalogItem` and `Cesium3DTilesCatalogItem`.
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 
 

--- a/lib/Traits/Cesium3DCatalogItemTraits.ts
+++ b/lib/Traits/Cesium3DCatalogItemTraits.ts
@@ -3,6 +3,7 @@ import anyTrait from "./anyTrait";
 import CatalogMemberTraits from "./CatalogMemberTraits";
 import FeatureInfoTraits from "./FeatureInfoTraits";
 import MappableTraits from "./MappableTraits";
+import ShadowTraits from "./ShadowTraits";
 import mixTraits from "./mixTraits";
 import ModelTraits from "./ModelTraits";
 import objectArrayTrait from "./objectArrayTrait";
@@ -98,7 +99,8 @@ export default class Cesium3DTilesCatalogItemTraits extends mixTraits(
   FeatureInfoTraits,
   MappableTraits,
   UrlTraits,
-  CatalogMemberTraits
+  CatalogMemberTraits,
+  ShadowTraits
 ) {
   @primitiveTrait({
     type: "number",
@@ -120,22 +122,6 @@ export default class Cesium3DTilesCatalogItemTraits extends mixTraits(
     description: "URL of the Cesium Ion API server."
   })
   ionServer?: string;
-
-  @primitiveTrait({
-    type: "string",
-    name: "Shadows",
-    description:
-      "Determines whether the tileset casts or receives shadows from each light source."
-  })
-  shadows = "NONE";
-
-  @primitiveTrait({
-    type: "boolean",
-    name: "Show Shadow UI",
-    description:
-      "Determines whether the shadow UI component will be shown on the workbench item"
-  })
-  showShadowUi: boolean = true;
 
   @objectTrait({
     type: OptionsTraits,

--- a/lib/Traits/GltfTraits.ts
+++ b/lib/Traits/GltfTraits.ts
@@ -5,9 +5,7 @@ import ModelTraits from "./ModelTraits";
 import ShadowTraits from "./ShadowTraits";
 import mixTraits from "./mixTraits";
 
-export default class GltfTraits extends mixTraits(
-  ShadowTraits
-) {
+export default class GltfTraits extends mixTraits(ShadowTraits) {
   @objectTrait({
     type: LatLonHeightTraits,
     name: "Origin",

--- a/lib/Traits/GltfTraits.ts
+++ b/lib/Traits/GltfTraits.ts
@@ -2,8 +2,12 @@ import objectTrait from "./objectTrait";
 import LatLonHeightTraits from "./LatLonHeightTraits";
 import primitiveTrait from "./primitiveTrait";
 import ModelTraits from "./ModelTraits";
+import ShadowTraits from "./ShadowTraits";
+import mixTraits from "./mixTraits";
 
-export default class GltfTraits extends ModelTraits {
+export default class GltfTraits extends mixTraits(
+  ShadowTraits
+) {
   @objectTrait({
     type: LatLonHeightTraits,
     name: "Origin",
@@ -34,12 +38,4 @@ export default class GltfTraits extends ModelTraits {
     description: "The scale factor to apply to the model"
   })
   scale?: number;
-
-  @primitiveTrait({
-    type: "string",
-    name: "Shadows",
-    description:
-      'Indicates whether this tileset casts and receives shadows. Valid values are "NONE", "BOTH", "CAST", and "RECEIVE".'
-  })
-  shadows?: string = "NONE";
 }

--- a/lib/Traits/ShadowTraits.ts
+++ b/lib/Traits/ShadowTraits.ts
@@ -1,0 +1,20 @@
+import primitiveTrait from "./primitiveTrait";
+import ModelTraits from "./ModelTraits";
+
+export default class ShadowTraits extends ModelTraits {
+  @primitiveTrait({
+    type: "string",
+    name: "Shadows",
+    description:
+      "Determines whether the tileset casts or receives shadows from each light source."
+  })
+  shadows: "CAST" | "RECEIVE" | "BOTH" | "NONE" = "NONE";
+
+  @primitiveTrait({
+    type: "boolean",
+    name: "Show Shadow UI",
+    description:
+      "Determines whether the shadow UI component will be shown on the workbench item"
+  })
+  showShadowUi: boolean = true;
+}

--- a/test/Models/Cesium3DTilesCatalogItemSpec.ts
+++ b/test/Models/Cesium3DTilesCatalogItemSpec.ts
@@ -177,7 +177,7 @@ describe("Cesium3DTilesCatalogItemSpec", function() {
           });
 
           it("sets the shadow mode", function() {
-            runInAction(() => item.setTrait("definition", "shadows", "cast"));
+            runInAction(() => item.setTrait("definition", "shadows", "CAST"));
             expect(item.mapItems[0].shadows).toBe(ShadowMode.CAST_ONLY);
           });
 
@@ -198,7 +198,7 @@ describe("Cesium3DTilesCatalogItemSpec", function() {
           });
 
           it("sets the shadow mode", function() {
-            runInAction(() => item.setTrait("definition", "shadows", "cast"));
+            runInAction(() => item.setTrait("definition", "shadows", "CAST"));
             expect(item.mapItems[0].shadows).toBe(ShadowMode.CAST_ONLY);
           });
 


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/qld-digital-twin/issues/99
I noticed that `GltfCatalogItem` didn't have a `hideShadowUi` trait but `Cesium3DTilesCatalogItem` did. So I created a `ShadowTraits` class which is shared between  `GltfCatalogItem` and `Cesium3DTilesCatalogItem`. 

### Checklist

-   [x] Rejigged the existing unit tests accordingly, although more would be good
-   [x] I've updated CHANGES.md with what I changed.
