### PR TITLE
Fix mobx warnings for geojson catalog item.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### next release (8.0.0-alpha.62)
 * Fixed an issue with not loading the base map from init file and an issue with viewerMode from init files overriding the persisted viewerMode
+* Fixed mobx warnings when loading geojson catalog items.
 * [The next improvement]
 
 #### 8.0.0-alpha.61


### PR DESCRIPTION
### What this PR does

Wraps bunch of stuff inside `action` to fix mobx warnings when loading a geojson item.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
