### PR TITLE
Fixes error when selecting an existing polygon in WPS input form.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Change Log
 * Update/re-enable `GeoJsonCatalogItemSpec` for v8.
 * add `DataCustodianTraits` to `WebMapServiceCatalogGroupTraits`
 * Changed behaviour of `updateModelFromJson` such that catalog groups with the same id/name from different json files will be merged into one single group. 
+* Fixed error when selecting an existing polygon in WPS input form.
 * [The next improvement]
 
 #### 8.0.0-alpha.61

--- a/lib/Models/FunctionParameters/SelectAPolygonParameter.ts
+++ b/lib/Models/FunctionParameters/SelectAPolygonParameter.ts
@@ -1,6 +1,5 @@
 import { Feature, Polygon } from "geojson";
-import { computed } from "mobx";
-import isDefined from "../../Core/isDefined";
+import { computed, isObservableArray } from "mobx";
 import { JsonObject } from "../../Core/Json";
 import FunctionParameter from "./FunctionParameter";
 import { GeoJsonFunctionParameter } from "./GeoJsonParameter";
@@ -13,7 +12,7 @@ export default class SelectAPolygonParameter
   readonly type = "polygon";
 
   static formatValueForUrl(value: Feature[]) {
-    if (!isDefined(value) || !Array.isArray(value)) {
+    if (!(Array.isArray(value) || isObservableArray(value))) {
       return undefined;
     }
 

--- a/lib/Models/WebProcessingServiceCatalogFunction.ts
+++ b/lib/Models/WebProcessingServiceCatalogFunction.ts
@@ -34,6 +34,7 @@ import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
 import StratumOrder from "./StratumOrder";
 import updateModelFromJson from "./updateModelFromJson";
 import WebProcessingServiceCatalogFunctionJob from "./WebProcessingServiceCatalogFunctionJob";
+import flatten from "lodash-es/flatten";
 
 type AllowedValues = {
   Value?: string | string[];
@@ -261,11 +262,15 @@ export default class WebProcessingServiceCatalogFunction extends XmlRequestMixin
         name: `WPS: ${this.name ||
           this.identifier ||
           this.uniqueId} result ${new Date().toISOString()}`,
-        geojsonFeatures: this.functionParameters
-          .map(param =>
-            isGeoJsonFunctionParameter(param) ? param.geoJsonFeature : undefined
-          )
-          .filter(isDefined),
+        geojsonFeatures: flatten(
+          this.functionParameters
+            .map(param =>
+              isGeoJsonFunctionParameter(param)
+                ? param.geoJsonFeature
+                : undefined
+            )
+            .filter(isDefined)
+        ),
         url: this.url,
         identifier: this.identifier,
         executeWithHttpGet: this.executeWithHttpGet,

--- a/lib/Models/WebProcessingServiceCatalogFunction.ts
+++ b/lib/Models/WebProcessingServiceCatalogFunction.ts
@@ -2,6 +2,7 @@ import i18next from "i18next";
 import { action, computed, isObservableArray, runInAction } from "mobx";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import URI from "urijs";
+import filterOutUndefined from "../Core/filterOutUndefined";
 import isDefined from "../Core/isDefined";
 import TerriaError from "../Core/TerriaError";
 import Reproject from "../Map/Reproject";
@@ -247,10 +248,12 @@ export default class WebProcessingServiceCatalogFunction extends XmlRequestMixin
   protected async createJob(id: string) {
     const job = new WebProcessingServiceCatalogFunctionJob(id, this.terria);
 
-    let dataInputs = await Promise.all(
-      this.functionParameters
-        .filter(p => isDefined(p.value) && p.value !== null)
-        .map(p => this.convertParameterToInput(p))
+    let dataInputs = filterOutUndefined(
+      await Promise.all(
+        this.functionParameters
+          .filter(p => isDefined(p.value) && p.value !== null)
+          .map(p => this.convertParameterToInput(p))
+      )
     );
 
     runInAction(() =>


### PR DESCRIPTION
### What this PR does

Fixes an error when selecting an existing polygon in WPS input form.

Testing:
* Visit this `next` branch map - http://ci.terria.io/next/#share=s-dhsrzko6CvsCsw59AMzzmgzEj9U
* From the explorer open the first item "Mean for point or region (monthly)"
* In the WPS input form select "Existing polygon"
* Select the polygon on the map
* Click "Run analysis"
* Watch an error throw up with message "TypeError: can't convert undefined to object"
* Now to test the fix follow the same steps on this branch - http://ci.terria.io/fix-wps-existing-polygon-selection/#share=s-xDaJP7L7TahNYgtFnkQOSVxmN3Y

### Checklist

~-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [x] I've updated CHANGES.md with what I changed.
