### PR TITLE
Bump version to release v8.0.0-alpha.47

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.47)
+* [The next improvement]
+
+#### 8.0.0-alpha.47
 * Removed hard coded senaps base url.
 * Added option for manual Table region mapping with `enableManualRegionMapping` TableTrait. This provides `SelectableDimensions` for the region column and region type.
 * Added WMS Dimensions (using `SelectableDimensions`)
@@ -19,7 +22,6 @@ Change Log
 * Moved `DiscretelyTimeVaryingMixin` from `TableAutomaticStylesStratum` to `TableMixin`
 * Added basic region-mapping time support
 * Add short report to `ArcGisFeatureServerItem` for exceeding the feature limit.
-* [The next improvement]
 
 #### 8.0.0-alpha.46
 * Fixed i18n initialisation for magda based configurations

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Change Log
 
 ### MobX Development
 
-#### next release (8.0.0-alpha.47)
+#### next release (8.0.0-alpha.48)
 * [The next improvement]
 
 #### 8.0.0-alpha.47
@@ -22,6 +22,7 @@ Change Log
 * Moved `DiscretelyTimeVaryingMixin` from `TableAutomaticStylesStratum` to `TableMixin`
 * Added basic region-mapping time support
 * Add short report to `ArcGisFeatureServerItem` for exceeding the feature limit.
+* Added shift-drag quick zoom
 
 #### 8.0.0-alpha.46
 * Fixed i18n initialisation for magda based configurations
@@ -32,7 +33,6 @@ Change Log
 * Add basic WFS support with `WebFeatureServiceCatalogGroup` and `WebFeatureServiceCatalogItem`
 * Update style of diff tool close button to match new design
 * Remove sass code from the `HelpPanel` component
-* Added shift-drag quick zoom
 * Added an option for translation override from TerriaMap
 * Help content, trainer bar & help terms can use translation overrides
 * Accepts `backend` options under a new `terria.start()` property, `i18nOptions`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.0.0-alpha.46",
+  "version": "8.0.0-alpha.47",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### What this PR does

This PR releases v8.0.0-alpha.47


### Checklist

-   [x] I've updated CHANGES.md with what I changed.
