### PR TITLE
Hide empty info sections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.62)
-* Fixed an issue with not loading the base map from init file and an issue with viewerMode from init files overriding the persisted viewerMode
+* Fixed an issue with not loading the base map from init file and an issue with viewerMode from init files overriding the persisted viewerMode.
+* Hide info sections with empty content in the explorer preview.
 * [The next improvement]
 
 #### 8.0.0-alpha.61

--- a/lib/ReactViews/Preview/DataPreviewSections.jsx
+++ b/lib/ReactViews/Preview/DataPreviewSections.jsx
@@ -62,7 +62,7 @@ const DataPreviewSections = observer(
         <div>
           <For each="item" index="i" of={this.sortInfoSections(items)}>
             <Choose>
-              <When condition={item.content !== undefined}>
+              <When condition={item.content?.length > 0}>
                 <div key={i}>
                   <h4 className={Styles.h4}>{item.name}</h4>
                   {parseCustomMarkdownToReact(


### PR DESCRIPTION
### What this PR does

Hide info sections with empty content in explorer preview.

eg:

in v7 

![image](https://user-images.githubusercontent.com/1430/99616319-20821880-2a71-11eb-9d4e-2a830651da5b.png)

vs in v8

![image](https://user-images.githubusercontent.com/1430/99616258-01838680-2a71-11eb-8652-487ad276bf12.png)


### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [x] I've updated CHANGES.md with what I changed.
