### PR TITLE
Revert magda config ID patch + add shareKey

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,8 +74,7 @@ Change Log
 * Chart expanded from feature info panel will now by default show only the first chart line.
 * Chart component attribtues `column-titles` and `column-units` will now accept a simpler syntax like: "Time,Speed" or "ms,kmph"
 * Fix presentation of the WMS Dimension metadata.
-* Magda based maps now mimic "root group uniqueId === '/'" behaviour, so that mix and matching map init approaches behave more consistently
-* [The next improvement]
+* Magda based maps now mimic "root group uniqueId === '/'" behaviour, so that mix and matching map init approaches behave more consistently (REVERTED in 8.0.0-alpha.62)
   
 #### 8.0.0-alpha.56
 * Add `itemProperties` trait to `WebMapMapCatalogGroup`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,7 @@ Change Log
 * Chart component attribtues `column-titles` and `column-units` will now accept a simpler syntax like: "Time,Speed" or "ms,kmph"
 * Fix presentation of the WMS Dimension metadata.
 * Magda based maps now mimic "root group uniqueId === '/'" behaviour, so that mix and matching map init approaches behave more consistently
+* [The next improvement]
   
 #### 8.0.0-alpha.56
 * Add `itemProperties` trait to `WebMapMapCatalogGroup`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ Change Log
 * Port `shareKeys` from version 7
 * Update/re-enable `GeoJsonCatalogItemSpec` for v8.
 * add `DataCustodianTraits` to `WebMapServiceCatalogGroupTraits`
+* Revert "Improve magda root group behaviour for sharing" - This reverts commit 7e860b24cd7b0cc8406327c507501cf9fc232b27.
+* Revert "Fix magda based maps when mix matching init styles" - This reverts commit 12eb658b3a64ecd17dc4527d26183c82873e71d9 and 69f045dc5f82efb3c91c2a8193a240f968177834.
+* Add `"/"` share key for magda root group so we have backward compatibility with JSON-based map share links
 * [The next improvement]
 
 #### 8.0.0-alpha.61
@@ -32,7 +35,7 @@ Change Log
 * Improve handling of `ArcGisMapServerCatalogItem` when dealing with tiled layers.
 * Ensure there aren't more bins than unique values for a `TableStyle`
 * Add access control properties to items fetched from Esri Portal.
