### PR TITLE
Fix timeline not reacting to resizes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 ### Next Release
 
+* Fixed a bug where the timeline would not update properly when the timeline panel was resized.
+
 ### v7.11.15
 
 * Fixed a bug when clicking the expand button on a chart in feature info when the clicked feature was a polygon.

--- a/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
@@ -61,6 +61,10 @@ const CesiumTimeline = createReactClass({
       false
     );
 
+    this.resizeListener = () =>
+      this.cesiumTimeline && this.cesiumTimeline.resize();
+    window.addEventListener("resize", this.resizeListener, false);
+
     this.topLayerSubscription = knockout
       .getObservable(this.props.terria.timeSeriesStack, "topLayer")
       .subscribe(() => this.zoom());
@@ -76,6 +80,7 @@ const CesiumTimeline = createReactClass({
 
   componentWillUnmount() {
     this.topLayerSubscription.dispose();
+    window.removeEventListener("resize", this.resizeListener);
   },
 
   shouldComponentUpdate() {

--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -45,9 +45,6 @@ export const Timeline = createReactClass({
 
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
-    this.resizeListener = () => this.timeline && this.timeline.resize();
-    window.addEventListener("resize", this.resizeListener, false);
-
     const updateCurrentTimeString = clock => {
       const time = clock.currentTime;
       let currentTime;
@@ -88,7 +85,6 @@ export const Timeline = createReactClass({
   componentWillUnmount() {
     this.removeTickEvent();
     this.topLayerSubscription.dispose();
-    window.removeEventListener("resize", this.resizeListener);
   },
 
   updateForNewTopLayer() {


### PR DESCRIPTION
### What this PR does

The timeline at the moment doesn't handle window resizing or side panels being opened closed. It updates properly when you interact with it, but otherwise doesn't update.

With this PR timeline resizing is now properly handled in all events of timeline container width changes (window resize, story builder & workbench minimizing via triggerResize) 

### Checklist

- [x] No unit tests. UI change in `master`.
- [x] I've updated CHANGES.md with what I changed.
