### PR TITLE
Fix CKAN naming

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Fix zooming bug for datasets with invalid bounding boxes.
 * Add new model for `ArcGisTerrainCatalogItem`.
 * Add 3D Tiles to 'Add web data' dropdown.
+* Fix naming of item in a `CkanCatalogGroup` when using an item naming scheme other than the default.
 * [The next improvement]
 
 #### 8.0.0-alpha.57

--- a/lib/Models/CkanCatalogGroup.ts
+++ b/lib/Models/CkanCatalogGroup.ts
@@ -1,5 +1,5 @@
 import i18next from "i18next";
-import { action, computed, runInAction } from "mobx";
+import { action, computed, observable, runInAction } from "mobx";
 import URI from "urijs";
 import isDefined from "../Core/isDefined";
 import loadJson from "../Core/loadJson";
@@ -8,6 +8,7 @@ import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
 import GroupMixin from "../ModelMixins/GroupMixin";
 import UrlMixin from "../ModelMixins/UrlMixin";
 import CkanCatalogGroupTraits from "../Traits/CkanCatalogGroupTraits";
+import CkanSharedTraits from "../Traits/CkanSharedTraits";
 import ModelReference from "../Traits/ModelReference";
 import CatalogGroup from "./CatalogGroupNew";
 import { CkanDataset, CkanServerResponse } from "./CkanDefinitions";
@@ -15,10 +16,34 @@ import CkanItemReference from "./CkanItemReference";
 import CommonStrata from "./CommonStrata";
 import CreateModel from "./CreateModel";
 import LoadableStratum from "./LoadableStratum";
-import { BaseModel } from "./Model";
+import Model, { BaseModel } from "./Model";
 import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
+import StratumFromTraits from "./StratumFromTraits";
 import StratumOrder from "./StratumOrder";
 import Terria from "./Terria";
