### PR TITLE
Add trait `showInWorkbenchOnLoad` for all catalog members.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.62)
+* Added trait `showInWorkbenchOnload` for all catalog members which adds the item to the workbench when the init file is loaded. This is equivalent to the property `isEnabled` in the v7.
 
 #### 8.0.0-alpha.61
 * New `CatalogFunctionMixin` and `CatalogFunctionJobMixin`

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -44,6 +44,7 @@ import { HelpContentItem } from "../ReactViewModels/defaultHelpContent";
 import { defaultTerms, Term } from "../ReactViewModels/defaultTerms";
 import { Notification } from "../ReactViewModels/ViewState";
 import { shareConvertNotification } from "../ReactViews/Notification/shareConvertNotification";
+import CatalogMemberTraits from "../Traits/CatalogMemberTraits";
 import ShowableTraits from "../Traits/ShowableTraits";
 import { BaseMapViewModel } from "../ViewModels/BaseMapViewModel";
 import TerriaViewer from "../ViewModels/TerriaViewer";
@@ -882,7 +883,13 @@ export default class Terria {
           })
         );
 
-        this.workbench.items = newItems;
+        // Items marked with `showInWorkbenchOnLoad` also need to be added to the workbench
+        const itemsToShowInWorkbenchOnLoad = [...this.models.values()].filter(
+          m =>
+            hasTraits(m, CatalogMemberTraits, "showInWorkbenchOnLoad") &&
+            m.showInWorkbenchOnLoad
+        );
+        this.workbench.items = newItems.concat(itemsToShowInWorkbenchOnLoad);
 
         // TODO: the timelineStack should be populated from the `timeline` property,
         // not from the workbench.
@@ -895,7 +902,7 @@ export default class Terria {
 
         // Load the items on the workbench
         return Promise.all(
-          newItems.map(async model => {
+          this.workbench.items.map(async model => {
             if (ReferenceMixin.is(model)) {
               await model.loadReference();
               model = model.target || model;

--- a/lib/Traits/CatalogMemberTraits.ts
+++ b/lib/Traits/CatalogMemberTraits.ts
@@ -158,4 +158,12 @@ export default class CatalogMemberTraits extends ModelTraits {
       "Indicates that the source of this data should be hidden from the UI (obviously this isn't super-secure as you can just look at the network requests)."
   })
   hideSource: boolean = false;
+
+  @primitiveTrait({
+    type: "boolean",
+    name: "Show in workbench on load",
+    description:
+      "If true, this item will be shown in the workbench when the init file is loaded"
+  })
+  showInWorkbenchOnLoad: boolean = false;
 }

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -4,6 +4,7 @@ import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import ImagerySplitDirection from "terriajs-cesium/Source/Scene/ImagerySplitDirection";
 import hashEntity from "../../lib/Core/hashEntity";
 import PickedFeatures from "../../lib/Map/PickedFeatures";
+import CatalogMemberMixin from "../../lib/ModelMixins/CatalogMemberMixin";
 import CameraView from "../../lib/Models/CameraView";
 import Cesium from "../../lib/Models/Cesium";
 import CommonStrata from "../../lib/Models/CommonStrata";
@@ -530,6 +531,36 @@ describe("Terria", function() {
         });
         expect(terria.pickedFeatures).toBeDefined();
         expect(terria.selectedFeature).toBeDefined();
+      });
+    });
+
+    fdescribe("items marked `showInWorkbenchOnLoad`", function() {
+      it("adds them to the workbench", async function() {
+        try {
+          await terria.applyInitData({
+            initData: {
+              catalog: [
+                {
+                  type: "csv",
+                  name: "Shown in workbench",
+                  showInWorkbenchOnLoad: true,
+                  csvString: ""
+                },
+                {
+                  type: "csv",
+                  name: "Not shown in workbench",
+                  csvString: ""
+                }
+              ]
+            }
+          });
+        } catch {}
+        expect(terria.workbench.items.length).toBe(1);
+        const item = terria.workbench.items[0];
+        expect(CatalogMemberMixin.isMixedInto(item)).toBe(true);
+        if (CatalogMemberMixin.isMixedInto(item)) {
+          expect(item.name).toBe("Shown in workbench");
+        }
       });
     });
   });

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -534,7 +534,7 @@ describe("Terria", function() {
       });
     });
 
-    fdescribe("items marked `showInWorkbenchOnLoad`", function() {
+    describe("items marked `showInWorkbenchOnLoad`", function() {
       it("adds them to the workbench", async function() {
         try {
           await terria.applyInitData({


### PR DESCRIPTION
### What this PR does

Adds trait `showInWorkbenchOnload` for all catalog members which adds the item to the workbench when the init file is loaded. This is equivalent to setting `isEnabled: true` in the v7.

Required for https://github.com/TerriaJS/RaPPMap/issues/87

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
