### PR TITLE
Fix for CKAN instances with wms_api_url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 #### next release (8.0.0-alpha.45)
 * Update style of diff tool close button to match new design
 * Remove sass code from the `HelpPanel` component
+* Use `wms_api_url` for CKAN resources where it exists
 * [The next improvement]
 
 #### next release (8.0.0-alpha.44)

--- a/lib/Models/CkanDefinitions.ts
+++ b/lib/Models/CkanDefinitions.ts
@@ -5,6 +5,10 @@ export interface CkanResource {
   url: string;
   license_id: string;
   id: string;
+  // Present on data.vic.gov.au
+  wms_url?: string;
+  wms_layer?: string;
+  wms_api_url?: string;
 }
 
 export interface CkanOrganisation {

--- a/lib/Models/CkanItemReference.ts
+++ b/lib/Models/CkanItemReference.ts
@@ -119,6 +119,14 @@ export class CkanDatasetStratum extends LoadableStratum(
 
   @computed get url() {
     if (this.ckanResource === undefined) return undefined;
+    if (this.ckanItemReference._supportedFormat !== undefined) {
+      if (
+        this.ckanItemReference._supportedFormat.definition.type === "wms" &&
+        this.ckanResource.wms_api_url
+      ) {
+        return this.ckanResource.wms_api_url;
+      }
+    }
     return this.ckanResource.url;
   }
 


### PR DESCRIPTION
### What this PR does

Some CKAN instances provide some non-standard fields for WMS, particularly for identifying the url of the service. This PR uses one of those alternate fields (`wms_api_url`) where it's available. I've test this with data.gov.au and data.vic.gov.au and it works.

````
{
      "filterQuery": [
        {
          "fq": "(res_format:(WMS OR wms))"
        }
      ],
      "url": "https://data.gov.au/",
      "type": "ckan-group",
      "name": "Data.vic.gov.au (Victorian Government open data)",
      "groupBy": "organization"
    }
````

### Checklist

-   [ ] No tests provided
-   [x] I've updated CHANGES.md with what I changed.
