### PR TITLE
Don't set recordId since magdaRecord is available

### DIFF
--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1023,7 +1023,6 @@ export default class Terria {
       const reference = existingReference;
 
       reference.setTrait(CommonStrata.definition, "url", magdaRoot);
-      reference.setTrait(CommonStrata.definition, "recordId", id);
       reference.setTrait(CommonStrata.definition, "magdaRecord", config);
       await reference.loadReference();
       if (reference.target instanceof CatalogGroup) {


### PR DESCRIPTION
The existing code misrepresents the recordId as "/". While the Terria id used for the root group is "/" the recordId used to talk to magda about the root group is still (usually) map-config[-something].