### PR TITLE
Fix CI PR build for external contributors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ matrix:
       - xvfb
     script:
     - npm run prettier-check
-    - pyenv shell 2.7
     - pip install -r doc/requirements.txt
     - gulp lint docs release
-    - gulp test-firefox
     - gulp test-travis
     env:
     - NODE_OPTIONS=--max_old_space_size=3072

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
-dist: trusty
+dist: xenial
 sudo: false
 matrix:
   include:
   - language: node_js
     node_js:
     - '10'
+    services:
+      - xvfb
     script:
     - npm run prettier-check
     - pyenv shell 2.7
     - pip install -r doc/requirements.txt
     - gulp lint docs release
+    - gulp test-firefox
     - gulp test-travis
     env:
     - NODE_OPTIONS=--max_old_space_size=3072

--- a/buildprocess/karma-firefox.conf.js
+++ b/buildprocess/karma-firefox.conf.js
@@ -5,11 +5,7 @@ var createKarmaBaseConfig = require('./createKarmaBaseConfig');
 
 module.exports = function(config) {
     var options = Object.assign({}, createKarmaBaseConfig(config), {
-        browsers: ['Electron'],
-
-        electronOpts : {
-            show : false
-        }
+        browsers: ['Firefox'],
     });
 
     config.set(options);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,16 +94,16 @@ gulp.task('test-saucelabs', function(done) {
     runKarma('./buildprocess/karma-saucelabs.conf.js', done);
 });
 
-gulp.task('test-electron', function(done) {
-    runKarma('./buildprocess/karma-electron.conf.js', done);
+gulp.task('test-firefox', function(done) {
+    runKarma('./buildprocess/karma-firefox.conf.js', done);
 });
 
 gulp.task('test-travis', function(done) {
     if (process.env.SAUCE_ACCESS_KEY) {
         runKarma('./buildprocess/karma-saucelabs.conf.js', done);
     } else {
-        console.log('SauceLabs testing is not available for pull requests outside the main repo; using Electron instead.');
-        runKarma('./buildprocess/karma-electron.conf.js', done);
+        console.log('SauceLabs testing is not available for pull requests outside the main repo; using local headless Firefox instead.');
+        runKarma('./buildprocess/karma-firefox.conf.js', done);
     }
 });
 
@@ -124,7 +124,7 @@ function runKarma(configFile, done) {
 
 gulp.task('code-attribution', function userAttribution(done) {
     var spawnSync = require('child_process').spawnSync;
-    
+
     var result = spawnSync('yarn', ['licenses generate-disclaimer > doc/acknowledgements/attributions.md'], {
         stdio: 'inherit',
         shell: true

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
   "devDependencies": {
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "babel-eslint": "^10.0.1",
-    "electron": "^2.0.0",
     "eslint": "^5.14.1",
     "eslint-plugin-jsx-control-statements": "^2.2.1",
     "eslint-plugin-react": "^7.12.4",
@@ -109,7 +108,6 @@
     "karma-browserstack-launcher": "^1.4.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-detect-browsers": "^2.0.2",
-    "karma-electron": "^6.0.0",
     "karma-firefox-launcher": "^1.0.0",
     "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "^1.1.0",


### PR DESCRIPTION
This PR brings us most of the way to solving https://github.com/TerriaJS/terriajs/issues/4703 I think.
Still needs to be tested by an external contributor. I think we need to merge it to master first then get an external contributor to test pushing a PR to master.

Changes are:
* Upgrade Travis dist from Trusty to Xenial
* Remove `pyenv` which was failing on Xenial. The python version provided in Xenial works and is guaranteed to be consistent.
* Switch Travis CI external PR builds from trying to run on Electron to using Firefox, [as recommended by Karma](http://karma-runner.github.io/5.2/plus/travis.html)
* Remove electron from dependencies. It was only used on Travis CI external PR builds, which always failed
