### PR TITLE
Remove isMixedInto from AsyncMappable and AsyncChartable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 #### next release (8.0.0-alpha.59)
 * Update magda error message
 * Add a short report section if trying to view a `3d-tiles` item in a 2d map.
+* Remove `isMixedInto` for `AsyncMappableMixin` and `AsyncChartableMixin`.
 * [The next improvement]
 
 #### 8.0.0-alpha.58
@@ -13,8 +14,6 @@ Change Log
 * Fix zooming bug for datasets with invalid bounding boxes.
 * Add new model for `ArcGisTerrainCatalogItem`.
 * Add 3D Tiles to 'Add web data' dropdown.
-* Remove `isMixedInto` for `AsyncMappableMixin` and `AsyncChartableMixin`.
-* [The next improvement]
 * Fix naming of item in a `CkanCatalogGroup` when using an item naming scheme other than the default.
 
 #### 8.0.0-alpha.57

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Fix zooming bug for datasets with invalid bounding boxes.
 * Add new model for `ArcGisTerrainCatalogItem`.
 * Add 3D Tiles to 'Add web data' dropdown.
+* Remove `isMixedInto` for `AsyncMappableMixin` and `AsyncChartableMixin`.
 * [The next improvement]
 
 #### 8.0.0-alpha.57

--- a/lib/ModelMixins/AsyncChartableMixin.ts
+++ b/lib/ModelMixins/AsyncChartableMixin.ts
@@ -1,4 +1,3 @@
-import ChartData from "../Charts/ChartData";
 import AsyncLoader from "../Core/AsyncLoader";
 import Constructor from "../Core/Constructor";
 import Chartable, { ChartAxis, ChartItem } from "../Models/Chartable";
@@ -56,9 +55,6 @@ function AsyncChartableMixin<T extends Constructor<Model<MappableTraits>>>(
 namespace AsyncChartableMixin {
   export interface AsyncChartableMixin
     extends InstanceType<ReturnType<typeof AsyncChartableMixin>> {}
-  export function isMixedInto(model: any): model is AsyncChartableMixin {
-    return model && model.isChartable;
-  }
 }
 
 export default AsyncChartableMixin;

--- a/lib/ModelMixins/AsyncMappableMixin.ts
+++ b/lib/ModelMixins/AsyncMappableMixin.ts
@@ -1,4 +1,3 @@
-import { computed, observable, runInAction } from "mobx";
 import Constructor from "../Core/Constructor";
 import Mappable, { MapItem } from "../Models/Mappable";
 import Model from "../Models/Model";
@@ -53,9 +52,6 @@ function AsyncMappableMixin<T extends Constructor<Model<MappableTraits>>>(
 namespace AsyncMappableMixin {
   export interface AsyncMappableMixin
     extends InstanceType<ReturnType<typeof AsyncMappableMixin>> {}
-  export function isMixedInto(model: any): model is AsyncMappableMixin {
-    return model && model.isMappable;
-  }
 }
 
 export default AsyncMappableMixin;


### PR DESCRIPTION
### Remove isMixedInto from AsyncMappable and AsyncChartable

Related to #4910

Remove confusion between checking `Mappable.is` or `AsyncMappable.isMixedInto` (and for `Chartable`)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
