### PR TITLE
Add itemProperties trait

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Change Log
 * Don't calculate a `rectangle` on a `ArcGisPortalReferenceItem` as they appear to contain less precision than the services they point to.
 * Allow an `ArcGisPortalReferenceItem` to belong to multiple `CatalogGroup`'s.
 * Made possible to internationalize tour contend.
+* Add `itemProperties` trait to `WebMapMapCatalogGroup`.
 * [The next improvement]
 
 #### 8.0.0-alpha.53

--- a/lib/Models/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/WebMapServiceCatalogGroup.ts
@@ -273,6 +273,12 @@ class GetCapabilitiesStratum extends LoadableStratum(
       "hideLegendInWorkbench",
       this.catalogGroup.hideLegendInWorkbench
     );
+
+    if (this.catalogGroup.itemProperties !== undefined) {
+      Object.keys(this.catalogGroup.itemProperties).map((k: any) => {
+        model.setTrait(stratum, k, this.catalogGroup.itemProperties[k]);
+      });
+    }
     model.createGetCapabilitiesStratumFromParent(this.capabilities);
   }
 

--- a/lib/Models/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/WebMapServiceCatalogGroup.ts
@@ -276,7 +276,8 @@ class GetCapabilitiesStratum extends LoadableStratum(
 
     if (this.catalogGroup.itemProperties !== undefined) {
       Object.keys(this.catalogGroup.itemProperties).map((k: any) => {
-        model.setTrait(stratum, k, this.catalogGroup.itemProperties[k]);
+        if (this.catalogGroup.itemProperties !== undefined)
+          model.setTrait(stratum, k, this.catalogGroup.itemProperties[k]);
       });
     }
     model.createGetCapabilitiesStratumFromParent(this.capabilities);

--- a/lib/Traits/WebMapServiceCatalogGroupTraits.ts
+++ b/lib/Traits/WebMapServiceCatalogGroupTraits.ts
@@ -2,8 +2,10 @@ import CatalogMemberTraits from "./CatalogMemberTraits";
 import GetCapabilitiesTraits from "./GetCapabilitiesTraits";
 import GroupTraits from "./GroupTraits";
 import mixTraits from "./mixTraits";
+import anyTrait from "./anyTrait";
 import primitiveTrait from "./primitiveTrait";
 import UrlTraits from "./UrlTraits";
+import { JsonObject } from "../Core/Json";
 
 export default class WebMapServiceCatalogGroupTraits extends mixTraits(
   GetCapabilitiesTraits,
@@ -18,4 +20,10 @@ export default class WebMapServiceCatalogGroupTraits extends mixTraits(
       "True to flatten the layers into a single list; false to use the layer hierarchy."
   })
   flatten?: boolean;
+
+  @anyTrait({
+    name: "Item Properties",
+    description: "Sets traits on child WebMapServiceCatalogItem's"
+  })
+  itemProperties?: JsonObject;
 }

--- a/test/Models/WebMapServiceCatalogGroupSpec.ts
+++ b/test/Models/WebMapServiceCatalogGroupSpec.ts
@@ -1,4 +1,5 @@
 import WebMapServiceCatalogGroup from "../../lib/Models/WebMapServiceCatalogGroup";
+import WebMapServiceCatalogItem from "../../lib/Models/WebMapServiceCatalogItem";
 import { runInAction } from "mobx";
 import Terria from "../../lib/Models/Terria";
 import i18next from "i18next";
@@ -75,6 +76,11 @@ describe("WebMapServiceCatalogGroup", function() {
     beforeEach(async function() {
       runInAction(() => {
         wms.setTrait("definition", "url", "test/WMS/single_metadata_url.xml");
+        wms.setTrait("definition", "itemProperties", {
+          parameters: {
+            foo: "baa"
+          }
+        });
       });
       await wms.loadMembers();
     });
@@ -82,6 +88,11 @@ describe("WebMapServiceCatalogGroup", function() {
     it("loads", async function() {
       expect(wms.members.length).toEqual(1);
       expect(wms.memberModels.length).toEqual(1);
+    });
+
+    it("item properties are passed down", async function() {
+      const member: any = wms.memberModels[0];
+      expect(member.parameters.foo).toEqual("baa");
     });
   });
 


### PR DESCRIPTION
### What this PR does

This ports the `itemProperties` property on `WebMapServiceCatalogGroup` from master to next

### Checklist

-   [x] Added a basic test
-   [x] I've updated CHANGES.md with what I changed.
