### PR TITLE
Add ArcGisTerrainCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 #### next release (8.0.0-alpha.58)
 * Add `FeatureInfoTraits` to `ArcGisMapServerCatalogItem`
 * Fix zooming bug for datasets with invalid bounding boxes.
+* Add new model for `ArcGisTerrainCatalogItem`.
 * [The next improvement]
 
 #### 8.0.0-alpha.57

--- a/lib/Models/ArcGisTerrainCatalogItem.ts
+++ b/lib/Models/ArcGisTerrainCatalogItem.ts
@@ -1,0 +1,41 @@
+import { computed } from "mobx";
+import ArcGISTiledElevationTerrainProvider from "terriajs-cesium/Source/Core/ArcGISTiledElevationTerrainProvider";
+import IonResource from "terriajs-cesium/Source/Core/IonResource";
+import AsyncMappableMixin from "../ModelMixins/AsyncMappableMixin";
+import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
+import UrlMixin from "../ModelMixins/UrlMixin";
+import ArcGisTerrainCatalogItemTraits from "../Traits/ArcGisTerrainCatalogItemTraits";
+import CreateModel from "./CreateModel";
+import Mappable from "./Mappable";
+
+export default class ArcGisTerrainCatalogItem
+  extends UrlMixin(
+    AsyncMappableMixin(
+      CatalogMemberMixin(CreateModel(ArcGisTerrainCatalogItemTraits))
+    )
+  )
+  implements Mappable {
+  static type = "arcgis-terrain";
+
+  get type() {
+    return ArcGisTerrainCatalogItem.type;
+  }
+
+  protected forceLoadMetadata() {
+    return Promise.resolve();
+  }
+
+  protected forceLoadMapItems() {
+    return Promise.resolve();
+  }
+
+  @computed
+  get mapItems() {
+    if (this.url === undefined) return [];
+    return [
+      new ArcGISTiledElevationTerrainProvider({
+        url: this.url
+      })
+    ];
+  }
+}

--- a/lib/Models/registerCatalogMembers.ts
+++ b/lib/Models/registerCatalogMembers.ts
@@ -5,6 +5,7 @@ import ArcGisMapServerCatalogGroup from "./ArcGisMapServerCatalogGroup";
 import ArcGisMapServerCatalogItem from "./ArcGisMapServerCatalogItem";
 import ArcGisPortalCatalogGroup from "./ArcGisPortalCatalogGroup";
 import ArcGisPortalItemReference from "./ArcGisPortalItemReference";
+import ArcGisTerrainCatalogItem from "./ArcGisTerrainCatalogItem";
 import BingMapsCatalogItem from "./BingMapsCatalogItem";
 import CartoMapCatalogItem from "./CartoMapCatalogItem";
 import CatalogGroup from "./CatalogGroupNew";
@@ -98,6 +99,10 @@ export default function registerCatalogMembers() {
   CatalogMemberFactory.register(
     ArcGisPortalItemReference.type,
     ArcGisPortalItemReference
+  );
+  CatalogMemberFactory.register(
+    ArcGisTerrainCatalogItem.type,
+    ArcGisTerrainCatalogItem
   );
   CatalogMemberFactory.register(
     Cesium3DTilesCatalogItem.type,

--- a/lib/Traits/ArcGisTerrainCatalogItemTraits.ts
+++ b/lib/Traits/ArcGisTerrainCatalogItemTraits.ts
@@ -1,0 +1,10 @@
+import CatalogMemberTraits from "./CatalogMemberTraits";
+import MappableTraits from "./MappableTraits";
+import mixTraits from "./mixTraits";
+import UrlTraits from "./UrlTraits";
+
+export default class ArcGisTerrainCatalogItemTraits extends mixTraits(
+  UrlTraits,
+  MappableTraits,
+  CatalogMemberTraits
+) {}


### PR DESCRIPTION
### What this PR does

This PR adds support for an esri terrain service from an elevation enabled ImageServer, using native cesium functionality.

It was requested in discussions here #4890 and will probably be useful for NSW.

Working example
````
    {
      "type": "arcgis-terrain",
      "name": "esri world terrain",
      "url": "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
    }
````

In theory NSW ought to work but it doesn't
````
    {
      "type": "arcgis-terrain",
      "name": "NSW 5m Terrain",
      "url": "https://maps.six.nsw.gov.au/arcgis/rest/services/public/NSW_5M_Elevation/ImageServer"
    }
````
I notice that the first thing Cesium does is a tile request for tile 0/0/0, (I'm guessing [here](https://github.com/CesiumGS/cesium/blob/1.74/Source/Core/ArcGISTiledElevationTerrainProvider.js#L152-L158)) and then no further requests are made, and so perhaps if there is no useful content in tile 0/0/0 that might throw Cesium into a spin so perhaps that's a bug we need to pursue upstream to fully realise this work for NSW...
Same sort of thing happens in the Cesium Sandcastle
https://sandcastle.cesium.com/#c=bVBLSwMxEP4rw55aKAkevLTbohSRgi/YopeFkmbH7WA2WSbZ1Cr976ZblKo9TebL92KiYoiEW2SYgsUtzNFT14jnHhuUme73ubNBkUUusxF8lhYgIHNCnthFqpDHp+Jr1reLYkkGqxuDUQVydvmbP+hNADo24+MLoMw2IbR+LGWjWi88vQvrt6J2UahOKtY1ecnog/TIkVIz2XZrQ1o+FC+ry/vVT5hcNKrGIrH6xoeA/TCN/XAC2SjLfdgZnH3nXlHTOg6HLgMhZMCmNSok93Wn3zAI7f1wciTn8lSaVxSBqumZK4E2yvv089oZU9AHltksl4n/T2qcqsjWj6mqUbsDbXMxuzuCQohcpvW8Mjhn1or/OH8B

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
