### PR TITLE
added reverseColorOrder to ColorPalette

### DIFF
--- a/lib/Table/ColorPalette.ts
+++ b/lib/Table/ColorPalette.ts
@@ -59,4 +59,8 @@ export default class ColorPalette {
   selectColor(index: number): Color {
     return this._colors[index % this._colors.length];
   }
+  
+  reverseColorOrder(): void {
+    this._colors.reverse();
+  }
 }

--- a/lib/Table/ColorPalette.ts
+++ b/lib/Table/ColorPalette.ts
@@ -59,7 +59,7 @@ export default class ColorPalette {
   selectColor(index: number): Color {
     return this._colors[index % this._colors.length];
   }
-  
+
   reverseColorOrder(): void {
     this._colors.reverse();
   }


### PR DESCRIPTION
### What this PR does

The world's tiniest PR to let  you reverse the colours in a palette without having to reach into the private ._colors member in the class.

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~ TOO TINY
-   [ ] ~I've updated CHANGES.md with what I changed.~ TOO TINY