### PR TITLE
Add Opacity to 3DTiles

### DIFF
--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -21,8 +21,10 @@ import runLater from "../Core/runLater";
 import CommonStrata from "../Models/CommonStrata";
 import createStratumInstance from "../Models/createStratumInstance";
 import Feature from "../Models/Feature";
-import Model from "../Models/Model";
+import LoadableStratum from "../Models/LoadableStratum";
+import Model, { BaseModel } from "../Models/Model";
 import proxyCatalogItemUrl from "../Models/proxyCatalogItemUrl";
+import StratumOrder from "../Models/StratumOrder";
 import Cesium3DTilesCatalogItemTraits from "../Traits/Cesium3DCatalogItemTraits";
 import Cesium3dTilesTraits, {
   OptionsTraits
@@ -30,6 +32,20 @@ import Cesium3dTilesTraits, {
 import AsyncMappableMixin from "./AsyncMappableMixin";
 import ShadowMixin from "./ShadowMixin";
 
+class Cesium3dTilesStratum extends LoadableStratum(Cesium3dTilesTraits) {
+  constructor() {
+    super();
+  }
+
+  duplicateLoadableStratum(model: BaseModel): this {
+    return new Cesium3dTilesStratum() as this;
+  }
+
+  @computed
+  get opacity() {
+    return 1.0;
+  }
+}
 interface Cesium3DTilesCatalogItemIface
   extends InstanceType<ReturnType<typeof Cesium3dTilesMixin>> {}
 
@@ -50,7 +66,7 @@ class ObservableCesium3DTileset extends Cesium3DTileset {
   }
 }
 
-export default function Cesium3dTilesMixin<
+function Cesium3dTilesMixin<
   T extends Constructor<Model<Cesium3dTilesTraits>>
 >(Base: T) {
   abstract class Cesium3dTilesMixin extends ShadowMixin(
@@ -380,6 +396,13 @@ export default function Cesium3dTilesMixin<
 
   return Cesium3dTilesMixin;
 }
+
+namespace Cesium3dTilesMixin {
+  StratumOrder.addLoadStratum(Cesium3dTilesStratum.name);
+  export interface Cesium3dTilesMixin extends Cesium3DTilesCatalogItemIface {}
+}
+
+export default Cesium3dTilesMixin;
 
 function normalizeShowExpression(
   show: any

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -77,6 +77,13 @@ function Cesium3dTilesMixin<T extends Constructor<Model<Cesium3dTilesTraits>>>(
 
     private tileset?: ObservableCesium3DTileset;
 
+    constructor(...args: any[]) {
+      super(...args);
+      runInAction(() => {
+        this.strata.set(Cesium3dTilesStratum.name, new Cesium3dTilesStratum());
+      });
+    }
+
     get isMappable() {
       return true;
     }
@@ -407,11 +414,6 @@ function Cesium3dTilesMixin<T extends Constructor<Model<Cesium3dTilesTraits>>>(
   }
 
   return Cesium3dTilesMixin;
-}
-
-namespace Cesium3dTilesMixin {
-  StratumOrder.addLoadStratum(Cesium3dTilesStratum.name);
-  export interface Cesium3dTilesMixin extends Cesium3DTilesCatalogItemIface {}
 }
 
 export default Cesium3dTilesMixin;

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -47,6 +47,10 @@ class Cesium3dTilesStratum extends LoadableStratum(Cesium3dTilesTraits) {
     return 1.0;
   }
 }
+
+// Register the Cesium3dTilesStratum
+StratumOrder.instance.addLoadStratum(Cesium3dTilesStratum.name);
+
 interface Cesium3DTilesCatalogItemIface
   extends InstanceType<ReturnType<typeof Cesium3dTilesMixin>> {}
 

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -304,14 +304,24 @@ export default function Cesium3dTilesMixin<
       }
     }
 
+  
     @computed get cesiumTileStyle() {
       if (
         !isDefined(this.style) &&
+        (!isDefined(this.opacity) || this.opacity === 1) &&
         !isDefined(this.showExpressionFromFilters)
       ) {
         return;
       }
-      const style = clone(toJS(this.style) || {});
+
+      let style = clone(toJS(this.style) || {});
+      let opacity = clone(toJS(this.opacity) || 1.0);
+
+      if (opacity <= 1) {
+        const _color = `color('${style.color || "#FFFFFF"}', ${this.opacity})`;
+        style = Object.assign(style, { color: _color });
+      }
+
       if (isDefined(this.showExpressionFromFilters)) {
         style.show = toJS(this.showExpressionFromFilters);
       }

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -66,9 +66,9 @@ class ObservableCesium3DTileset extends Cesium3DTileset {
   }
 }
 
