### PR TITLE
Fix magda based maps when mix matching init styles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Chart expanded from feature info panel will now by default show only the first chart line.
 * Chart component attribtues `column-titles` and `column-units` will now accept a simpler syntax like: "Time,Speed" or "ms,kmph"
 * Fix presentation of the WMS Dimension metadata.
+* Magda based maps now mimic "root group uniqueId === '/'" behaviour, so that mix and matching map init approaches behave more consistently
 * [The next improvement]
   
 #### 8.0.0-alpha.56

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -918,7 +918,10 @@ export default class Terria {
     }
 
     if (aspects.group && aspects.group.members) {
-      const id = config.id;
+      // const id = config.id;
+      // force config id to be `/`, purely to emulate regular terria behaviour
+      const id = "/";
+      this.removeModelReferences(this.catalog.group);
 
       let existingReference = this.getModelById(MagdaReference, id);
       if (existingReference === undefined) {
@@ -929,7 +932,7 @@ export default class Terria {
       const reference = existingReference;
 
       reference.setTrait(CommonStrata.definition, "url", magdaRoot);
-      reference.setTrait(CommonStrata.definition, "recordId", config.id);
+      reference.setTrait(CommonStrata.definition, "recordId", id);
       reference.setTrait(CommonStrata.definition, "magdaRecord", config);
       await reference.loadReference().then(() => {
         if (reference.target instanceof CatalogGroup) {

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -82,6 +82,8 @@ describe("Terria", function() {
 
     describe("via loadMagdaConfig", function() {
       it("should dereference uniqueId to `/`", function(done) {
+        expect(terria.catalog.group.uniqueId).toEqual("/");
+
         jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
           // terria's "Magda derived url"
           responseText: mapConfigBasicString
@@ -168,6 +170,7 @@ describe("Terria", function() {
           });
       });
       it("parses dereferenced group aspect", function(done) {
+        expect(terria.catalog.group.uniqueId).toEqual("/");
         // dereferenced res
         jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
           responseText: mapConfigDereferencedString
@@ -179,6 +182,10 @@ describe("Terria", function() {
           .then(function() {
             const groupAspect = mapConfigDereferencedJson.aspects["group"];
             const ids = groupAspect.members.map((member: any) => member.id);
+            expect(terria.catalog.group.uniqueId).toEqual("/");
+            // ensure user added data co-exists with dereferenced magda members
+            expect(terria.catalog.group.members.length).toEqual(3);
+            expect(terria.catalog.userAddedDataGroup).toBeDefined();
             ids.forEach((id: string) => {
               const model = terria.getModelById(MagdaReference, id);
               if (!model) {

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -81,7 +81,31 @@ describe("Terria", function() {
     });
 
     describe("via loadMagdaConfig", function() {
+      it("should dereference uniqueId to `/`", function(done) {
+        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
+          // terria's "Magda derived url"
+          responseText: mapConfigBasicString
+        });
+        // no init sources before starting
+        expect(terria.initSources.length).toEqual(0);
+
+        terria
+          .start({
+            configUrl: "test/Magda/map-config-basic.json"
+          })
+          .then(function() {
+            expect(terria.catalog.group.uniqueId).toEqual("/");
+            done();
+          })
+          .catch(error => {
+            done.fail(error);
+          });
+      });
       it("works with basic initializationUrls", function(done) {
+        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
+          // terria's "Magda derived url"
+          responseText: mapConfigBasicString
+        });
         // no init sources before starting
         expect(terria.initSources.length).toEqual(0);
 
@@ -107,6 +131,10 @@ describe("Terria", function() {
           });
       });
       it("works with inline init", function(done) {
+        // inline init
+        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
+          responseText: mapConfigInlineInitString
+        });
         // no init sources before starting
         expect(terria.initSources.length).toEqual(0);
         terria
@@ -140,6 +168,10 @@ describe("Terria", function() {
           });
       });
       it("parses dereferenced group aspect", function(done) {
+        // dereferenced res
+        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
+          responseText: mapConfigDereferencedString
+        });
         terria
           .start({
             configUrl: "test/Magda/map-config-dereferenced.json"


### PR DESCRIPTION
### What this PR does

Fix magda based maps when mix matching init styles

When loading in magda based maps with `initializationUrls`, the id of the map config record would be used as the child records now referenced a root group with ID `map-config` instead of `/` in a static-json based catalog.

I also realise this is going to be hard to reproduce/test, basically, with this branch, and terrace (https://github.com/TerriaJS/terrace / https://github.com/TerriaJS/handbook/blob/master/DeveloperGuides/SaasMaps.md), point it at any magda based map, and observe 

`//Corona Virus - Cases`
vs
`map-config-pacificmap/Corona Virus - Cases`

![image](https://user-images.githubusercontent.com/9134432/96693495-0a7e2b00-13d3-11eb-8a9a-79ee3a7fbda6.png)

![image](https://user-images.githubusercontent.com/9134432/96693535-1669ed00-13d3-11eb-936c-d89c2b771e0d.png)


### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
