### PR TITLE
Add trait `leafletUpdateInterval`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Merged the `StyleSelector` and `DimensionsSelector`, and created a `SelectableDimensions` interface.
 * Added `chartColor` trait for DiscretelyTimeVarying items.
 * Replaced all instances of `createInfoSection` and `newInfo` with calls to `createStratumInstance` using an initialisation object.
+* Added trait `leafletUpdateInterval` to RasterLayerTraits.
 * [The next improvement]
 
 #### 8.0.0-alpha.46

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -46,6 +46,7 @@ import LatLonHeight from "../Core/LatLonHeight";
 import MapInteractionMode from "./MapInteractionMode";
 import i18next from "i18next";
 import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
+import RasterLayerTraits from "../Traits/RasterLayerTraits";
 
 // We want TS to look at the type declared in lib/ThirdParty/terriajs-cesium-extra/index.d.ts
 // and import doesn't allows us to do that, so instead we use require + type casting to ensure
@@ -324,14 +325,29 @@ export default class Leaflet extends GlobeOrMap {
         this.terriaViewer.baseMap
       ];
       // Flatmap
-      const allMapItems = ([] as MapItem[]).concat(
-        ...catalogItems.filter(isDefined).map(item => item.mapItems)
+      const allImageryMapItems = ([] as {
+        item: Mappable;
+        parts: ImageryParts;
+      }[]).concat(
+        ...catalogItems
+          .filter(isDefined)
+          .map(item =>
+            item.mapItems
+              .filter(ImageryParts.is)
+              .map(parts => ({ item, parts }))
+          )
       );
 
-      const allImagery = allMapItems.filter(ImageryParts.is).map(parts => ({
-        parts: parts,
-        layer: this._createImageryLayer(parts.imageryProvider)
-      }));
+      const allImagery = allImageryMapItems.map(({ item, parts }) => {
+        if (hasTraits(item, RasterLayerTraits, "leafletUpdateInterval")) {
+          (parts.imageryProvider as any)._leafletUpdateInterval =
+            item.leafletUpdateInterval;
+        }
+        return {
+          parts: parts,
+          layer: this._createImageryLayer(parts.imageryProvider)
+        };
+      });
 
       // Delete imagery layers no longer in the model
       this.map.eachLayer(mapLayer => {
@@ -363,6 +379,9 @@ export default class Leaflet extends GlobeOrMap {
       });
 
       /* Handle datasources */
+      const allMapItems = ([] as MapItem[]).concat(
+        ...catalogItems.filter(isDefined).map(item => item.mapItems)
+      );
       const allDataSources = allMapItems.filter(isDataSource);
 
       // Remove deleted data sources

--- a/lib/Traits/RasterLayerTraits.ts
+++ b/lib/Traits/RasterLayerTraits.ts
@@ -8,4 +8,12 @@ export default class RasterLayerTraits extends ModelTraits {
     description: "The opacity of the map layers."
   })
   opacity: number = 0.8;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Leaflet update interval",
+    description:
+      "Update a tile only once during this interval when the map is panned. Value should be specified in milliseconds."
+  })
+  leafletUpdateInterval?: number;
 }


### PR DESCRIPTION
### What this PR does

    Adds trait `leafletUpdateInterval` to RasterLayerTraits.

    Controls the tile update interval for a layer in leaflet view.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
