### PR TITLE
Add a short report section if trying to view a 3d-tiles item in 2D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.57)
+* Add a short report section if trying to view a `3d-tiles` item in a 2d map.
 * [The next improvement]
   
 #### 8.0.0-alpha.56

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -843,7 +843,7 @@
       "name": "Cesium Terrain",
       "name3D": "Cesium 3D Tiles",
       "notSupportedErrorTitle": "Not supported in 2D",
-      "notSupportedErrorMessage": "\"{{name}}\" cannot be show in the 2D view.  Switch to 3D and try again.",
+      "notSupportedErrorMessage": "\"{{name}}\" cannot be show in the 2D view. Switch to 3D and try again.",
       "errorRenderingTitle": "Error rendering in 3D",
       "errorRenderingMessage": "<p>An error occurred while rendering in 3D.  This probably indicates a bug in {{appName}} or an incompatibility with your system or web browser.  We'll now switch you to 2D so that you can continue your work. We would appreciate it if you report this error by sending an email to {{email}} with the technical details below.  Thank you!</p>"
     },
@@ -1229,7 +1229,7 @@
     },
     "terrainCatalog": {
       "notSupportedErrorTitle": "Not supported in 2D",
-      "notSupportedErrorMessage": "{{name}} cannot be show in the 2D view.  Switch to 3D and try again"
+      "notSupportedErrorMessage": "{{name}} cannot be shown in the 2D view. Switch to 3D and try again"
     },
     "terria": {
       "proxyableDomainsDeprecation": "`proxyableDomainsUrl` is no longer supported in v8",
@@ -1391,6 +1391,7 @@
       "groupNotAvailableMessage": "An error occurred while invoking GetFeature on the WFS server. <p>If you entered the link manually, please verify that the link is correct.</p><p>This error may also indicate that the server does not support <a href=\"http://enable-cors.org/\" target=\"_blank\">CORS</a>.  If this is your server, verify that CORS is enabled and enable it if it is not. If you do not control the server, please contact the administrator of the server and ask them to enable CORS.  Or, contact the '{{appName}}' Map team by emailing {{email}} and ask us to add this server to the list of non-CORS-supporting servers that may be proxied by '{{appName}}' itself.</p><p>If you did not enter this link manually, this error may indicate that the group you opened is temporarily unavailable or there is a problem with your internet connection.  Try opening the group again, and if the problem persists, please report it by sending an email to {{email}}.</p>"
     },
     "commonModelErrors": {
+      "3dTypeIn2dMode": "**Note:** This dataset can not be displayed in the 2D viewer. Switch to one of the 3D map modes.",
       "datasetScaleErrorTitle": "Dataset will not be shown at this scale",
       "datasetScaleErrorMessage": "The {{name}} dataset will not be shown when zoomed in this close to the map because the data custodian has indicated that the data is not intended or suitable for display at this scale.  Click the dataset's Info button on the Now Viewing tab for more information about the dataset and the data custodian."
     }

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import { action, computed, observable, runInAction, toJS } from "mobx";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
@@ -216,6 +217,14 @@ export default function Cesium3dTilesMixin<
       );
 
       return [this.tileset];
+    }
+
+    @computed
+    get shortReport(): string | undefined {
+      if (this.terria.currentViewer.type === "Leaflet") {
+        return i18next.t("models.commonModelErrors.3dTypeIn2dMode", this);
+      }
+      return undefined;
     }
 
     @computed get optionsObj() {


### PR DESCRIPTION
### What this PR does

Partially fixes #4575 - although happy to take feedback on whether this approach is worthwhile. 
In terms of replicating master I'm not sure it's best behaviour, if you have multiple 3d-tiles items in your workbench you get a message box for each item, and you also loose the warning straight away. 
With this approach the warning is kept as a short report, and warning boxes aren't shown.

![Screen_2020_10_20](https://user-images.githubusercontent.com/6735870/96523168-c3a01080-12c0-11eb-9587-9366aea06199.jpg)


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
