### PR TITLE
Add `multiplierDefaultDeltaStep` Trait, which tries to calculate sensible multiplier for `DistrectelyTimeVarying` datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Ensure there aren't more bins than unique values for a `TableStyle`
 * Add access control properties to items fetched from Esri Portal.
 * Improves magda based root group mimic behaviour introdcued in 8.0.0-alpha.57 by adding `/` to `knownContainerUniqueIds` when `map-config*` is encountered
+* Add `multiplierDefaultDeltaStep` Trait, which tries to calculate sensible multiplier for `DistrectelyTimeVarying` datasets. By default it is set to 2, which results in a new timestep being displayed every 2 seconds (on average) if timeline is playing.
 
 #### 8.0.0-alpha.60
 * Fix WMS legend for default styles.

--- a/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
+++ b/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
@@ -259,7 +259,7 @@ function DiscretelyTimeVaryingMixin<
     }
 
     /**
-     * Try to calculate a multiplier which results in a new time step every {this.multiplierDefaultDeltaStep} seconds. For example, if {this.multiplierDefaultDeltaStep = 5} it would set the `multiplier` so that a new time step (of this dataset) would appear every five seconds if the timeline is playing.
+     * Try to calculate a multiplier which results in a new time step every {this.multiplierDefaultDeltaStep} seconds. For example, if {this.multiplierDefaultDeltaStep = 5} it would set the `multiplier` so that a new time step (of this dataset) would appear every five seconds (on average) if the timeline is playing.
      */
     @computed
     get multiplier() {

--- a/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
+++ b/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
@@ -258,6 +258,34 @@ function DiscretelyTimeVaryingMixin<
       return time;
     }
 
+    /**
+     * Try to calculate a multiplier which results in a new time step every {this.multiplierDefaultDeltaStep} seconds. For example, if {this.multiplierDefaultDeltaStep = 5} it would set the `multiplier` so that a new time step (of this dataset) would appear every five seconds if the timeline is playing.
+     */
+    @computed
+    get multiplier() {
+      if (super.multiplier) return super.multiplier;
+
+      if (
+        !isDefined(this.startTimeAsJulianDate) ||
+        !isDefined(this.stopTimeAsJulianDate) ||
+        !isDefined(this.multiplierDefaultDeltaStep)
+      )
+        return;
+
+      const dSeconds =
+        (this.stopTimeAsJulianDate.dayNumber -
+          this.startTimeAsJulianDate.dayNumber) *
+          24 *
+          60 *
+          60 +
+        this.stopTimeAsJulianDate.secondsOfDay -
+        this.startTimeAsJulianDate.secondsOfDay;
+      const meanDSeconds =
+        dSeconds / this.discreteTimesAsSortedJulianDates!.length;
+
+      return meanDSeconds / this.multiplierDefaultDeltaStep;
+    }
+
     @action
     moveToPreviousDiscreteTime(stratumId: string) {
       const index = this.previousDiscreteTimeIndex;

--- a/lib/Traits/DiscretelyTimeVaryingTraits.ts
+++ b/lib/Traits/DiscretelyTimeVaryingTraits.ts
@@ -60,4 +60,12 @@ export default class DiscretelyTimeVaryingTraits extends mixTraits(
     description: "When true, disables the date time selector in the workbench"
   })
   disableDateTimeSelector = false;
+
+  @primitiveTrait({
+    name: "Time Multiplier",
+    description:
+      "The multiplierDefaultDeltaStep is used to set the default multiplier (see `TimeVaryingTraits.multiplier` trait) - it represents the average number of (real-time) seconds between (dataset) time steps. For example, a value of five would set the `multiplier` so that a new time step (of this dataset) would appear every five seconds if the timeline is playing. This trait will only take effect if `multiplier` is **not** explicitly set.",
+    type: "number"
+  })
+  multiplierDefaultDeltaStep?: number = 2;
 }

--- a/lib/Traits/DiscretelyTimeVaryingTraits.ts
+++ b/lib/Traits/DiscretelyTimeVaryingTraits.ts
@@ -64,7 +64,7 @@ export default class DiscretelyTimeVaryingTraits extends mixTraits(
   @primitiveTrait({
     name: "Time Multiplier",
     description:
-      "The multiplierDefaultDeltaStep is used to set the default multiplier (see `TimeVaryingTraits.multiplier` trait) - it represents the average number of (real-time) seconds between (dataset) time steps. For example, a value of five would set the `multiplier` so that a new time step (of this dataset) would appear every five seconds if the timeline is playing. This trait will only take effect if `multiplier` is **not** explicitly set.",
+      "The multiplierDefaultDeltaStep is used to set the default multiplier (see `TimeVaryingTraits.multiplier` trait) - it represents the average number of (real-time) seconds between (dataset) time steps. For example, a value of five would set the `multiplier` so that a new time step (of this dataset) would appear every five seconds (on average) if the timeline is playing. This trait will only take effect if `multiplier` is **not** explicitly set.",
     type: "number"
   })
   multiplierDefaultDeltaStep?: number = 2;

--- a/lib/Traits/TimeVaryingTraits.ts
+++ b/lib/Traits/TimeVaryingTraits.ts
@@ -1,7 +1,6 @@
-import primitiveTrait from "./primitiveTrait";
-import mixTraits from "./mixTraits";
 import CatalogMemberTraits from "./CatalogMemberTraits";
-import MappableTraits from "./MappableTraits";
+import mixTraits from "./mixTraits";
+import primitiveTrait from "./primitiveTrait";
 
 export default class TimeVaryingTraits extends mixTraits(CatalogMemberTraits) {
   @primitiveTrait({

--- a/test/ModelMixins/DiscretelyTimeVaryingMixinSpec.ts
+++ b/test/ModelMixins/DiscretelyTimeVaryingMixinSpec.ts
@@ -43,4 +43,23 @@ describe("DiscretelyTimeVaryingMixin", () => {
     await wmsItem.loadChartItems();
     expect(wmsItem.chartItems[0].getColor()).toBe("#efefef");
   });
+
+  it("sets multiplier correctly from multiplierDefaultDeltaStep", async function() {
+    wmsItem = new WebMapServiceCatalogItem("mywms2", terria);
+    wmsItem.setTrait(
+      "definition",
+      "url",
+      "/test/WMS/period_datetimes_many_intervals.xml"
+    );
+
+    await wmsItem.loadMetadata();
+
+    expect(wmsItem.multiplier).toBeDefined();
+    expect(wmsItem.multiplierDefaultDeltaStep).toBeDefined();
+
+    // This dataset has a timestep every minute
+    expect(Math.round(wmsItem.multiplier!)).toBe(
+      60 / wmsItem.multiplierDefaultDeltaStep!
+    );
+  });
 });


### PR DESCRIPTION
### Add `multiplierDefaultDeltaStep` Trait, which tries to calculate sensible multiplier for `DistrectelyTimeVarying` datasets

Fixes  https://github.com/PacificCommunity/Terria-PacificMap/issues/53

Add `multiplierDefaultDeltaStep` Trait, which tries to calculate sensible multiplier for `DistrectelyTimeVarying` datasets. By default it is set to 2, which results in a new timestep being displayed every 2 seconds (on average) if timeline is playing.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