-function Cesium3dTilesMixin<
-  T extends Constructor<Model<Cesium3dTilesTraits>>
->(Base: T) {
+function Cesium3dTilesMixin<T extends Constructor<Model<Cesium3dTilesTraits>>>(
+  Base: T
+) {
   abstract class Cesium3dTilesMixin extends ShadowMixin(
     AsyncMappableMixin(Base)
   ) {
@@ -320,7 +320,6 @@ function Cesium3dTilesMixin<
       }
     }
 
-  
     @computed get cesiumTileStyle() {
       if (
         !isDefined(this.style) &&

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
@@ -8,6 +8,7 @@ import React from "react";
 import CommonStrata from "../../../Models/CommonStrata";
 import hasTraits from "../../../Models/hasTraits";
 import RasterLayerTraits from "../../../Traits/RasterLayerTraits";
+import OpacityTrait from "../../../Traits/OpacityTrait";
 import Styles from "./opacity-section.scss";
 import { withTranslation } from "react-i18next";
 import { runInAction } from "mobx";
@@ -23,7 +24,7 @@ const OpacitySection = observer(
 
     changeOpacity(value) {
       const item = this.props.item;
-      if (hasTraits(item, RasterLayerTraits, "opacity")) {
+      if (hasTraits(item, RasterLayerTraits, "opacity") || hasTraits(item, OpacityTrait, "opacity"))  {
         runInAction(() => {
           item.setTrait(CommonStrata.user, "opacity", value / 100.0);
         });
@@ -34,8 +35,8 @@ const OpacitySection = observer(
       const item = this.props.item;
       const { t } = this.props;
       if (
-        !hasTraits(item, RasterLayerTraits, "opacity") ||
-        item.disableOpacityControl
+         (!hasTraits(item, RasterLayerTraits, "opacity") && !hasTraits(item, OpacityTrait, "opacity")) ||
+         item.disableOpacityControl
       ) {
         return null;
       }

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
@@ -7,7 +7,6 @@ import Slider from "rc-slider";
 import React from "react";
 import CommonStrata from "../../../Models/CommonStrata";
 import hasTraits from "../../../Models/hasTraits";
-import RasterLayerTraits from "../../../Traits/RasterLayerTraits";
 import OpacityTrait from "../../../Traits/OpacityTrait";
 import Styles from "./opacity-section.scss";
 import { withTranslation } from "react-i18next";
@@ -24,10 +23,7 @@ const OpacitySection = observer(
 
     changeOpacity(value) {
       const item = this.props.item;
-      if (
-        hasTraits(item, RasterLayerTraits, "opacity") ||
-        hasTraits(item, OpacityTrait, "opacity")
-      ) {
+      if (hasTraits(item, OpacityTrait, "opacity")) {
         runInAction(() => {
           item.setTrait(CommonStrata.user, "opacity", value / 100.0);
         });
@@ -38,8 +34,7 @@ const OpacitySection = observer(
       const item = this.props.item;
       const { t } = this.props;
       if (
-        (!hasTraits(item, RasterLayerTraits, "opacity") &&
-          !hasTraits(item, OpacityTrait, "opacity")) ||
+        !hasTraits(item, OpacityTrait, "opacity") ||
         item.disableOpacityControl
       ) {
         return null;

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.jsx
@@ -24,7 +24,10 @@ const OpacitySection = observer(
 
     changeOpacity(value) {
       const item = this.props.item;
-      if (hasTraits(item, RasterLayerTraits, "opacity") || hasTraits(item, OpacityTrait, "opacity"))  {
+      if (
+        hasTraits(item, RasterLayerTraits, "opacity") ||
+        hasTraits(item, OpacityTrait, "opacity")
+      ) {
         runInAction(() => {
           item.setTrait(CommonStrata.user, "opacity", value / 100.0);
         });
@@ -35,8 +38,9 @@ const OpacitySection = observer(
       const item = this.props.item;
       const { t } = this.props;
       if (
-         (!hasTraits(item, RasterLayerTraits, "opacity") && !hasTraits(item, OpacityTrait, "opacity")) ||
-         item.disableOpacityControl
+        (!hasTraits(item, RasterLayerTraits, "opacity") &&
+          !hasTraits(item, OpacityTrait, "opacity")) ||
+        item.disableOpacityControl
       ) {
         return null;
       }

--- a/lib/Traits/Cesium3dTilesTraits.ts
+++ b/lib/Traits/Cesium3dTilesTraits.ts
@@ -13,6 +13,7 @@ import UrlTraits from "./UrlTraits";
 import TransformationTraits from "./TransformationTraits";
 import PlaceEditorTraits from "./PlaceEditorTraits";
 import primitiveArrayTrait from "./primitiveArrayTrait";
+import OpacityTrait from "./OpacityTrait";
 
 export class FilterTraits extends ModelTraits {
   @primitiveTrait({
@@ -105,7 +106,8 @@ export default class Cesium3DTilesTraits extends mixTraits(
   MappableTraits,
   UrlTraits,
   CatalogMemberTraits,
-  ShadowTraits
+  ShadowTraits,
+  OpacityTrait
 ) {
   @primitiveTrait({
     type: "number",

--- a/lib/Traits/OpacityTrait.ts
+++ b/lib/Traits/OpacityTrait.ts
@@ -1,0 +1,11 @@
+import ModelTraits from "./ModelTraits";
+import primitiveTrait from "./primitiveTrait";
+ 
+export default class OpacityTrait extends ModelTraits {
+  @primitiveTrait({
+    type: "number",
+    name: "Opacity",
+    description: "The opacity of the item."
+  })
+  opacity: number = 1.0;
+}

--- a/lib/Traits/OpacityTrait.ts
+++ b/lib/Traits/OpacityTrait.ts
@@ -1,6 +1,6 @@
 import ModelTraits from "./ModelTraits";
 import primitiveTrait from "./primitiveTrait";
- 
+
 export default class OpacityTrait extends ModelTraits {
   @primitiveTrait({
     type: "number",

--- a/lib/Traits/OpacityTrait.ts
+++ b/lib/Traits/OpacityTrait.ts
@@ -7,5 +7,5 @@ export default class OpacityTrait extends ModelTraits {
     name: "Opacity",
     description: "The opacity of the item."
   })
-  opacity: number = 1.0;
+  opacity: number = 0.8;
 }

--- a/lib/Traits/RasterLayerTraits.ts
+++ b/lib/Traits/RasterLayerTraits.ts
@@ -1,6 +1,7 @@
 import ModelTraits from "./ModelTraits";
 import objectTrait from "./objectTrait";
 import primitiveTrait from "./primitiveTrait";
+import OpacityTrait from "./OpacityTrait";
 
 export class TileErrorHandlingTraits extends ModelTraits {
   @primitiveTrait({
@@ -35,14 +36,7 @@ export class TileErrorHandlingTraits extends ModelTraits {
   ignoreUnknownTileErrors?: boolean;
 }
 
-export default class RasterLayerTraits extends ModelTraits {
-  @primitiveTrait({
-    type: "number",
-    name: "Opacity",
-    description: "The opacity of the map layers."
-  })
-  opacity: number = 0.8;
-
+export default class RasterLayerTraits extends OpacityTrait {
   @primitiveTrait({
     type: "number",
     name: "Leaflet update interval",

--- a/lib/Traits/RasterLayerTraits.ts
+++ b/lib/Traits/RasterLayerTraits.ts
@@ -1,7 +1,7 @@
 import ModelTraits from "./ModelTraits";
 import objectTrait from "./objectTrait";
-import primitiveTrait from "./primitiveTrait";
 import OpacityTrait from "./OpacityTrait";
+import primitiveTrait from "./primitiveTrait";
 
 export class TileErrorHandlingTraits extends ModelTraits {
   @primitiveTrait({


### PR DESCRIPTION
### Change opacity to 3DTiles.

As an end user of Terria,
I want to be able to change 3DTiles opacity from the workbench, just like Items that uses RasterLayerTraits, 
example: ArcGisMapServerCatalogItem.

To control the opacity on 3DTiles you need to change its color according to style.

This PR proposes the following:
- Create a more general Trait called OpacityTrait , Initially it could be used only in 3DTiles but later it could be applied to other types of items.
-Add OpacityTrait to Cesium3DTilesTraits.
-Modify Cesium3dTilesMixin to update the style with its opacity, keeping both options (Style and Opacity). 
-Modify the OpacitySection React component to support items that has OpacityTrait  and keep the RasterLayerTraits too.

See an small video that show the functionality. [Link to video.](https://youtu.be/AP-E_HVP4Z8)
