### PR TITLE
Fix zoom for satellite imagery in DEA maps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### next release (8.0.0-alpha.57)
 * Fix memoization of `traitsClassToModelClass`.
+* Fix zooming bug for datasets with invalid bounding boxes.
 * [The next improvement]
   
 #### 8.0.0-alpha.56

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
@@ -111,7 +111,16 @@ const ViewingControls = observer(
 
     zoomTo() {
       const viewer = this.props.viewState.terria.currentViewer;
-      viewer.zoomTo(this.props.item);
+      const item = this.props.item;
+      let zoomToView = item;
+      if (
+        item.rectangle !== undefined &&
+        item.rectangle.east - item.rectangle.west >= 360
+      ) {
+        zoomToView = this.props.viewState.terria.mainViewer.homeCamera;
+        console.log("Extent is wider than world so using homeCamera.");
+      }
+      viewer.zoomTo(zoomToView);
     },
 
     openFeature() {


### PR DESCRIPTION
### What this PR does

Fixes #4853 

In master we perform some kind of "check" before zooming in (see [here](https://github.com/TerriaJS/terriajs/blob/master/lib/Models/CatalogItem.js#L1002)), to make sure that zooming doesn't break for datasets with bounding boxes that are overly large (or invalid), which is the underlying problem in the linked issue. The default zoom extent in such cases should be the `homeCamera` view (this is the behaviour in master). I am basically replicating that in mobx.

I added the code to `zoomTo` in `ViewingControls`, which seems like a weird place to add it. Though it allows me to _not_ have to add the code to both Leaflet and Cesium's `zoomTo`. The other alternative I thought of was to replace the `rectangle` property when it's first initialised in the catalogue item, but doing it this way allows me to _not_ have to do that for all catalogue items with `RectangleTraits` (ArcGis/WebMap/everything else that has `.rectangle`) so 🤷 

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
