### PR TITLE
Translation and configuration documentation

### DIFF
--- a/doc/contributing/translation-guide-dev.md
+++ b/doc/contributing/translation-guide-dev.md
@@ -1,0 +1,166 @@
+# Development translation guide
+
+Before reading this read the [user translation guide](../customizing/translation-guide.md), to get familiar with all possible translation options.
+
+## Development
+
+All the string visible to the user should be translated using the below explained mechanisms.
+
+### useTranslation (hook)
+
+It gets the `t` function and `i18n` instance inside your **functional components**.
+
+**Usage**
+
+```js
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export function MyComponent() {
+  const { t, i18n } = useTranslation();
+  // or const [t, i18n] = useTranslation();
+
+  return <p>{t('key')}</p> //returns corresponding translated text from translation files
+}
+```
+
+See the [useTranslation documentation](https://react.i18next.com/latest/usetranslation-hook#what-it-does) for more details.
+
+### withTranslation (HOC)
+
+The `withTranslation` is a classic HOC (higher order component) and gets the `t` function and `i18n` instance inside your component via props.
+
+**Usage**
+
+```js
+import React from 'react';
+import { withTranslation } from 'react-i18next';
+
+function MyComponent({ t, i18n }) {
+  return <p>{t('my translated text')}</p>
+}
+
+export default withTranslation()(MyComponent);
+```
+
+See the [withTranslation documentation](https://react.i18next.com/latest/withtranslation-hoc#what-it-does) for more details.
+
+
+### Trans component
+
+While the Trans component gives you a lot of power by letting you interpolate or translate complex react elements - the truth is - in most cases you won't need it.
+
+As long you have no react nodes you like to be integrated into a translated text (text formatting, like strong, i, ...) or adding some link component - you won't need it - most can be done by using the good old t function.
+
+```js
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next'
+
+function MyComponent() {
+  const { t } = useTranslation('myNamespace');
+
+  return <Trans t={t} key="keyHelloWorld">Hello World</Trans>;
+}
+
+```
+
+See the [withTranslation documentation](https://react.i18next.com/latest/trans-component) for more details.
+
+
+### Interesting functions
+
+#### Interpolation
+
+Use dynamic values in translations.
+```json
+{
+  "key": "{{what}} is {{how}}"
+}
+```
+Sample
+```js
+i18next.t('key', { what: 'i18next', how: 'great' });
+// -> "i18next is great"
+```
+See the [i18next interpolation documentation](https://www.i18next.com/translation-function/interpolation#basic) for further details.
+
+#### Singular / Plural
+
+i18next features automatic recognition of singular and plural forms.
+> The variable name must be `count`!
+
+**Keys**
+
+```json
+{
+  "key": "item",
+  "key_plural": "items",
+  "keyWithCount": "{{count}} item",
+  "keyWithCount_plural": "{{count}} items"
+}
+```
+
+**Example**
+
+```js
+i18next.t('key', {count: 0}); // -> "items"
+i18next.t('key', {count: 1}); // -> "item"
+i18next.t('key', {count: 5}); // -> "items"
+i18next.t('key', {count: 100}); // -> "items"
+i18next.t('keyWithCount', {count: 0}); // -> "0 items"
+i18next.t('keyWithCount', {count: 1}); // -> "1 item"
+i18next.t('keyWithCount', {count: 5}); // -> "5 items"
+i18next.t('keyWithCount', {count: 100}); // -> "100 items"
+```
+
+See the [i18next singular-plural documentation](https://www.i18next.com/translation-function/plurals#singular-plural) for more details.
+
+#### Nesting
+
+Nesting allows you to reference other keys in a translation.
+
+**Keys**
+
+```json
+{
+  "nesting1": "1 $t(nesting2)",
+  "nesting2": "2 $t(nesting3)",
+  "nesting3": "3",
+}
+```
+
+**Example**
+
+```js
+i18next.t('nesting1'); // -> "1 2 3"
+```
+
+See the [i18next nesting documentation](https://www.i18next.com/translation-function/nesting#basic) for more details.
+
+#### Context
+
+By providing a context you can differ translations.
+
+**Keys**
+
+```json
+{
+  "friend": "A friend",
+  "friend_male": "A boyfriend",
+  "friend_female": "A girlfriend"
+}
+```
+
+**Example**
+
+```js
+  i18next.t('friend'); // -> "A friend"
+  i18next.t('friend', { context: 'male' }); // -> "A boyfriend"
+  i18next.t('friend', { context: 'female' }); // -> "A girlfriend"
+```
+See the [react-i18next context documentation](https://www.i18next.com/translation-function/context) for more details.
+
+
+## Future work
+
+* Support internationalization of catalog content.

--- a/doc/customizing/client-side-config.md
+++ b/doc/customizing/client-side-config.md
@@ -1,8 +1,14 @@
-The file `wwwroot/config.json` in TerriaMap contains client-side configuration parameters.
+The file `wwwroot/config.json` in TerriaMap contains client-side configuration parameters. See [this file for an example](https://github.com/TerriaJS/TerriaMap/blob/next/wwwroot/config.json).
 
-It has this structure:
+It has following structure:
 
-```
+|Name|Required|Type|Default|Description|
+|----|--------|----|-------|-----------|
+|[initializationUrls](#intializationurls)|yes|**string[]**|[]|The list of initialization files which define the catalog content, for more details check [below](#intializationurls).|
+|parameters|yes|**[Parameters](#parameters)**||TerriaJS configuration options|
+
+**Example**
+```json5
 {
     "initializationUrls" : [
         "myinitfile",
@@ -27,48 +33,123 @@ If the string does not end with `.json`, such as `"foo"`, it refers to an init f
 
 It is also possible to add version 7 init files &mdash; these will be converted on-the-fly in `terriajs` when a map is loaded. See [`catalog-converter`](https://github.com/TerriaJS/catalog-converter) repo for more information.
 
-## parameters
+## Parameters
 
 Specifies various options for configuring TerriaJS:
 
-Option                      | Meaning
-----------------------------|--------
-`"appName"`                 | TerriaJS uses this name whenever it needs to display the name of the application.
-`"autoPlay"` | true to start playing time-dynamic datasets on load, or false to start them paused.
-`"bingMapsKey"`             | A [Bing Maps API key](https://msdn.microsoft.com/en-us/library/ff428642.aspx) used for requesting Bing Maps base maps and using the Bing Maps geocoder for searching. It is your responsibility to request a key and comply with all terms and conditions.
-`"brandBarElements": [ ]`   | An array of strings of HTML that fill up the top left logo space.
-`"defaultMaximumShownFeatureInfos"` | The maximum number of "feature info" boxes that can be displayed when clicking a point. (Default: 100)
-`"disclaimer": {`<span><br/>&nbsp;&nbsp;`"text": "",`<br/>&nbsp;&nbsp;`"url": ""`<br/>`}`</span> | This text will be displayed prominently at the bottom of the map, with a clickable link to the URL.
-`"feedbackUrl"`					| URL of the service used to send feedback.  If not specified, the "Give Feedback" button will not appear. | None
-`"googleAnalyticsKey"`      | A Google API key for [Google Analytics](https://analytics.google.com).  If specified, TerriaJS will send various events about how it's used to Google Analytics.
-`"googleAnalyticsOptions"`  | Additional options that will be passed to the Google Analytics call.
-`"printDisclaimer": {`<span><br/>&nbsp;&nbsp;`"text": "",`<br/>&nbsp;&nbsp;`"url": ""`<br/>`}`</span> | Same as `disclaimer`, except only shown in printed views.
-`"supportEmail"`            | The email address shown when things go wrong.
-`"mobileDefaultViewerMode"` | A string specifying the default view mode to load when running on a mobile platform. Options are: `"3DTerrain"`, `"3DSmooth"`, `"2D"`. (Default: `"2D"`)
-`"initFragmentPaths"`       | An array of base paths to use to try to use to resolve init fragments in the URL.  For example, if this property is `[ "init/", "http://example.com/init/"]`, then a URL with `#test` will first try to load `init/test.json` and, if that fails, next try to load `http://example.com/init/test.json`.  If not specified, this property defaults to `[ "init/" ]`.
-`"disableMyLocation"`       | True to disable the "Centre map at your current location" button.
-`"disableSplitter"`         | True to disable the use of the splitter control.
-`"tabbedCatalog"`           | True to create a separate explorer panel tab for each top-level catalog group to list its items in.
-`"interceptBrowserPrint"`   | True (the default) to intercept the browser's print feature and use a custom one accessible through the Share panel.
-`"openAddData"`             | True to automatically open Add Data dialog at startup.
-`"showWelcomeMessage"`      | True to display welcome message on startup.
-`"showInAppGuides"`         | True to display in-app guides.
-`"showFeaturePrompts"`      | True to display new feature popups.
-`"useCesiumIonTerrain"`     | True to use Cesium World Terrain from Cesium ion. False to use terrain from the URL specified with the `"cesiumTerrainUrl"` property. If this property is false and `"cesiumTerrainUrl"` is not specified, the 3D view will use a smooth ellipsoid instead of a terrain surface. Defaults to true.
-`"useCesiumIonBingImagery"` | True to use Bing Maps from Cesium ion (Cesium World Imagery). By default, Ion will be used, unless the `bingMapsKey` property is specified, in which case that will be used instead. To disable the Bing Maps layers entirely, set this property to false and set `bingMapsKey` to null.
-`"cesiumIonAccessToken"`    | The access token to use with Cesium ion. If `"useCesiumIonTerrain"` is true and this property is not specified, the Cesium default Ion key will be used. It is a violation of the Ion terms of use to use the default key in a deployed application.
-`"cesiumTerrainUrl"`        | The URL to use for Cesium terrain in the 3D model. This property is ignored if `"useCesiumIonTerrain"` is set to true.
-`"rollbarAccessToken"`      | Your `post_client_item` from Rollbar - as of right now, TerriaMap also needs to be modified such that you construct `RollbarErrorProvider` in `index.js`
-`"helpContent"`             | The content to be displayed in the help panel
+|Name|Required|Type|Default|Description|
+|----|--------|----|-------|-----------|
+|`appName`|no|**string**|`"TerriaJS App"`|TerriaJS uses this name whenever it needs to display the name of the application.|
+|`supportEmail`|no|**string**|`"info@terria.io"`|The email address shown when things go wrong.|
+|`defaultMaximumShownFeatureInfos`|no|**number**|`100`|The maximum number of "feature info" boxes that can be displayed when clicking a point.|
+|`regionMappingDefinitionsUrl`|yes|**string**|`"build/TerriaJS/data/regionMapping.json"`|URL of the JSON file that defines region mapping for CSV files. This option only needs to be changed in unusual deployments. It has to be changed if deploying as static site, for instance.|
+|`conversionServiceBaseUrl`|no|**string**|`"convert/"`|URL of OGR2OGR conversion service (part of TerriaJS-Server). This option only needs to be changed in unusual deployments. It has to be changed if deploying as static site, for instance.|
+|`proj4ServiceBaseUrl`|no|**string**|`"proj4/"`|URL of Proj4 projection lookup service (part of TerriaJS-Server). This option only needs to be changed in unusual deployments. It has to be changed if deploying as static site, for instance.|
+|`corsProxyBaseUrl`|no|**string**|`"proxy/"`|URL of CORS proxy service (part of TerriaJS-Server). This option only needs to be changed in unusual deployments. It has to be changed if deploying as static site, for instance.|
+|`proxyableDomainsUrl`|no|**string**|`"proxyabledomains/"`|Deprecated, will be determined from serverconfig.|
+|`serverConfigUrl`|no|**string**|`"serverconfig/"`|
+|`shareUrl`|no|**string**|`"share"`|
+|`feedbackUrl`|no|**string**||URL of the service used to send feedback.  If not specified, the "Give Feedback" button will not appear.|
+|`initFragmentPaths`|yes|**string[]**|`["init/"]`|An array of base paths to use to try to use to resolve init fragments in the URL.  For example, if this property is `[ "init/", "http://example.com/init/"]`, then a URL with `#test` will first try to load `init/test.json` and, if that fails, next try to load `http://example.com/init/test.json`.|
+|`storyEnabled`|yes|**boolean**|`true`|Whether the story is enabled. If false story function button won't be available.|
+|`interceptBrowserPrint`|no|**boolean**|`true`|True (the default) to intercept the browser's print feature and use a custom one accessible through the Share panel.|
+|`tabbedCatalog`|no|**boolean**|`false`|True to create a separate explorer panel tab for each top-level catalog group to list its items in.|
+|`useCesiumIonTerrain`|no|**boolean**|`true`|True to use Cesium World Terrain from Cesium ion. False to use terrain from the URL specified with the `"cesiumTerrainUrl"` property. If this property is false and `"cesiumTerrainUrl"` is not specified, the 3D view will use a smooth ellipsoid instead of a terrain surface. Defaults to true.|
+|`cesiumIonAccessToken`|no|**string**|undefined|The access token to use with Cesium ion. If `"useCesiumIonTerrain"` is true and this property is not specified, the Cesium default Ion key will be used. It is a violation of the Ion terms of use to use the default key in a deployed application.|
+|`useCesiumIonBingImagery`|no|**boolean**|`true`|True to use Bing Maps from Cesium ion (Cesium World Imagery). By default, Ion will be used, unless the `bingMapsKey` property is specified, in which case that will be used instead. To disable the Bing Maps layers entirely, set this property to false and set `bingMapsKey` to null.|
+|`bingMapsKey`|no|**string**|undefined|A [Bing Maps API key](https://msdn.microsoft.com/en-us/library/ff428642.aspx) used for requesting Bing Maps base maps and using the Bing Maps geocoder for searching. It is your responsibility to request a key and comply with all terms and conditions.|
+|`hideTerriaLogo`|no|**boolean**|`false`|
+|`brandBarElements`|no|**string[]**|undefined|An array of strings of HTML that fill up the top left logo space.|
+|`displayOneBrand`|no|**number**|`0`|Index of which brandBarElements to show for mobile header.|
+|`disableMyLocation`|no|**boolean**|undefined|True to disable the "Centre map at your current location" button.|
+|`disableSplitter`|no|**boolean**|undefined|True to disable the use of the splitter control.|
+|`experimentalFeatures`|no|**boolean**|undefined||
+|`magdaReferenceHeaders`|no|**[MagdaReferenceHeaders](#MagdaReferenceHeaders)**|undefined|
+|`locationSearchBoundingBox`|no|**number**|undefined|
+|`googleAnalyticsKey`|no|**string**|undefined|A Google API key for [Google Analytics](https://analytics.google.com).  If specified, TerriaJS will send various events about how it's used to Google Analytics.|
+|`rollbarAccessToken`|no|**string**|undefined|Your `post_client_item` from Rollbar - as of right now, TerriaMap also needs to be modified such that you construct `RollbarErrorProvider` in `index.js`|
+|`globalDisclaimer`|no|**any**|undefined||
+|`showWelcomeMessage`|no|**boolean**|`false`|True to display welcome message on startup.|
+|`welcomeMessageVideo`|no|**any**||Video to show in welcome message.|
+|`showInAppGuides`|no|**boolean**|`false`|True to display in-app guides.|
+|`helpContent`|no|**[HelpContentItem](#HelpContentItem)**|`[]`|The content to be displayed in the help panel.|
+|`helpContentTerms`|no|**[Term](#Term)**|||
+|`languageConfiguration`|no|**[LanguageConfiguration](#LanguageConfiguration)**|undefined|Language configuration of TerriaJS.|
 
+### MagdaReferenceHeaders
 
-## Advanced options
+***
 
-These options only need to be changed in unusual deployments. They define the URLs that are accessed for certain additional services, so must be changed if deploying as a static site, for instance.
+### HelpContentItem
+Configuration of items to appear in the search bar
 
-Option                      | Meaning | Default
-----------------------------|---------|---------
-`"conversionServiceBaseUrl"`    | URL of OGR2OGR conversion service (part of TerriaJS-Server). | `convert/`
-`"corsProxyBaseUrl"`            | URL of CORS proxy service (part of TerriaJS-Server)| `proxy/`
-`"proj4ServiceBaseUrl"`         | URL of Proj4 projection lookup service (part of TerriaJS-Server) | `proj4/`
-`"regionMappingDefinitionsUrl"` | URL of the JSON file that defines region mapping for CSV files. | `build/TerriaJS/data/regionMapping.json`
+|Name|Required|Type|Default|Description|
+|----|--------|----|-------|-----------|
+|`itemName`|yes|**string**|undefined|
+|`title`|no|**string**|undefined|Title of the help item|
+|`videoUrl`|no|**string**|undefined|The video to show on the top of help item.|
+|`placeholderImage`|no|**string**|undefined|Placeholder image for the video.|
+|`paneMode`|no|**enum["videoAndContent","slider","trainer"]**|`"videoAndContent"`|
+|`trainerItems`|no|**[TrainerItem[]](#TrainerItem)**|undefined|List of the trainer steps|
+|`markdownText`|no|**string**|undefined|The content of the help item, can use Markdown syntax.|
+|`icon`|no|**string**|undefined|Icon to show next to the itemName.|
+
+#### TrainerItem
+
+|Name|Required|Type|Default|Description|
+|----|--------|----|-------|-----------|
+|title|yes|**string**||Title of the trainer item.|
+|footnote|yes|**string**||Text to show below steps.|
+|steps|yes|**StepItem**||List of the steps for this trainer item.|
+
+#### StepItem
+
+|Name|Required|Type|Default|Description|
+|----|--------|----|-------|-----------|
+|title|yes|**string**||Title of the step.|
+|markdownDescription|no|**string**||The content of the step item.|
+
+***
+
+### Term
+|Name|Required|Type|Default|Description|
+|----|--------|----|-------|-----------|
+|term|yes|**string**||Name of the term, content will be attached to it when found in text.|
+|content|yes|**string**||Description of the content.|
+|aliases|no|**string[]**||Aliases of the term.|
+
+***
+
+### LanguageConfiguration
+
+|Name|Required|Type|Default|Description|
+|----|--------|----|-------|-----------|
+|enabled|yes|**boolean**|`false`|Controls whether a button to switch the portal's language is provided.|
+|debug|yes|**boolean**|`false`|Controls whether debug information regarding translations is logged to the console.|
+|react|yes|**ReactOptions**||
+|languages|yes|**Object**|`{en: "english"}`|Language abbreviations. Please mind that matching locale files must exist.|
+|fallbackLanguage|yes|**string**|`"en"`|Fallback language used if contents are not available in the currently selected language.|
+|changeLanguageOnStartWhen|yes|**string[]**|`["querystring", "localStorage", "navigator", "htmlTag"]`|Order of user language detection. See [i18next browser language detection documentation](https://github.com/i18next/i18next-browser-languageDetector) for details.|
+
+**Example**
+
+```json
+{
+  "enabled": true,
+  "debug": false,
+  "react": {
+    "useSuspense": false
+  },
+  "languages": {
+    "en": "english",
+    "de": "deutsch"
+  },
+  "fallbackLanguage": "en",
+  "changeLanguageOnStartWhen": [
+    "querystring",
+    "localStorage",
+    "navigator",
+    "htmlTag"
+  ]
+}
+```

--- a/doc/customizing/translation-guide.md
+++ b/doc/customizing/translation-guide.md
@@ -1,0 +1,100 @@
+# TerriaJS translation guide
+
+This document describes how to work with languages and translation in the TerriaJS and TerriaMap.
+
+## Introduction
+
+### Technology
+
+For the translations TerriaJS uses [react-i18next](https://react.i18next.com/) technology, react implementation of famous [i18next](https://i18next.com) ecosystem.
+If you are an advanced user or expert, we recommend reading the short and concise react-i18next documentation.
+
+The following i18next plugins are used:
+* [i18next-browser-languagedetector](https://github.com/i18next/i18next-browser-languageDetector) to detect the browser language, use the localStorage and react to URL query
+* [i18next-http-backend](https://github.com/i18next/i18next-http-backend) to enable loading translations from editable language files
+
+### Languages
+
+Currently, the only available language is English, and it is configured as the default fallback language. Default fallback language can be changed in the [`config.json`] file.
+
+**List of available languages**
+|Abbreviation|Language|
+|------------|--------|
+|en|english|
+
+### Configuration
+
+Language configuration is done within [`config.json`]. See the [config.json documentation](../customizing/client-side-config.md#LanguageConfiguration) for details on configuration.
+
+## Language files
+
+Language files are translation core. To add an additional language, a separate language file is needed for it. Translations can be provided using two files:
+1. translation
+2. languageOverrides
+
+### Translation language file - `translation.json`
+
+The translation language file contains all translations used throughout the TerriaJS. This file is located in TerriaJS source code, and changes to it require a rebuild of the application. A namespace for this translation file is `translation`.
+
+### Language overrides language file - `languageOverrides.json`
+
+The languageOverrides language file is used to override the translation language file's translations without rebuilding the application and specifying the additional translations needed. This file is located in `/wwwroot/languages/{abbreviation}/languageOverrides.json` inside the root folder of TerriaMap (where the abbreviation is a short name of the language specified in the config). A namespace for this translation file is `languageOverrides`.
+
+## Best practice
+
+This section describes how to use i18next to provide a translation of TerriaJS.
+
+### Translation of configurable elements
+
+To translate configurable elements, the value itself must be formatted correctly (it is called a translation key). The formatted value must then be added to the translation files with the corresponding translation. Currently only elements that are available for translation are `helpContent` and `helpContentTerms`.
+
+>***This is likely to be changed in the future by adding an additional parameter to specify which configurable elements should be changed. The reason for it is that there is a possible issue with using single words when specifying static names of items to get a `missing key` as translation.***
+
+**Translation file**
+```json
+{
+  "help": {
+    "gettingstarted": {
+      "title": "Getting started with the map",
+      "content": "",
+      "video": "https://...",
+      "image": "https://..."
+    }
+  }
+}
+```
+
+**Translateable content**
+```json
+"helpContent": [
+  {
+    "title": "help.gettingstarted.title",
+    "itemName": "gettingstarted",
+    "paneMode": "videoAndContent",
+    "markdownText": "help.gettingstarted.content",
+    "icon": "video",
+    "videoUrl": "help.gettingstarted.video",
+    "placeholderImage": "help.gettingstarted.image"
+  }
+]
+```
+
+### Overriding translation
+
+To override the translation of an already translated element you need to override its translation in the language overrides language file. This is done by specifying the new translation for its key.
+
+**Example**
+Button MapSetting has a name specified using key `settingPanel.btnText`:
+```json5
+"settingPanel": {
+  "btnText": "Map Settings",
+  ...
+}
+```
+
+Defining the following in the language overrides language file will override the name of the map settings button and it will be named *Map Configuration*:
+```json5
+"settingPanel": {
+  "btnText": "Map Configuration"
+}
+```

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -83,41 +83,123 @@ import Workbench from "./Workbench";
 
 interface ConfigParameters {
   [key: string]: ConfigParameters[keyof ConfigParameters];
+  /**
+   * TerriaJS uses this name whenever it needs to display the name of the application.
+   */
   appName?: string;
+  /**
+   * The email address shown when things go wrong.
+   */
   supportEmail?: string;
+  /**
+   * The maximum number of "feature info" boxes that can be displayed when clicking a point.
+   */
   defaultMaximumShownFeatureInfos?: number;
+  /**
+   * URL of the JSON file that defines region mapping for CSV files.
+   */
   regionMappingDefinitionsUrl: string;
+  /**
+   * URL of OGR2OGR conversion service (part of TerriaJS-Server).
+   */
   conversionServiceBaseUrl?: string;
+  /**
+   * URL of Proj4 projection lookup service (part of TerriaJS-Server).
+   */
   proj4ServiceBaseUrl?: string;
+  /**
+   * URL of CORS proxy service (part of TerriaJS-Server)
+   */
   corsProxyBaseUrl?: string;
+  /**
+   * @deprecated
+   */
   proxyableDomainsUrl?: string;
   serverConfigUrl?: string;
   shareUrl?: string;
+  /**
+   * URL of the service used to send feedback.  If not specified, the "Give Feedback" button will not appear.
+   */
   feedbackUrl?: string;
+  /**
+   * An array of base paths to use to try to use to resolve init fragments in the URL.  For example, if this property is `[ "init/", "http://example.com/init/"]`, then a URL with `#test` will first try to load `init/test.json` and, if that fails, next try to load `http://example.com/init/test.json`.
+   */
   initFragmentPaths: string[];
+  /**
+   * Whether the story is enabled. If false story function button won't be available.
+   */
   storyEnabled: boolean;
+  /**
+   * True (the default) to intercept the browser's print feature and use a custom one accessible through the Share panel.
+   */
   interceptBrowserPrint?: boolean;
+  /**
+   * True to create a separate explorer panel tab for each top-level catalog group to list its items in.
+   */
   tabbedCatalog?: boolean;
+  /**
+   * True to use Cesium World Terrain from Cesium ion. False to use terrain from the URL specified with the `"cesiumTerrainUrl"` property. If this property is false and `"cesiumTerrainUrl"` is not specified, the 3D view will use a smooth ellipsoid instead of a terrain surface. Defaults to true.
+   */
   useCesiumIonTerrain?: boolean;
+  /**
+   * The access token to use with Cesium ion. If `"useCesiumIonTerrain"` is true and this property is not specified, the Cesium default Ion key will be used. It is a violation of the Ion terms of use to use the default key in a deployed application.
+   */
   cesiumIonAccessToken?: string;
-  hideTerriaLogo?: boolean;
+  /**
+   * True to use Bing Maps from Cesium ion (Cesium World Imagery). By default, Ion will be used, unless the `bingMapsKey` property is specified, in which case that will be used instead. To disable the Bing Maps layers entirely, set this property to false and set `bingMapsKey` to null.
+   */
   useCesiumIonBingImagery?: boolean;
+  /**
+   * A [Bing Maps API key](https://msdn.microsoft.com/en-us/library/ff428642.aspx) used for requesting Bing Maps base maps and using the Bing Maps geocoder for searching. It is your responsibility to request a key and comply with all terms and conditions.
+   */
   bingMapsKey?: string;
+  hideTerriaLogo?: boolean;
+  /**
+   * An array of strings of HTML that fill up the top left logo space.
+   */
   brandBarElements?: string[];
+  /**
+   * Index of which brandBarElements to show for mobile header.
+   */
+  displayOneBrand?: number;
+  /**
+   * True to disable the "Centre map at your current location" button.
+   */
   disableMyLocation?: boolean;
+  disableSplitter?: boolean;
   experimentalFeatures?: boolean;
   magdaReferenceHeaders?: MagdaReferenceHeaders;
   locationSearchBoundingBox?: number[];
+  /**
+   * A Google API key for [Google Analytics](https://analytics.google.com).  If specified, TerriaJS will send various events about how it's used to Google Analytics.
+   */
   googleAnalyticsKey?: string;
+  /**
+   * Your `post_client_item` from Rollbar - as of right now, TerriaMap also needs to be modified such that you construct `RollbarErrorProvider` in `index.js`
+   */
   rollbarAccessToken?: string;
   globalDisclaimer?: any;
+  /**
+   * True to display welcome message on startup.
+   */
   showWelcomeMessage?: boolean;
+  /**
+   * Video to show in welcome message.
+   */
   welcomeMessageVideo?: any;
+  /**
+   * True to display in-app guides.
+   */
   showInAppGuides?: boolean;
+  /**
+   * The content to be displayed in the help panel.
+   */
   helpContent?: HelpContentItem[];
   helpContentTerms?: Term[];
+  /**
+   *
+   */
   languageConfiguration?: LanguageConfiguration;
-  displayOneBrand?: number;
 }
 
 interface StartOptions {
@@ -231,11 +313,13 @@ export default class Terria {
     tabbedCatalog: false,
     useCesiumIonTerrain: true,
     cesiumIonAccessToken: undefined,
-    hideTerriaLogo: false,
     useCesiumIonBingImagery: undefined,
     bingMapsKey: undefined,
+    hideTerriaLogo: false,
     brandBarElements: undefined,
+    displayOneBrand: 0, // index of which brandBarElements to show for mobile header
     disableMyLocation: undefined,
+    disableSplitter: undefined,
     experimentalFeatures: undefined,
     magdaReferenceHeaders: undefined,
     locationSearchBoundingBox: undefined,
@@ -252,8 +336,7 @@ export default class Terria {
     showInAppGuides: false,
     helpContent: [],
     helpContentTerms: defaultTerms,
-    languageConfiguration: undefined,
-    displayOneBrand: 0 // index of which brandBarElements to show for mobile header
+    languageConfiguration: undefined
   };
 
   @observable


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

This PR documents the ways translation language files should be used. It also provides an updated list of configuration parameters in the config documentation. I didn't plan to update the entire config documentation but it happened while adding the `languageConfiguration` parameter.

There are some parameters I didn't know how to describe so they are missing a description. 
Parameters missing in configParameters list when compared with v7 are, I am not sure which ones are deprecated and which one will be implemented again:
***
`autoPlay`
`googleAnalyticsOptions`
`printDisclaimer`
`mobileDefaultViewerMode`
`openAddData`
`showFeaturePrompts`
`cesiumTerrainUrl`
***

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
