### PR TITLE
Fix up duplicating loading of GetCapabilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 #### next release (8.0.0-alpha.51)
 * Fix story prompt being permanent/un-dismissable
 * Fixed a bug that caused the feature info chart for SOS items to not load.
+* Prevent duplicate loading of GetCapabilities
 * [The next improvement]
 
 #### 8.0.0-alpha.50

--- a/lib/Models/WebFeatureServiceCatalogGroup.ts
+++ b/lib/Models/WebFeatureServiceCatalogGroup.ts
@@ -166,6 +166,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
         layerId,
         this.catalogGroup.terria
       );
+      model.createGetCapabilitiesStratumFromParent(this.capabilities);
       this.catalogGroup.terria.addModel(model);
     } else {
       model = existingModel;
@@ -226,6 +227,11 @@ export default class WebFeatureServiceCatalogGroup extends GetCapabilitiesMixin(
   }
 
   protected forceLoadMetadata(): Promise<void> {
+    if (
+      this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName) !==
+      undefined
+    )
+      return Promise.resolve();
     return GetCapabilitiesStratum.load(this).then(stratum => {
       runInAction(() => {
         this.strata.set(

--- a/lib/Models/WebFeatureServiceCatalogGroup.ts
+++ b/lib/Models/WebFeatureServiceCatalogGroup.ts
@@ -162,7 +162,6 @@ class GetCapabilitiesStratum extends LoadableStratum(
         layerId,
         this.catalogGroup.terria
       );
-      model.createGetCapabilitiesStratumFromParent(this.capabilities);
 
       this.catalogGroup.terria.addModel(model);
     } else {
@@ -200,6 +199,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
       "isExperiencingIssues",
       this.catalogGroup.isExperiencingIssues
     );
+    model.createGetCapabilitiesStratumFromParent(this.capabilities);
   }
 
   getLayerId(layer: FeatureType) {

--- a/lib/Models/WebFeatureServiceCatalogItem.ts
+++ b/lib/Models/WebFeatureServiceCatalogItem.ts
@@ -65,6 +65,13 @@ class GetCapabilitiesStratum extends LoadableStratum(
     );
   }
 
+  static createFromParent(
+    catalogItem: WebFeatureServiceCatalogItem,
+    capabilities: WebFeatureServiceCapabilities
+  ): GetCapabilitiesStratum {
+    return new GetCapabilitiesStratum(catalogItem, capabilities);
+  }
+
   constructor(
     readonly catalogItem: WebFeatureServiceCatalogItem,
     readonly capabilities: WebFeatureServiceCapabilities
@@ -300,7 +307,21 @@ class WebFeatureServiceCatalogItem
     }
   }
 
+  createGetCapabilitiesStratumFromParent(
+    capabilities: WebFeatureServiceCapabilities
+  ) {
+    const stratum = GetCapabilitiesStratum.createFromParent(this, capabilities);
+    runInAction(() => {
+      this.strata.set(GetCapabilitiesMixin.getCapabilitiesStratumName, stratum);
+    });
+  }
+
   protected forceLoadMetadata(): Promise<void> {
+    if (
+      this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName) !==
+      undefined
+    )
+      return Promise.resolve();
     return GetCapabilitiesStratum.load(this).then(stratum => {
       runInAction(() => {
         this.strata.set(

--- a/lib/Models/WebFeatureServiceCatalogItem.ts
+++ b/lib/Models/WebFeatureServiceCatalogItem.ts
@@ -292,10 +292,10 @@ class WebFeatureServiceCatalogItem extends ExportableMixin(
     }
   }
 
-  createGetCapabilitiesStratumFromParent(
+  async createGetCapabilitiesStratumFromParent(
     capabilities: WebFeatureServiceCapabilities
   ) {
-    const stratum = GetCapabilitiesStratum.load(this, capabilities);
+    const stratum = await GetCapabilitiesStratum.load(this, capabilities);
     runInAction(() => {
       this.strata.set(GetCapabilitiesMixin.getCapabilitiesStratumName, stratum);
     });

--- a/lib/Models/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/WebMapServiceCatalogGroup.ts
@@ -235,6 +235,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
     let model: WebMapServiceCatalogItem;
     if (existingModel === undefined) {
       model = new WebMapServiceCatalogItem(layerId, this.catalogGroup.terria);
+      model.createGetCapabilitiesStratumFromParent(this.capabilities);
       this.catalogGroup.terria.addModel(model);
     } else {
       model = existingModel;
@@ -298,6 +299,11 @@ export default class WebMapServiceCatalogGroup extends GetCapabilitiesMixin(
   }
 
   protected forceLoadMetadata(): Promise<void> {
+    if (
+      this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName) !==
+      undefined
+    )
+      return Promise.resolve();
     return GetCapabilitiesStratum.load(this).then(stratum => {
       runInAction(() => {
         this.strata.set(

--- a/lib/Models/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/WebMapServiceCatalogGroup.ts
@@ -231,7 +231,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
     let model: WebMapServiceCatalogItem;
     if (existingModel === undefined) {
       model = new WebMapServiceCatalogItem(layerId, this.catalogGroup.terria);
-      model.createGetCapabilitiesStratumFromParent(this.capabilities);
+
       this.catalogGroup.terria.addModel(model);
     } else {
       model = existingModel;
@@ -273,6 +273,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
       "hideLegendInWorkbench",
       this.catalogGroup.hideLegendInWorkbench
     );
+    model.createGetCapabilitiesStratumFromParent(this.capabilities);
   }
 
   getLayerId(layer: CapabilitiesLayer) {

--- a/lib/Models/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/WebMapServiceCatalogGroup.ts
@@ -29,28 +29,24 @@ import WebMapServiceCatalogItem from "./WebMapServiceCatalogItem";
 class GetCapabilitiesStratum extends LoadableStratum(
   WebMapServiceCatalogGroupTraits
 ) {
-  static load(
+  static async load(
     catalogItem: WebMapServiceCatalogGroup
   ): Promise<GetCapabilitiesStratum> {
     if (catalogItem.getCapabilitiesUrl === undefined) {
-      return Promise.reject(
-        new TerriaError({
-          title: i18next.t("models.webMapServiceCatalogGroup.missingUrlTitle"),
-          message: i18next.t(
-            "models.webMapServiceCatalogGroup.missingUrlMessage"
-          )
-        })
-      );
+      throw new TerriaError({
+        title: i18next.t("models.webMapServiceCatalogGroup.missingUrlTitle"),
+        message: i18next.t("models.webMapServiceCatalogGroup.missingUrlMessage")
+      });
     }
 
-    const proxiedUrl = proxyCatalogItemUrl(
-      catalogItem,
-      catalogItem.getCapabilitiesUrl,
-      catalogItem.getCapabilitiesCacheDuration
+    const capabilities = await WebMapServiceCapabilities.fromUrl(
+      proxyCatalogItemUrl(
+        catalogItem,
+        catalogItem.getCapabilitiesUrl,
+        catalogItem.getCapabilitiesCacheDuration
+      )
     );
-    return WebMapServiceCapabilities.fromUrl(proxiedUrl).then(capabilities => {
-      return new GetCapabilitiesStratum(catalogItem, capabilities);
-    });
+    return new GetCapabilitiesStratum(catalogItem, capabilities);
   }
 
   constructor(
@@ -298,31 +294,26 @@ export default class WebMapServiceCatalogGroup extends GetCapabilitiesMixin(
     return WebMapServiceCatalogGroup.type;
   }
 
-  protected forceLoadMetadata(): Promise<void> {
+  protected async forceLoadMetadata(): Promise<void> {
     if (
       this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName) !==
       undefined
     )
-      return Promise.resolve();
-    return GetCapabilitiesStratum.load(this).then(stratum => {
-      runInAction(() => {
-        this.strata.set(
-          GetCapabilitiesMixin.getCapabilitiesStratumName,
-          stratum
-        );
-      });
+      return;
+    const stratum = await GetCapabilitiesStratum.load(this);
+    runInAction(() => {
+      this.strata.set(GetCapabilitiesMixin.getCapabilitiesStratumName, stratum);
     });
   }
 
-  protected forceLoadMembers(): Promise<void> {
-    return this.loadMetadata().then(() => {
-      const getCapabilitiesStratum = <GetCapabilitiesStratum | undefined>(
-        this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName)
-      );
-      if (getCapabilitiesStratum) {
-        getCapabilitiesStratum.createMembersFromLayers();
-      }
-    });
+  protected async forceLoadMembers(): Promise<void> {
+    await this.loadMetadata();
+    const getCapabilitiesStratum = <GetCapabilitiesStratum | undefined>(
+      this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName)
+    );
+    if (getCapabilitiesStratum) {
+      getCapabilitiesStratum.createMembersFromLayers();
+    }
   }
 
   protected get defaultGetCapabilitiesUrl(): string | undefined {

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -90,6 +90,13 @@ class GetCapabilitiesStratum extends LoadableStratum(
     });
   }
 
+  static createFromParent(
+    catalogItem: WebMapServiceCatalogItem,
+    capabilities: WebMapServiceCapabilities
+  ): GetCapabilitiesStratum {
+    return new GetCapabilitiesStratum(catalogItem, capabilities);
+  }
+
   constructor(
     readonly catalogItem: WebMapServiceCatalogItem,
     readonly capabilities: WebMapServiceCapabilities
@@ -629,7 +636,21 @@ class WebMapServiceCatalogItem
     return true;
   }
 
+  createGetCapabilitiesStratumFromParent(
+    capabilities: WebMapServiceCapabilities
+  ) {
+    const stratum = GetCapabilitiesStratum.createFromParent(this, capabilities);
+    runInAction(() => {
+      this.strata.set(GetCapabilitiesMixin.getCapabilitiesStratumName, stratum);
+    });
+  }
+
   protected forceLoadMetadata(): Promise<void> {
+    if (
+      this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName) !==
+      undefined
+    )
+      return Promise.resolve();
     return GetCapabilitiesStratum.load(this).then(stratum => {
       runInAction(() => {
         this.strata.set(

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -621,10 +621,15 @@ class WebMapServiceCatalogItem
     return WebMapServiceCatalogItem.type;
   }
 
-  createGetCapabilitiesStratumFromParent(
+  // TODO
+  get isMappable() {
+    return true;
+  }
+
+  async createGetCapabilitiesStratumFromParent(
     capabilities: WebMapServiceCapabilities
   ) {
-    const stratum = GetCapabilitiesStratum.load(this, capabilities);
+    const stratum = await GetCapabilitiesStratum.load(this, capabilities);
     runInAction(() => {
       this.strata.set(GetCapabilitiesMixin.getCapabilitiesStratumName, stratum);
     });

--- a/lib/Models/WebMapTileServiceCatalogGroup.ts
+++ b/lib/Models/WebMapTileServiceCatalogGroup.ts
@@ -27,33 +27,29 @@ import WebMapTileServiceCatalogItem from "./WebMapTileServiceCatalogItem";
 class GetCapabilitiesStratum extends LoadableStratum(
   WebMapTileServiceCatalogGroupTraits
 ) {
-  static load(
+  static async load(
     catalogItem: WebMapTileServiceCatalogGroup
   ): Promise<GetCapabilitiesStratum> {
     if (catalogItem.getCapabilitiesUrl === undefined) {
-      return Promise.reject(
-        new TerriaError({
-          title: i18next.t(
-            "models.webMapTileServiceCatalogGroup.invalidWMTSServerTitle"
-          ),
-          message: i18next.t(
-            "models.webMapTileServiceCatalogGroup.invalidWMTSServerMessage",
-            this
-          )
-        })
-      );
+      throw new TerriaError({
+        title: i18next.t(
+          "models.webMapTileServiceCatalogGroup.invalidWMTSServerTitle"
+        ),
+        message: i18next.t(
+          "models.webMapTileServiceCatalogGroup.invalidWMTSServerMessage",
+          this
+        )
+      });
     }
 
-    const proxiedUrl = proxyCatalogItemUrl(
-      catalogItem,
-      catalogItem.getCapabilitiesUrl,
-      catalogItem.getCapabilitiesCacheDuration
+    const capabilities = await WebMapTileServiceCapabilities.fromUrl(
+      proxyCatalogItemUrl(
+        catalogItem,
+        catalogItem.getCapabilitiesUrl,
+        catalogItem.getCapabilitiesCacheDuration
+      )
     );
-    return WebMapTileServiceCapabilities.fromUrl(proxiedUrl).then(
-      capabilities => {
-        return new GetCapabilitiesStratum(catalogItem, capabilities);
-      }
-    );
+    return new GetCapabilitiesStratum(catalogItem, capabilities);
   }
 
   constructor(
@@ -166,6 +162,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
         layerId,
         this.catalogGroup.terria
       );
+      model.createGetCapabilitiesStratumFromParent(this.capabilities);
       this.catalogGroup.terria.addModel(model);
     } else {
       model = existingModel;
@@ -224,26 +221,26 @@ export default class WebMapTileServiceCatalogGroup extends GetCapabilitiesMixin(
     return WebMapTileServiceCatalogGroup.type;
   }
 
-  protected forceLoadMetadata(): Promise<void> {
-    return GetCapabilitiesStratum.load(this).then(stratum => {
-      runInAction(() => {
-        this.strata.set(
-          GetCapabilitiesMixin.getCapabilitiesStratumName,
-          stratum
-        );
-      });
+  protected async forceLoadMetadata() {
+    if (
+      this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName) !==
+      undefined
+    )
+      return;
+    const stratum = await GetCapabilitiesStratum.load(this);
+    runInAction(() => {
+      this.strata.set(GetCapabilitiesMixin.getCapabilitiesStratumName, stratum);
     });
   }
 
-  protected forceLoadMembers(): Promise<void> {
-    return this.loadMetadata().then(() => {
-      const getCapabilitiesStratum = <GetCapabilitiesStratum | undefined>(
-        this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName)
-      );
-      if (getCapabilitiesStratum) {
-        getCapabilitiesStratum.createMembersFromLayers();
-      }
-    });
+  protected async forceLoadMembers(): Promise<void> {
+    await this.loadMetadata();
+    const getCapabilitiesStratum = <GetCapabilitiesStratum | undefined>(
+      this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName)
+    );
+    if (getCapabilitiesStratum) {
+      getCapabilitiesStratum.createMembersFromLayers();
+    }
   }
 
   protected get defaultGetCapabilitiesUrl(): string | undefined {

--- a/lib/Models/WebMapTileServiceCatalogGroup.ts
+++ b/lib/Models/WebMapTileServiceCatalogGroup.ts
@@ -162,7 +162,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
         layerId,
         this.catalogGroup.terria
       );
-      model.createGetCapabilitiesStratumFromParent(this.capabilities);
+
       this.catalogGroup.terria.addModel(model);
     } else {
       model = existingModel;
@@ -198,6 +198,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
       "isExperiencingIssues",
       this.catalogGroup.isExperiencingIssues
     );
+    model.createGetCapabilitiesStratumFromParent(this.capabilities);
   }
 
   getLayerId(layer: WmtsLayer) {

--- a/lib/Models/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/WebMapTileServiceCatalogItem.ts
@@ -449,10 +449,10 @@ class WebMapTileServiceCatalogItem extends AsyncMappableMixin(
     return WebMapTileServiceCatalogItem.type;
   }
 
-  createGetCapabilitiesStratumFromParent(
+  async createGetCapabilitiesStratumFromParent(
     capabilities: WebMapTileServiceCapabilities
   ) {
-    const stratum = GetCapabilitiesStratum.load(this, capabilities);
+    const stratum = await GetCapabilitiesStratum.load(this, capabilities);
     runInAction(() => {
       this.strata.set(GetCapabilitiesMixin.getCapabilitiesStratumName, stratum);
     });

--- a/lib/Models/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/WebMapTileServiceCatalogItem.ts
@@ -40,37 +40,34 @@ interface UsableTileMatrixSets {
   tileHeight: number;
 }
 
-class WmtsCapabilitiesStratum extends LoadableStratum(
+class GetCapabilitiesStratum extends LoadableStratum(
   WebMapTileServiceCatalogItemTraits
 ) {
   static stratumName = "wmtsServer";
 
-  static load(
-    catalogItem: WebMapTileServiceCatalogItem
-  ): Promise<WmtsCapabilitiesStratum> {
-    if (catalogItem.getCapabilitiesUrl === undefined) {
-      return Promise.reject(
-        new TerriaError({
-          title: i18next.t(
-            "models.webMapTileServiceCatalogItem.missingUrlTitle"
-          ),
-          message: i18next.t(
-            "models.webMapTileServiceCatalogItem.missingUrlMessage"
-          )
-        })
-      );
+  static async load(
+    catalogItem: WebMapTileServiceCatalogItem,
+    capabilities?: WebMapTileServiceCapabilities
+  ): Promise<GetCapabilitiesStratum> {
+    if (!isDefined(catalogItem.getCapabilitiesUrl)) {
+      throw new TerriaError({
+        title: i18next.t("models.webMapTileServiceCatalogItem.missingUrlTitle"),
+        message: i18next.t(
+          "models.webMapTileServiceCatalogItem.missingUrlMessage"
+        )
+      });
     }
 
-    const proxiedUrl = proxyCatalogItemUrl(
-      catalogItem,
-      catalogItem.getCapabilitiesUrl,
-      catalogItem.getCapabilitiesCacheDuration
-    );
-    return WebMapTileServiceCapabilities.fromUrl(proxiedUrl).then(
-      capabilities => {
-        return new WmtsCapabilitiesStratum(catalogItem, capabilities);
-      }
-    );
+    if (!isDefined(capabilities))
+      capabilities = await WebMapTileServiceCapabilities.fromUrl(
+        proxyCatalogItemUrl(
+          catalogItem,
+          catalogItem.getCapabilitiesUrl,
+          catalogItem.getCapabilitiesCacheDuration
+        )
+      );
+
+    return new GetCapabilitiesStratum(catalogItem, capabilities);
   }
 
   constructor(
@@ -81,7 +78,7 @@ class WmtsCapabilitiesStratum extends LoadableStratum(
   }
 
   duplicateLoadableStratum(model: BaseModel): this {
-    return new WmtsCapabilitiesStratum(
+    return new GetCapabilitiesStratum(
       model as WebMapTileServiceCatalogItem,
       this.capabilities
     ) as this;
@@ -452,14 +449,24 @@ class WebMapTileServiceCatalogItem extends AsyncMappableMixin(
     return WebMapTileServiceCatalogItem.type;
   }
 
-  protected forceLoadMetadata(): Promise<void> {
-    return WmtsCapabilitiesStratum.load(this).then(stratum => {
-      runInAction(() => {
-        this.strata.set(
-          GetCapabilitiesMixin.getCapabilitiesStratumName,
-          stratum
-        );
-      });
+  createGetCapabilitiesStratumFromParent(
+    capabilities: WebMapTileServiceCapabilities
+  ) {
+    const stratum = GetCapabilitiesStratum.load(this, capabilities);
+    runInAction(() => {
+      this.strata.set(GetCapabilitiesMixin.getCapabilitiesStratumName, stratum);
+    });
+  }
+
+  protected async forceLoadMetadata(): Promise<void> {
+    if (
+      this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName) !==
+      undefined
+    )
+      return;
+    const stratum = await GetCapabilitiesStratum.load(this);
+    runInAction(() => {
+      this.strata.set(GetCapabilitiesMixin.getCapabilitiesStratumName, stratum);
     });
   }
 
@@ -476,7 +483,7 @@ class WebMapTileServiceCatalogItem extends AsyncMappableMixin(
 
   @computed
   get imageryProvider() {
-    const stratum = <WmtsCapabilitiesStratum>(
+    const stratum = <GetCapabilitiesStratum>(
       this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName)
     );
 
@@ -582,7 +589,7 @@ class WebMapTileServiceCatalogItem extends AsyncMappableMixin(
         tileHeight: number;
       }
     | undefined {
-    const stratum = <WmtsCapabilitiesStratum>(
+    const stratum = <GetCapabilitiesStratum>(
       this.strata.get(GetCapabilitiesMixin.getCapabilitiesStratumName)
     );
     if (!this.layer) {


### PR DESCRIPTION
### What this PR does

Fixes #4740

This PR prevents the duplicate loading of GetCapabilities statements,
- The capabilities are now passed from a WebMapServiceCatalogGroup to a child WebMapServiceCatalogItem
- Capabilities are only requested when the strata doesn't already exist


### Checklist

-   [ ] Don't think tests are required but happy to be told otherwise
-   [x] I've updated CHANGES.md with what I changed.
