### PR TITLE
Clean up Terria.start and remove Magda specifics

### DIFF
--- a/lib/Core/ServerConfig.js
+++ b/lib/Core/ServerConfig.js
@@ -20,6 +20,7 @@ function ServerConfig() {
    *   newShareUrlPrefix: if defined, the share URL service is active
    *   shareUrlPrefixes: object defining share URL prefixes that can be resolved
    *   additionalFeedbackParameters: array of additional feedback parameters that can be used
+   *   clientConfigUrl: string to override client config URL
    * @type {Object}
    */
   this.config = undefined;

--- a/lib/Models/Internationalization.ts
+++ b/lib/Models/Internationalization.ts
@@ -3,6 +3,7 @@ import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 import HttpApi from "i18next-http-backend";
 import translationEN from "../Language/en/translation.json";
+import { JsonObject } from "../Core/Json";
 
 export interface I18nBackendOptions {
   /**
@@ -54,7 +55,7 @@ const defaultLanguageConfiguration = {
 
 class Internationalization {
   static initLanguage(
-    languageConfiguration: LanguageConfiguration | undefined,
+    languageConfiguration: LanguageConfiguration | JsonObject | undefined,
     /**
      * i18nOptions is explicitly a separate option from `languageConfiguration`,
      * as `languageConfiguration` can be serialised, but `i18nOptions` may have


### PR DESCRIPTION
### Clean up Terria.start and remove Magda specifics

For https://github.com/TerriaJS/saas/issues/118

- Rename `registryConfigurationId` to `clientConfigUrl` in server config 
- Load server config before client config + override clientConfigUrl

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
