### PR TITLE
Fix error when previewing an item in a open by default group.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### next release (8.0.0-alpha.62)
 * Fixed an issue with not loading the base map from init file and an issue with viewerMode from init files overriding the persisted viewerMode
+* Fixed errors when previewing an item in a group that is open by default (`isOpen: true` in init file).
 * [The next improvement]
 
 #### 8.0.0-alpha.61

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
@@ -88,6 +88,18 @@ const DataCatalogGroup = observer(
       return url.replace(/^https?:\/\//, "");
     },
 
+    componentDidMount() {
+      if (this.props.group.isOpen) {
+        this.props.group.loadMembers();
+      }
+    },
+
+    componentDidUpdate() {
+      if (this.props.group.isOpen) {
+        this.props.group.loadMembers();
+      }
+    },
+
     render() {
       const group = this.props.group;
       const { t } = this.props;


### PR DESCRIPTION
### What this PR does

Fixes #4994 

Fixes console errors when previewing an item in a open by default group (i.e `isOpen: true` in init file).

The errors are thrown because `loadMembers()` are not called for groups that are already open, so the `knownContainerUniqueIds` are not properly set for the members. 

This change ensures `loadMembers()` is called for all open groups by invoking them in `componentDidMount` and `componentWillMount` hooks of `DataCatalogGroup` component.

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [x] I've updated CHANGES.md with what I changed.
