### PR TITLE
Release alpha 63

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,10 @@ Change Log
 
 ### MobX Development
 
-#### next release (8.0.0-alpha.63)
+#### next release (8.0.0-alpha.64)
+* [The next improvement]
+
+#### 8.0.0-alpha.63
 * Add `v7initializationUrls` to terria config. It will convert catalogs to v8 and print warning messages to console.
 * Add `shareKeys` support for Madga map-config maps (through `terria` aspect)
 * Revert WMS-group item ID generation to match v7
@@ -16,7 +19,13 @@ Change Log
 * Update youtube urls to nocookie version
 * Share link conversion (through `catalog-converter`) is now done client-side
 * Fix Geoserver legend font colour bug
-* [The next improvement]
+* Remove legend broken image icon
+* Added high-DPI legends for geoserver WMS (+ font size, label margin and a few other tweaks)
+* `LegendTraits` is now part of `CatalogMemberTraits`
+* Add `imageScaling` to `LegendTraits`
+* WMS now `isGeoserver` if "geoserver` is in the URL
+* Add WMS `supportsGetLegendRequest` trait
+* Improved handling of WMS default styles
 
 #### 8.0.0-alpha.62
 * Fixed an issue with not loading the base map from init file and an issue with viewerMode from init files overriding the persisted viewerMode
@@ -31,13 +40,6 @@ Change Log
 * Port `shareKeys` from version 7
 * Update/re-enable `GeoJsonCatalogItemSpec` for v8.
 * add `DataCustodianTraits` to `WebMapServiceCatalogGroupTraits`
-* Remove legend broken image icon
-* Added high-DPI legends for geoserver WMS (+ font size, label margin and a few other tweaks)
-* `LegendTraits` is now part of `CatalogMemberTraits`
-* Add `imageScaling` to `LegendTraits`
-* WMS now `isGeoserver` if "geoserver` is in the URL
-* Add WMS `supportsGetLegendRequest` trait
-* Improved handling of WMS default styles
 * Changed behaviour of `updateModelFromJson` such that catalog groups with the same id/name from different json files will be merged into one single group. 
 * Fixed error when selecting an existing polygon in WPS input form.
 * Upgraded `catalog-converter` to 0.0.2-alpha.3.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.0.0-alpha.62",
+  "version": "8.0.0-alpha.63",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Moved some changelog entries so that diff to alpha 62 lines up: https://github.com/TerriaJS/terriajs/compare/8.0.0-alpha.62..8-alpha-63#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2

I ensured that the entries I moved were meant to go in 63 by checking the relevant PR: https://github.com/TerriaJS/terriajs/pull/4922