### PR TITLE
Chart cursor perf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Merged the `StyleSelector` and `DimensionsSelector`, and created a `SelectableDimensions` interface.
 * Added `chartColor` trait for DiscretelyTimeVarying items.
 * Replaced all instances of `createInfoSection` and `newInfo` with calls to `createStratumInstance` using an initialisation object.
+* Fixed a bug that caused re-rendering of xAxis of charts on mouse move. Chart cursor should be somewhat faster as a result of this fix.
 * [The next improvement]
 
 #### 8.0.0-alpha.46

--- a/lib/ReactViews/Custom/Chart/BottomDockChart.jsx
+++ b/lib/ReactViews/Custom/Chart/BottomDockChart.jsx
@@ -278,12 +278,6 @@ class Chart extends React.Component {
                 top={this.plotHeight + 1}
                 scale={this.xScale}
                 label={xAxis.units || (xAxis.scale === "time" && "Date")}
-                labelProps={{
-                  fill: labelColor,
-                  fontSize: 12,
-                  textAnchor: "middle",
-                  fontFamily: "Arial"
-                }}
               />
               <For each="y" index="i" of={this.yAxes}>
                 <YAxis
@@ -402,6 +396,12 @@ class Plot extends React.Component {
 }
 
 class XAxis extends React.PureComponent {
+  static propTypes = {
+    top: PropTypes.number.isRequired,
+    scale: PropTypes.func.isRequired,
+    label: PropTypes.bool.isRequired
+  };
+
   render() {
     return (
       <AxisBottom
@@ -413,6 +413,12 @@ class XAxis extends React.PureComponent {
           fontSize: 12,
           fontFamily: "Arial"
         })}
+        labelProps={{
+          fill: labelColor,
+          fontSize: 12,
+          textAnchor: "middle",
+          fontFamily: "Arial"
+        }}
         {...this.props}
       />
     );


### PR DESCRIPTION
### What this PR does

Slightly improves chart cursor performance by preventing re-rendering of the x-axes on mouse moves.
Issue: https://github.com/TerriaJS/terriajs/issues/4663

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
