### PR TITLE
Auto-convert MapServer layer names to IDs before requesting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Change Log
 * Changed behaviour of `updateModelFromJson` such that catalog groups with the same id/name from different json files will be merged into one single group. 
 * Fixed error when selecting an existing polygon in WPS input form.
 * Upgraded `catalog-converter` to 0.0.2-alpha.3.
+* `layers` trait for `ArcGisMapServerCatalogItem` can now be a comma separated string of layer IDs or names. Names will be auto-converted to IDs when making the request.
 
 #### 8.0.0-alpha.61
 * New `CatalogFunctionMixin` and `CatalogFunctionJobMixin`

--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -359,6 +359,13 @@ export default class ArcGisMapServerCatalogItem
     });
   }
 
+  @computed
+  get mapServerStratum(): MapServerStratum | undefined {
+    return this.strata.get(MapServerStratum.stratumName) as
+      | MapServerStratum
+      | undefined;
+  }
+
   loadMapItems() {
     return this.loadMetadata();
   }
@@ -371,10 +378,7 @@ export default class ArcGisMapServerCatalogItem
   }
 
   @computed get imageryProvider() {
-    const stratum = <MapServerStratum>(
-      this.strata.get(MapServerStratum.stratumName)
-    );
-
+    const stratum = this.mapServerStratum;
     if (!isDefined(this.url) || !isDefined(stratum)) {
       return;
     }
@@ -401,9 +405,10 @@ export default class ArcGisMapServerCatalogItem
 
     const maximumLevel = maximumScaleToLevel(this.maximumScale);
     const dynamicRequired = this.layers && this.layers.length > 0;
+    const layers = this.layerIds || this.layers;
     const imageryProvider = new ArcGisMapServerImageryProvider({
       url: cleanAndProxyUrl(this, getBaseURI(this).toString()),
-      layers: this.layers,
+      layers,
       tilingScheme: new WebMercatorTilingScheme(),
       maximumLevel: maximumLevel,
       parameters: this.parameters,
@@ -477,6 +482,13 @@ export default class ArcGisMapServerCatalogItem
         return lastSegment;
       }
     }
+  }
+
+  @computed
+  get layerIds(): string | undefined {
+    const stratum = this.mapServerStratum;
+    const ids = stratum ? stratum.allLayers.map(l => l.id) : [];
+    return ids.length === 0 ? undefined : ids.join(",");
   }
 
   @computed get allSelectedLayers() {

--- a/lib/Traits/ArcGisMapServerCatalogItemTraits.ts
+++ b/lib/Traits/ArcGisMapServerCatalogItemTraits.ts
@@ -22,7 +22,8 @@ export default class ArcGisMapServerCatalogItemTraits extends mixTraits(
   @primitiveTrait({
     type: "string",
     name: "Layer(s)",
-    description: "The layer or layers to display."
+    description:
+      "The layer or layers to display. This can be a comma seperated string of layer IDs or names."
   })
   layers?: string;
 

--- a/test/Models/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.ts
@@ -191,6 +191,12 @@ describe("ArcGisMapServerCatalogItem", function() {
           expect(imageryProvider.layers).toBe("31");
         });
 
+        it("converts layer names to layer ids when constructing imagery provider", function() {
+          item.setTrait("definition", "layers", "Offshore_Rocks_And_Wrecks");
+          const imageryProvider = item.mapItems[0].imageryProvider;
+          expect(imageryProvider.layers).toBe("31");
+        });
+
         it("tilingScheme should be a WebMercatorTilingScheme", function() {
           expect(
             imageryProvider.tilingScheme instanceof WebMercatorTilingScheme


### PR DESCRIPTION
### What this PR does

Fixes #5084 

Testing: As described in the issue, the following link should show a contour map instead of dots.
Test link: http://ci.terria.io/mapserver-layer-names-to-ids/#share=s-ujk3rpqAJMsy27hwYYLRFhT2jws

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
