### PR TITLE
Update GtfsCatalogItem to use AutoRefreshingMixin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Change Log
 #### next release (8.0.0-alpha.51)
 * Fix story prompt being permanent/un-dismissable
 * Fixed a bug that caused the feature info chart for SOS items to not load.
+* Update the `GtfsCatalogItem` to use the `AutoRefreshingMixin`.
+* Add a condition to the `AutoRefreshingMixin` to prevent unnecessary polling when an item is disabled in the workbench.
 * [The next improvement]
 
 #### 8.0.0-alpha.50

--- a/lib/ModelMixins/AutoRefreshingMixin.ts
+++ b/lib/ModelMixins/AutoRefreshingMixin.ts
@@ -49,7 +49,7 @@ export default function AutoRefreshingMixin<
         this.autoRefreshDisposer = reaction(
           () => this._pollingTimer,
           () => {
-            this.refreshData();
+            if (this.show) this.refreshData();
           }
         );
       }

--- a/lib/Models/GtfsCatalogItem.ts
+++ b/lib/Models/GtfsCatalogItem.ts
@@ -308,11 +308,13 @@ export default class GtfsCatalogItem extends AsyncMappableMixin(
   }
 
   protected forceLoadMapItems(): Promise<void> {
-    GtfsStratum.load(this).then(stratum => {
-      runInAction(() => {
-        this.strata.set(GtfsStratum.stratumName, stratum);
+    if (this.strata.get(GtfsStratum.stratumName) === undefined) {
+      GtfsStratum.load(this).then(stratum => {
+        runInAction(() => {
+          this.strata.set(GtfsStratum.stratumName, stratum);
+        });
       });
-    });
+    }
     const promise: Promise<void> = this.retrieveData()
       .then((data: FeedMessage) => {
         runInAction(() => {

--- a/lib/Models/GtfsCatalogItem.ts
+++ b/lib/Models/GtfsCatalogItem.ts
@@ -1,12 +1,4 @@
-import {
-  computed,
-  IReactionDisposer,
-  observable,
-  onBecomeObserved,
-  onBecomeUnobserved,
-  reaction,
-  runInAction
-} from "mobx";
+import { computed, IReactionDisposer, observable, runInAction } from "mobx";
 import { createTransformer, ITransformer, now } from "mobx-utils";
 import Pbf from "pbf";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";

--- a/lib/Traits/GltfCatalogItemTraits.ts
+++ b/lib/Traits/GltfCatalogItemTraits.ts
@@ -4,10 +4,12 @@ import MappableTraits from "./MappableTraits";
 import mixTraits from "./mixTraits";
 import UrlTraits from "./UrlTraits";
 import PlaceEditorTraits from "./PlaceEditorTraits";
+import AutoRefreshingTraits from "./AutoRefreshingTraits";
 
 export default class GltfCatalogItemTraits extends mixTraits(
   UrlTraits,
   MappableTraits,
+  AutoRefreshingTraits,
   CatalogMemberTraits,
   PlaceEditorTraits,
   GltfTraits


### PR DESCRIPTION
### What this PR does

Fixes #4766

This PR updates the `GtfsCatalogItem` to use the `AutoRefreshingMixin`.
It also adds a condition to the `AutoRefreshingMixin` to stop unnecessary polling when an item is disabled in the workbench.


### Checklist

-   [ ] No tests exist for either of these models or mixins currently :(
-   [x] I've updated CHANGES.md with what I changed.
