### PR TITLE
Add support for initializationUrls when loading configuration from Magda

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Add a `contentAsObject` trait to `InfoSectionTraits` where a json object is more suitable than a string.
 * Add `serviceDescription` and `dataDescription` to `WebMapServiceCatalogItem` info section.
 * Extend `DataPreviewSections.jsx` to support Mustache templates with context provided by the catalog item.
+* Add support for `initializationUrls` when loading configuration from Magda.
 * [The next improvement]
 
 #### 8.0.0-alpha.53

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -396,6 +396,18 @@ export default class Terria {
     }
   }
 
+  setupInitializationUrls(baseUri: uri.URI, config: any) {
+    const initializationUrls: string[] = config.initializationUrls || [];
+    const initSources = initializationUrls.map(url =>
+      generateInitializationUrl(
+        baseUri,
+        this.configParameters.initFragmentPaths,
+        url
+      )
+    );
+    this.initSources.push(...initSources);
+  }
+
   start(options: StartOptions) {
     this.shareDataService = options.shareDataService;
 
@@ -414,6 +426,7 @@ export default class Terria {
                 this.configParameters.languageConfiguration,
                 options.i18nOptions
               );
+              this.setupInitializationUrls(baseUri, config);
             });
           }
 
@@ -426,16 +439,7 @@ export default class Terria {
             );
           }
 
-          const initializationUrls: string[] = config.initializationUrls || [];
-          const initSources = initializationUrls.map(url =>
-            generateInitializationUrl(
-              baseUri,
-              this.configParameters.initFragmentPaths,
-              url
-            )
-          );
-
-          this.initSources.push(...initSources);
+          this.setupInitializationUrls(baseUri, config);
         });
       })
       .then(() => {
@@ -867,6 +871,8 @@ export default class Terria {
     const configParams =
       aspects["terria-config"] && aspects["terria-config"].parameters;
 
+    configParams.initializationUrls =
+      aspects["terria-config"] && aspects["terria-config"].initializationUrls;
     if (configParams) {
       this.updateParameters(configParams);
     }

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -426,7 +426,10 @@ export default class Terria {
                 this.configParameters.languageConfiguration,
                 options.i18nOptions
               );
-              this.setupInitializationUrls(baseUri, config);
+              this.setupInitializationUrls(
+                baseUri,
+                config.aspects?.["terria-config"]
+              );
             });
           }
 


### PR DESCRIPTION
### What this PR does

This PR allows `initializationUrls` config option to be used when retrieving configuration from Magda.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
