### PR TITLE
WMS style dimension fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.64)
+* Fix WMS style selector bug
 * [The next improvement]
 
 #### 8.0.0-alpha.63

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -1206,7 +1206,11 @@ class WebMapServiceCatalogItem
 
       // There is no way of finding out default style if no style has been selected :(
       // If !supportsGetLegendGraphic - we have to just use the first available style
-      if (!isDefined(selectedId) && !this.supportsGetLegendGraphic) {
+      if (
+        !isDefined(selectedId) &&
+        options.length > 0 &&
+        !this.supportsGetLegendGraphic
+      ) {
         selectedId = options[0].id;
       }
 


### PR DESCRIPTION
### WMS style dimension fix

Fixes https://github.com/TerriaJS/drought-map/issues/213

Fixes bug which crashes Terria if a layer has no styles

Test `Vegatation Layers` - /#clean&https://map.drought.gov.au/init/drought-map-v8.json

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
