### PR TITLE
Remove caching from TerriaJsonCatalogFunction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 ### Next Release
 
+* Remove caching from TerriaJsonCatalogFunction requests.
+
 
 ### v7.11.9
 

--- a/lib/Models/TerriaJsonCatalogFunction.js
+++ b/lib/Models/TerriaJsonCatalogFunction.js
@@ -434,7 +434,7 @@ TerriaJsonCatalogFunction.prototype.invoke = function() {
     }
   });
   const uri = new URI(this.url).addQuery(queryParameters);
-  const proxiedUrl = proxyCatalogItemUrl(this, uri.toString(), "1d");
+  const proxiedUrl = proxyCatalogItemUrl(this, uri.toString(), "0s");
   const promise = Resource.fetchXHR({
     url: proxiedUrl,
     responseType: "text",
@@ -631,7 +631,7 @@ TerriaJsonCatalogFunction.prototype._handleHttp202 = function(xhr) {
       }
       iteratorXhr = iteratorXhr[iteratorCaseMatched];
     }
-    newResourceOpts.url = proxyCatalogItemUrl(this, iteratorXhr, "1d");
+    newResourceOpts.url = proxyCatalogItemUrl(this, iteratorXhr, "0s");
 
     // waitms is a function because i think it is a little easier to read
     var waitms = function(inputs) {


### PR DESCRIPTION
### What this PR does

If a terria-json catalog item is going via the proxy it keeps polling for a response, however currently it defaults to a 1d caching which is problematic and prevents results from coming back. This changes it to not cache.

### Checklist

-   [ ] No unit tests
-   [x] I've updated CHANGES.md with what I changed.
