### PR TITLE
Allow welcome message to be hidden via url param

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Change Log
 * Deprecated `proxyableDomainsUrl` configuration parameter in favour of `serverconfig` route
 * Ported a support for `GpxCatalogItem`.
 * Fixes a bug that showed the chart download button when there is no downloadable source.
+* Add `hideWelcomeMessage` url parameter to allow the Welcome Message to be disabled for iframe embeds or sharing scenarios.
 * [The next improvement]
 
 #### 8.0.0-alpha.53

--- a/doc/deploying/controlling-with-url-parameters.md
+++ b/doc/deploying/controlling-with-url-parameters.md
@@ -21,6 +21,7 @@ Parameter      | Meaning
 `share=`...      | Load a map view previously saved using the "Share" function with URL shortening.
 `start=`...      | Load a map view previously saved without URL shortening. The argument is a URL-encoded JSON structure defined using an internal format described below.
 `<initfile>`     | Load catalog file as described below.
+`hideWelcomeMessage` | Forces the welcome message not to be displayed.
 
 ### Catalog files (init files)
 

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1045,6 +1045,8 @@ function interpretHash(
         const propertyValue = hashProperties[property];
         if (property === "clean") {
           terria.initSources.splice(0, terria.initSources.length);
+        } else if (property === "hideWelcomeMessage") {
+          terria.configParameters.showWelcomeMessage = false;
         } else if (property === "start") {
           // a share link that hasn't been shortened: JSON embedded in URL (only works for small quantities of JSON)
           const startData = JSON.parse(propertyValue);


### PR DESCRIPTION
### What this PR does

Fixes #4845

This PR adds a URL param called `hideWelcomeMessage` which will force hide the welcome message. This is potentially useful for scenarios like map embeds or sharing links.


### Checklist

-   [ ] No unit tests
-   [x] I've updated CHANGES.md with what I changed.
