### PR TITLE
Turn off IE11 for saucelabs

### DIFF
--- a/buildprocess/karma-saucelabs.conf.js
+++ b/buildprocess/karma-saucelabs.conf.js
@@ -36,7 +36,8 @@ module.exports = function(config) {
         },
 
         // start these browsers
-        browsers: ['sl_chrome', /*'sl_safari',*/ 'sl_firefox', 'sl_firefox_esr', 'sl_ie11'],
+        // browsers: ['sl_chrome', /*'sl_safari',*/ 'sl_firefox', 'sl_firefox_esr', 'sl_ie11'],
+        browsers: ['sl_chrome', 'sl_firefox', 'sl_firefox_esr'], 
 
         sauceLabels: {
             testName: 'TerriaJS Unit Tests',


### PR DESCRIPTION
### What this PR does

Turns off ie11 tests for saucelabs

### Checklist
n/a both
-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
