### PR TITLE
Fix WMS style DimensionSelector for layers with no styles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.50)
+* Fix WMS style `DimensionSelector` for layers with no styles
 * [The next improvement]
 
 #### 8.0.0-alpha.49

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -1010,7 +1010,7 @@ class WebMapServiceCatalogItem
         // Set selectedId to value stored in `styles` trait for this `layerIndex` or the first available style value
         // The `styles` parameter is CSV, a style for each layer
         selectedId:
-          this.styles?.split(",")?.[layerIndex] || layer.styles[0].name,
+          this.styles?.split(",")?.[layerIndex] || layer.styles[0]?.name,
 
         setDimensionValue: (stratumId: string, newStyle: string) => {
           runInAction(() => {


### PR DESCRIPTION
### Fix WMS style `DimensionSelector` for layers with no styles

Fixes #4753 

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