+
+export function createInheritedCkanSharedTraitsStratum(
+  model: Model<CkanSharedTraits>
+): Readonly<StratumFromTraits<CkanSharedTraits>> {
+  const propertyNames = Object.keys(CkanSharedTraits.traits);
+  const reduced: any = propertyNames.reduce(
+    (p, c) => ({
+      ...p,
+      get [c]() {
+        return (model as any)[c];
+      }
+    }),
+    {}
+  );
+  return observable(reduced);
+}
+
+createInheritedCkanSharedTraitsStratum.stratumName =
+  "ckanItemReferenceInheritedPropertiesStratum";
+
+StratumOrder.addDefinitionStratum(
+  createInheritedCkanSharedTraitsStratum.stratumName
+);
 
 export class CkanServerStratum extends LoadableStratum(CkanCatalogGroupTraits) {
   static stratumName = "ckanServer";
@@ -202,6 +227,11 @@ export class CkanServerStratum extends LoadableStratum(CkanCatalogGroupTraits) {
     const id = this._catalogGroup.uniqueId;
     const datasetId = id + "/" + ckanDataset.id;
 
+    // Create a computed stratum to pass shared configuration down to items
+    const inheritedPropertiesStratum = createInheritedCkanSharedTraitsStratum(
+      this._catalogGroup
+    );
+
     for (var i = 0; i < ckanDataset.resources.length; ++i) {
       const resource = ckanDataset.resources[i];
       const resourceId = datasetId + "/" + resource.id;
@@ -222,9 +252,8 @@ export class CkanServerStratum extends LoadableStratum(CkanCatalogGroupTraits) {
         item.setCkanStrata(item);
         item.terria.addModel(item);
 
-        if (this._catalogGroup.itemProperties !== undefined) {
-          item.setItemProperties(item, this._catalogGroup.itemProperties);
-        }
+        item.setSharedStratum(inheritedPropertiesStratum);
+
         if (this._catalogGroup.groupBy === "organization") {
           const groupId = ckanDataset.organization
             ? this._catalogGroup.uniqueId + "/" + ckanDataset.organization.id

--- a/lib/Models/CkanItemReference.ts
+++ b/lib/Models/CkanItemReference.ts
@@ -125,6 +125,12 @@ export class CkanDatasetStratum extends LoadableStratum(
   @computed get name() {
     if (this.ckanResource === undefined) return this.ckanItemReference.name;
     if (this.ckanItemReference.useResourceName) return this.ckanResource.name;
+    // via @steve9164
+    /** Switched the order [check `useCombinationNameWhereMultipleResources`
+     * first ] that these are checked so the default is checked last. Otherwise
+     * setting useCombinationNameWhereMultipleResources without setting
+     * useDatasetNameAndFormatWhereMultipleResources to false doesn't do
+     * anything */
     if (this.ckanDataset) {
       if (
         this.ckanItemReference.useCombinationNameWhereMultipleResources &&

--- a/test/Models/CkanCatalogGroupSpec.ts
+++ b/test/Models/CkanCatalogGroupSpec.ts
@@ -124,10 +124,13 @@ describe("CkanCatalogGroup", function() {
       expect(ckanCatalogGroup.members).toBeDefined();
       expect(ckanCatalogGroup.members.length).toBe(3);
       let member0 = <CatalogGroup>ckanCatalogGroup.memberModels[0];
+      expect(member0 instanceof CatalogGroup).toBeTruthy();
       expect(member0.name).toBe("Blah");
       let member1 = <CatalogGroup>ckanCatalogGroup.memberModels[1];
+      expect(member1 instanceof CatalogGroup).toBeTruthy();
       expect(member1.name).toBe("Environment");
       let member2 = <CatalogGroup>ckanCatalogGroup.memberModels[2];
+      expect(member2 instanceof CatalogGroup).toBeTruthy();
       expect(member2.name).toBe("Science");
     });
 
@@ -138,16 +141,62 @@ describe("CkanCatalogGroup", function() {
       }
     });
 
-    // it("itemProperties get added", async function(done) {
-    //   const m = terria.getModelById(CkanItemReference, ckanCatalogGroup.uniqueId + '/66e3efa7-fb5c-4bd7-9478-74adb6277955/1dae2cfe-345b-4320-bf0c-4da0de061dc5')
-    //   if (m) {
-    //     await m.loadReference()
-    //     const target = m.target as WebMapServiceCatalogItem
-    //     if (target) {
-    //       expect(target.layers).toBe('abc')
-    //     }
-    //   }
-    //   done()
-    // });
+    it("itemProperties get added", async function() {
+      const m = terria.getModelById(
+        CkanItemReference,
+        ckanCatalogGroup.uniqueId +
+          "/66e3efa7-fb5c-4bd7-9478-74adb6277955/1dae2cfe-345b-4320-bf0c-4da0de061dc5"
+      );
+      expect(m).toBeDefined();
+      if (m) {
+        await m.loadReference();
+        const target = m.target as WebMapServiceCatalogItem;
+        expect(target).toBeDefined();
+        if (target) {
+          expect(target.layers).toBe("abc");
+        }
+      }
+    });
+  });
+  describe("with item naming using", function() {
+    beforeEach(async function() {
+      runInAction(() => {
+        ckanCatalogGroup.setTrait(
+          "definition",
+          "url",
+          "test/CKAN/search-result.json"
+        );
+      });
+    });
+
+    it("useCombinationNameWhereMultipleResources", async function() {
+      runInAction(() => {
+        ckanCatalogGroup.setTrait(
+          "definition",
+          "useCombinationNameWhereMultipleResources",
+          true
+        );
+      });
+      await ckanCatalogGroup.loadMembers();
+      ckanServerStratum = <CkanServerStratum>(
+        ckanCatalogGroup.strata.get(CkanServerStratum.stratumName)
+      );
+
+      let group1 = <CatalogGroup>ckanCatalogGroup.memberModels[1];
+      expect(
+        group1.memberModels && group1.memberModels.length === 6
+      ).toBeTruthy();
+      if (group1.memberModels && group1.memberModels.length === 6) {
+        // These items include their Dataset name in their Resource name, so it's not the greatest demonstration
+        //  of useCombinationNameWhereMultipleResources, but it works for an automated test
+        const items = group1.memberModels as CkanItemReference[];
+        expect(items[0].name).toBe(
+          "Murray-Darling Basin Water Resource Plan Areas – Surface Water - Murray-Darling Basin Water Resource Plan Areas – Surface Water for Google Earth"
+        );
+        expect(items[1].name).toBe(
+          "Murray-Darling Basin Water Resource Plan Areas – Surface Water - Murray-Darling Basin Water Resource Plan Areas – Surface Water - Preview this Dataset (WMS)"
+        );
+      }
+    });
   });
 });

--- a/test/Models/CkanCatalogGroupSpec.ts
+++ b/test/Models/CkanCatalogGroupSpec.ts
@@ -169,6 +169,27 @@ describe("CkanCatalogGroup", function() {
       });
     });
 
+    it("useDatasetNameAndFormatWhereMultipleResources (the default)", async function() {
+      await ckanCatalogGroup.loadMembers();
+      ckanServerStratum = <CkanServerStratum>(
+        ckanCatalogGroup.strata.get(CkanServerStratum.stratumName)
+      );
+
+      let group1 = <CatalogGroup>ckanCatalogGroup.memberModels[1];
+      expect(
+        group1.memberModels && group1.memberModels.length === 6
+      ).toBeTruthy();
+      if (group1.memberModels && group1.memberModels.length === 6) {
+        const items = group1.memberModels as CkanItemReference[];
+        expect(items[0].name).toBe(
+          "Murray-Darling Basin Water Resource Plan Areas – Surface Water - KMZ"
+        );
+        expect(items[1].name).toBe(
+          "Murray-Darling Basin Water Resource Plan Areas – Surface Water - WMS"
+        );
+      }
+    });
+
     it("useCombinationNameWhereMultipleResources", async function() {
       runInAction(() => {
         ckanCatalogGroup.setTrait(
@@ -195,6 +216,30 @@ describe("CkanCatalogGroup", function() {
         );
         expect(items[1].name).toBe(
           "Murray-Darling Basin Water Resource Plan Areas – Surface Water - Murray-Darling Basin Water Resource Plan Areas – Surface Water - Preview this Dataset (WMS)"
+        );
+      }
+    });
+
+    it("useResourceName", async function() {
+      runInAction(() => {
+        ckanCatalogGroup.setTrait("definition", "useResourceName", true);
+      });
+      await ckanCatalogGroup.loadMembers();
+      ckanServerStratum = <CkanServerStratum>(
+        ckanCatalogGroup.strata.get(CkanServerStratum.stratumName)
+      );
+
+      let group1 = <CatalogGroup>ckanCatalogGroup.memberModels[1];
+      expect(
+        group1.memberModels && group1.memberModels.length === 6
+      ).toBeTruthy();
+      if (group1.memberModels && group1.memberModels.length === 6) {
+        const items = group1.memberModels as CkanItemReference[];
+        expect(items[0].name).toBe(
+          "Murray-Darling Basin Water Resource Plan Areas – Surface Water for Google Earth"
+        );
+        expect(items[1].name).toBe(
+          "Murray-Darling Basin Water Resource Plan Areas – Surface Water - Preview this Dataset (WMS)"
         );
       }
     });


### PR DESCRIPTION
### What this PR does

Fixes #4903.

Add a stratum of computeds so that CkanItemReference inherits shared traits from a containing CkanCatalogGroup

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
