### PR TITLE
ArcGisPortalCatalogGroup and ArcGisPortalItemReference cache and sorting enhancements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.48)
+* Allow `cacheDuration` to be set on `ArcGisPortalCatalogGroup` and `ArcGisPortalItemReference`.
+* Set default `ArcGisPortalCatalogGroup` item sorting by title using REST API parameter.
 * [The next improvement]
 
 #### 8.0.0-alpha.47

--- a/lib/Models/ArcGisPortalCatalogGroup.ts
+++ b/lib/Models/ArcGisPortalCatalogGroup.ts
@@ -354,6 +354,14 @@ export default class ArcGisPortalCatalogGroup extends UrlMixin(
     return i18next.t("models.arcgisPortal.nameGroup");
   }
 
+  @computed
+  get cacheDuration(): string {
+    if (isDefined(super.cacheDuration)) {
+      return super.cacheDuration;
+    }
+    return "0d";
+  }
+
   protected forceLoadMetadata(): Promise<void> {
     const portalStratum = <ArcGisPortalStratum | undefined>(
       this.strata.get(ArcGisPortalStratum.stratumName)
@@ -472,7 +480,11 @@ async function getPortalInformation(
 ) {
   try {
     const response = await loadJson(
-      proxyCatalogItemUrl(catalogGroup, uri.toString(), "1d")
+      proxyCatalogItemUrl(
+        catalogGroup,
+        uri.toString(),
+        catalogGroup.cacheDuration
+      )
     );
     return response;
   } catch (err) {

--- a/lib/Models/ArcGisPortalItemReference.ts
+++ b/lib/Models/ArcGisPortalItemReference.ts
@@ -2,6 +2,7 @@ import i18next from "i18next";
 import { runInAction, computed } from "mobx";
 import { createTransformer } from "mobx-utils";
 import filterOutUndefined from "../Core/filterOutUndefined";
+import isDefined from "../Core/isDefined";
 import URI from "urijs";
 import {
   isJsonObject,
@@ -266,6 +267,16 @@ export default class ArcGisPortalItemReference extends UrlMixin(
   }
 
   @computed
+  get cacheDuration(): string {
+    if (isDefined(super.cacheDuration)) {
+      return super.cacheDuration;
+    } else if (isDefined(this._arcgisPortalCatalogGroup)) {
+      return this._arcgisPortalCatalogGroup.cacheDuration;
+    }
+    return "0d";
+  }
+
+  @computed
   get preparedSupportedFormats(): PreparedSupportedFormat[] {
     return (
       this.supportedFormats && this.supportedFormats.map(prepareSupportedFormat)
@@ -417,7 +428,7 @@ async function loadPortalItem(portalItem: ArcGisPortalItemReference) {
     .addQuery({ f: "json" });
 
   const response: ArcGisItem = await loadJson(
-    proxyCatalogItemUrl(portalItem, uri.toString(), "1d")
+    proxyCatalogItemUrl(portalItem, uri.toString(), portalItem.cacheDuration)
   );
   return response;
 }
@@ -436,7 +447,7 @@ async function loadAdditionalPortalInfo(portalItem: ArcGisPortalItemReference) {
   // Sometimes it actually returns json containing an error, but not always
   try {
     const response: ArcGisItemInfo = await loadJson(
-      proxyCatalogItemUrl(portalItem, uri.toString(), "1d")
+      proxyCatalogItemUrl(portalItem, uri.toString(), portalItem.cacheDuration)
     );
     return response;
   } catch (err) {

--- a/lib/Traits/ArcGisPortalCatalogGroupTraits.ts
+++ b/lib/Traits/ArcGisPortalCatalogGroupTraits.ts
@@ -32,7 +32,8 @@ export default class ArcGisPortalCatalogGroupTraits extends mixTraits(
          type:"Map Service" OR
          type:"WMS" OR
          type:"WFS" OR
-         type:"KML")`
+         type:"KML")`,
+    sortField: "title"
   };
 
   @anyTrait({


### PR DESCRIPTION
### What this PR does

- Add cacheDuration trait to `ArcGisPortalCatalogGroup` and `ArcGisPortalItemReference`. Default to `0d` but overridable via config.
- Enable sorting of item `title` within `ArcGisPortalCatalogGroup` using the [ArcGIS REST API ](https://developers.arcgis.com/rest/users-groups-and-items/search.htm
)


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
