### PR TITLE
Add clipToRectangle trait

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Add `serviceDescription` and `dataDescription` to `WebMapServiceCatalogItem` info section.
 * Extend `DataPreviewSections.jsx` to support Mustache templates with context provided by the catalog item.
 * Add support for `initializationUrls` when loading configuration from Magda.
+* Add `clipToRectangle` trait to `RasterLayerTraits` and implement on `WebMapServiceCatalogItem`, `ArcGisMapServiceCatalogItem`, `CartoMapCatalogItem`, `WebMapTileServiceCatalogItem`.
 * [The next improvement]
 
 #### 8.0.0-alpha.53

--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -350,6 +350,26 @@ export default class ArcGisMapServerCatalogItem
       return;
     }
 
+    let rectangle;
+
+    if (
+      this.clipToRectangle &&
+      this.rectangle !== undefined &&
+      this.rectangle.east !== undefined &&
+      this.rectangle.west !== undefined &&
+      this.rectangle.north !== undefined &&
+      this.rectangle.south !== undefined
+    ) {
+      rectangle = Rectangle.fromDegrees(
+        this.rectangle.west,
+        this.rectangle.south,
+        this.rectangle.east,
+        this.rectangle.north
+      );
+    } else {
+      rectangle = undefined;
+    }
+
     const maximumLevel = maximumScaleToLevel(this.maximumScale);
     const dynamicRequired = this.layers && this.layers.length > 0;
     const imageryProvider = new ArcGisMapServerImageryProvider({
@@ -358,14 +378,7 @@ export default class ArcGisMapServerCatalogItem
       tilingScheme: new WebMercatorTilingScheme(),
       maximumLevel: maximumLevel,
       parameters: this.parameters,
-      rectangle: this.clipToRectangle
-        ? Rectangle.fromDegrees(
-            this.rectangle.west,
-            this.rectangle.south,
-            this.rectangle.east,
-            this.rectangle.north
-          )
-        : undefined,
+      rectangle: rectangle,
       enablePickFeatures: this.allowFeaturePicking,
       usePreCachedTilesIfAvailable: !dynamicRequired,
       mapServerData: stratum.mapServerData,

--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -2,6 +2,7 @@ import i18next from "i18next";
 import uniqWith from "lodash-es/uniqWith";
 import { computed, runInAction } from "mobx";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
+import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import WebMercatorTilingScheme from "terriajs-cesium/Source/Core/WebMercatorTilingScheme";
 import ArcGisMapServerImageryProvider from "terriajs-cesium/Source/Scene/ArcGisMapServerImageryProvider";
 import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
@@ -357,6 +358,14 @@ export default class ArcGisMapServerCatalogItem
       tilingScheme: new WebMercatorTilingScheme(),
       maximumLevel: maximumLevel,
       parameters: this.parameters,
+      rectangle: this.clipToRectangle
+        ? Rectangle.fromDegrees(
+            this.rectangle.west,
+            this.rectangle.south,
+            this.rectangle.east,
+            this.rectangle.north
+          )
+        : undefined,
       enablePickFeatures: this.allowFeaturePicking,
       usePreCachedTilesIfAvailable: !dynamicRequired,
       mapServerData: stratum.mapServerData,

--- a/lib/Models/CartoMapCatalogItem.ts
+++ b/lib/Models/CartoMapCatalogItem.ts
@@ -167,7 +167,7 @@ export default class CartoMapCatalogItem
     }
 
     let rectangle: Rectangle | undefined;
-    if (isDefined(this.rectangle)) {
+    if (isDefined(this.rectangle) && this.clipToRectangle) {
       const { west, south, east, north } = this.rectangle;
       if (
         isDefined(west) &&

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -953,7 +953,14 @@ class WebMapServiceCatalogItem
 
       let rectangle;
 
-      if (this.clipToRectangle && this.rectangle !== undefined) {
+      if (
+        this.clipToRectangle &&
+        this.rectangle !== undefined &&
+        this.rectangle.east !== undefined &&
+        this.rectangle.west !== undefined &&
+        this.rectangle.north !== undefined &&
+        this.rectangle.south !== undefined
+      ) {
         rectangle = Rectangle.fromDegrees(
           this.rectangle.west,
           this.rectangle.south,

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -953,14 +953,7 @@ class WebMapServiceCatalogItem
 
       let rectangle;
 
-      if (
-        this.clipToRectangle &&
-        this.rectangle !== undefined &&
-        this.rectangle.east !== undefined &&
-        this.rectangle.west !== undefined &&
-        this.rectangle.north !== undefined &&
-        this.rectangle.south !== undefined
-      ) {
+      if (this.clipToRectangle && this.rectangle !== undefined) {
         rectangle = Rectangle.fromDegrees(
           this.rectangle.west,
           this.rectangle.south,

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -954,6 +954,7 @@ class WebMapServiceCatalogItem
       let rectangle;
 
       if (
+        this.clipToRectangle &&
         this.rectangle !== undefined &&
         this.rectangle.east !== undefined &&
         this.rectangle.west !== undefined &&

--- a/lib/Models/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/WebMapTileServiceCatalogItem.ts
@@ -546,6 +546,7 @@ class WebMapTileServiceCatalogItem extends AsyncMappableMixin(
     let rectangle;
 
     if (
+      this.clipToRectangle &&
       this.rectangle !== undefined &&
       this.rectangle.east !== undefined &&
       this.rectangle.west !== undefined &&

--- a/lib/Traits/RasterLayerTraits.ts
+++ b/lib/Traits/RasterLayerTraits.ts
@@ -16,4 +16,15 @@ export default class RasterLayerTraits extends ModelTraits {
       "Update a tile only once during this interval when the map is panned. Value should be specified in milliseconds."
   })
   leafletUpdateInterval?: number;
+
+  @primitiveTrait({
+    type: "boolean",
+    name: "Clip to rectangle",
+    description: `Gets or sets a value indicating whether this dataset should be clipped to the {@link CatalogItem#rectangle}.
+If true, no part of the dataset will be displayed outside the rectangle. 
+This property is true by default, leading to better performance and avoiding tile request errors that might occur when requesting tiles outside the server-specified rectangle.
+However, it may also cause features to be cut off in some cases, such as if a server reports an extent that does not take into account that the representation of features sometimes require a larger spatial extent than the features themselves.
+For example, if a point feature on the edge of the extent is drawn as a circle with a radius of 5 pixels, half of that circle will be cut off.`
+  })
+  clipToRectangle: boolean = true;
 }


### PR DESCRIPTION
### What this PR does

This PR ports the `clipToRectangle` property that used to exist in master on [`ImageryLayerCatalogItem`](https://github.com/TerriaJS/terriajs/blob/master/lib/Models/ImageryLayerCatalogItem.js#L108-L119).

I've added the implementation to a few of the key catalog item types. Mostly it was implemented however you couldn't disable it.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
