### PR TITLE
Upgrade to cesium v1.73 and prepare for release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 Change Log
 ==========
 
-### Next Release
+### v7.11.12
 
 * Fixed a crash with GeoJsonCatalogItem when you set a `stroke-opacity` in `styles`.
+* Upgraded to Cesium v1.73.
+* Removed any references to `BingMapsApi` (now deprecated).
 
 ### v7.11.11
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,14 @@
 Change Log
 ==========
 
+### v7.11.13
+
+* Upgraded to Cesium v1.73.
+* Removed any references to `BingMapsApi` (now deprecated).
+
 ### v7.11.12
 
 * Fixed a crash with GeoJsonCatalogItem when you set a `stroke-opacity` in `styles`.
-* Upgraded to Cesium v1.73.
-* Removed any references to `BingMapsApi` (now deprecated).
 
 ### v7.11.11
 

--- a/lib/ViewModels/BingMapsSearchProviderViewModel.js
+++ b/lib/ViewModels/BingMapsSearchProviderViewModel.js
@@ -5,7 +5,6 @@ var inherit = require("../Core/inherit");
 var SearchProviderViewModel = require("./SearchProviderViewModel");
 var SearchResultViewModel = require("./SearchResultViewModel");
 
-var BingMapsApi = require("terriajs-cesium/Source/Core/BingMapsApi").default;
 var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
@@ -28,7 +27,7 @@ var BingMapsSearchProviderViewModel = function(options) {
   if (this.url.length > 0 && this.url[this.url.length - 1] !== "/") {
     this.url += "/";
   }
-  this.key = BingMapsApi.getKey(options.key);
+  this.key = options.key;
   this.flightDurationSeconds = defaultValue(options.flightDurationSeconds, 1.5);
   this.primaryCountry = defaultValue(options.primaryCountry, "Australia");
   this.culture = defaultValue(options.culture, "en-au");

--- a/lib/ViewModels/TerriaViewer.js
+++ b/lib/ViewModels/TerriaViewer.js
@@ -6,7 +6,6 @@
 "use strict";
 
 /*global require,console*/
-var BingMapsApi = require("terriajs-cesium/Source/Core/BingMapsApi").default;
 var Cartesian3 = require("terriajs-cesium/Source/Core/Cartesian3").default;
 //var Cesium = require('../Models/Cesium');
 var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
@@ -57,9 +56,6 @@ var ViewerMode = require("../Models/ViewerMode");
 var NoViewer = require("../Models/NoViewer");
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
 import i18next from "i18next";
-
-//use our own bing maps key
-BingMapsApi.defaultKey = undefined;
 
 // Make Cesium think pixelated image rendering is supported, always.
 // As a result, Cesium will honor the devicePixelRatio even in browsers (IE) that don't

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "7.11.11",
+  "version": "7.11.12",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "7.11.12",
+  "version": "7.11.13",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "string-replace-webpack-plugin": "^0.1.3",
     "style-loader": "^0.23.1",
     "svg-sprite-loader": "4.1.3",
-    "terriajs-cesium": "1.71.3",
+    "terriajs-cesium": "1.73.0",
     "terriajs-html2canvas": "1.0.0-alpha.12-terriajs-1",
     "urijs": "^1.18.12",
     "url-loader": "^1.1.2",


### PR DESCRIPTION
### What this PR does

Partially fixes https://github.com/TerriaJS/terriajs/issues/4722

Removed references to `BingMapsApi` (deprecated as of v1.72). Updated terriajs-cesium version and prepare terriajs for release

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
