### PR TITLE
Bump version to publish 7.11.12

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-### Next Release
+### v7.11.12
 
 * Fixed a crash with GeoJsonCatalogItem when you set a `stroke-opacity` in `styles`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "7.11.11",
+  "version": "7.11.12",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Publish v7.11.12. This version has a bug fixed where GeoJsonCatalogItem with a "stroke-opacity" could not be loaded.
