### PR TITLE
Port catalogue search from digital twins implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.53)
+* Ported an implementation of CatalogSearchProvider and set it as the default
 * [The next improvement]
 
 #### 8.0.0-alpha.52

--- a/lib/Models/CatalogSearchProvider.ts
+++ b/lib/Models/CatalogSearchProvider.ts
@@ -1,8 +1,8 @@
 import { autorun, observable, runInAction } from "mobx";
-import SearchProvider from "terriajs/lib/Models/SearchProvider";
-import SearchResult from "terriajs/lib/Models/SearchResult";
-import Terria from "terriajs/lib/Models/Terria";
-import SearchProviderResults from "terriajs/lib/Models/SearchProviderResults";
+import SearchProvider from "./SearchProvider";
+import SearchResult from "./SearchResult";
+import Terria from "./Terria";
+import SearchProviderResults from "./SearchProviderResults";
 import GroupMixin from "../ModelMixins/GroupMixin";
 import ReferenceMixin from "../ModelMixins/ReferenceMixin";
 

--- a/lib/Models/CatalogSearchProvider.ts
+++ b/lib/Models/CatalogSearchProvider.ts
@@ -1,0 +1,156 @@
+import { observable, runInAction } from "mobx";
+import SearchProvider from "terriajs/lib/Models/SearchProvider";
+import SearchResult from "terriajs/lib/Models/SearchResult";
+import Terria from "terriajs/lib/Models/Terria";
+import SearchProviderResults from "terriajs/lib/Models/SearchProviderResults";
+import GroupMixin from "../ModelMixins/GroupMixin";
+import ReferenceMixin from "../ModelMixins/ReferenceMixin";
+
+interface CatalogSearchProviderOptions {
+  terria: Terria;
+}
+
+type UniqueIdString = string;
+type ResultMap = Map<UniqueIdString, boolean>;
+export function loadAndSearchCatalogRecursively(
+  terria: Terria,
+  searchTextLowercase: string,
+  searchResults: SearchProviderResults,
+  resultMap: ResultMap,
+  iteration: number = 0
+): Promise<Terria> {
+  // checkTerriaAgainstResults(terria, searchResults)
+  // don't go further than 10 deep, but also if we have references that never
+  // resolve to a target, might overflow
+  if (iteration > 10) {
+    return Promise.resolve(terria);
+  }
+  // add some public interface for terria's `models`?
+  const referencesAndGroupsToLoad: any[] = Array.from(
+    (<any>terria).models.values()
+  ).filter((model: any) => {
+    if (resultMap.get(model.uniqueId) === undefined) {
+      const modelToSave = model.target || model;
+      // Use a flattened string of definition data later,
+      // without only checking name/id/descriptions?
+      // saveModelToJson(modelToSave, {
+      //   includeStrata: [CommonStrata.definition]
+      // });
+      const matchesString =
+        `${modelToSave.name} ${modelToSave.uniqueId} ${modelToSave.description}`
+          .toLowerCase()
+          .indexOf(searchTextLowercase) !== -1;
+      resultMap.set(model.uniqueId, matchesString);
+      if (matchesString) {
+        runInAction(() => {
+          searchResults.results.push(
+            new SearchResult({
+              name: name,
+              catalogItem: model
+            })
+          );
+        });
+      }
+    }
+
+    if (ReferenceMixin.is(model) || GroupMixin.isMixedInto(model)) {
+      return true;
+    }
+    // Could also check for loadMembers() here, but will be even slower
+    // (relies on external non-magda services to be performant)
+
+    return false;
+  });
+  if (referencesAndGroupsToLoad.length === 0) {
+    return Promise.resolve(terria);
+  }
+  return new Promise(resolve => {
+    Promise.all(
+      referencesAndGroupsToLoad.map(model => {
+        if (ReferenceMixin.is(model)) {
+          return model.loadReference();
+        } else if (GroupMixin.isMixedInto(model)) {
+          return model.loadMembers();
+        }
+      })
+    ).then(() => {
+      // Then call this function again to see if new child references were loaded in
+      resolve(
+        loadAndSearchCatalogRecursively(
+          terria,
+          searchTextLowercase,
+          searchResults,
+          resultMap,
+          iteration + 1
+        )
+      );
+    });
+  });
+}
+
+export default class CatalogSearchProvider extends SearchProvider {
+  readonly terria: Terria;
+  @observable isSearching: boolean = false;
+  @observable debounceDurationOnceLoaded: number = 300;
+
+  constructor(options: CatalogSearchProviderOptions) {
+    super();
+
+    this.terria = options.terria;
+    this.name = "Catalog Items";
+  }
+
+  protected doSearch(
+    searchText: string,
+    searchResults: SearchProviderResults
+  ): Promise<void> {
+    this.isSearching = true;
+    searchResults.results.length = 0;
+    searchResults.message = undefined;
+
+    if (searchText === undefined || /^\s*$/.test(searchText)) {
+      this.isSearching = false;
+      return Promise.resolve();
+    }
+
+    this.terria.analytics.logEvent("search", "catalog", searchText);
+    const resultMap: ResultMap = new Map();
+
+    const promise: Promise<any> = loadAndSearchCatalogRecursively(
+      this.terria,
+      searchText.toLowerCase(),
+      searchResults,
+      resultMap
+    );
+
+    return promise
+      .then(terria => {
+        runInAction(() => {
+          this.isSearching = false;
+        });
+
+        if (searchResults.isCanceled) {
+          // A new search has superseded this one, so ignore the result.
+          return;
+        }
+
+        runInAction(() => {
+          terria.catalogReferencesLoaded = true;
+        });
+
+        if (searchResults.results.length === 0) {
+          searchResults.message =
+            "Sorry, no locations match your search query.";
+        }
+      })
+      .catch(() => {
+        if (searchResults.isCanceled) {
+          // A new search has superseded this one, so ignore the result.
+          return;
+        }
+
+        searchResults.message =
+          "An error occurred while searching.  Please check your internet connection or try again later.";
+      });
+  }
+}

--- a/lib/ReactViewModels/SearchState.ts
+++ b/lib/ReactViewModels/SearchState.ts
@@ -10,6 +10,7 @@ import Terria from "../Models/Terria";
 import SearchProviderResults from "../Models/SearchProviderResults";
 import SearchProvider from "../Models/SearchProvider";
 import filterOutUndefined from "../Core/filterOutUndefined";
+import CatalogSearchProvider from "../Models/CatalogSearchProvider";
 
 interface SearchStateOptions {
   terria: Terria;
@@ -45,9 +46,9 @@ export default class SearchState {
   private _unifiedSearchDisposer: IReactionDisposer;
 
   constructor(options: SearchStateOptions) {
-    // this.catalogSearchProvider =
-    //   options.catalogSearchProvider ||
-    //   new CatalogItemNameSearchProviderViewModel({ terria: options.terria });
+    this.catalogSearchProvider =
+      options.catalogSearchProvider ||
+      new CatalogSearchProvider({ terria: options.terria });
     this.locationSearchProviders = options.locationSearchProviders || [];
 
     this._catalogSearchDisposer = reaction(


### PR DESCRIPTION
### What this PR does

Fixes #3657 

Basically took the magda search implemented for digital twins and modified it so that it doesn't just load `MagdaReference` items but loads all groups and references

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
