### PR TITLE
Add regionMapping applyReplacements from v7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Added a new `lineAndPoint` chart type
 * CustomChartComponent now has a "chart-type" attribute
 * Added `AttributionTraits` to mappable and send it as property when creating Cesium's data sources and imagery providers. [#5167](https://github.com/TerriaJS/terriajs/pull/5167) 
+* Re-add region mapping `applyReplacements`.
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/lib/Map/RegionProviderTs.ts
+++ b/lib/Map/RegionProviderTs.ts
@@ -8,21 +8,25 @@ import isDefined from "../Core/isDefined";
  * @param {String} s The string.
  * @param {String} replacementsProp Name of a property containing [ [ regex, replacement], ... ], where replacement is a string which can contain '$1' etc.
  */
+
 export function applyReplacements(
   regionProvider: RegionProvider,
   s: string | number,
-  replacementsProp: "dataReplacements" = "dataReplacements"
+  replacementsProp:
+    | "dataReplacements"
+    | "serverReplacements"
+    | "disambigDataReplacements"
 ): string | undefined {
   if (!isDefined(s)) {
     return undefined;
   }
-  var r: string;
+  let r: string;
   if (typeof s === "number") {
     r = String(s);
   } else {
     r = s.toLowerCase().trim();
   }
-  var replacements = regionProvider[replacementsProp];
+  let replacements = regionProvider[replacementsProp];
   if (replacements === undefined || replacements.length === 0) {
     return r;
   }
@@ -34,7 +38,7 @@ export function applyReplacements(
     return (regionProvider._appliedReplacements as any)[replacementsProp][r];
   }
 
-  replacements.forEach(function(rep) {
+  replacements.forEach(function(rep: any) {
     r = r.replace(rep[2], rep[1]);
   });
   (regionProvider._appliedReplacements as any)[replacementsProp][s] = r;

--- a/lib/Map/RegionProviderTs.ts
+++ b/lib/Map/RegionProviderTs.ts
@@ -1,0 +1,42 @@
+import RegionProvider from "./RegionProvider";
+import isDefined from "../Core/isDefined";
+
+/**
+ * Apply an array of regular expression replacements to a string. Also caches the applied replacements in regionProvider._appliedReplacements.
+ * @private
+ * @param {RegionProvider} regionProvider The RegionProvider instance.
+ * @param {String} s The string.
+ * @param {String} replacementsProp Name of a property containing [ [ regex, replacement], ... ], where replacement is a string which can contain '$1' etc.
+ */
+export function applyReplacements(
+  regionProvider: RegionProvider,
+  s: string | number,
+  replacementsProp: "dataReplacements" = "dataReplacements"
+): string | undefined {
+  if (!isDefined(s)) {
+    return undefined;
+  }
+  var r: string;
+  if (typeof s === "number") {
+    r = String(s);
+  } else {
+    r = s.toLowerCase().trim();
+  }
+  var replacements = regionProvider[replacementsProp];
+  if (replacements === undefined || replacements.length === 0) {
+    return r;
+  }
+
+  if (
+    (regionProvider._appliedReplacements as any)[replacementsProp][r] !==
+    undefined
+  ) {
+    return (regionProvider._appliedReplacements as any)[replacementsProp][r];
+  }
+
+  replacements.forEach(function(rep) {
+    r = r.replace(rep[2], rep[1]);
+  });
+  (regionProvider._appliedReplacements as any)[replacementsProp][s] = r;
+  return r;
+}

--- a/lib/Table/TableColumn.ts
+++ b/lib/Table/TableColumn.ts
@@ -313,10 +313,10 @@ export default class TableColumn {
     rowValue: string
   ): string | null {
     // TODO: validate that the rowValue is actually a valid region, if possible.
-    // TODO: implement replacements
+    // TODO: implement serverReplacements and disambigDataReplacements replacements
 
     return rowValue.length > 0
-      ? applyReplacements(regionType, rowValue) ?? null
+      ? applyReplacements(regionType, rowValue, "dataReplacements") ?? null
       : null;
   }
 

--- a/lib/Table/TableColumn.ts
+++ b/lib/Table/TableColumn.ts
@@ -1,13 +1,14 @@
 import countBy from "lodash-es/countBy";
 import { computed } from "mobx";
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import JSRegionProvider from "../Map/RegionProvider";
 import JSRegionProviderList from "../Map/RegionProviderList";
+import { applyReplacements } from "../Map/RegionProviderTs";
 import createCombinedModel from "../Models/createCombinedModel";
 import Model from "../Models/Model";
 import TableColumnTraits from "../Traits/TableColumnTraits";
 import TableTraits from "../Traits/TableTraits";
 import TableColumnType, { stringToTableColumnType } from "./TableColumnType";
-import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 
 // TypeScript 3.6.3 can't tell JSRegionProviderList is a class and reports
 //   Cannot use namespace 'JSRegionProviderList' as a type.ts(2709)
@@ -313,7 +314,10 @@ export default class TableColumn {
   ): string | null {
     // TODO: validate that the rowValue is actually a valid region, if possible.
     // TODO: implement replacements
-    return rowValue.length > 0 ? rowValue.toLowerCase() : null;
+
+    return rowValue.length > 0
+      ? applyReplacements(regionType, rowValue) ?? null
+      : null;
   }
 
   /**


### PR DESCRIPTION
### Add regionMapping applyReplacements from v7

This enables region mapping `dataReplacements` to work.

Also I started a typescript file to move region mapping stuff across - https://github.com/TerriaJS/terriajs/issues/4715

### Checklist

-   [x] Tests will wait until more Typescript has been written
-   [x] I've updated CHANGES.md with what I changed.
