### PR TITLE
Mobx always breadcrumbs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Tsify `proxyCatalogItemUrl`.
 * Simplified SidePanel React refs by removing the double wrapping of the `withTerriaRef()` HOC
 * Merged `withTerriaRef()` HOC with `useRefForTerria()` hook logic
+* Breadcrumbs are always shown instead of only when doing a catalog search
 * [The next improvement]
 
 #### 8.0.0-alpha.40

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -73,7 +73,6 @@ export default class ViewState {
   @observable topElement: string = "FeatureInfo";
   @observable lastUploadedFiles: any[] = [];
   @observable storyBuilderShown: boolean = false;
-  @observable breadcrumbsShown: boolean = false;
 
   // Flesh out later
   @observable showHelpMenu: boolean = false;
@@ -573,7 +572,7 @@ export default class ViewState {
 
   @action
   showBreadcrumbs(isActive: boolean) {
-    this.breadcrumbsShown = isActive;
+    // this.breadcrumbsShown = isActive;
   }
 
   @action
@@ -657,6 +656,14 @@ export default class ViewState {
   @action
   closeTool() {
     this.currentTool = undefined;
+  }
+
+  @computed
+  get breadcrumbsShown() {
+    return (
+      this.previewedItem !== undefined ||
+      this.userDataPreviewedItem !== undefined
+    );
   }
 
   @computed

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -510,7 +510,6 @@ export default class ViewState {
     this.explorerPanelIsVisible = false;
     this.switchMobileView(null);
     this.clearPreviewedItem();
-    this.showBreadcrumbs(false);
   }
 
   @action
@@ -568,11 +567,6 @@ export default class ViewState {
   @action
   changeSearchState(newText: string) {
     this.searchState.catalogSearchText = newText;
-  }
-
-  @action
-  showBreadcrumbs(isActive: boolean) {
-    // this.breadcrumbsShown = isActive;
   }
 
   @action

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
@@ -67,11 +67,6 @@ const DataCatalogGroup = observer(
       this.toggleOpen();
       this.props.group.loadMembers();
       this.props.viewState.viewCatalogMember(this.props.group);
-
-      // Show search breadcrumbs
-      if (this.props.viewState.searchState.catalogSearchText.length > 0) {
-        this.props.viewState.showBreadcrumbs(true);
-      }
     },
 
     isSelected() {

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.jsx
@@ -101,11 +101,6 @@ export const DataCatalogItem = observer(
       this.props.viewState.switchMobileView(
         this.props.viewState.mobileViewOptions.preview
       );
-
-      // Show search breadcrumbs
-      if (this.props.viewState.searchState.catalogSearchText.length > 0) {
-        this.props.viewState.showBreadcrumbs(true);
-      }
     },
 
     isSelected() {

--- a/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
@@ -49,12 +49,8 @@ class DataCatalogTab extends React.Component {
     return (
       <div className={Styles.root}>
         <Box fullHeight column>
-          <Box
-            css={`
-              height: ${showBreadcrumbs ? `calc(100% - 32px)` : `100%`};
-            `}
-          >
-            <Box className={Styles.dataExplorer} flex="1 1 40rem">
+          <Box fullHeight overflow="hidden">
+            <Box className={Styles.dataExplorer} styledWidth="40%">
               {/* ~TODO: Put this back once we add a MobX DataCatalogSearch Provider~ */}
               {/* TODO2: Implement a more generic MobX DataCatalogSearch */}
               {searchState.catalogSearchProvider && (
@@ -81,7 +77,7 @@ class DataCatalogTab extends React.Component {
                 items={this.props.items}
               />
             </Box>
-            <Box flex="1 1 60rem">
+            <Box styledWidth="60%" wordBreak="break-all">
               <DataPreview
                 terria={terria}
                 viewState={this.props.viewState}

--- a/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
@@ -58,7 +58,6 @@ class DataCatalogTab extends React.Component {
                   searchText={searchState.catalogSearchText}
                   onSearchTextChanged={val => this.changeSearchText(val)}
                   onDoSearch={() => this.search()}
-                  onClear={() => this.props.viewState.showBreadcrumbs(false)}
                   placeholder={this.searchPlaceholder}
                   debounceDuration={
                     terria.catalogReferencesLoaded &&

--- a/lib/ReactViews/Search/Breadcrumbs.jsx
+++ b/lib/ReactViews/Search/Breadcrumbs.jsx
@@ -53,7 +53,6 @@ class Breadcrumbs extends React.Component {
       // Note: should it reset the text if a person deletes current search and starts a new search?
       <Box
         left
-        // styledHeight={"32px"}
         styledMinHeight={"32px"}
         fullWidth
         backgroundColor={this.props.theme.greyLighter}

--- a/lib/ReactViews/Search/Breadcrumbs.jsx
+++ b/lib/ReactViews/Search/Breadcrumbs.jsx
@@ -38,6 +38,7 @@ class Breadcrumbs extends React.Component {
         item.setTrait(CommonStrata.user, "isOpen", true);
       });
     });
+    this.props.viewState.viewCatalogMember(items[0]);
     this.props.viewState.changeSearchState("");
     this.props.viewState.showBreadcrumbs(false);
   }
@@ -53,11 +54,13 @@ class Breadcrumbs extends React.Component {
       // Note: should it reset the text if a person deletes current search and starts a new search?
       <Box
         left
-        styledHeight={"32px"}
+        // styledHeight={"32px"}
+        styledMinHeight={"32px"}
         fullWidth
         backgroundColor={this.props.theme.greyLighter}
         paddedHorizontally={2.4}
         paddedVertically={1}
+        wordBreak="break-all"
       >
         <StyledIcon
           styledWidth={"16px"}
@@ -65,35 +68,47 @@ class Breadcrumbs extends React.Component {
           glyph={Icon.GLYPHS.globe}
         />
         <Spacing right={1.2} />
-        {parentGroups && (
-          <For each="parent" index="i" of={parentGroups}>
-            {/* The first and last two groups use the full name */}
-            <If condition={i <= 1 || i >= parentGroups.length - 2}>
-              <RawButtonAndUnderline
-                type="button"
-                onClick={() => this.openInCatalog(ancestors.slice(0, i + 1))}
-              >
-                <Text small textDark>
-                  {parent}
-                </Text>
-              </RawButtonAndUnderline>
-            </If>
-            {/* The remainder are just '..' to prevent/minimise overflowing */}
-            <If condition={i > 1 && i < parentGroups.length - 2}>
-              <Text small textDark>
-                {"..."}
-              </Text>
-            </If>
+        <Box wrap>
+          {parentGroups && (
+            <For each="parent" index="i" of={parentGroups}>
+              <Choose>
+                {/* No link when it's the current member */}
+                <When condition={i === parentGroups.length - 1}>
+                  <Text small textDark>
+                    {parent}
+                  </Text>
+                </When>
+                {/* The first and last two groups use the full name */}
+                <When condition={i <= 1 || i >= parentGroups.length - 2}>
+                  <RawButtonAndUnderline
+                    type="button"
+                    onClick={() =>
+                      this.openInCatalog(ancestors.slice(i, i + 1))
+                    }
+                  >
+                    <Text small textDark>
+                      {parent}
+                    </Text>
+                  </RawButtonAndUnderline>
+                </When>
+                {/* The remainder are just '..' to prevent/minimise overflowing */}
+                <When condition={i > 1 && i < parentGroups.length - 2}>
+                  <Text small textDark>
+                    {"..."}
+                  </Text>
+                </When>
+              </Choose>
 
-            <If condition={i !== parentGroups.length - 1}>
-              <Box paddedHorizontally={1}>
-                <Text small textDark>
-                  {">"}
-                </Text>
-              </Box>
-            </If>
-          </For>
-        )}
+              <If condition={i !== parentGroups.length - 1}>
+                <Box paddedHorizontally={1}>
+                  <Text small textDark>
+                    {">"}
+                  </Text>
+                </Box>
+              </If>
+            </For>
+          )}
+        </Box>
       </Box>
     );
   }

--- a/lib/ReactViews/Search/Breadcrumbs.jsx
+++ b/lib/ReactViews/Search/Breadcrumbs.jsx
@@ -40,7 +40,6 @@ class Breadcrumbs extends React.Component {
     });
     this.props.viewState.viewCatalogMember(items[0]);
     this.props.viewState.changeSearchState("");
-    this.props.viewState.showBreadcrumbs(false);
   }
 
   render() {

--- a/lib/Styled/Box.jsx
+++ b/lib/Styled/Box.jsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 
 export const Box = styled.div`
   ${props => props.relative && `position:relative;`}
-  
+
   display: flex;
   position: relative;
   ${props =>
@@ -24,7 +24,7 @@ export const Box = styled.div`
   ${props => props.styledHeight && `height: ${props.styledHeight};`}
   ${props => props.styledMinHeight && `min-height: ${props.styledMinHeight};`}
   ${props => props.styledMaxHeight && `max-height: ${props.styledMaxHeight};`}
-  
+
   ${props =>
     props.col &&
     `
@@ -51,7 +51,7 @@ export const Box = styled.div`
   ${props =>
     props.justifyContentSpaceAround && `justify-content: space-around;`}
   ${props => props.justifySpaceBetween && `justify-content: space-between;`}
-  
+
   ${props => props.left && `align-items: center;`}
   ${props => props.alignItemsFlexStart && `align-items: flex-start;`}
   ${props => props.left && `justify-content: flex-start;`}
@@ -82,7 +82,7 @@ export const Box = styled.div`
   /* Unsure of padding API as yet */
 
   ${props => props.padded && `padding: 5px;`}
-  
+
   ${props => props.paddedRatio && `padding: ${5 * props.paddedRatio}px;`}
   ${props =>
     props.paddedHorizontally &&
@@ -100,7 +100,7 @@ export const Box = styled.div`
       padding-bottom: ${5 *
         (props.paddedVertically === true ? 1 : props.paddedVertically)}px;
     `}
-  
+
   ${props =>
     props.backgroundImage &&
     `
@@ -118,7 +118,8 @@ export const Box = styled.div`
       background-repeat: no-repeat;
       background-position: center;
     `}
-  
+
+  ${props => props.wordBreak && `word-break: ${props.wordBreak};`}
   ${props =>
     props.overflow &&
     `

--- a/test/ReactViews/Search/BreadcrumbsSpec.tsx
+++ b/test/ReactViews/Search/BreadcrumbsSpec.tsx
@@ -2,6 +2,7 @@ const create: any = require("react-test-renderer").create;
 import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../lib/Models/Terria";
+import CatalogGroup from "../../../lib/Models/CatalogGroupNew";
 import ViewState from "../../../lib/ReactViewModels/ViewState";
 import Breadcrumbs from "../../../lib/ReactViews/Search/Breadcrumbs";
 const DataCatalogTab: any = require("../../../lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab")
@@ -14,6 +15,7 @@ import { runInAction } from "mobx";
 describe("Breadcrumbs", function() {
   let terria: Terria;
   let viewState: ViewState;
+  let catalogGroup: CatalogGroup;
 
   let testRenderer: any;
 
@@ -26,12 +28,14 @@ describe("Breadcrumbs", function() {
       catalogSearchProvider: null,
       locationSearchProviders: []
     });
+    catalogGroup = new CatalogGroup("group-of-geospatial-cats", terria);
+    terria.addModel(catalogGroup);
   });
 
-  describe("with breadcrumbsShown set to true", function() {
+  describe("with a prevewied catalog item", function() {
     it("renders", function() {
       runInAction(() => {
-        viewState.showBreadcrumbs(true);
+        viewState.viewCatalogMember(catalogGroup);
       });
 
       act(() => {
@@ -49,11 +53,14 @@ describe("Breadcrumbs", function() {
     });
   });
 
-  describe("with breadcrumbsShown set to false", function() {
+  describe("without a previewed catalog item", function() {
     it("does not render", function() {
       runInAction(() => {
-        viewState.showBreadcrumbs(false);
+        viewState.clearPreviewedItem();
       });
+      // ensure it's truly undefined
+      expect(viewState.previewedItem).toBeUndefined();
+      expect(viewState.userDataPreviewedItem).toBeUndefined();
 
       act(() => {
         testRenderer = create(


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs/issues/4169

Currently breadcrumbs only show when you are doing a data search.
This does 2 things:
- makes them always shown
- fixes it so when you click on its parents, it opens up that item in the catalog

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
