### PR TITLE
remove unnecessary check

### DIFF
--- a/lib/Models/ArcGisPortalCatalogGroup.ts
+++ b/lib/Models/ArcGisPortalCatalogGroup.ts
@@ -89,17 +89,9 @@ export class ArcGisPortalStratum extends LoadableStratum(
         );
         if (portalGroupsServerResponse === undefined) return undefined;
       } else if (catalogGroup.groupBy === "usersGroups") {
-        const portalUsername = terria.userProperties.get("portalUsername");
-        if (portalUsername === undefined) {
-          throw new TerriaError({
-            title: i18next.t("models.arcgisPortal.errorLoadingTitle"),
-            message: "still"
-          });
-          return undefined;
-        }
         const groupSearchUri = new URI(catalogGroup.url)
           .segment(`/sharing/rest/community/self`)
-          .addQuery({ num: 100, f: "json" });
+          .addQuery({ f: "json" });
 
         const response = await getPortalInformation(
           groupSearchUri,


### PR DESCRIPTION
### What this PR does

When we deployed #4496 to the NSW dev environment I found a bug where a portal item configured with `"groupBy": "usersGroups"` wasn't working, you'd just get an empty group.
I'd made a change to my local terriamap environment at some stage when working with an early version of the portal APIs. The early attempt required passing in the esri username into the url, but I found a way to get around it using the `/self` endpoint. This PR removes the unnecessary check for the username property which was resulting in the empty group.


### Checklist

-   [ ] No tests required
-   [x] I've updated CHANGES.md with what I changed.
