### PR TITLE
Fix LeftRightSection styles to use theme colours

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,6 @@ Change Log
 
 ### MobX Development
 
-#### next release (7.11.5-mobx-35)
 #### next release (mobx-37)
 * Add `header` option to `loadText`
 * Add `isMixtedInto` function for `AsyncMappableMixin` and `AsyncChartableMixin`
@@ -12,6 +11,7 @@ Change Log
 * Updated default welcome video defaults to a newer, slower video
 * Update date picker to use theme colours
 * Removed some sass overrides on `Select` through `StyleSelectorSection`
+* Update LeftRightSection to use theme colours
 
 #### mobx-36
 * Added `pointer-events` to `MapNavigation` and `MenuBar` elements, so the bar don't block mouse click outside of the button.

--- a/lib/ReactViews/Workbench/Controls/LeftRightSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/LeftRightSection.jsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import React from "react";
+import styled from "styled-components";
 
 import defined from "terriajs-cesium/Source/Core/defined";
 import ImagerySplitDirection from "terriajs-cesium/Source/Scene/ImagerySplitDirection";
@@ -14,6 +15,21 @@ import Styles from "./left-right-section.scss";
 import { observer } from "mobx-react";
 import CommonStrata from "../../../Models/CommonStrata";
 import { runInAction } from "mobx";
+
+const LeftRightButton = styled.button`
+  text-align: center;
+  color: ${p => p.theme.textLight};
+  background-color: ${p => p.theme.dark};
+  ${p =>
+    p.isActive &&
+    `
+    background-color: ${p.theme.colorSplitter};
+  `}
+  &:hover,
+  &:focus {
+    background-color: ${p => p.theme.colorSplitter};
+  }
+`;
 
 const LeftRightSection = observer(
   createReactClass({
@@ -67,36 +83,33 @@ const LeftRightSection = observer(
       }
       return (
         <div className={Styles.leftRightSection}>
-          <button
+          <LeftRightButton
             type="button"
             onClick={this.goLeft}
-            className={classNames(Styles.goLeft, {
-              [Styles.isActive]: splitDirection === ImagerySplitDirection.LEFT
-            })}
+            className={classNames(Styles.goLeft)}
             title={t("splitterTool.workbench.goleftTitle")}
+            isActive={splitDirection === ImagerySplitDirection.LEFT}
           >
             {t("splitterTool.workbench.goleft")}
-          </button>
-          <button
+          </LeftRightButton>
+          <LeftRightButton
             type="button"
             onClick={this.goBoth}
-            className={classNames(Styles.goBoth, {
-              [Styles.isActive]: splitDirection === ImagerySplitDirection.NONE
-            })}
+            className={classNames(Styles.goBoth)}
             title={t("splitterTool.workbench.bothTitle")}
+            isActive={splitDirection === ImagerySplitDirection.NONE}
           >
             {t("splitterTool.workbench.both")}
-          </button>
-          <button
+          </LeftRightButton>
+          <LeftRightButton
             type="button"
             onClick={this.goRight}
-            className={classNames(Styles.goRight, {
-              [Styles.isActive]: splitDirection === ImagerySplitDirection.RIGHT
-            })}
+            className={classNames(Styles.goRight)}
             title={t("splitterTool.workbench.gorightTitle")}
+            isActive={splitDirection === ImagerySplitDirection.RIGHT}
           >
             {t("splitterTool.workbench.goright")}
-          </button>
+          </LeftRightButton>
         </div>
       );
     }

--- a/lib/ReactViews/Workbench/Controls/left-right-section.scss
+++ b/lib/ReactViews/Workbench/Controls/left-right-section.scss
@@ -6,42 +6,11 @@
   margin-top: 10px;
 }
 
-.go-left {
-  float: left;
-  background-color: #444;
-}
-
-.go-both {
-  float: left;
-  background-color: #444;
-}
-
-.go-right {
-  float: left;
-  background-color: #444;
-}
-
-.isActive {
-  // background-color: $color-primary;
-  background-color: $color-splitter;
-  &:hover,
-  &:focus {
-    background-color: $color-splitter;
-  }
-  color: #444;
-}
-
 .go-left,
 .go-right,
 .go-both {
   width: 33%;
   float: left;
   padding: 5px;
-  color: #fff;
   composes: btn from "../../../Sass/common/_buttons.scss";
-  composes: btn-primary from "../../../Sass/common/_buttons.scss";
-  &:hover,
-  &:focus {
-    background-color: $color-splitter;
-  }
 }

--- a/lib/ReactViews/Workbench/Controls/left-right-section.scss.d.ts
+++ b/lib/ReactViews/Workbench/Controls/left-right-section.scss.d.ts
@@ -7,7 +7,6 @@ interface CssExports {
   'goBoth': string;
   'goLeft': string;
   'goRight': string;
-  'isActive': string;
   'left-right-section': string;
   'leftRightSection': string;
 }


### PR DESCRIPTION
Update LeftRightSection to use theme colours

Fixes this:
<img width="342" alt="image" src="https://user-images.githubusercontent.com/9134432/87015451-c8a8ea80-c210-11ea-8f01-477a9ed898ae.png">

To use the proper splitter colours
<img width="320" alt="image" src="https://user-images.githubusercontent.com/9134432/87015463-cc3c7180-c210-11ea-83a0-4757dc9c9155.png">


### Checklist

-   [x] unit test n/a ui themeing
-   [x] I've updated CHANGES.md with what I changed.
