### PR TITLE
Fix for WMS GetFeatureInfo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,14 +4,14 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.49)
-
+* WMS GetFeatureInfo fix to ensure `style=undefined` is not sent to server
+* [The next improvement]
 
 #### 8.0.0-alpha.48
 * Allow `cacheDuration` to be set on `ArcGisPortalCatalogGroup` and `ArcGisPortalItemReference`.
 * Set default `ArcGisPortalCatalogGroup` item sorting by title using REST API parameter.
 * Call `registerCatalogMembers` before running tests and remove manual calls to `CatalogMemberFactory.register` and `UrlMapping.register` in various tests so that tests reflect the way the library is used.
 * Updated stratum definitions which used hardcoded string to use `CommonStrata` values.
-* [The next improvement]
 
 #### 8.0.0-alpha.47
 * Removed hard coded senaps base url.

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -916,7 +916,7 @@ class WebMapServiceCatalogItem
         parameters: parameters,
         getFeatureInfoParameters: {
           ...dimensionParameters,
-          styles: this.styles
+          styles: this.styles === undefined ? "" : this.styles
         },
         tilingScheme: /*defined(this.tilingScheme) ? this.tilingScheme :*/ new WebMercatorTilingScheme(),
         maximumLevel: maximumLevel,


### PR DESCRIPTION
### What this PR does

Ensure styles=undefined isn't sent to the server for GetFeatureInfo requests with WMS.

See this broken example in `next` by clicking on the WMS
http://ci.terria.io/next/#share=s-nXqxSC877lOzu7zuca2Z5EY2LNW


### Checklist

-   [x] No tests, trivial change
-   [x] I've updated CHANGES.md with what I changed.
