### PR TITLE
Update Basemaps url and attributions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### v7.11.14
+
+* Update CARTO Basemaps CDN URL and attribution.
+
 ### v7.11.13
 
 * Upgraded to Cesium v1.73.

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -79,15 +79,15 @@ const DataPreviewMap = createReactClass({
     // TODO: we shouldn't hard code the base map here. (copied from branch analyticsWithCharts)
     const positron = new OpenStreetMapCatalogItem(this.terriaPreview);
     positron.name = "Positron (Light)";
-    positron.url = "//global.ssl.fastly.net/light_all/";
+    positron.url = "//basemaps.cartocdn.com/light_all/";
     positron.attribution =
-      "© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0";
+      "© OpenStreetMap contributors ODbL, © CARTO CC-BY 3.0";
     positron.opacity = 1.0;
     positron.subdomains = [
-      "cartodb-basemaps-a",
-      "cartodb-basemaps-b",
-      "cartodb-basemaps-c",
-      "cartodb-basemaps-d"
+      "a",
+      "b",
+      "c",
+      "d"
     ];
     this.terriaPreview.baseMap = positron;
 

--- a/lib/ViewModels/createGlobalBaseMapOptions.js
+++ b/lib/ViewModels/createGlobalBaseMapOptions.js
@@ -48,7 +48,7 @@ var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
 
   var positron = new OpenStreetMapCatalogItem(terria);
   positron.name = "Positron (Light)";
-  positron.url = "https://global.ssl.fastly.net/light_all/";
+  positron.url = "https://basemaps.cartocdn.com/light_all/";
 
   // https://cartodb.com/basemaps/ gives two different attribution strings. In any case HTML gets swallowed, so we have to adapt.
   // 1 '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy;
@@ -56,14 +56,14 @@ var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
   // 2 Map tiles by <a href="http://cartodb.com/attributions#basemaps">CartoDB</a>, under <a href="https://creativecommons.org/licenses/by/3.0/">
   //   CC BY 3.0</a>. Data by <a href="http://www.openstreetmap.org/">OpenStreetMap</a>, under ODbL.
   positron.attribution =
-    "© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0";
+    "© OpenStreetMap contributors ODbL, © CARTO CC-BY 3.0";
 
   positron.opacity = 1.0;
   positron.subdomains = [
-    "cartodb-basemaps-a",
-    "cartodb-basemaps-b",
-    "cartodb-basemaps-c",
-    "cartodb-basemaps-d"
+    "a",
+    "b",
+    "c",
+    "d"
   ];
   result.push(
     new BaseMapViewModel({
@@ -75,17 +75,17 @@ var createGlobalBaseMapOptions = function(terria, bingMapsKey) {
 
   var darkMatter = new OpenStreetMapCatalogItem(terria);
   darkMatter.name = "Dark Matter";
-  darkMatter.url = "https://global.ssl.fastly.net/dark_all/";
+  darkMatter.url = "https://basemaps.cartocdn.com/dark_all/";
 
   darkMatter.attribution =
-    "© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0";
+    "© OpenStreetMap contributors ODbL, © CARTO CC-BY 3.0";
 
   darkMatter.opacity = 1.0;
   darkMatter.subdomains = [
-    "cartodb-basemaps-a",
-    "cartodb-basemaps-b",
-    "cartodb-basemaps-c",
-    "cartodb-basemaps-d"
+    "a",
+    "b",
+    "c",
+    "d"
   ];
   result.push(
     new BaseMapViewModel({


### PR DESCRIPTION
### What this PR does

This PR updates CARTO Basemaps URL to the new CDN URL and fixes the attributions to match current requirements.

I did not add the proper attribution HTML since there is a comment regarding that was not working properly, which I don't know if is still true:
https://github.com/TerriaJS/terriajs/blob/8ec9a207164d719ea898e5ac19876c5c42181b6a/lib/ViewModels/createGlobalBaseMapOptions.js#L53-L57

If the issue is now fixed the preferred attribution (both by OSM and CARTO) is:

```html
&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/about-carto/">CARTO</a>
```

#### Context
We've recently changed our CDN (last week) and we have a plan mid-long term (depends on how quick we manage to stop all the traffic there) to deprecate our `.global.ssl.fastly.net` domains.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.