### PR TITLE
Fix height calculation when dropping pedestrian in pedestrian mode.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Change Log
 * Added Pedestrian mode for easily navigating the map at street level.
 * Clean up `LayerOrderingTraits`, remove `WorkbenchItem` interface, fix `keepOnTop` layer insert/re-ordering.
 * Remove `wordBreak="break-all"` from Box surrounding DataPreview
+* Fixes a bug in pedestrian mode where dropping the pedestrian in northern hemisphere will position the camera underground.
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/lib/ReactViews/Tools/PedestrianMode/DropPedestrianToGround.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/DropPedestrianToGround.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
+import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
 import EllipsoidTerrainProvider from "terriajs-cesium/Source/Core/EllipsoidTerrainProvider";
 import sampleTerrainMostDetailed from "terriajs-cesium/Source/Core/sampleTerrainMostDetailed";
 import ScreenSpaceEventHandler from "terriajs-cesium/Source/Core/ScreenSpaceEventHandler";
@@ -41,8 +42,9 @@ const DropPedestrianToGround: React.FC<DropPedestrianToGroundProps> = props => {
 
       setShowMouseTooltip(false);
       // Get the precise position and fly to it.
-      getPrecisePosition(scene, pickPosition).then(position => {
-        position.z -= props.minHeightFromGround;
+      getPrecisePosition(scene, pickPosition).then(cartographic => {
+        cartographic.height += props.minHeightFromGround;
+        const position = Cartographic.toCartesian(cartographic);
         flyTo(scene, position, {
           orientation: {
             heading: 0,
@@ -88,7 +90,7 @@ const DropPedestrianToGround: React.FC<DropPedestrianToGroundProps> = props => {
 async function getPrecisePosition(
   scene: Scene,
   position: Cartesian3
-): Promise<Cartesian3> {
+): Promise<Cartographic> {
   const terrainProvider = scene.terrainProvider;
   const cartographic = Cartographic.fromCartesian(position);
   let preciseCartographic: Cartographic;
@@ -103,8 +105,7 @@ async function getPrecisePosition(
       cartographic
     ]);
   }
-  const precisePosition = Cartographic.toCartesian(preciseCartographic);
-  return precisePosition;
+  return preciseCartographic;
 }
 
 async function flyTo(

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.3.3",
+    "@babel/parser": "^7.12.14",
     "@babel/plugin-proposal-decorators": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.0.0",


### PR DESCRIPTION
### What this PR does

Previously when dropping a pedestrian in northern hemisphere, the camera goes underground. Fix the height calculation so that the camera is above surface in both north and south hemisphere.

#### Testing
* Visit https://ci.terria.io/next/ 
* Enter pedestrian mode and drop the pedestrian anywhere in the northern hemisphere
* Witness the camera go underground
* Now visit http://ci.terria.io/fix-pedestrian-drop-height/
* Try dropping the pedestrian in north and south hemisphere, the camera should stay above ground.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
