### PR TITLE
Ports chartColor trait for DiscretelyTimeVarying items from master.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### next release (8.0.0-alpha.47)
 * Removed hard coded senaps base url.
+* Added `chartColor` trait for DiscretelyTimeVarying items.
 * [The next improvement]
 
 #### 8.0.0-alpha.46

--- a/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
+++ b/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
@@ -313,7 +313,9 @@ function DiscretelyTimeVaryingMixin<
             });
           },
           getColor: () => {
-            return getChartColorForId(colorId);
+            return this.chartColor
+              ? this.chartColor
+              : getChartColorForId(colorId);
           },
           onClick: (point: any) => {
             runInAction(() => {

--- a/lib/Traits/DiscretelyTimeVaryingTraits.ts
+++ b/lib/Traits/DiscretelyTimeVaryingTraits.ts
@@ -47,6 +47,13 @@ export default class DiscretelyTimeVaryingTraits extends mixTraits(
   chartDisclaimer?: string;
 
   @primitiveTrait({
+    type: "string",
+    name: "Chart color",
+    description: "The color to use when the data set is displayed on the chart"
+  })
+  chartColor?: string;
+
+  @primitiveTrait({
     type: "boolean",
     name: "Disable date time selector",
     description: "When true, disables the date time selector in the workbench"

--- a/lib/Traits/DiscretelyTimeVaryingTraits.ts
+++ b/lib/Traits/DiscretelyTimeVaryingTraits.ts
@@ -49,7 +49,8 @@ export default class DiscretelyTimeVaryingTraits extends mixTraits(
   @primitiveTrait({
     type: "string",
     name: "Chart color",
-    description: "The color to use when the data set is displayed on the chart"
+    description:
+      "The color to use when the data set is displayed on the chart. The value can be any html color string, eg: 'cyan' or '#00ffff' or 'rgba(0, 255, 255, 1)' for the color cyan."
   })
   chartColor?: string;
 

--- a/test/ModelMixins/DiscretelyTimeVaryingMixinSpec.ts
+++ b/test/ModelMixins/DiscretelyTimeVaryingMixinSpec.ts
@@ -1,3 +1,4 @@
+import CommonStrata from "../../lib/Models/CommonStrata";
 import Terria from "../../lib/Models/Terria";
 import WebMapServiceCatalogItem from "../../lib/Models/WebMapServiceCatalogItem";
 
@@ -27,5 +28,19 @@ describe("DiscretelyTimeVaryingMixin", () => {
     const months = years[years.indice[0]];
     expect(months.dates.length).toBe(1000);
     expect(months.indice[0]).toBe(3);
+  });
+
+  it("supports specifying a chartColor", async function() {
+    wmsItem = new WebMapServiceCatalogItem("mywms2", terria);
+    wmsItem.setTrait(
+      "definition",
+      "url",
+      "/test/WMS/period_datetimes_many_intervals.xml"
+    );
+    wmsItem.setTrait(CommonStrata.definition, "layers", "single_period");
+    wmsItem.setTrait(CommonStrata.user, "showInChartPanel", true);
+    wmsItem.setTrait(CommonStrata.user, "chartColor", "#efefef");
+    await wmsItem.loadMapItems();
+    expect(wmsItem.chartItems[0].getColor()).toBe("#efefef");
   });
 });


### PR DESCRIPTION
### What this PR does

Ports the `chartColor` trait for DiscretelyTimeVarying items from master.

### Testing

You can use the following config for testing. Charts have become really slow for some reason, you will be able to see the effect of setting `chartColor` but interacting with the chart itself will be painful.

```
{
          "type": "wms",
          "name": "Daily Landsat and Sentinel-2 satellite images",
          "url": "https://gsky.nci.org.au/ows/dea",
          "layers": "blend_sentinel2_landsat_nbart_daily",
          "opacity": 1,
          "chartColor": "yellow",
          "timeFilterPropertyName": "data_available_for_dates",
          "chartType": "momentPoints"
}
```

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
