### PR TITLE
Update Bing key & use Cesium Ion imagery

### DIFF
--- a/buildprocess/ci-values.yml
+++ b/buildprocess/ci-values.yml
@@ -42,7 +42,7 @@ terriamap:
         - helm
         - terria
         parameters:
-            bingMapsKey: "AiKyh8RfSWfiQyzh1iaiL2EBSwKK0EoB1dFpvApJZs3KibbXtxclGaj5540y70Si"
+            bingMapsKey: "ApZeR4iLSH_Pl2w5OSXrIqjvc_KzgPn_UXjn6jTtQDiueg72InBThCeIO4OSs6Fq"
             cesiumIonAccessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxZDY5MDE1YS0yNGFlLTQ1MzctYWNkNy0wNDQ1YWNiNTM5MDIiLCJpZCI6Mjk5Miwic2NvcGVzIjpbImFzciIsImdjIl0sImlhdCI6MTUzODAzMzgyNn0.a2uTotdiHUo8FiHsO4MVNZ1KT5pOF0rb7CFdwbRAsOo"
             useCesiumIonBingImagery: true
             googleAnalyticsKey:

--- a/buildprocess/ci-values.yml
+++ b/buildprocess/ci-values.yml
@@ -44,6 +44,7 @@ terriamap:
         parameters:
             bingMapsKey: "AiKyh8RfSWfiQyzh1iaiL2EBSwKK0EoB1dFpvApJZs3KibbXtxclGaj5540y70Si"
             cesiumIonAccessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxZDY5MDE1YS0yNGFlLTQ1MzctYWNkNy0wNDQ1YWNiNTM5MDIiLCJpZCI6Mjk5Miwic2NvcGVzIjpbImFzciIsImdjIl0sImlhdCI6MTUzODAzMzgyNn0.a2uTotdiHUo8FiHsO4MVNZ1KT5pOF0rb7CFdwbRAsOo"
+            useCesiumIonBingImagery: true
             googleAnalyticsKey:
             disclaimer:
                 text: "Disclaimer: This map must not be used for navigation or precise spatial analysis"


### PR DESCRIPTION
### What this PR does

Fixes #5118 

This PR tells our CI instances to get imagery from Cesium Ion, and updates the default Bing Maps Key used for geocoding.

### Checklist

-   [x] Unit tests aren't applicable
-   [ ] ~I've updated CHANGES.md with what I changed.~ Config-only change
