### PR TITLE
Fix a bug in auto-detected user added data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.50)
+* Fixed a bug causing users to be brought back to the Data Catalogue tab when clicking on an auto-detected user added catalogue item.
+* Fixed a bug causing Data Preview to not appear under the My Data tab.
 * [The next improvement]
 
 #### 8.0.0-alpha.49

--- a/lib/Models/createUrlReferenceFromUrl.ts
+++ b/lib/Models/createUrlReferenceFromUrl.ts
@@ -28,6 +28,8 @@ export default function createUrlReferenceFromUrl(
     return Promise.resolve(undefined);
   }
 
+  terria.catalog.userAddedDataGroup.add(CommonStrata.user, item);
+
   return item.loadReference().then(() => {
     if (item.target !== undefined) {
       return Promise.resolve(item);

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -4,6 +4,7 @@ import { observer } from "mobx-react";
 import classNames from "classnames";
 import createReactClass from "create-react-class";
 import Icon from "../../../Icon.jsx";
+import Box from "../../../../Styled/Box.jsx";
 import PropTypes from "prop-types";
 
 import DataCatalog from "../../../DataCatalog/DataCatalog.jsx";
@@ -125,7 +126,7 @@ const MyDataTab = observer(
       const showTwoColumn = this.hasUserAddedData() & !this.state.activeTab;
       const { t } = this.props;
       return (
-        <div className={Styles.root}>
+        <Box className={Styles.root}>
           <div
             className={classNames({
               [Styles.leftCol]: showTwoColumn,
@@ -162,7 +163,7 @@ const MyDataTab = observer(
               />
             </If>
             <If condition={showTwoColumn}>
-              <div className={Styles.addedData}>
+              <Box flexShrinkZero column>
                 <p className={Styles.explanation}>
                   <Trans i18nKey="addData.note">
                     <strong>Note: </strong>Data added in this way is not saved
@@ -181,18 +182,20 @@ const MyDataTab = observer(
                     terria={this.props.terria}
                   />
                 </ul>
-              </div>
+              </Box>
             </If>
             <If condition={!this.state.activeTab}>{this.renderPromptBox()}</If>
           </div>
           <If condition={showTwoColumn}>
-            <DataPreview
-              terria={this.props.terria}
-              viewState={this.props.viewState}
-              previewed={this.props.viewState.userDataPreviewedItem}
-            />
+            <Box styledWidth="60%" wordBreak="break-all">
+              <DataPreview
+                terria={this.props.terria}
+                viewState={this.props.viewState}
+                previewed={this.props.viewState.userDataPreviewedItem}
+              />
+            </Box>
           </If>
-        </div>
+        </Box>
       );
     }
   })

--- a/test/Models/createUrlReferenceFromUrlSpec.ts
+++ b/test/Models/createUrlReferenceFromUrlSpec.ts
@@ -9,6 +9,7 @@ import Terria from "../../lib/Models/Terria";
 import UrlReference from "../../lib/Models/UrlReference";
 import WebMapServiceCatalogGroup from "../../lib/Models/WebMapServiceCatalogGroup";
 import ViewState from "../../lib/ReactViewModels/ViewState";
+import { USER_ADDED_CATEGORY_ID } from "../../lib/Core/addedByUser";
 
 const Water_Network = {
   layerDefs: JSON.stringify(
@@ -77,6 +78,15 @@ describe("createUrlReferenceFromUrl", function() {
     expect(item).toBeDefined();
     if (item !== undefined) {
       expect(item instanceof CsvCatalogItem).toBe(true);
+    }
+  });
+
+  it("should create an item that has the user-added data unique id in its knownContainerUniqueIds", async function() {
+    const url = "test/csv/lat_lon_val.csv";
+    const item = await createUrlReferenceFromUrl(url, terria, true);
+    expect(item).toBeDefined();
+    if (item !== undefined) {
+      expect(item.knownContainerUniqueIds.includes(USER_ADDED_CATEGORY_ID));
     }
   });
 

--- a/test/Models/createUrlReferenceFromUrlSpec.ts
+++ b/test/Models/createUrlReferenceFromUrlSpec.ts
@@ -81,7 +81,7 @@ describe("createUrlReferenceFromUrl", function() {
     }
   });
 
-  it("should create an item that has the user-added data unique id in its knownContainerUniqueIds", async function() {
+  it("should create an item that has the USER_ADDED_CATEGORY_ID in its knownContainerUniqueIds", async function() {
     const url = "test/csv/lat_lon_val.csv";
     const item = await createUrlReferenceFromUrl(url, terria, true);
     expect(item).toBeDefined();


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs/issues/4285 (the bug that causes changing tabs)

After some investigation the main cause of the problem is described below:
* When adding a data using from a web service using the auto-detect feature, a `UrlCatalogItem` is created. We then treat this `UrlCatalogItem` as a reference item and so the `loadReferences` function gets called. This (sort of?) wraps a proper catalog item (in my case `WMSCatalogItem`) around it and so we now treat it as `WMSCatalogItem`
* The way we detect whether or not a catalogue item is "added by a user" is by checking its `knownContainerUniqueIds` property in the `sourceReference` **if it exists**, or otherwise the catalogue item itself. If it contains the value `__User-Added_Data__` then it is declared a catalogue item that is "added by user". 
* The main problem is when we first create the catalogue item, the `__User-Added_Data` is added to `knownContainerUniqueIds` at the `WMSCatalogItem` level and not the `UrlCatalogItem` level. So when we perform the check whether or not the catalogue item is "added by user" it looks at the `knownContainerUniqueIds` property in the `sourceReference` (which is `UrlCatalogItem`) and finds that the `__User-Added_Data__`  value is not there, and so declares the catalogue item as not added by user. Hence the flicking back to the "Data Catalog" tab.
* I added a fix so that upon creating every new `UrlCatalogItem` the `__User-Added_Data__` value is added to its `knownContainerUniqueIds` property, before calling `loadReference`. 
* Apart from that I also fixed the layout of the Data Preview tab of the My Data tab because it was previously not showing anything

### Checklist

-   [x] There are unit tests to verify my changes are correct ~~or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~~
-   [x] I've updated CHANGES.md with what I changed.
