### PR TITLE
Pass the chartDisclaimer from a catalog item to derived charts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Add `clipToRectangle` trait to `RasterLayerTraits` and implement on `WebMapServiceCatalogItem`, `ArcGisMapServiceCatalogItem`, `CartoMapCatalogItem`, `WebMapTileServiceCatalogItem`.
 * Ported a support for `GpxCatalogItem`.
 * Fixes a bug that showed the chart download button when there is no downloadable source.
+* Ensure the `chartDisclaimer` is passed from catalog items to derived chart items.
 * [The next improvement]
 
 #### 8.0.0-alpha.53

--- a/lib/ReactViews/BottomDock/ChartDisclaimer.tsx
+++ b/lib/ReactViews/BottomDock/ChartDisclaimer.tsx
@@ -30,7 +30,9 @@ const ChartDisclaimer: React.FC<ChartDisclaimerProps> = ({ terria }) => {
       )
     )
   ];
-  if (uniqueChartDisclaimers.length === 0) return null;
+  const chartItems = chartView.chartItems.filter(c => c.showInChartPanel);
+  if (uniqueChartDisclaimers.length === 0 || chartItems.length === 0)
+    return null;
 
   return (
     <Box

--- a/lib/ReactViews/Custom/ChartCustomComponent.ts
+++ b/lib/ReactViews/Custom/ChartCustomComponent.ts
@@ -12,6 +12,7 @@ import Model, { BaseModel } from "../../Models/Model";
 import CatalogMemberTraits from "../../Traits/CatalogMemberTraits";
 import CsvCatalogItemTraits from "../../Traits/CsvCatalogItemTraits";
 import hasTraits from "../../Models/hasTraits";
+import DiscretelyTimeVaryingTraits from "../../Traits/DiscretelyTimeVaryingTraits";
 
 export interface ChartCustomComponentAttributes {
   /**  The title of the chart.  If not supplied, defaults to the name of the context-supplied feature, if available, or else simply "Chart". */
@@ -186,6 +187,8 @@ export default abstract class ChartCustomComponent<
 
     checkAllPropertyKeys(node.attribs, this.attributes);
 
+    const chartDisclaimer = (context.catalogItem as any).chartDisclaimer;
+
     const attrs = this.parseNodeAttrs(node.attribs);
     const csvString: any =
       typeof children[0] == "string" ? children[0] : undefined;
@@ -209,6 +212,16 @@ export default abstract class ChartCustomComponent<
               hasTraits(item, CsvCatalogItemTraits, "csvString")
             ) {
               item.setTrait(CommonStrata.user, "csvString", csvString);
+            }
+            if (
+              hasTraits(item, DiscretelyTimeVaryingTraits, "chartDisclaimer") &&
+              chartDisclaimer !== undefined
+            ) {
+              item.setTrait(
+                CommonStrata.definition,
+                "chartDisclaimer",
+                chartDisclaimer
+              );
             }
           });
 
@@ -240,6 +253,17 @@ export default abstract class ChartCustomComponent<
         hasTraits(chartItem, CsvCatalogItemTraits, "csvString")
       ) {
         chartItem.setTrait(CommonStrata.user, "csvString", csvString);
+      }
+
+      if (
+        hasTraits(chartItem, DiscretelyTimeVaryingTraits, "chartDisclaimer") &&
+        chartDisclaimer !== undefined
+      ) {
+        chartItem.setTrait(
+          CommonStrata.definition,
+          "chartDisclaimer",
+          chartDisclaimer
+        );
       }
     });
 


### PR DESCRIPTION
### What this PR does

Fixes #4841

This PR ensures that a `chartDisclaimer` is passed from a catalog item to derived charts.

For example with this `WebMapServiceCatalogItem` a chart is generated from from some of the GetFeatureInfo data, the chart data becomes it's own `CsvCatalogItem` which ought to have the same chartDisclaimer as the `WebMapServiceCatalogItem`.

