### PR TITLE
add 3d tiles to 'add web data' dropdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,12 +3,11 @@ Change Log
 
 ### MobX Development
 
-#### next release (8.0.0-alpha.57)
-* Add 3D Tiles to 'Add web data' dropdown.
 #### next release (8.0.0-alpha.58)
 * Add `FeatureInfoTraits` to `ArcGisMapServerCatalogItem`
 * Fix zooming bug for datasets with invalid bounding boxes.
 * Add new model for `ArcGisTerrainCatalogItem`.
+* Add 3D Tiles to 'Add web data' dropdown.
 * [The next improvement]
 
 #### 8.0.0-alpha.57

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.57)
+* Add 3D Tiles to 'Add web data' dropdown.
 * [The next improvement]
   
 #### 8.0.0-alpha.56

--- a/lib/Core/getDataType.js
+++ b/lib/Core/getDataType.js
@@ -12,10 +12,6 @@ module.exports = function() {
         name: i18next.t("core.dataType.wms-group")
       },
       {
-        value: "wmts-group",
-        name: i18next.t("core.dataType.wmts-group")
-      },
-      {
         value: "wfs-group",
         name: i18next.t("core.dataType.wfs-group")
       },
@@ -43,6 +39,10 @@ module.exports = function() {
         name: "Esri ArcGIS FeatureServer"
       }, */
       {
+        value: "3d-tiles",
+        name: i18next.t("core.dataType.3d-tiles")
+      },
+      {
         value: "open-street-map",
         name: i18next.t("core.dataType.open-street-map")
       },
@@ -57,6 +57,10 @@ module.exports = function() {
       {
         value: "csv",
         name: i18next.t("core.dataType.csv")
+      },
+      {
+        value: "wmts-group",
+        name: i18next.t("core.dataType.wmts-group")
       },
       {
         value: "carto",

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -639,6 +639,7 @@
       "esri-group": "Esri ArcGIS Server",
       "esri-mapServer": "Esri ArcGIS MapServer (single layer)",
       "esri-featureServer": "Esri ArcGIS FeatureServer (single layer)",
+      "3d-tiles": "3D Tiles",
       "open-street-map": "Open Street Map Server",
       "geojson": "GeoJSON",
       "geoRss": "GeoRSS",


### PR DESCRIPTION
### What this PR does

This PR add support for `3d-tiles` urls to the "Add web data" dropdown.

![Screen_2020_10_20](https://user-images.githubusercontent.com/6735870/96521359-d3b5f100-12bc-11eb-9535-2d514d6ba129.jpg)

Test by pasting the following url
https://sample.aero3dpro.com.au/BrisbaneCBD/Scene/recon_h_3DTiles.json

### Checklist

-   [ ] Doesn't really require a unit test
-   [x] I've updated CHANGES.md with what I changed.
