### PR TITLE
Fix failing CI due to blank target

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.66)
-* Fix failing tests due to `react/jsx-no-target-blank` error.
+* Fix failing CI due to lint `react/jsx-no-target-blank` error.
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.66)
+* Fix failing tests due to `react/jsx-no-target-blank` error.
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/lib/ReactViews/Map/MenuButton.jsx
+++ b/lib/ReactViews/Map/MenuButton.jsx
@@ -10,14 +10,23 @@ import Styles from "./menu-button.scss";
  * @constructor
  */
 function MenuButton(props) {
+  const hrefAtt =
+    props.href !== "#"
+      ? {
+          target: "_blank",
+          rel: "noreferrer"
+        }
+      : {
+          target: undefined
+        };
   return (
     <a
       className={classNames(Styles.btnAboutLink, {
         [Styles.aboutTweak]: props.href === "about.html"
       })}
       href={props.href}
-      target={props.href !== "#" ? "_blank" : undefined}
       title={props.caption}
+      {...hrefAtt}
     >
       {props.href !== "#" && <Icon glyph={Icon.GLYPHS.externalLink} />}
       <span>{props.caption}</span>


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

CI is failing due to `react/jsx-no-target-blank`, this introduces a quick fix for it.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
