### PR TITLE
Add support for using Title in WebMapServiceCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Create `OwsInterfaces` to reduce duplicate code across OWS servies
 * Fix story prompt being permanent/un-dismissable
 * Fixed a bug that caused the feature info chart for SOS items to not load.
+* Add support for resolving `layer` parameter from `Title` and not just `Name` in `WebMapServiceCatalogItem`.
 * [The next improvement]
 
 #### 8.0.0-alpha.50

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Change Log
 * Create `OwsInterfaces` to reduce duplicate code across OWS servies
 * Fix story prompt being permanent/un-dismissable
 * Fixed a bug that caused the feature info chart for SOS items to not load.
-* Add support for resolving `layer` parameter from `Title` and not just `Name` in `WebMapServiceCatalogItem`.
+* Add support for resolving `layers` parameter from `Title` and not just `Name` in `WebMapServiceCatalogItem`.
 * [The next improvement]
 
 #### 8.0.0-alpha.50

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -930,9 +930,19 @@ class WebMapServiceCatalogItem
         rectangle = undefined;
       }
 
+      let lyrs: any = "";
+      const gcStratum: GetCapabilitiesStratum | undefined = this.strata.get(
+        GetCapabilitiesMixin.getCapabilitiesStratumName
+      ) as GetCapabilitiesStratum;
+      if (this.layers && gcStratum !== undefined) {
+        lyrs = this.layersArray.map(
+          lyr => gcStratum.capabilities.findLayer(lyr).Name
+        );
+      }
+
       const imageryOptions = {
         url: proxyCatalogItemUrl(this, baseUrl.toString()),
-        layers: this.layers || "",
+        layers: lyrs,
         parameters: parameters,
         getFeatureInfoParameters: {
           ...dimensionParameters,

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -930,19 +930,21 @@ class WebMapServiceCatalogItem
         rectangle = undefined;
       }
 
-      let lyrs: any = "";
       const gcStratum: GetCapabilitiesStratum | undefined = this.strata.get(
         GetCapabilitiesMixin.getCapabilitiesStratumName
       ) as GetCapabilitiesStratum;
+
+      let lyrs: string[] = [];
       if (this.layers && gcStratum !== undefined) {
-        lyrs = this.layersArray.map(
-          lyr => gcStratum.capabilities.findLayer(lyr).Name
-        );
+        this.layersArray.forEach(function(lyr) {
+          const gcLayer = gcStratum.capabilities.findLayer(lyr);
+          if (gcLayer !== undefined && gcLayer.Name) lyrs.push(gcLayer.Name);
+        });
       }
 
       const imageryOptions = {
         url: proxyCatalogItemUrl(this, baseUrl.toString()),
-        layers: lyrs,
+        layers: lyrs.length > 0 ? lyrs.join(",") : "",
         parameters: parameters,
         getFeatureInfoParameters: {
           ...dimensionParameters,

--- a/test/Models/WebMapServiceCatalogItemSpec.ts
+++ b/test/Models/WebMapServiceCatalogItemSpec.ts
@@ -97,6 +97,31 @@ describe("WebMapServiceCatalogItem", function() {
     }
   });
 
+  it("constructs correct ImageryProvider when layers trait provided Title", async function() {
+    let wms: WebMapServiceCatalogItem;
+    const terria = new Terria();
+    wms = new WebMapServiceCatalogItem("test", terria);
+    runInAction(() => {
+      wms.setTrait("definition", "url", "test/WMS/wms_nested_groups.xml");
+      wms.setTrait(
+        "definition",
+        "layers",
+        "Landsat 30+ Barest Earth 25m albers (Combined Landsat)"
+      );
+    });
+    let mapItems: ImageryParts[] = [];
+    const cleanup = autorun(() => {
+      mapItems = wms.mapItems.slice();
+    });
+    try {
+      await wms.loadMetadata();
+      //@ts-ignore
+      expect(mapItems[0].imageryProvider.layers).toBe("landsat_barest_earth");
+    } finally {
+      cleanup();
+    }
+  });
+
   it("dimensions and styles for a 'real' WMS layer", function(done) {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);


### PR DESCRIPTION
### What this PR does

Fixes #4795

This PR allows the `layers` trait on a `WebMapServiceCatalogItem` to be resolved from either name or title for passing it into the `WebMapServiceImageryProvider`. Typically the `layers` trait ought to be a layer's name, however occasionally someone might accidentally set the trait as the layer title resulting in nothing being displayed on the map.


### Checklist

-   [x] Added a test
-   [x] I've updated CHANGES.md with what I changed.
