### PR TITLE
Fix for alpha of outline when deselecting a feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 * Update Geoscience Australia Topo basemap.
 * remove caching from WPS requests.
+* Fix entity outline alpha value when de-selecting a feature
 
 ### v7.11.8
 

--- a/lib/Models/GlobeOrMap.js
+++ b/lib/Models/GlobeOrMap.js
@@ -278,7 +278,7 @@ GlobeOrMap.prototype._highlightFeature = function(feature) {
         cesiumPolygon.polygon.outline = polygonOutline;
         cesiumPolygon.polygon.outlineColor = polygonOutlineColor
           .getValue()
-          .withAlpha(highlightFeatureColor.alpha);
+          .withAlpha(polygonOutlineColor.alpha);
         cesiumPolygon.polygon.material.color = currentColor.withAlpha(
           highlightFeatureColor.alpha
         );


### PR DESCRIPTION
### What this PR does

When selecting a feature on the map it is highlighted changing the symbology. I noticed that when deselecting a feature the outline was sometimes becoming invisible when it had previously been visible. This PR ensures that the alpha of the outline is re-adopted.

### Checklist

-   [ ] No unit tests
-   [x] I've updated CHANGES.md with what I changed.
