### PR TITLE
Sdmx category fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.65)
+* Fixed SDMX-group nested categories
+* SDMX-group will now remove top-level groups with only 1 child
 * [The next improvement]
 
 #### 8.0.0-alpha.64

--- a/test/Models/SdmxJsonCatalogGroupSpec.ts
+++ b/test/Models/SdmxJsonCatalogGroupSpec.ts
@@ -62,11 +62,9 @@ describe("SdmxCatalogGroup", function() {
 
     it("loadsNestedMembers", async function() {
       await sdmxGroup.loadMembers();
-      const agencies = sdmxGroup.memberModels;
-      expect(agencies.length).toEqual(1);
-      const agency = agencies[0] as CatalogGroup;
-      expect(agency.memberModels.length).toEqual(2);
-      const categoryScheme = agency.memberModels[0] as CatalogGroup;
+      const agency = sdmxGroup.memberModels;
+      expect(agency.length).toEqual(2);
+      const categoryScheme = agency[0] as CatalogGroup;
       expect(categoryScheme.memberModels.length).toEqual(3);
       const category = categoryScheme.memberModels[0] as CatalogGroup;
       expect(category.memberModels.length).toEqual(6);
@@ -82,9 +80,8 @@ describe("SdmxCatalogGroup", function() {
 
     it("loadsDataflow-timeseries", async function() {
       await sdmxGroup.loadMembers();
-      const agencies = sdmxGroup.memberModels;
-      const agency = agencies[0] as CatalogGroup;
-      const categoryScheme = agency.memberModels[0] as CatalogGroup;
+      const agency = sdmxGroup.memberModels;
+      const categoryScheme = agency[0] as CatalogGroup;
       const category = categoryScheme.memberModels[0] as CatalogGroup;
 
       const dataflowNoRegion = category.memberModels[0] as SdmxJsonCatalogItem;
@@ -111,9 +108,8 @@ describe("SdmxCatalogGroup", function() {
 
     it("loadsDataflow-region", async function() {
       await sdmxGroup.loadMembers();
-      const agencies = sdmxGroup.memberModels;
-      const agency = agencies[0] as CatalogGroup;
-      const categoryScheme = agency.memberModels[0] as CatalogGroup;
+      const agency = sdmxGroup.memberModels;
+      const categoryScheme = agency[0] as CatalogGroup;
       const category = categoryScheme.memberModels[0] as CatalogGroup;
 
       const dataflowRegion = category.memberModels[1] as SdmxJsonCatalogItem;


### PR DESCRIPTION
### SDMX category fixes

* Fixed SDMX-group nested categories
* SDMX-group will now remove top-level groups with only 1 child (to reduce clicks)

Nationalmap + Pacific map SDMX with changes:

http://ci.terria.io/sdmx-category-fixes/#clean&https://gist.githubusercontent.com/nf-s/24b9288c6cdb6ba41d12f3d269318a0d/raw/c5ed64071c8a651ae458b4c0d3dc79c8618cb86d/sdmx.json

Before:

http://ci.terria.io/next/#clean&https://gist.githubusercontent.com/nf-s/24b9288c6cdb6ba41d12f3d269318a0d/raw/c5ed64071c8a651ae458b4c0d3dc79c8618cb86d/sdmx.json

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
