### PR TITLE
Revert some mobx.action changes

### DIFF
--- a/lib/ModelMixins/CatalogFunctionJobMixin.ts
+++ b/lib/ModelMixins/CatalogFunctionJobMixin.ts
@@ -202,7 +202,6 @@ function CatalogFunctionJobMixin<
      * - `pollForResults` returns true {@link CatalogFunctionJobMixin#refreshData}
      * - on `loadMetadata` if `jobStatus` is "finished", and `!downloadedResults`  {@link CatalogFunctionJobMixin#forceLoadMetadata}
      */
-    @action
     private async onJobFinish(addResultsToWorkbench = this.inWorkbench) {
       // Download results when finished
       if (
@@ -291,7 +290,6 @@ function CatalogFunctionJobMixin<
     }
     protected async forceLoadMapItems() {}
 
-    @action
     protected async forceLoadMetadata() {
       if (this.jobStatus === "finished" && !this.downloadedResults) {
         await this.onJobFinish();

--- a/lib/Models/CsvCatalogItem.ts
+++ b/lib/Models/CsvCatalogItem.ts
@@ -1,21 +1,21 @@
 import i18next from "i18next";
-import { runInAction, computed, action } from "mobx";
+import { computed, runInAction } from "mobx";
+import isDefined from "../Core/isDefined";
 import TerriaError from "../Core/TerriaError";
 import AsyncChartableMixin from "../ModelMixins/AsyncChartableMixin";
+import AutoRefreshingMixin from "../ModelMixins/AutoRefreshingMixin";
 import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
+import ExportableMixin from "../ModelMixins/ExportableMixin";
 import TableMixin from "../ModelMixins/TableMixin";
 import UrlMixin from "../ModelMixins/UrlMixin";
 import Csv from "../Table/Csv";
 import TableAutomaticStylesStratum from "../Table/TableAutomaticStylesStratum";
 import CsvCatalogItemTraits from "../Traits/CsvCatalogItemTraits";
 import CreateModel from "./CreateModel";
+import { BaseModel } from "./Model";
 import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
 import StratumOrder from "./StratumOrder";
 import Terria from "./Terria";
-import AutoRefreshingMixin from "../ModelMixins/AutoRefreshingMixin";
-import isDefined from "../Core/isDefined";
-import { BaseModel } from "./Model";
-import ExportableMixin from "../ModelMixins/ExportableMixin";
 
 // Types of CSVs:
 // - Points - Latitude and longitude columns or address
@@ -158,7 +158,6 @@ export default class CsvCatalogItem extends AsyncChartableMixin(
     return Promise.resolve();
   }
 
-  @action
   protected forceLoadTableData(): Promise<string[][]> {
     if (this.csvString !== undefined) {
       return Csv.parseString(this.csvString, true);

--- a/lib/Models/GeoJsonCatalogItem.ts
+++ b/lib/Models/GeoJsonCatalogItem.ts
@@ -119,50 +119,48 @@ class GeoJsonCatalogItem extends AsyncMappableMixin(
         })
       });
 
-    return new Promise<JsonValue | undefined>(
-      action((resolve, reject) => {
-        if (isDefined(this.geoJsonData)) {
-          resolve(toJS(this.geoJsonData));
-        } else if (isDefined(this.geoJsonString)) {
-          resolve(<JsonValue>JSON.parse(this.geoJsonString));
-        } else if (isDefined(this._geoJsonFile)) {
-          resolve(readJson(this._geoJsonFile));
-        } else if (isDefined(this.url)) {
-          // try loading from a zip file url or a regular url
-          if (zipFileRegex.test(this.url)) {
-            if (typeof FileReader === "undefined") {
-              throw new TerriaError({
-                title: i18next.t("models.userData.fileApiNotSupportedTitle"),
-                message: i18next.t("models.userData.fileApiNotSupportedTitle", {
-                  appName: this.terria.appName,
-                  internetExplorer:
-                    '<a href="http://www.microsoft.com/ie" target="_blank">' +
-                    i18next.t("models.userData.internetExplorer") +
-                    "</a>",
-                  chrome:
-                    '<a href="http://www.google.com/chrome" target="_blank">' +
-                    i18next.t("models.userData.chrome") +
-                    "</a>",
-                  firefox:
-                    '<a href="http://www.mozilla.org/firefox" target="_blank">' +
-                    i18next.t("models.userData.firefox") +
-                    "</a>"
-                })
-              });
-            }
-            resolve(loadZipFile(proxyCatalogItemUrl(this, this.url)));
-          } else {
-            resolve(loadJson(proxyCatalogItemUrl(this, this.url)));
+    return new Promise<JsonValue | undefined>((resolve, reject) => {
+      if (isDefined(this.geoJsonData)) {
+        resolve(toJS(this.geoJsonData));
+      } else if (isDefined(this.geoJsonString)) {
+        resolve(<JsonValue>JSON.parse(this.geoJsonString));
+      } else if (isDefined(this._geoJsonFile)) {
+        resolve(readJson(this._geoJsonFile));
+      } else if (isDefined(this.url)) {
+        // try loading from a zip file url or a regular url
+        if (zipFileRegex.test(this.url)) {
+          if (typeof FileReader === "undefined") {
+            throw new TerriaError({
+              title: i18next.t("models.userData.fileApiNotSupportedTitle"),
+              message: i18next.t("models.userData.fileApiNotSupportedTitle", {
+                appName: this.terria.appName,
+                internetExplorer:
+                  '<a href="http://www.microsoft.com/ie" target="_blank">' +
+                  i18next.t("models.userData.internetExplorer") +
+                  "</a>",
+                chrome:
+                  '<a href="http://www.google.com/chrome" target="_blank">' +
+                  i18next.t("models.userData.chrome") +
+                  "</a>",
+                firefox:
+                  '<a href="http://www.mozilla.org/firefox" target="_blank">' +
+                  i18next.t("models.userData.firefox") +
+                  "</a>"
+              })
+            });
           }
+          resolve(loadZipFile(proxyCatalogItemUrl(this, this.url)));
         } else {
-          throw new TerriaError({
-            sender: this,
-            title: i18next.t("models.geoJson.unableToLoadItemTitle"),
-            message: i18next.t("models.geoJson.unableToLoadItemMessage")
-          });
+          resolve(loadJson(proxyCatalogItemUrl(this, this.url)));
         }
-      })
-    )
+      } else {
+        throw new TerriaError({
+          sender: this,
+          title: i18next.t("models.geoJson.unableToLoadItemTitle"),
+          message: i18next.t("models.geoJson.unableToLoadItemMessage")
+        });
+      }
+    })
       .then((geoJson: JsonValue | undefined) => {
         if (!isJsonObject(geoJson)) {
           throw createLoadError();
@@ -203,7 +201,6 @@ class GeoJsonCatalogItem extends AsyncMappableMixin(
     return Promise.resolve();
   }
 
-  @action
   private loadDataSource(geoJson: JsonObject): Promise<GeoJsonDataSource> {
     /* Style information is applied as follows, in decreasing priority:
            - simple-style properties set directly on individual features in the GeoJSON file


### PR DESCRIPTION
### What this PR does

Removes some `mobx.action` usages that could cause memoisation problems.

Fixes failing test added #5026.

### Checklist

-   [x] There are unit tests to verify my changes are correct (see #5026)
-   [x] Changes are fixing a previous change within this version, so no CHANGES.md entry needed
