### PR TITLE
Fix styling of WFS and GeoRSS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Merged the `StyleSelector` and `DimensionsSelector`, and created a `SelectableDimensions` interface.
 * Added `chartColor` trait for DiscretelyTimeVarying items.
 * Replaced all instances of `createInfoSection` and `newInfo` with calls to `createStratumInstance` using an initialisation object.
+* Fix styling of WFS and GeoRSS.
 * [The next improvement]
 
 #### 8.0.0-alpha.46

--- a/lib/Models/GeoJsonCatalogItem.ts
+++ b/lib/Models/GeoJsonCatalogItem.ts
@@ -76,6 +76,13 @@ class GeoJsonCatalogItem extends AsyncMappableMixin(
     this._geoJsonFile = file;
   }
 
+  @computed get name() {
+    if (CatalogMemberMixin.isMixedInto(this.sourceReference)) {
+      return super.name || this.sourceReference.name;
+    }
+    return super.name;
+  }
+
   @computed
   get hasLocalData(): boolean {
     return isDefined(this._geoJsonFile);

--- a/lib/Models/GeoRssCatalogItem.ts
+++ b/lib/Models/GeoRssCatalogItem.ts
@@ -81,7 +81,7 @@ class GeoRssStratum extends LoadableStratum(GeoRssCatalogItemTraits) {
   }
 
   static async load(item: GeoRssCatalogItem) {
-    const geoJsonItem = new GeoJsonCatalogItem(createGuid(), item.terria);
+    const geoJsonItem = new GeoJsonCatalogItem(createGuid(), item.terria, item);
     geoJsonItem.setTrait(
       CommonStrata.definition,
       "clampToGround",

--- a/lib/Models/WebFeatureServiceCatalogItem.ts
+++ b/lib/Models/WebFeatureServiceCatalogItem.ts
@@ -415,7 +415,8 @@ class WebFeatureServiceCatalogItem
     runInAction(() => {
       this.geojsonCatalogItem = new GeoJsonCatalogItem(
         createGuid(),
-        this.terria
+        this.terria,
+        this
       );
 
       this.geojsonCatalogItem.setTrait(


### PR DESCRIPTION
### What this PR does

Fixes #4682

Sets the name of GeojsonCatalogItem to the `sourceReference` name if the name is not defined. The name is used to choose default styling if a style is not defined some other way.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable - Small change
-   [x] I've updated CHANGES.md with what I changed.
