### PR TITLE
Fix default gltf rotation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Added basic CSV export function
 * Extend `UserDrawing` to handle rectangles
 * Tsxify `MapInteractionMode`
+* Changed default orientation for `GltfCatalogItem` to no rotation, instead of zero rotation wrt to terrain
 * (💫The next rad feature💫 but please be mostly bug fixes from now until June!)
 
 #### mobx-35

--- a/lib/Models/GltfCatalogItem.ts
+++ b/lib/Models/GltfCatalogItem.ts
@@ -82,11 +82,13 @@ export default class GltfCatalogItem
   @computed
   private get orientation(): Quaternion {
     const { heading, pitch, roll } = this.rotation;
-    const hpr = HeadingPitchRoll.fromDegrees(
-      heading || 0,
-      pitch || 0,
-      roll || 0
-    );
+
+    // If no hpr rotation defined, we default to no rotation
+    if (heading === undefined || pitch === undefined || roll === undefined) {
+      return Quaternion.IDENTITY.clone();
+    }
+
+    const hpr = HeadingPitchRoll.fromDegrees(heading, pitch, roll);
     const orientation = Transforms.headingPitchRollQuaternion(
       this.cesiumPosition,
       hpr

--- a/test/Models/GltfCatalogItemSpec.ts
+++ b/test/Models/GltfCatalogItemSpec.ts
@@ -1,24 +1,64 @@
 import GltfCatalogItem from "../../lib/Models/GltfCatalogItem";
 import Mappable from "../../lib/Models/Mappable";
 import Terria from "../../lib/Models/Terria";
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import createStratumInstance from "../../lib/Models/createStratumInstance";
+import HeadingPitchRollTraits from "../../lib/Traits/HeadingPitchRollTraits";
+import CommonStrata from "../../lib/Models/CommonStrata";
 
 describe("GltfCatalogItem", function() {
+  let gltf: GltfCatalogItem;
+
+  beforeEach(function() {
+    gltf = new GltfCatalogItem("test", new Terria());
+    gltf.setTrait("definition", "url", "test/gltf/Cesium_Air.glb");
+  });
+
   it("is Mappable", function() {
-    const terria = new Terria();
-    const gltf = new GltfCatalogItem("test", terria);
     expect(Mappable.is(gltf)).toBeTruthy();
   });
 
-  it("creates a DataSource with a model", function() {
-    const terria = new Terria();
-    const gltf = new GltfCatalogItem("test", terria);
-    const url = "test/gltf/Cesium_Air.glb";
-    gltf.setTrait("definition", "url", url);
-    gltf.loadMapItems().then(() => {
-      expect(gltf.mapItems.length).toBe(1);
-      expect(gltf.mapItems[0].entities.values.length).toBe(1);
-      expect(gltf.mapItems[0].entities.values[0].polygon).toBeUndefined();
-      expect(gltf.mapItems[0].entities.values[0].model).toBeDefined();
+  it("creates a DataSource with a model", async function() {
+    await gltf.loadMapItems();
+    expect(gltf.mapItems.length).toBe(1);
+    expect(gltf.mapItems[0].entities.values.length).toBe(1);
+    expect(gltf.mapItems[0].entities.values[0].polygon).toBeUndefined();
+    expect(gltf.mapItems[0].entities.values[0].model).toBeDefined();
+  });
+
+  describe("orientation", function() {
+    describe("when no rotation is defined", function() {
+      it("defaults to Quatenrion.IDENTITY", async function() {
+        await gltf.loadMapItems();
+        const entity = gltf.mapItems[0]?.entities.values[0];
+        const orientation = entity?.orientation.getValue(JulianDate.now());
+        expect(orientation).toBeDefined();
+        expect(orientation.x).toEqual(0);
+        expect(orientation.y).toEqual(0);
+        expect(orientation.z).toEqual(0);
+        expect(orientation.w).toEqual(1);
+      });
+    });
+
+    describe("when rotation is defined", function() {
+      it("correctly sets the orientation", async function() {
+        gltf.setTrait(
+          CommonStrata.user,
+          "rotation",
+          createStratumInstance(HeadingPitchRollTraits, {
+            heading: 30,
+            pitch: 40,
+            roll: 50
+          })
+        );
+        await gltf.loadMapItems();
+        const entity = gltf.mapItems[0]?.entities.values[0];
+        const orientation = entity?.orientation.getValue(JulianDate.now());
+        expect(orientation.x.toFixed(2)).toEqual("0.50");
+        expect(orientation.y.toFixed(2)).toEqual("-0.07");
+        expect(orientation.z.toFixed(2)).toEqual("0.55");
+        expect(orientation.w.toFixed(2)).toEqual("0.67");
+      });
     });
   });
 });


### PR DESCRIPTION
### What this PR does

Reverts back to the old behavior of defaulting to an orientation of `Quaternion.IDENTITY` when no rotation is defined.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
