### PR TITLE
Styled components type fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,8 @@ Change Log
 * Fix `TableTimeStyleTraits.idColumns` trait type.
 * Added a new `lineAndPoint` chart type
 * CustomChartComponent now has a "chart-type" attribute
-* Added `AttributionTraits` to mappable and send it as property when creating Cesium's data sources and imagery providers. [#5167](https://github.com/TerriaJS/terriajs/pull/5167) 
+* Added `AttributionTraits` to mappable and send it as property when creating Cesium's data sources and imagery providers. [#5167](https://github.com/TerriaJS/terriajs/pull/5167)
+* Fixed an issue where a TerriaMap sometimes doesn't build because of typing issues with styled-components.
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/lib/ThirdParty/styled-components/index.d.ts
+++ b/lib/ThirdParty/styled-components/index.d.ts
@@ -2,10 +2,20 @@
 /// <reference types="styled-components/cssprop" />
 
 // import your custom theme
+import { CSSProp } from "styled-components";
 import { terriaTheme } from "../../ReactViews/StandardUserInterface/StandardTheme";
 
 type Theme = typeof terriaTheme;
 
 declare module "styled-components" {
   export interface DefaultTheme extends Theme {}
+}
+
+// See https://github.com/styled-components/styled-components/issues/2528
+// .css isn't included in @types/styled-components because it has to be enabled
+// through a babel plugin or macro
+declare module "react" {
+  interface Attributes {
+    css?: CSSProp;
+  }
 }


### PR DESCRIPTION
### What this PR does

Fixes an issue where a TerriaMap sometimes doesn't build because of typing issues with styled-components.

I really wanted a less hacky fix than this, but I did some research and I think this is actually the canonically correct solution, which I hate.

### Checklist

-   [x] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~ N/A, type error
-   [x] I've updated CHANGES.md with what I changed.
