### PR TITLE
 Hide the chart download button when there is no downloadable source.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Update Carto basemaps URL and attribution.
 * Add `clipToRectangle` trait to `RasterLayerTraits` and implement on `WebMapServiceCatalogItem`, `ArcGisMapServiceCatalogItem`, `CartoMapCatalogItem`, `WebMapTileServiceCatalogItem`.
 * Ported a support for `GpxCatalogItem`.
+* Fixes a bug that showed the chart download button when there is no downloadable source.
 * [The next improvement]
 
 #### 8.0.0-alpha.53

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -67,9 +67,12 @@ class ChartExpandAndDownloadButtons extends React.Component {
     }
 
     // The downloads and download names default to the sources and source names if not defined.
-    const downloads = runInAction(() => {
-      return this.props.downloads || this.sourceItems.map(item => item.url);
-    });
+    let downloads = filterOutUndefined(
+      runInAction(() => {
+        return this.props.downloads || this.sourceItems.map(item => item.url);
+      })
+    );
+    downloads = downloads.length > 0 ? downloads : undefined;
     const downloadNames = this.props.downloadNames || this.props.sourceNames;
     let downloadButton;
     const { t } = this.props;


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs/issues/4836

The fix reflects the behavior in master.
eg from master: https://maps.dea.ga.gov.au/#share=s-fhMSo2vlaqT8iFFH3r4sZ0WU2zh

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
