### PR TITLE
Add support Clipping Planes in 3DTiles 

### DIFF
--- a/lib/Traits/Cesium3dTilesTraits.ts
+++ b/lib/Traits/Cesium3dTilesTraits.ts
@@ -13,6 +13,7 @@ import UrlTraits from "./UrlTraits";
 import TransformationTraits from "./TransformationTraits";
 import PlaceEditorTraits from "./PlaceEditorTraits";
 import primitiveArrayTrait from "./primitiveArrayTrait";
+import ClippingPlanesTrait from "./ClippingPlanesTrait";
 
 export class FilterTraits extends ModelTraits {
   @primitiveTrait({
@@ -105,7 +106,8 @@ export default class Cesium3DTilesTraits extends mixTraits(
   MappableTraits,
   UrlTraits,
   CatalogMemberTraits,
-  ShadowTraits
+  ShadowTraits,
+  ClippingPlanesTrait
 ) {
   @primitiveTrait({
     type: "number",

--- a/lib/Traits/Cesium3dTilesTraits.ts
+++ b/lib/Traits/Cesium3dTilesTraits.ts
@@ -13,7 +13,7 @@ import UrlTraits from "./UrlTraits";
 import TransformationTraits from "./TransformationTraits";
 import PlaceEditorTraits from "./PlaceEditorTraits";
 import primitiveArrayTrait from "./primitiveArrayTrait";
-import ClippingPlanesTrait from "./ClippingPlanesTrait";
+import ClippingPlanesTraits from "./ClippingPlanesTraits";
 
 export class FilterTraits extends ModelTraits {
   @primitiveTrait({
@@ -107,7 +107,7 @@ export default class Cesium3DTilesTraits extends mixTraits(
   UrlTraits,
   CatalogMemberTraits,
   ShadowTraits,
-  ClippingPlanesTrait
+  ClippingPlanesTraits
 ) {
   @primitiveTrait({
     type: "number",

--- a/lib/Traits/ClippingPlanesTrait.ts
+++ b/lib/Traits/ClippingPlanesTrait.ts
@@ -1,0 +1,84 @@
+import ModelTraits from "./ModelTraits";
+import anyTrait from "./anyTrait";
+import primitiveTrait from "./primitiveTrait";
+import primitiveArrayTrait from "./primitiveArrayTrait";
+import objectArrayTrait from "./objectArrayTrait";
+import objectTrait from "./objectTrait";
+import { JsonObject } from "../Core/Json";
+
+export class ClippingPlaneTrait extends ModelTraits {
+  @primitiveTrait({
+    name: "Distance",
+    type: "number",
+    description:
+      " The shortest distance from the origin to the plane. The sign of distance determines which side of the plane the origin is on. If distance is positive, the origin is in the half-space in the direction of the normal; if negative, the origin is in the half-space opposite to the normal; if zero, the plane passes through the origin."
+  })
+  distance: number = 0;
+
+  @primitiveArrayTrait({
+    name: "Normal Cartesian3",
+    type: "number",
+    description: "The plane's normal (normalized)."
+  })
+  normal: number[] = [];
+}
+
+export class ClippingPlaneCollectionTrait extends ModelTraits {
+  @primitiveTrait({
+    type: "boolean",
+    name: "Enabled Clipping Plane",
+    description: "Determines whether the clipping planes are active."
+  })
+  enabled: boolean = true;
+
+  @primitiveTrait({
+    type: "boolean",
+    name: "UnionClippingRegions",
+    description:
+      "If true, a region will be clipped if it is on the outside of any plane in the collection. Otherwise, a region will only be clipped if it is on the outside of every plane."
+  })
+  unionClippingRegions: boolean = false;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Edge Width",
+    description:
+      "The width, in pixels, of the highlight applied to the edge along which an object is clipped."
+  })
+  edgeWidth?: number;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Edge Color",
+    description:
+      "The color applied to highlight the edge along which an object is clipped."
+  })
+  edgeColor?: string;
+
+  @objectArrayTrait({
+    type: ClippingPlaneTrait,
+    name: "Clipping Plane Array",
+    description:
+      "An array of ClippingPlane objects used to selectively disable rendering on the outside of each plane.",
+    idProperty: "index"
+  })
+  planes?: ClippingPlaneTrait[];
+
+  @primitiveArrayTrait({
+    name: "Model Matrix",
+    type: "number",
+    description:
+      "The 4x4 transformation matrix specifying an additional transform relative to the clipping planes original coordinate system."
+  })
+  modelMatrix?: number[];
+}
+
+export default class ClippingPlanesTrait extends ModelTraits {
+  @objectTrait({
+    type: ClippingPlaneCollectionTrait,
+    name: "ClippingPlanes",
+    description:
+      "The ClippingPlaneCollection used to selectively disable rendering the tileset."
+  })
+  clippingPlanes?: ClippingPlaneCollectionTrait;
+}

--- a/lib/Traits/ClippingPlanesTraits.ts
+++ b/lib/Traits/ClippingPlanesTraits.ts
@@ -6,7 +6,7 @@ import objectArrayTrait from "./objectArrayTrait";
 import objectTrait from "./objectTrait";
 import { JsonObject } from "../Core/Json";
 
-export class ClippingPlaneTrait extends ModelTraits {
+export class ClippingPlaneDefinitionTraits extends ModelTraits {
   @primitiveTrait({
     name: "Distance",
     type: "number",
@@ -23,7 +23,7 @@ export class ClippingPlaneTrait extends ModelTraits {
   normal: number[] = [];
 }
 
-export class ClippingPlaneCollectionTrait extends ModelTraits {
+export class ClippingPlaneCollectionTraits extends ModelTraits {
   @primitiveTrait({
     type: "boolean",
     name: "Enabled Clipping Plane",
@@ -56,13 +56,13 @@ export class ClippingPlaneCollectionTrait extends ModelTraits {
   edgeColor?: string;
 
   @objectArrayTrait({
-    type: ClippingPlaneTrait,
+    type: ClippingPlaneDefinitionTraits,
     name: "Clipping Plane Array",
     description:
       "An array of ClippingPlane objects used to selectively disable rendering on the outside of each plane.",
     idProperty: "index"
   })
-  planes?: ClippingPlaneTrait[];
+  planes?: ClippingPlaneDefinitionTraits[];
 
   @primitiveArrayTrait({
     name: "Model Matrix",
@@ -73,12 +73,12 @@ export class ClippingPlaneCollectionTrait extends ModelTraits {
   modelMatrix?: number[];
 }
 
-export default class ClippingPlanesTrait extends ModelTraits {
+export default class ClippingPlanesTraits extends ModelTraits {
   @objectTrait({
-    type: ClippingPlaneCollectionTrait,
+    type: ClippingPlaneCollectionTraits,
     name: "ClippingPlanes",
     description:
       "The ClippingPlaneCollection used to selectively disable rendering the tileset."
   })
-  clippingPlanes?: ClippingPlaneCollectionTrait;
+  clippingPlanes?: ClippingPlaneCollectionTraits;
 }

--- a/test/ModelMixins/Cesium3dTilesMixinSpec.ts
+++ b/test/ModelMixins/Cesium3dTilesMixinSpec.ts
@@ -1,0 +1,108 @@
+import { runInAction } from "mobx";
+import Terria from "../../lib/Models/Terria";
+import Cesium3DTilesCatalogItem from "../../lib/Models/Cesium3DTilesCatalogItem";
+import ClippingPlaneCollection from "terriajs-cesium/Source/Scene/ClippingPlaneCollection";
+import ClippingPlane from "terriajs-cesium/Source/Scene/ClippingPlane";
+import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import Color from "terriajs-cesium/Source/Core/Color";
+import Matrix4 from "terriajs-cesium/Source/Core/Matrix4";
+
+describe("Cesium3dTilesMixin", function() {
+  describe(" - loadClippingPlanes", function() {
+    let terria: Terria;
+    let cesium3dTiles: Cesium3DTilesCatalogItem;
+
+    beforeEach(async function() {
+      terria = new Terria({
+        baseUrl: "./"
+      });
+      cesium3dTiles = new Cesium3DTilesCatalogItem("test", terria);
+
+      runInAction(() => {
+        cesium3dTiles.setTrait(
+          "definition",
+          "url",
+          "test/Cesium3DTiles/tileset.json"
+        );
+
+        cesium3dTiles.setTrait("definition", "clippingPlanes", {
+          enabled: true,
+          unionClippingRegions: false,
+          planes: [
+            {
+              normal: [-1, 0.0, 0.0],
+              distance: 40
+            }
+          ],
+          modelMatrix: [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0
+          ],
+          edgeColor: "blue",
+          edgeWidth: 12.0
+        });
+      });
+
+      await cesium3dTiles.loadMetadata();
+    });
+
+    it(" - Property ClippingPlaneCollection to be defined", function() {
+      expect(cesium3dTiles.cesiumTileClippingPlaneCollection).toBeDefined();
+    });
+
+    it(" - Property ClippingPlaneCollection is a ClippingPlaneCollection type", function() {
+      expect(
+        cesium3dTiles.cesiumTileClippingPlaneCollection instanceof
+          ClippingPlaneCollection
+      ).toBe(true);
+    });
+
+    it(" - ClippingPlaneCollection must contain a ClippingPlane", function() {
+      const cpc = cesium3dTiles.cesiumTileClippingPlaneCollection;
+      expect(
+        cpc?.contains(
+          new ClippingPlane(Cartesian3.fromArray([-1, 0.0, 0.0]), 40)
+        )
+      ).toBe(true);
+    });
+
+    it(" - ClippingPlaneCollection must be enabled", function() {
+      const cpc = cesium3dTiles.cesiumTileClippingPlaneCollection;
+      expect(cpc?.enabled).toBe(true);
+    });
+
+    it(" - ClippingPlaneCollection unionClippingRegions must be false", function() {
+      const cpc = cesium3dTiles.cesiumTileClippingPlaneCollection;
+      expect(cpc?.unionClippingRegions).toBe(false);
+    });
+
+    it(" - ClippingPlaneCollection edgeWidth must be 12.0", function() {
+      const cpc = cesium3dTiles.cesiumTileClippingPlaneCollection;
+      expect(cpc?.edgeWidth).toBe(12.0);
+    });
+
+    it(" - ClippingPlaneCollection edgeColor must be Blue", function() {
+      const cpc = cesium3dTiles.cesiumTileClippingPlaneCollection;
+      expect(cpc?.edgeColor.equals(Color.BLUE)).toBe(true);
+    });
+
+    it(" - ClippingPlaneCollection must content Identity Matrix as modelMatrix", function() {
+      const cpc = cesium3dTiles.cesiumTileClippingPlaneCollection;
+      expect(cpc?.modelMatrix.equals(Matrix4.IDENTITY)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
### What this PR does

Fixes #4981

Add support Clipping Planes in 3DTiles, more description in Issue #4981 

### Checklist

-   [X]  Implement Traits to compose the ClippingPlaneCollection definition
-   [X]  Implement Unit Test Cesium3dTilesMixinSpec

### Example of usage:

```json
{
    "name": "Brisbane 3D city model (aero3Dpro)",
    "type": "3d-tiles",
    "url": "https://sample.aero3dpro.com.au/BrisbaneCBD/Scene/recon_h_3DTiles.json",
    "clippingPlanes": {
        "enabled": true,
        "unionClippingRegions": false,
        "planes": [
              {
                "normal": [-1, 0.0, 0.0],
                "distance": 40
              }
        ],
        "modelMatrix":  [
            1.0, 0.0, 0.0, 0.0,
            0.0, 1.0, 0.0, 0.0,
            0.0, 0.0, 1.0, 0.0,
            0.0, 0.0, 0.0, 1.0
        ],
        "edgeColor": "blue",
        "edgeWidth": 12.0
    }
}
```
