### PR TITLE
Add sortMembers method to GroupMixin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.47)
-* [The next improvement]
+* Ad `sortMembers` method to `GroupMixin`
+* Implement member sorting within `ArcGisPortalCatalogGroup`
 
 #### 8.0.0-alpha.46
 * Fixed i18n initialisation for magda based configurations

--- a/lib/ModelMixins/GroupMixin.ts
+++ b/lib/ModelMixins/GroupMixin.ts
@@ -50,6 +50,24 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
     }
 
     @action
+    sortMembers(
+      stratumId: string,
+      sortFunction: (a: BaseModel, b: BaseModel) => number
+    ) {
+      const members: any = this.getTrait(stratumId, "members");
+      const models = this.memberModels as Array<BaseModel>;
+      if (members === undefined || models.length === 0) return;
+      const unsortedModels = models.splice(0);
+      members.clear();
+      const sortedModels = filterOutUndefined(
+        unsortedModels.sort(sortFunction)
+      );
+      sortedModels.forEach((m: BaseModel) => {
+        this.add(stratumId, m);
+      }, this);
+    }
+
+    @action
     toggleOpen(stratumId: string) {
       this.setTrait(stratumId, "isOpen", !this.isOpen);
     }

--- a/lib/Models/ArcGisPortalCatalogGroup.ts
+++ b/lib/Models/ArcGisPortalCatalogGroup.ts
@@ -232,7 +232,7 @@ export class ArcGisPortalStratum extends LoadableStratum(
       return groupIds;
     }
     // Otherwise return the id's of all the resources of all the filtered datasets
-    return this.filteredDatasets.sort(this.sortingComparitor).map(ds => {
+    return this.filteredDatasets.sort(sortByNameInCatalog).map(ds => {
       return this._catalogGroup.uniqueId + "/" + ds.id;
     }, this);
   }

--- a/lib/Models/Group.ts
+++ b/lib/Models/Group.ts
@@ -19,8 +19,4 @@ export default interface Group {
     member: BaseModel,
     newIndex: number
   ): void;
-  sortMembers(
-    stratumId: string,
-    sortFunction: (a: BaseModel, b: BaseModel) => number
-  ): void;
 }

--- a/lib/Models/Group.ts
+++ b/lib/Models/Group.ts
@@ -19,4 +19,8 @@ export default interface Group {
     member: BaseModel,
     newIndex: number
   ): void;
+  sortMembers(
+    stratumId: string,
+    sortFunction: (a: BaseModel, b: BaseModel) => number
+  ): void;
 }

--- a/lib/Traits/ArcGisPortalCatalogGroupTraits.ts
+++ b/lib/Traits/ArcGisPortalCatalogGroupTraits.ts
@@ -71,6 +71,17 @@ export default class ArcGisPortalCatalogGroupTraits extends mixTraits(
 
   @primitiveTrait({
     type: "string",
+    name: "Sort By",
+    description: `Determines how items should be sorted in the catalog. Valid values are:
+       * title - Items are sorted by the dataset title.
+       * dateCreated - Items are sorted by when they were created.
+       * dateModified - Items are sorted by when they were last modified.
+      Defaults to being sorted by title.`
+  })
+  sortBy?: "dateCreated" | "dateModified" | "title" = "title";
+
+  @primitiveTrait({
+    type: "string",
     name: "Ungrouped title",
     description: `A title for the group holding all items that don't have a group in an ArcGIS Portal.
       If the value is a blank string or undefined, these items will be left at the top level, not grouped.`

--- a/test/ModelMixins/GroupMixinSpec.ts
+++ b/test/ModelMixins/GroupMixinSpec.ts
@@ -1,0 +1,73 @@
+import Terria from "../../lib/Models/Terria";
+import CatalogGroup from "../../lib/Models/CatalogGroupNew";
+import CatalogMemberFactory from "../../lib/Models/CatalogMemberFactory";
+import upsertModelFromJson from "../../lib/Models/upsertModelFromJson";
+
+describe("GroupMixin", function() {
+  describe(" - can sort members", function() {
+    let terria: Terria;
+    let group: CatalogGroup;
+    let json: any;
+
+    beforeEach(async function() {
+      terria = new Terria();
+      CatalogMemberFactory.register(CatalogGroup.type, CatalogGroup);
+
+      json = {
+        type: "group",
+        id: "mama",
+        name: "Test Group",
+        members: [
+          {
+            type: "wms",
+            id: "child1",
+            name: "foo"
+          },
+          {
+            type: "wms",
+            id: "child2",
+            name: "baa"
+          }
+        ]
+      };
+
+      group = <CatalogGroup>(
+        upsertModelFromJson(
+          CatalogMemberFactory,
+          terria,
+          "",
+          undefined,
+          "definition",
+          json
+        )
+      );
+    });
+
+    it(" - items are not sorted by default", function() {
+      const memberModels: any = group.memberModels;
+      console.log(group, memberModels);
+      expect(memberModels.length).toBe(2);
+      expect(memberModels[0].name).toBe("foo");
+      expect(memberModels[1].name).toBe("baa");
+    });
+
+    it(" - items can be sorted", function() {
+      group.sortMembers("definition", sortByNameInCatalog);
+      const memberModels: any = group.memberModels;
+      expect(memberModels.length).toBe(2);
+      expect(memberModels[0].name).toBe("baa");
+      expect(memberModels[1].name).toBe("foo");
+    });
+  });
+});
+
+function sortByNameInCatalog(a: any, b: any) {
+  if (a.nameInCatalog === undefined || b.nameInCatalog === undefined) {
+    return 0;
+  } else if (a.nameInCatalog < b.nameInCatalog) {
+    return -1;
+  } else if (a.nameInCatalog > b.nameInCatalog) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
### What this PR does

I needed a way to sort members of a catalog group **after** they'd be added to a group, this is because you don't always have all the members of a group prior to adding them. 

So this PR add a `sortMembers` method to the `GroupMixin` which accepts a sorting function.

I also implemented the sorting of `ArcGisPortalGroup`, it can be tested with a config such as 
````
    {
      "type": "arcgis-portal-group",
      "name": "All open Content",
      "url": "https://portal.spatial.nsw.gov.au/portal",
      "groupBy": "portalCategories"
    },
````
Where you will notice that the contents of all the sub-groups are sorted by their title.



### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
