### PR TITLE
Fix errors when switching explorer tabs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### next release (8.0.0-alpha.62)
 * Fixed an issue with not loading the base map from init file and an issue with viewerMode from init files overriding the persisted viewerMode
+* Fixed erros when switching explorer tabs.
 * [The next improvement]
 
 #### 8.0.0-alpha.61

--- a/lib/ReactViews/ExplorerWindow/Tabs.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs.jsx
@@ -11,8 +11,9 @@ import { withTranslation } from "react-i18next";
 
 import Styles from "./tabs.scss";
 import { observer } from "mobx-react";
-import { runInAction } from "mobx";
+import { runInAction, action } from "mobx";
 import Mappable from "../../Models/Mappable";
+import openGroup from "../../Models/openGroup.ts";
 
 const Tabs = observer(
   createReactClass({
@@ -66,7 +67,7 @@ const Tabs = observer(
               name: member.nameInCatalog,
               title: `data-catalog-${member.name}`,
               category: "data-catalog",
-              idInCategory: member.name,
+              idInCategory: member.uniqueId,
               panel: (
                 <DataCatalogTab
                   terria={this.props.terria}
@@ -105,14 +106,15 @@ const Tabs = observer(
           this.props.viewState.activeTabIdInCategory = idInCategory;
           if (category === "data-catalog") {
             const member = this.props.terria.catalog.group.memberModels.filter(
-              m => m.name === idInCategory
+              m => m.uniqueId === idInCategory
             )[0];
             // If member was found and member can be opened, open it (causes CkanCatalogGroups to fetch etc.)
             if (defined(member)) {
-              if (member.toggleOpen) {
-                member.isOpen = true;
-              }
-              this.props.viewState.previewedItem = member;
+              openGroup(member).finally(
+                action(() => {
+                  this.props.viewState.previewedItem = member;
+                })
+              );
             }
           }
         }


### PR DESCRIPTION
### What this PR does

Fixes console errors when switching explorer tabs. On tab switch `isOpen` was being set, but `loadMembers` were not getting called. This change use `openGroup` method to correctly perform both. Also switched to `.uniqueId` for tracking tabs instead of `.name`.

### Checklist

-   ~[ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [x] I've updated CHANGES.md with what I changed.
