### PR TITLE
Geoserver WMS transparent legend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Add `ThreddsCatalogGroup` model.
 * Port `supportsColorScaleRange`, `colorScaleMinimum` and `colorScaleMaximimum` from `master` to `WebMapServiceCatalogItem` model.
 * Ported MapboxVectorTileCatalogItem ("mvt").
+* Request transparent legend from GeoServer.
 * [The next improvement]
 
 #### 8.0.0-alpha.58


### PR DESCRIPTION
### What this PR does

Fixes 

In master the legend requested from Geoserver was transparent, this ports that functionality.

### Checklist

-   [x] no tests
-   [x] I've updated CHANGES.md with what I changed.
