### PR TITLE
Release 7.11.15 with fix to expand chart feature info button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 Change Log
 ==========
 
-### Next version
+### v7.11.15
+* Fixed a bug when clicking the expand button on a chart in feature info when the clicked feature was a polygon.
 
 ### v7.11.14
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Change Log
 ==========
 
 ### v7.11.15
+
 * Fixed a bug when clicking the expand button on a chart in feature info when the clicked feature was a polygon.
 
 ### v7.11.14

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 Change Log
 ==========
 
+### Next Release
+
 ### v7.11.15
 
 * Fixed a bug when clicking the expand button on a chart in feature info when the clicked feature was a polygon.

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.jsx
@@ -219,7 +219,7 @@ function expand(props, sourceIndex) {
     });
     const items = [newCatalogItem];
     let newGeoJsonAvailable = false;
-    if (defined(feature.position._value)) {
+    if (defined(feature.position) && defined(feature.position._value)) {
       newGeoJsonAvailable = true;
       const newGeoJsonItem = new GeoJsonCatalogItem(terria, null);
       newGeoJsonItem.isUserSupplied = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "7.11.14",
+  "version": "7.11.15",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### Release 7.11.15


Fixes issue raised on Gitter https://gitter.im/TerriaJS/terriajs?at=5f8cfd377be0d67d2780e3bc

See also http://ci.terria.io/master/#clean&https://gist.githubusercontent.com/steve9164/fe01ca4c1da56eece7d46cdddffea1c3/raw/089dd2ef6510c35a70b4ec12aef23fd45dfefd8d/geojson-catalog.json

When a polygon feature of an item with `<chart>` in it's feature info template is clicked the chart cannot be expanded into the chart panel.