-* Improves magda based root group mimic behaviour introdcued in 8.0.0-alpha.57 by adding `/` to `knownContainerUniqueIds` when `map-config*` is encountered
+* Improves magda based root group mimic behaviour introdcued in 8.0.0-alpha.57 by adding `/` to `knownContainerUniqueIds` when `map-config*` is encountered (REVERTED in 8.0.0-alpha.62)
 * Fixed broken chart disclaimers in shared views.
 * Fixed a bug where chart disclaimers were shown even for chart items disabled in the workbench.
 * Fixed a bug where charts with titles containing the text "lat" or "lon" were hidden from feature info panel.

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -980,13 +980,12 @@ export default class Terria {
 
     if (aspects.group && aspects.group.members) {
       const id = config.id;
-      // Add share key for magda root group so we have backward compatibility with JSON-based map share links
-      this.addShareKey(id, "/");
 
       let existingReference = this.getModelById(MagdaReference, id);
       if (existingReference === undefined) {
         existingReference = new MagdaReference(id, this);
-        this.addModel(existingReference);
+        // Add terria aspects shareKeys
+        this.addModel(existingReference, aspects?.terria?.shareKeys);
       }
 
       const reference = existingReference;

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1018,10 +1018,7 @@ export default class Terria {
     }
 
     if (aspects.group && aspects.group.members) {
-      // const id = config.id;
-      // force config id to be `/`, purely to emulate regular terria behaviour
-      const id = "/";
-      this.removeModelReferences(this.catalog.group);
+      const id = config.id;
 
       let existingReference = this.getModelById(MagdaReference, id);
       if (existingReference === undefined) {
@@ -1032,7 +1029,7 @@ export default class Terria {
       const reference = existingReference;
 
       reference.setTrait(CommonStrata.definition, "url", magdaRoot);
-      reference.setTrait(CommonStrata.definition, "recordId", id);
+      reference.setTrait(CommonStrata.definition, "recordId", config.id);
       reference.setTrait(CommonStrata.definition, "magdaRecord", config);
       await reference.loadReference();
       if (reference.target instanceof CatalogGroup) {

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -75,43 +75,6 @@ import ViewerMode from "./ViewerMode";
 import Workbench from "./Workbench";
 // import overrides from "../Overrides/defaults.jsx";
 
-interface InitModels {
-  [key: string]: {
-    [key: string]: JsonValue;
-    knownContainerUniqueIds: string[];
-  };
-}
-/**
- * This is a short term gap to addresing the issue of old share links being
- * generated with a record similar to `map-config` in its share data, but
- * newer-Terria forcing the root record to an ID of `/` for a consistent
- * approach to the root record
- *
- * The hardcode approach - it will check for any `knownContainerUniqueIds` for
- * each model, and add an entry for `/` if it detects `map-config-*`
- */
-export function makeModelsMagdaCompatible(models: InitModels) {
-  return Object.entries(models).reduce((acc: any, current) => {
-    const key = current[0];
-    const value = current[1];
-    const hasMapConfig =
-      value.knownContainerUniqueIds &&
-      value.knownContainerUniqueIds.find(
-        value => value.indexOf("map-config") !== -1
-      );
-    const improvedKnownContainerUniqueIds = hasMapConfig
-      ? [...value.knownContainerUniqueIds, "/"]
-      : value.knownContainerUniqueIds;
-
-    acc[key] = {
-      ...value,
-      knownContainerUniqueIds: improvedKnownContainerUniqueIds
-    };
-
-    return acc;
-  }, {});
-}
-
 interface ConfigParameters {
   [key: string]: ConfigParameters[keyof ConfigParameters];
   appName?: string;
@@ -884,10 +847,8 @@ export default class Terria {
 
     const models = initData.models;
     if (isJsonObject(models)) {
-      const modelsTyped = <InitModels>models;
-      const magdaCompatibleModels = makeModelsMagdaCompatible(modelsTyped);
       promise = Promise.all(
-        Object.keys(magdaCompatibleModels).map(modelId => {
+        Object.keys(models).map(modelId => {
           return this.loadModelStratum(
             modelId,
             stratumId,

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -980,6 +980,8 @@ export default class Terria {
 
     if (aspects.group && aspects.group.members) {
       const id = config.id;
+      // Add share key for magda root group so we have backward compatibility with JSON-based map share links
+      this.addShareKey(id, "/");
 
       let existingReference = this.getModelById(MagdaReference, id);
       if (existingReference === undefined) {

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -121,33 +121,7 @@ describe("Terria", function() {
     });
 
     describe("via loadMagdaConfig", function() {
-      it("should dereference uniqueId to `/`", function(done) {
-        expect(terria.catalog.group.uniqueId).toEqual("/");
-
-        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
-          // terria's "Magda derived url"
-          responseText: mapConfigBasicString
-        });
-        // no init sources before starting
-        expect(terria.initSources.length).toEqual(0);
-
-        terria
-          .start({
-            configUrl: "test/Magda/map-config-basic.json"
-          })
-          .then(function() {
-            expect(terria.catalog.group.uniqueId).toEqual("/");
-            done();
-          })
-          .catch(error => {
-            done.fail(error);
-          });
-      });
       it("works with basic initializationUrls", function(done) {
-        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
-          // terria's "Magda derived url"
-          responseText: mapConfigBasicString
-        });
         // no init sources before starting
         expect(terria.initSources.length).toEqual(0);
 
@@ -173,10 +147,6 @@ describe("Terria", function() {
           });
       });
       it("works with inline init", async function() {
-        // inline init
-        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
-          responseText: mapConfigInlineInitString
-        });
         // no init sources before starting
         expect(terria.initSources.length).toEqual(0);
         await terria.start({
@@ -202,11 +172,6 @@ describe("Terria", function() {
         }
       });
       it("parses dereferenced group aspect", function(done) {
-        expect(terria.catalog.group.uniqueId).toEqual("/");
-        // dereferenced res
-        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
-          responseText: mapConfigDereferencedString
-        });
         terria
           .start({
             configUrl: "test/Magda/map-config-dereferenced.json"

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -13,7 +13,7 @@ import { isInitData, isInitUrl } from "../../lib/Models/InitSource";
 import MagdaReference from "../../lib/Models/MagdaReference";
 import { BaseModel } from "../../lib/Models/Model";
 import openGroup from "../../lib/Models/openGroup";
-import Terria, { makeModelsMagdaCompatible } from "../../lib/Models/Terria";
+import Terria from "../../lib/Models/Terria";
 import UrlReference, {
   UrlToCatalogMemberMapping
 } from "../../lib/Models/UrlReference";
@@ -38,49 +38,6 @@ describe("Terria", function() {
   beforeEach(function() {
     terria = new Terria({
       baseUrl: "./"
-    });
-  });
-
-  describe("makeModelsMagdaCompatible", function() {
-    it("should return models", function() {
-      const models = {
-        foo: {
-          knownContainerUniqueIds: ["mochi-is-fluffy"]
-        },
-        bar: {
-          knownContainerUniqueIds: ["neko-is-hungry"]
-        },
-        cat: {
-          knownContainerUniqueIds: [""]
-        }
-      };
-      expect(makeModelsMagdaCompatible(models)).toEqual(models);
-    });
-
-    it("should inject `/` to `knownContainerUniqueIds` if map-config exists", function() {
-      const models = {
-        foo: {
-          knownContainerUniqueIds: ["map-config"]
-        },
-        bar: {
-          knownContainerUniqueIds: ["map-config-another"]
-        },
-        cat: {
-          knownContainerUniqueIds: ["bar"]
-        }
-      };
-      const expected = {
-        foo: {
-          knownContainerUniqueIds: ["map-config", "/"]
-        },
-        bar: {
-          knownContainerUniqueIds: ["map-config-another", "/"]
-        },
-        cat: {
-          knownContainerUniqueIds: ["bar"]
-        }
-      };
-      expect(makeModelsMagdaCompatible(models)).toEqual(expected);
     });
   });
 

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -121,6 +121,26 @@ describe("Terria", function() {
     });
 
     describe("via loadMagdaConfig", function() {
+      it("should dereference uniqueId to `/`", function(done) {
+        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
+          // terria's "Magda derived url"
+          responseText: mapConfigBasicString
+        });
+        // no init sources before starting
+        expect(terria.initSources.length).toEqual(0);
+
+        terria
+          .start({
+            configUrl: "test/Magda/map-config-basic.json"
+          })
+          .then(function() {
+            expect(terria.catalog.group.uniqueId).toEqual("/");
+            done();
+          })
+          .catch(error => {
+            done.fail(error);
+          });
+      });
       it("works with basic initializationUrls", function(done) {
         // no init sources before starting
         expect(terria.initSources.length).toEqual(0);
@@ -172,6 +192,10 @@ describe("Terria", function() {
         }
       });
       it("parses dereferenced group aspect", function(done) {
+        // dereferenced res
+        jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
+          responseText: mapConfigDereferencedString
+        });
         terria
           .start({
             configUrl: "test/Magda/map-config-dereferenced.json"
@@ -179,10 +203,6 @@ describe("Terria", function() {
           .then(function() {
             const groupAspect = mapConfigDereferencedJson.aspects["group"];
             const ids = groupAspect.members.map((member: any) => member.id);
-            expect(terria.catalog.group.uniqueId).toEqual("/");
-            // ensure user added data co-exists with dereferenced magda members
-            expect(terria.catalog.group.members.length).toEqual(3);
-            expect(terria.catalog.userAddedDataGroup).toBeDefined();
             ids.forEach((id: string) => {
               const model = terria.getModelById(MagdaReference, id);
               if (!model) {


### PR DESCRIPTION
### Revert magda config ID patch + add shareKey

Fixes https://github.com/TerriaJS/terriajs/issues/4978 https://github.com/TerriaJS/qld-digital-twin/issues/237 https://github.com/TerriaJS/terrace/issues/142

Partially fixes (chill github don't close the issue when I merge this) https://github.com/TerriaJS/terriajs/issues/4774 

### Checklist

-   [x] Mostly reverting things - no Tests needed
-   [x] I've updated CHANGES.md with what I changed.
