### PR TITLE
Update leaflet attribution style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### next release (8.0.0-alpha.50)
 * Fix WMS style `DimensionSelector` for layers with no styles
+* Updated leaflet attribution to match the style of cesium credits.
 * [The next improvement]
 
 #### 8.0.0-alpha.49

--- a/lib/ReactViews/Map/terria-viewer-wrapper.scss
+++ b/lib/ReactViews/Map/terria-viewer-wrapper.scss
@@ -72,12 +72,20 @@
       #terriaLogo {
         vertical-align: middle;
       }
+
+      .leaflet-bottom {
+        font-size: $font-size-credits;
+
+        font-family: $font-base;
+        opacity: 0.75;
+        background: linear-gradient(180deg, #000000 0%, #000000 100%);
+        width: 100%;
+      }
+
       .leaflet-control-attribution {
-        line-height: 1em;
+        line-height: 30px;
         background: none;
-        color: white;
-        position: relative;
-        bottom: 10px;
+        color: rgba(#fff, 0.8);
         #terriaLogoWrapper {
           display: block;
         }

--- a/lib/ReactViews/Map/terria-viewer-wrapper.scss
+++ b/lib/ReactViews/Map/terria-viewer-wrapper.scss
@@ -75,11 +75,16 @@
 
       .leaflet-bottom {
         font-size: $font-size-credits;
-
         font-family: $font-base;
+
         opacity: 0.75;
         background: linear-gradient(180deg, #000000 0%, #000000 100%);
         width: 100%;
+
+        a {
+          color: #fff;
+          text-decoration: underline;
+        }
       }
 
       .leaflet-control-attribution {


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Update the style of leaflet attribution to match the style of the cesium credits (background, height and color)

### Checklist

-   [x] Visual change, tests not needed
-   [x] I've updated CHANGES.md with what I changed.
