### PR TITLE
Make TableTimeStyleTraits.timeColumn nullable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.66)
+* Make `TableTimeStyleTraits.timeColumn` nullable
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/lib/Table/TableStyle.ts
+++ b/lib/Table/TableStyle.ts
@@ -158,7 +158,7 @@ export default class TableStyle {
    */
   @computed
   get timeColumn(): TableColumn | undefined {
-    return this.resolveColumn(this.timeTraits.timeColumn);
+    return this.resolveColumn(this.timeTraits.timeColumn ?? undefined);
   }
 
   /**

--- a/lib/Traits/TableTimeStyleTraits.ts
+++ b/lib/Traits/TableTimeStyleTraits.ts
@@ -6,9 +6,10 @@ export default class TableTimeStyleTraits extends ModelTraits {
     name: "Time Column",
     description:
       "The column that indicates the time of a sample or the start time of an interval.",
-    type: "string"
+    type: "string",
+    isNullable: true
   })
-  timeColumn?: string;
+  timeColumn?: string | null;
 
   @primitiveTrait({
     name: "End Time Column",


### PR DESCRIPTION
### Make `TableTimeStyleTraits.timeColumn` nullable

This is needed to disable `TableMixin` autodetected time columns - for example:

```json
{
"name": "Transmission substations",
  "url": "https://uts-nom.herokuapp.com/capacity/published/combined-transmission-substations.csv",
  "type": "csv",
  "tableStyle": {
    "timeColumn": null,
"..."
```

Test AREMI catalog: https://gist.githubusercontent.com/nf-s/9ff1422d9528c16a9e71403ec720558a/raw/fe86f1c9bf2dd4053148475dd1361fc7e205ec22/aremi-elec-infra.json

### Checklist

-   [x] Doesn't require tests
-   [x] I've updated CHANGES.md with what I changed.
