### PR TITLE
Merge properties from vector tiles into feature info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Change Log
 * Added Pedestrian mode for easily navigating the map at street level.
 * Clean up `LayerOrderingTraits`, remove `WorkbenchItem` interface, fix `keepOnTop` layer insert/re-ordering.
 * Remove `wordBreak="break-all"` from Box surrounding DataPreview
+* Re-added merging of csv row properties and vector tile feature properties for feature info (to match v7 behaviour).
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -717,7 +717,7 @@ function TableMixin<T extends Constructor<Model<TableTraits>>>(Base: T) {
 
                 return this.featureInfoFromFeature(
                   regionType,
-                  d,
+                  Object.assign({}, feature.properties, d),
                   feature.properties[regionType.uniqueIdProp]
                 );
               }

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -717,7 +717,8 @@ function TableMixin<T extends Constructor<Model<TableTraits>>>(Base: T) {
 
                 return this.featureInfoFromFeature(
                   regionType,
-                  Object.assign({}, feature.properties, d),
+                  // Preserve values from d and insert feature properties after entries from d
+                  Object.assign({}, d, feature.properties, d),
                   feature.properties[regionType.uniqueIdProp]
                 );
               }


### PR DESCRIPTION
### What this PR does

Re-implement vector tile feature & csv row property merging in v8.

### Checklist

-   [x] Not easily testable (best I can think of is: set a custom regionMapping, have a small sample vector tileset with just a 0/0/0 tile, have a small sample csv that uses the tileset, emulate feature picking)
-  [x] I've updated CHANGES.md with what I changed.
