### PR TITLE
Fix issue with CSV retireved from THREDDS

### DIFF
--- a/lib/Map/TableStructure.js
+++ b/lib/Map/TableStructure.js
@@ -394,6 +394,7 @@ TableStructure.fromCsv = function(csvString, result) {
     csvString += "\r\n";
   }
   var json = csv.toArrays(csvString, {
+    delimiter: "|",
     onParseValue: castToScalar
   });
   // Remove any blank lines. Completely blank lines come back as [null]; lines with no entries as [null, null, ..., null].


### PR DESCRIPTION
### What this PR does

Fixes #4665 

header of CSV returned from THREDDS contain `"` caracter that are
seen as "delimiter" by default and cause the csv parsing to crash.
Extensive descritpion and related conversation can be seen looking at the issue #4665 

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
I didn't do any change in functionalities or modified any function. I just passed a different delimiter as input to the parser function.
-   [ ] I've updated CHANGES.md with what I changed.
