### PR TITLE
Fix remove all bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Replaced all instances of `createInfoSection` and `newInfo` with calls to `createStratumInstance` using an initialisation object.
 * Fix styling of WFS and GeoRSS.
 * Fixed a bug that caused re-rendering of xAxis of charts on mouse move. Chart cursor should be somewhat faster as a result of this fix.
+* Fixed a bug that caused some catalogue items to remain on the map after clicking "Remove all" on the workbench.
 * [The next improvement]
 
 #### 8.0.0-alpha.46

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -527,6 +527,7 @@ export default class Cesium extends GlobeOrMap {
         const d = dataSources.get(i);
         if (allDataSources.indexOf(d) === -1) {
           dataSources.remove(d);
+          --i;
         }
       }
 

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -371,6 +371,7 @@ export default class Leaflet extends GlobeOrMap {
         const d = dataSources.get(i);
         if (allDataSources.indexOf(d) === -1) {
           dataSources.remove(d);
+          --i;
         }
       }
 


### PR DESCRIPTION
### What this PR does

Fixes #4342

In the `observeModelLayer` (in Cesium.ts and Leaflet.ts), the for loop is removing catalogue items from the globe without updating the indices in the process so some of the items are skipped in the process, and this PR fixes that

Tried on the share links posted on the issues page:
* http://ci.terria.io/fix-remove-all-bug/#share=s-wRuUNPqGylt0zdxlPf2OulrqIGg
* http://ci.terria.io/fix-remove-all-bug/#share=s-8JkiUGTmZw64CwrkOCrgPp1EnEb

### Checklist

-   [x] It's a small fix and I imagine there would already be unit tests that already cover that 
-   [x] I've updated CHANGES.md with what I changed.
