### PR TITLE
Fix Trans strings with obviously wrong indices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 ### next verion
 * Rework the handling of point datasets on the anti-meridian when using LeafletJS.
+* Fix indices in some translation strings including strings for descriptions of WMS and WMS service.
 
 ### v7.11.5
 

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -228,7 +228,7 @@
     "hideStoryPanel": "hide story builder"
   },
   "satelliteGuidance": {
-    "menuTitle": "You can access map guides at any time by looking in the <0>help menu</0>.",
+    "menuTitle": "You can access map guides at any time by looking in the <2>help menu</2>.",
     "dismissText": "Got it, thanks!",
     "titleI": "Satellite Imagery: How do I…?",
     "bodyI": "A super-quick guide to getting the most out of historical satellite imagery.",
@@ -310,8 +310,8 @@
     "name": "Description",
     "dataLocal": "This file only exists in your browser. To share it, you must load it onto a public web server.",
     "dataNotLocal": "Please contact the provider of this data for more information, including information about usage rights and constraints.",
-    "wms": "This is a <0>WMS service</0>, which generates map images on request. It can be used in GIS software with this URL:",
-    "wfs": "This is a <0>WFS service</0>, which transfers raw spatial data on request. It can be used in GIS software with this URL:",
+    "wms": "This is a <1>WMS service</1>, which generates map images on request. It can be used in GIS software with this URL:",
+    "wfs": "This is a <1>WFS service</1>, which transfers raw spatial data on request. It can be used in GIS software with this URL:",
     "layerName": "Layer name",
     "typeName": "Type name",
     "metadataUrl": "Metadata URL",


### PR DESCRIPTION
### What this PR does

Fixes #4469.

Fix translation strings for WMS & WFS description and a string from the satellite imagery help guide.

### Checklist

-   [x] I've updated CHANGES.md with what I changed.
