### PR TITLE
add short report for esri feature server when exceeding  limit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Fix styling of WFS and GeoRSS.
 * Fixed a bug that caused re-rendering of xAxis of charts on mouse move. Chart cursor should be somewhat faster as a result of this fix.
 * Fixed a bug that caused some catalogue items to remain on the map after clicking "Remove all" on the workbench.
+* Add short report to `ArcGisFeatureServerItem` for exceeding the feature limit.
 * [The next improvement]
 
 #### 8.0.0-alpha.46

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -764,6 +764,7 @@
       "missingUrlMessage": "Could not load the ArcGis FeatureServer endpoint because the catalog item does not have a `url`.",
       "invalidServiceTitle": "Invalid ArcGIS Feature Service layer",
       "invalidServiceMessage": "An error occurred while invoking the ArcGIS Feature Service.  The server's response does not appear to be a valid Feature Service layer.",
+      "reachedMaxFeatureLimit": "Warning: This layer has reached the FeatureService feature limit.",
       "unusableMetadataTitle": "ArcGIS FeatureServer Error",
       "unusableMetadataDefaultMessage": "This dataset returned unusable metadata."
     },


### PR DESCRIPTION
### What this PR does

This PR adds a short report to esri-featureServer items if the response only contains a portion of the available features. By default most esri feature services only return 1000 features.

See this example which has one feature with the warning, and one without
http://ci.terria.io/feature-server-limit/#share=s-tMnlk8spb2igWcPeaSfjwzapL2f

![Screen_2020_09_04](https://user-images.githubusercontent.com/6735870/92198373-8b32a780-eeb7-11ea-969a-d5076d6b88b2.jpg)


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
