### PR TITLE
Adds new config parameter `defaultBaseMapId`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Change Log
 * Fixed broken chart disclaimers in shared views.
 * Fixed a bug where chart disclaimers were shown even for chart items disabled in the workbench.
 * Fixed a bug where charts with titles containing the text "lat" or "lon" were hidden from feature info panel.
+* Added config parameter `defaultBaseMapId` which is used as a fallback map if no persisted map is found.
 
 #### 8.0.0-alpha.60
 * Fix WMS legend for default styles.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.62)
+* Added config parameter `defaultBaseMapId` which is used as a fallback map if no persisted map is found.
+
 
 #### 8.0.0-alpha.61
 * New `CatalogFunctionMixin` and `CatalogFunctionJobMixin`
@@ -23,7 +25,6 @@ Change Log
 * Fixed broken chart disclaimers in shared views.
 * Fixed a bug where chart disclaimers were shown even for chart items disabled in the workbench.
 * Fixed a bug where charts with titles containing the text "lat" or "lon" were hidden from feature info panel.
-* Added config parameter `defaultBaseMapId` which is used as a fallback map if no persisted map is found.
 * Fixed a bug that occurred when loading config from magda. `initializationUrls` are now applied even if `group` aspect is not set
 
 #### 8.0.0-alpha.60

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -20,6 +20,7 @@ import WebMapServiceCatalogGroup from "../../lib/Models/WebMapServiceCatalogGrou
 import WebMapServiceCatalogItem from "../../lib/Models/WebMapServiceCatalogItem";
 import ViewState from "../../lib/ReactViewModels/ViewState";
 import { buildShareLink } from "../../lib/ReactViews/Map/Panels/SharePanel/BuildShareLink";
+import { BaseMapViewModel } from "../../lib/ViewModels/BaseMapViewModel";
 import SimpleCatalogItem from "../Helpers/SimpleCatalogItem";
 
 const mapConfigBasicJson = require("../../wwwroot/test/Magda/map-config-basic.json");
@@ -600,6 +601,36 @@ describe("Terria", function() {
       });
       expect(terria.selectedFeature).toBeDefined();
       expect(terria.selectedFeature?.name).toBe("foo");
+    });
+  });
+
+  describe("updateBaseMaps", function() {
+    let baseMaps: BaseMapViewModel[];
+    beforeEach(function() {
+      baseMaps = [
+        new BaseMapViewModel(new WebMapServiceCatalogItem("baseMap0", terria)),
+        new BaseMapViewModel(new WebMapServiceCatalogItem("baseMap1", terria))
+      ];
+    });
+
+    it("updates the basemaps list", function() {
+      terria.updateBaseMaps(baseMaps);
+      expect(terria.baseMaps).toEqual(baseMaps);
+    });
+
+    describe("automatically setting viewer basemap", function() {
+      it("sets it to the persisted base map if present", function() {
+        spyOn(terria, "getLocalProperty").and.returnValue("baseMap1");
+        terria.updateBaseMaps(baseMaps);
+        expect(terria.mainViewer.baseMap).toBe(baseMaps[1].mappable);
+      });
+
+      it("otherwise, sets it to the default basemap", function() {
+        spyOn(terria, "getLocalProperty").and.returnValue(undefined);
+        terria.configParameters.defaultBaseMapId = "baseMap1";
+        terria.updateBaseMaps(baseMaps);
+        expect(terria.mainViewer.baseMap).toBe(baseMaps[1].mappable);
+      });
     });
   });
 });


### PR DESCRIPTION
### What this PR does

Adds a new config parameter `defaultBaseMapId` which is used as a fallback if no persisted map is found.

Required for https://github.com/TerriaJS/RaPPMap/issues/87

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
