### PR TITLE
Fix handling of `ArcGisPortalItemReference` for when a feature layer …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 #### next release (8.0.0-alpha.56)
 * Add `itemProperties` trait to `WebMapMapCatalogGroup`.
 * Add support for `formats` traits within `featureInfoTemplate` traits.
+* Fix handling of `ArcGisPortalItemReference` for when a feature layer contains multiple sublayers.
 * [The next improvement]
 
 #### 8.0.0-alpha.55

--- a/lib/Models/ArcGisPortalItemReference.ts
+++ b/lib/Models/ArcGisPortalItemReference.ts
@@ -327,7 +327,7 @@ export default class ArcGisPortalItemReference extends UrlMixin(
       | undefined = await loadAdditionalPortalInfo(this);
     if (itemDataInfo !== undefined && this._arcgisItem !== undefined) {
       if (!itemDataInfo.error && itemDataInfo.layers) {
-        if (itemDataInfo.layers.length > 0) {
+        if (itemDataInfo.layers.length === 1) {
           this._arcgisItem.url = `${this._arcgisItem.url}/${itemDataInfo.layers[0].id}`;
         }
       }


### PR DESCRIPTION
### What this PR does

This PR fixes a condition where a portal item supports multiple sub-layers. 

A portal item contains a url, often this points to something like https://portal.spatial.nsw.gov.au/server/rest/services/NSW_Administrative_Boundaries_Theme/FeatureServer
which as an entire feature service contains 17 sublayers.

However sometimes the portal item also lists a subset of layers at the `/data` endpoint for the portal item, for example it might specify that this portal item only includes layers 1,2 & 3.

The condition I originally wrote was broken. Basically the condition should be that if there is only 1 layer associated with the portal item we update the url to point at the sublayer, eg 
so
https://portal.spatial.nsw.gov.au/server/rest/services/NSW_Administrative_Boundaries_Theme/FeatureServer
becomes
https://portal.spatial.nsw.gov.au/server/rest/services/NSW_Administrative_Boundaries_Theme/FeatureServer/2 
(or whatever the relevant layer id is) 


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
