### PR TITLE
Disable Tool specs.

### DIFF
--- a/test/ReactViews/ToolSpec.tsx
+++ b/test/ReactViews/ToolSpec.tsx
@@ -19,7 +19,9 @@ describe("Tool", function() {
     });
   });
 
-  it("renders the item returned by getToolComponent", async function() {
+  // The following specs are excluded as they will break in react version
+  // 16.3.2, we can enable them after migrating to a newer version.
+  xit("renders the item returned by getToolComponent", async function() {
     let rendered: any;
     await act(async () => {
       rendered = TestRenderer.create(
@@ -34,7 +36,7 @@ describe("Tool", function() {
     expect(testComponent).toBeDefined();
   });
 
-  it("renders the promised item returned by getToolComponent", async function() {
+  xit("renders the promised item returned by getToolComponent", async function() {
     let rendered: any;
     await act(async () => {
       rendered = TestRenderer.create(


### PR DESCRIPTION
### What this PR does

Disables specs for tools which is broken in the current specified version of react `16.3.1`. We can enable them after migrating to a newer version that supports asynchronous `act`.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
