### PR TITLE
Fixed pickedFeatures for dynamic layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.66)
+* Fixed `pickedFeatures` not setting `_catalogItem` property correctly
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/lib/Map/PickedFeatures.ts
+++ b/lib/Map/PickedFeatures.ts
@@ -46,7 +46,7 @@ export default class PickedFeatures {
    * Gets or sets the array of picked features.  The array is observable and may be updated up until the point that
    * {@see PickedFeatures#allFeaturesAvailablePromise} resolves.
    */
-  @observable features: Entity[] = [];
+  @observable features: Feature[] = [];
 
   /**
    * Gets or sets a message describing an error that occurred while picking features.

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import { autorun, computed, runInAction } from "mobx";
 import { createTransformer } from "mobx-utils";
 import BoundingSphere from "terriajs-cesium/Source/Core/BoundingSphere";
@@ -16,12 +17,14 @@ import EventHelper from "terriajs-cesium/Source/Core/EventHelper";
 import FeatureDetection from "terriajs-cesium/Source/Core/FeatureDetection";
 import HeadingPitchRange from "terriajs-cesium/Source/Core/HeadingPitchRange";
 import Ion from "terriajs-cesium/Source/Core/Ion";
+import KeyboardEventModifier from "terriajs-cesium/Source/Core/KeyboardEventModifier";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import Matrix4 from "terriajs-cesium/Source/Core/Matrix4";
 import PerspectiveFrustum from "terriajs-cesium/Source/Core/PerspectiveFrustum";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import sampleTerrain from "terriajs-cesium/Source/Core/sampleTerrain";
 import ScreenSpaceEventType from "terriajs-cesium/Source/Core/ScreenSpaceEventType";
+import TerrainProvider from "terriajs-cesium/Source/Core/TerrainProvider";
 import Transforms from "terriajs-cesium/Source/Core/Transforms";
 import BoundingSphereState from "terriajs-cesium/Source/DataSources/BoundingSphereState";
 import DataSource from "terriajs-cesium/Source/DataSources/DataSource";
@@ -37,14 +40,19 @@ import SceneTransforms from "terriajs-cesium/Source/Scene/SceneTransforms";
 import SingleTileImageryProvider from "terriajs-cesium/Source/Scene/SingleTileImageryProvider";
 import when from "terriajs-cesium/Source/ThirdParty/when";
 import CesiumWidget from "terriajs-cesium/Source/Widgets/CesiumWidget/CesiumWidget";
+import getElement from "terriajs-cesium/Source/Widgets/getElement";
+import filterOutUndefined from "../Core/filterOutUndefined";
 import isDefined from "../Core/isDefined";
+import LatLonHeight from "../Core/LatLonHeight";
 import pollToPromise from "../Core/pollToPromise";
 import CesiumRenderLoopPauser from "../Map/CesiumRenderLoopPauser";
 import CesiumSelectionIndicator from "../Map/CesiumSelectionIndicator";
+import MapboxVectorTileImageryProvider from "../Map/MapboxVectorTileImageryProvider";
 import PickedFeatures, {
-  ProviderCoordsMap,
-  featureBelongsToCatalogItem
+  featureBelongsToCatalogItem,
+  ProviderCoordsMap
 } from "../Map/PickedFeatures";
+import TileErrorHandlerMixin from "../ModelMixins/TileErrorHandlerMixin";
 import SplitterTraits from "../Traits/SplitterTraits";
 import TerriaViewer from "../ViewModels/TerriaViewer";
 import CameraView from "./CameraView";
@@ -59,16 +67,7 @@ import Mappable, {
   MapItem
 } from "./Mappable";
 import Terria from "./Terria";
-import MapboxVectorTileImageryProvider from "../Map/MapboxVectorTileImageryProvider";
-import getElement from "terriajs-cesium/Source/Widgets/getElement";
-import LatLonHeight from "../Core/LatLonHeight";
-import filterOutUndefined from "../Core/filterOutUndefined";
-import KeyboardEventModifier from "terriajs-cesium/Source/Core/KeyboardEventModifier";
 import UserDrawing from "./UserDrawing";
-import i18next from "i18next";
-import TerrainProvider from "terriajs-cesium/Source/Core/TerrainProvider";
-import TileErrorHandlerMixin from "../ModelMixins/TileErrorHandlerMixin";
-import { Primitive } from "terriajs-cesium";
 
 //import Cesium3DTilesInspector from "terriajs-cesium/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspector";
 

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -29,7 +29,8 @@ import LeafletSelectionIndicator from "../Map/LeafletSelectionIndicator";
 import LeafletVisualizer from "../Map/LeafletVisualizer";
 import PickedFeatures, {
   ProviderCoords,
-  ProviderCoordsMap
+  ProviderCoordsMap,
+  featureBelongsToCatalogItem
 } from "../Map/PickedFeatures";
 import rectangleToLatLngBounds from "../Map/rectangleToLatLngBounds";
 import SplitterTraits from "../Traits/SplitterTraits";
@@ -596,6 +597,12 @@ export default class Leaflet extends GlobeOrMap {
     }
 
     const feature = Feature.fromEntityCollectionOrEntity(entity);
+    // Set _catalogItem for feature if necessary
+    feature._catalogItem =
+      feature._catalogItem ??
+      this.terria.workbench.items.find(item =>
+        featureBelongsToCatalogItem(feature, item)
+      );
     if (isDefined(this._pickedFeatures)) {
       this._pickedFeatures.features.push(feature);
 
@@ -608,7 +615,7 @@ export default class Leaflet extends GlobeOrMap {
   private _pickFeatures(
     latlng: L.LatLng,
     tileCoordinates?: any,
-    existingFeatures?: Entity[],
+    existingFeatures?: Feature[],
     ignoreSplitter: boolean = false
   ) {
     if (isDefined(this._pickedFeatures)) {
@@ -769,6 +776,15 @@ export default class Leaflet extends GlobeOrMap {
             })
           );
         }, pickedFeatures.features);
+
+        // Set _catalogItem for each feature if necessary
+        features.forEach(feature => {
+          feature._catalogItem =
+            feature._catalogItem ??
+            this.terria.workbench.items.find(item =>
+              featureBelongsToCatalogItem(feature, item)
+            );
+        });
         runInAction(() => {
           pickedFeatures.features = features;
         });

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -1,5 +1,6 @@
+import i18next from "i18next";
 import L, { GridLayer } from "leaflet";
-import { autorun, action, runInAction } from "mobx";
+import { action, autorun, runInAction } from "mobx";
 import { createTransformer } from "mobx-utils";
 import cesiumCancelAnimationFrame from "terriajs-cesium/Source/Core/cancelAnimationFrame";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
@@ -8,47 +9,46 @@ import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
 import Clock from "terriajs-cesium/Source/Core/Clock";
 import defaultValue from "terriajs-cesium/Source/Core/defaultValue";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
-import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import EventHelper from "terriajs-cesium/Source/Core/EventHelper";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import cesiumRequestAnimationFrame from "terriajs-cesium/Source/Core/requestAnimationFrame";
 import DataSource from "terriajs-cesium/Source/DataSources/DataSource";
 import DataSourceCollection from "terriajs-cesium/Source/DataSources/DataSourceCollection";
+import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import ImageryLayerFeatureInfo from "terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo";
+import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
 import ImagerySplitDirection from "terriajs-cesium/Source/Scene/ImagerySplitDirection";
 import when from "terriajs-cesium/Source/ThirdParty/when";
 import html2canvas from "terriajs-html2canvas";
 import filterOutUndefined from "../Core/filterOutUndefined";
 import isDefined from "../Core/isDefined";
+import LatLonHeight from "../Core/LatLonHeight";
 import runLater from "../Core/runLater";
 import CesiumTileLayer from "../Map/CesiumTileLayer";
 import LeafletDataSourceDisplay from "../Map/LeafletDataSourceDisplay";
 import LeafletScene from "../Map/LeafletScene";
 import LeafletSelectionIndicator from "../Map/LeafletSelectionIndicator";
 import LeafletVisualizer from "../Map/LeafletVisualizer";
+import MapboxVectorCanvasTileLayer from "../Map/MapboxVectorCanvasTileLayer";
+import MapboxVectorTileImageryProvider from "../Map/MapboxVectorTileImageryProvider";
 import PickedFeatures, {
+  featureBelongsToCatalogItem,
   ProviderCoords,
-  ProviderCoordsMap,
-  featureBelongsToCatalogItem
+  ProviderCoordsMap
 } from "../Map/PickedFeatures";
 import rectangleToLatLngBounds from "../Map/rectangleToLatLngBounds";
+import TileErrorHandlerMixin from "../ModelMixins/TileErrorHandlerMixin";
+import RasterLayerTraits from "../Traits/RasterLayerTraits";
 import SplitterTraits from "../Traits/SplitterTraits";
 import TerriaViewer from "../ViewModels/TerriaViewer";
 import CameraView from "./CameraView";
 import Feature from "./Feature";
 import GlobeOrMap from "./GlobeOrMap";
 import hasTraits from "./hasTraits";
+import MapInteractionMode from "./MapInteractionMode";
 import Mappable, { ImageryParts, MapItem } from "./Mappable";
 import Terria from "./Terria";
-import MapboxVectorCanvasTileLayer from "../Map/MapboxVectorCanvasTileLayer";
-import MapboxVectorTileImageryProvider from "../Map/MapboxVectorTileImageryProvider";
-import LatLonHeight from "../Core/LatLonHeight";
-import MapInteractionMode from "./MapInteractionMode";
-import i18next from "i18next";
-import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
-import RasterLayerTraits from "../Traits/RasterLayerTraits";
-import TileErrorHandlerMixin from "../ModelMixins/TileErrorHandlerMixin";
 
 // We want TS to look at the type declared in lib/ThirdParty/terriajs-cesium-extra/index.d.ts
 // and import doesn't allows us to do that, so instead we use require + type casting to ensure

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1067,6 +1067,7 @@ export default class Terria {
         entities.forEach(entity => {
           const hash = hashEntity(entity, this.timelineClock);
           const feature = Feature.fromEntityCollectionOrEntity(entity);
+          feature._catalogItem = item;
           featureIndex[hash] = (featureIndex[hash] || []).concat([feature]);
         });
       });

--- a/test/Models/UserDrawingSpec.ts
+++ b/test/Models/UserDrawingSpec.ts
@@ -12,6 +12,7 @@ import supportsWebGL from "../../lib/Core/supportsWebGL";
 import PickedFeatures from "../../lib/Map/PickedFeatures";
 import Terria from "../../lib/Models/Terria";
 import UserDrawing from "../../lib/Models/UserDrawing";
+import Feature from "../../lib/Models/Feature";
 
 const describeIfSupported = supportsWebGL() ? describe : xdescribe;
 
@@ -329,7 +330,9 @@ describe("UserDrawing", function() {
     pickedFeatures.pickPosition = pt1CartesianPosition;
     // If in the UI the user clicks on a point, it returns that entity, so we're pulling it out of userDrawing and
     // pretending the user actually clicked on it.
-    const pt1Entity = userDrawing.pointEntities.entities.values[0];
+    const pt1Entity = Feature.fromEntity(
+      userDrawing.pointEntities.entities.values[0]
+    );
     pickedFeatures.features = [pt1Entity];
     runInAction(() => {
       userDrawing.terria.mapInteractionModeStack[0].pickedFeatures = pickedFeatures;
@@ -393,7 +396,9 @@ describe("UserDrawing", function() {
     pickedFeatures.pickPosition = pt1CartesianPosition;
     // If in the UI the user clicks on a point, it returns that entity, so we're pulling it out of userDrawing and
     // pretending the user actually clicked on it.
-    const pt1Entity = userDrawing.pointEntities.entities.values[0];
+    const pt1Entity = Feature.fromEntity(
+      userDrawing.pointEntities.entities.values[0]
+    );
     pickedFeatures.features = [pt1Entity];
     runInAction(() => {
       userDrawing.terria.mapInteractionModeStack[0].pickedFeatures = pickedFeatures;
@@ -457,7 +462,9 @@ describe("UserDrawing", function() {
     pickedFeatures.pickPosition = pt1CartesianPosition;
     // If in the UI the user clicks on a point, it returns that entity, so we're pulling it out of userDrawing and
     // pretending the user actually clicked on it.
-    const pt1Entity = userDrawing.pointEntities.entities.values[0];
+    const pt1Entity = Feature.fromEntity(
+      userDrawing.pointEntities.entities.values[0]
+    );
     pickedFeatures.features = [pt1Entity];
     runInAction(() => {
       userDrawing.terria.mapInteractionModeStack[0].pickedFeatures = pickedFeatures;
@@ -537,7 +544,9 @@ describe("UserDrawing", function() {
     pickedFeatures.pickPosition = pt2CartesianPosition;
     // If in the UI the user clicks on a point, it returns that entity, so we're pulling it out of userDrawing and
     // pretending the user actually clicked on it.
-    const pt2Entity = userDrawing.pointEntities.entities.values[1];
+    const pt2Entity = Feature.fromEntity(
+      userDrawing.pointEntities.entities.values[1]
+    );
     pickedFeatures.features = [pt2Entity];
     runInAction(() => {
       userDrawing.terria.mapInteractionModeStack[0].pickedFeatures = pickedFeatures;

--- a/test/ReactViews/Map/Panels/SharePanel/BuildShareLinkSpec.ts
+++ b/test/ReactViews/Map/Panels/SharePanel/BuildShareLinkSpec.ts
@@ -239,7 +239,7 @@ describe("BuildShareLink", function() {
           83234.52,
           952313.73
         );
-        terria.pickedFeatures.features.push(new Entity());
+        terria.pickedFeatures.features.push(Feature.fromEntity(new Entity()));
         const shareLink = buildShareLink(terria, viewState);
         const params = decodeAndParseStartHash(shareLink);
         const initSources = flattenInitSources(params.initSources);
@@ -263,7 +263,7 @@ describe("BuildShareLink", function() {
           "https://foo": { x: 123, y: 456, level: 7 },
           "https://bar": { x: 42, y: 42, level: 4 }
         };
-        terria.pickedFeatures.features.push(new Entity());
+        terria.pickedFeatures.features.push(Feature.fromEntity(new Entity()));
         const shareLink = buildShareLink(terria, viewState);
         const params = decodeAndParseStartHash(shareLink);
         const initSources = flattenInitSources(params.initSources);
@@ -306,10 +306,10 @@ describe("BuildShareLink", function() {
           952313.73
         );
         terria.pickedFeatures.features.push(
-          new Entity({ name: "testFeature1" })
+          Feature.fromEntity(new Entity({ name: "testFeature1" }))
         );
         terria.pickedFeatures.features.push(
-          new Entity({ name: "testFeature2" })
+          Feature.fromEntity(new Entity({ name: "testFeature2" }))
         );
         const shareLink = buildShareLink(terria, viewState);
         const params = decodeAndParseStartHash(shareLink);


### PR DESCRIPTION
### Fixed pickedFeatures for dynamic layers

Fixes https://github.com/TerriaJS/terriajs/issues/4768

Layers which are dynamic (i.e. `mapItems` change due to things like time or other dimensions) - would lose `pickedFeatures` when `mapItems` change. 

#### Replicate problem

For example, auto updating datasets will hide `FeatureInfoPanel` when the dataset is updated:

- http://ci.terria.io/next/#clean&https://gist.githubusercontent.com/nf-s/875ba30b1fb6cad9a3450e08ef8eef33/raw/27812f29500669911c03f93eb60d59c8565cef46/power-gen.json
- Add `Current Power Generation` dataset
- Select point
- Wait for update
- `FeatureInfoPanel` will disappear after update

This was due to `feature._catalogItem` not being set correctly.

#### Fixed

- http://ci.terria.io/picked-feature-catalogitem/#clean&https://gist.githubusercontent.com/nf-s/875ba30b1fb6cad9a3450e08ef8eef33/raw/27812f29500669911c03f93eb60d59c8565cef46/power-gen.json
- Add `Current Power Generation` dataset
- Select point
- Wait for update

### Future work

While the `FeatureInfoPanel` will stay open when the dataset changes, the actual feature info does **not** update &mdash; it will show the feature info from the feature that was selected before the change.

~This is the same behavior in master. At some point it may be worth updating `pickedFeatures` as the datasets change.~

This is a bug, it has an issue here https://github.com/TerriaJS/terriajs/issues/5127

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
