### PR TITLE
Update Carto basemaps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Add a `contentAsObject` trait to `InfoSectionTraits` where a json object is more suitable than a string.
 * Add `serviceDescription` and `dataDescription` to `WebMapServiceCatalogItem` info section.
 * Extend `DataPreviewSections.jsx` to support Mustache templates with context provided by the catalog item.
+* Update Carto basemaps URL and attribution.
 * [The next improvement]
 
 #### 8.0.0-alpha.53

--- a/lib/ViewModels/createGlobalBaseMapOptions.ts
+++ b/lib/ViewModels/createGlobalBaseMapOptions.ts
@@ -83,11 +83,9 @@ export default function createGlobalBaseMapOptions(
       "https://basemaps.cartocdn.com/light_all/"
     );
 
-    // https://cartodb.com/basemaps/ gives two different attribution strings. In any case HTML gets swallowed, so we have to adapt.
-    // 1 '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy;
-    //   <a href="http://cartodb.com/attributions">CartoDB</a>'
-    // 2 Map tiles by <a href="http://cartodb.com/attributions#basemaps">CartoDB</a>, under <a href="https://creativecommons.org/licenses/by/3.0/">
-    //   CC BY 3.0</a>. Data by <a href="http://www.openstreetmap.org/">OpenStreetMap</a>, under ODbL.
+    // https://github.com/CartoDB/basemap-styles#1-web-raster-basemaps gives the following attribution string.
+    // '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy;
+    //   <a href="http://carto.com/attributions">Carto</a>'
     positron.setTrait(
       CommonStrata.user,
       "attribution",

--- a/lib/ViewModels/createGlobalBaseMapOptions.ts
+++ b/lib/ViewModels/createGlobalBaseMapOptions.ts
@@ -80,7 +80,7 @@ export default function createGlobalBaseMapOptions(
     positron.setTrait(
       CommonStrata.user,
       "url",
-      "https://global.ssl.fastly.net/light_all/"
+      "https://basemaps.cartocdn.com/light_all/"
     );
 
     // https://cartodb.com/basemaps/ gives two different attribution strings. In any case HTML gets swallowed, so we have to adapt.
@@ -91,16 +91,11 @@ export default function createGlobalBaseMapOptions(
     positron.setTrait(
       CommonStrata.user,
       "attribution",
-      "© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0"
+      "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>, © <a href='https://carto.com/about-carto/'>CARTO</a>"
     );
 
     positron.setTrait(CommonStrata.user, "opacity", 1.0);
-    positron.setTrait(CommonStrata.user, "subdomains", [
-      "cartodb-basemaps-a",
-      "cartodb-basemaps-b",
-      "cartodb-basemaps-c",
-      "cartodb-basemaps-d"
-    ]);
+    positron.setTrait(CommonStrata.user, "subdomains", ["a", "b", "c", "d"]);
   });
   result.push(
     new BaseMapViewModel(positron, require("../../wwwroot/images/positron.png"))
@@ -112,20 +107,15 @@ export default function createGlobalBaseMapOptions(
     darkMatter.setTrait(
       CommonStrata.user,
       "url",
-      "https://global.ssl.fastly.net/dark_all/"
+      "https://basemaps.cartocdn.com/dark_all/"
     );
     darkMatter.setTrait(
       CommonStrata.user,
       "attribution",
-      "© OpenStreetMap contributors ODbL, © CartoDB CC-BY 3.0"
+      "© <a href'https://www.openstreetmap.org/copyright'>OpenStreetMap</a>, © <a href='https://carto.com/about-carto/'>CARTO</a>"
     );
     darkMatter.setTrait(CommonStrata.user, "opacity", 1.0);
-    darkMatter.setTrait(CommonStrata.user, "subdomains", [
-      "cartodb-basemaps-a",
-      "cartodb-basemaps-b",
-      "cartodb-basemaps-c",
-      "cartodb-basemaps-d"
-    ]);
+    darkMatter.setTrait(CommonStrata.user, "subdomains", ["a", "b", "c", "d"]);
   });
 
   result.push(


### PR DESCRIPTION
### What this PR does

Fixes 

As stated by @skgsergio in #4824. This updates Carto base maps to updated URLs, and attribution to the correct one. This was changed in #971, but it seems that new URLs support https. If the footer is the only place the attribution is used I can confirm that it works.
![2D](https://user-images.githubusercontent.com/19208948/94844556-b8269b80-041e-11eb-9f1d-62e00930af54.png)
![3D](https://user-images.githubusercontent.com/19208948/94844610-cb396b80-041e-11eb-95b0-f34cd0e0f16e.png)

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
