### PR TITLE
Release 8.0.0-alpha.55 and fix exports error on new node versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,11 @@ Change Log
 
 ### MobX Development
 
-#### next release (8.0.0-alpha.55)
+#### next release (8.0.0-alpha.56)
 * [The next improvement]
+
+#### 8.0.0-alpha.55
+* Upgraded to patched terriajs-cesium v1.73.1 to avoid build error on node 12 & 14.
 
 #### 8.0.0-alpha.54
 * Add a `infoAsObject` property to the `CatalogMemberMixin` for providing simpler access to `info` entries within templating

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.0.0-alpha.54",
+  "version": "8.0.0-alpha.55",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {
@@ -133,7 +133,7 @@
     "style-loader": "^0.23.1",
     "styled-components": "^5.1.0",
     "svg-sprite-loader": "4.1.3",
-    "terriajs-cesium": "1.73.0",
+    "terriajs-cesium": "1.73.1",
     "terriajs-html2canvas": "1.0.0-alpha.12-terriajs-1",
     "ts-loader": "^5.3.3",
     "ts-node": "^5.0.1",


### PR DESCRIPTION
Parallel of #4867 on version 8.