````
{
      "type": "wms",
      "name": "Digital Earth Australia Coastlines (beta)",
      "url": "https://geoserver.dea.ga.gov.au/geoserver/wms",
      "layers": "dea:DEACoastLines",
      "chartDisclaimer": "The graph below shows the distance (in metres) from each 1988-2018 coastline relative to the 2019 baseline. Negative distances below indicate coastlines that were located inland of the 2019 coastline, while positive values indicate coastlines located towards the ocean.",
      "featureInfoTemplate": {
        "name": "something",
        "template": "<div style='width:480px'>{{#n}}<h3 style='font-weight:normal'>Digital Earth Australia Coastlines</h3>Zoom in until labelled points appear and click on any point to view a <b>time series chart of how an area of coastline has changed over time</b> (press 'Expand' on the pop-up for more detail):</br></br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_1.gif' alt='Clicking on points'></br></br>Zoom in further to view individual annual coastlines:</br></br><img src='https://data.dea.ga.gov.au/projects/coastlines/DEACoastLines_DEAMaps_2.gif' alt='Zooming to coastlines'>{{/n}}{{#sce}}<h2 style='font-weight:normal'>This coastline has <b>{{#retreat}}retreated{{/retreat}}{{#growth}}grown{{/growth}}</b> by</br> <b>{{#terria.formatNumber}}{maximumFractionDigits:1}{{rate_time}}{{/terria.formatNumber}} metres (±{{#terria.formatNumber}}{maximumFractionDigits:1}{{conf_time}}{{/terria.formatNumber}}) per year</b></br>on average since <b>1988</b></h2>The coastline at this location was <b>most seaward in {{max_year}}</b>, and <b>most landward in {{min_year}}</b>{{#outl_time}} (excluding outlier years; see below){{/outl_time}}. Since 1988, the coastline has moved over a total distance of approximately <b>{{#terria.formatNumber}}{maximumFractionDigits:0}{{sce}}{{/terria.formatNumber}} metres.</b></br></br><chart title='DEA Coastlines ({{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.latitude}}{{/terria.formatNumber}}, {{#terria.formatNumber}}{maximumFractionDigits:4}{{terria.coords.longitude}}{{/terria.formatNumber}})' y-column='Distance (metres) relative to 2019 coastline' x-column='Year' column-units='{{terria.timeSeries.units}}' preview-x-label='Year'>Year,Distance (metres) relative to 2019 coastline\n1988,{{dist_1988}}\n1989,{{dist_1989}}\n1990,{{dist_1990}}\n1991,{{dist_1991}}\n1992,{{dist_1992}}\n1993,{{dist_1993}}\n1994,{{dist_1994}}\n1995,{{dist_1995}}\n1996,{{dist_1996}}\n1997,{{dist_1997}}\n1998,{{dist_1998}}\n1999,{{dist_1999}}\n2000,{{dist_2000}}\n2001,{{dist_2001}}\n2002,{{dist_2002}}\n2003,{{dist_2003}}\n2004,{{dist_2004}}\n2005,{{dist_2005}}\n2006,{{dist_2006}}\n2007,{{dist_2007}}\n2008,{{dist_2008}}\n2009,{{dist_2009}}\n2010,{{dist_2010}}\n2011,{{dist_2011}}\n2012,{{dist_2012}}\n2013,{{dist_2013}}\n2014,{{dist_2014}}\n2015,{{dist_2015}}\n2016,{{dist_2016}}\n2017,{{dist_2017}}\n2018,{{dist_2018}}\n2019,{{dist_2019}}</chart>{{#outl_time}}The following years were identified as potential outliers, and should be interpreted with caution:</br></br><b>{{outl_time}}</b>{{/outl_time}}{{/sce}}{{#year}}<h2 style='font-weight:normal'>{{year}} annual coastline</h2><h3 style='font-weight:normal'>Certainty: {{certainty}}</h3>Annual coastlines represent the typical (i.e. median) position of the shoreline at approximately mean sea level (~0 m AHD) across the entire year period.</br></br>{{/year}}</div>"
      }
    }
`````

This PR also ensures that the chartDisclaimer is only shown when the bottom chart is shown, without the modification to `ChartDisclaimer.tsx` the disclaimer would still show even when the chart item was disabled was in the workbench.


### Checklist

-   [ ] No tests, a whole bunch need to be written for this stuff :(
-   [x] I've updated CHANGES.md with what I changed.
