### PR TITLE
Publish v7.11.10 with upgraded node-sass dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,11 @@ Change Log
 
 ### Next Release
 
-* Remove caching from TerriaJsonCatalogFunction requests.
 
+### v7.11.10
+
+* Remove caching from TerriaJsonCatalogFunction requests.
+* Upgraded minimum node-sass version to one that has binaries for node v14.
 
 ### v7.11.9
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "7.11.9",
+  "version": "7.11.10",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "karma-spec-reporter": "^0.0.32",
     "klaw-sync": "^4.0.0",
     "node-notifier": "^5.1.2",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.14.1",
     "plugin-error": "^1.0.1",
     "prettier": "1.17.0",
     "pretty-quick": "^1.10.0",


### PR DESCRIPTION
### What this PR does

Publishes v7.11.10 with upgraded minimum node-sass version that has pre-built binaries for node v14.

Only merge this if `b0146d2` is the HEAD of [master](https://github.com/TerriaJS/terriajs/commits/master)

### Checklist

-   [x] Dependency change & release, no tests
-   [x] I've updated CHANGES.md with what I changed.
