### PR TITLE
Fix crash when using stroke-opacity with GeoJSON

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 ### Next Release
 
+* Fixed a crash with GeoJsonCatalogItem when you set a `stroke-opacity` in `styles`.
 
 ### v7.11.11
 

--- a/lib/Models/GeoJsonCatalogItem.js
+++ b/lib/Models/GeoJsonCatalogItem.js
@@ -530,7 +530,8 @@ function loadGeoJson(geoJsonItem) {
 
   options.fill = defaultColor(style.fill, (geoJsonItem.name || "") + " fill");
   if (defined(style["stroke-opacity"])) {
-    options.stroke.alpha = parseFloat(style["stroke-opacity"]);
+    options.polygonStroke.alpha = parseFloat(style["stroke-opacity"]);
+    options.polylineStroke.alpha = parseFloat(style["stroke-opacity"]);
   }
   if (defined(style["fill-opacity"])) {
     options.fill.alpha = parseFloat(style["fill-opacity"]);


### PR DESCRIPTION
### What this PR does

Fixes a crash with GeoJsonCatalogItem and "stroke-opacity". 

E.g. add "GeoJSON with stroke-opacity" to the map in the following:
http://ci.terria.io/steve9164-patch-1/#clean&https://gist.githubusercontent.com/steve9164/f00c5d8c54f1f2381e4e3b836d594400/raw/733747a468da1ab04477a791c3c2ffe27df0ec69/geojson-catalog.json

http://ci.terria.io/master/#clean&https://gist.githubusercontent.com/steve9164/f00c5d8c54f1f2381e4e3b836d594400/raw/733747a468da1ab04477a791c3c2ffe27df0ec69/geojson-catalog.json

There's still some weirdness when you change the opacity slider, but ¯\\\_(ツ)\_/¯ at least it doesn't crash.

### Checklist

-   [x] Version 7, so no updated tests.
-   [x] I've updated CHANGES.md with what I changed.
