### PR TITLE
added support for skipping comments in csv files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ Change Log
 * Fix Leaflet `ImageryLayer` feature info sorting
 * Fix hard-coded colour value in Story
 * Use `configParameters.cesiumIonAccessToken` in `IonImageryCatalogItem`
+* Added support for skipping comments in CSV files
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/lib/Models/CsvCatalogItem.ts
+++ b/lib/Models/CsvCatalogItem.ts
@@ -141,17 +141,19 @@ export default class CsvCatalogItem extends AsyncChartableMixin(
       return;
     }
 
-    Csv.parseUrl(proxyCatalogItemUrl(this, this.refreshUrl), true).then(
-      dataColumnMajor => {
-        runInAction(() => {
-          if (this.polling.shouldReplaceData) {
-            this.dataColumnMajor = dataColumnMajor;
-          } else {
-            this.append(dataColumnMajor);
-          }
-        });
-      }
-    );
+    Csv.parseUrl(
+      proxyCatalogItemUrl(this, this.refreshUrl),
+      true,
+      this.ignoreRowsStartingWithComment
+    ).then(dataColumnMajor => {
+      runInAction(() => {
+        if (this.polling.shouldReplaceData) {
+          this.dataColumnMajor = dataColumnMajor;
+        } else {
+          this.append(dataColumnMajor);
+        }
+      });
+    });
   }
 
   protected forceLoadMetadata(): Promise<void> {
@@ -160,11 +162,23 @@ export default class CsvCatalogItem extends AsyncChartableMixin(
 
   protected forceLoadTableData(): Promise<string[][]> {
     if (this.csvString !== undefined) {
-      return Csv.parseString(this.csvString, true);
+      return Csv.parseString(
+        this.csvString,
+        true,
+        this.ignoreRowsStartingWithComment
+      );
     } else if (this._csvFile !== undefined) {
-      return Csv.parseFile(this._csvFile, true);
+      return Csv.parseFile(
+        this._csvFile,
+        true,
+        this.ignoreRowsStartingWithComment
+      );
     } else if (this.url !== undefined) {
-      return Csv.parseUrl(proxyCatalogItemUrl(this, this.url), true);
+      return Csv.parseUrl(
+        proxyCatalogItemUrl(this, this.url),
+        true,
+        this.ignoreRowsStartingWithComment
+      );
     } else {
       return Promise.reject(
         new TerriaError({

--- a/lib/Table/Csv.ts
+++ b/lib/Table/Csv.ts
@@ -17,11 +17,12 @@ export default class Csv {
    */
   static parseString(
     csv: string,
-    columnMajor: boolean = false
+    columnMajor: boolean = false,
+    filterOutComments: boolean = false
   ): Promise<string[][]> {
     return new Promise<string[][]>((resolve, reject) => {
       papaparse.parse(csv, {
-        ...getParseOptions(columnMajor, resolve, reject)
+        ...getParseOptions(columnMajor, filterOutComments, resolve, reject)
       });
     });
   }
@@ -34,11 +35,12 @@ export default class Csv {
    */
   static parseFile(
     file: File,
-    columnMajor: boolean = false
+    columnMajor: boolean = false,
+    filterOutComments: boolean = false
   ): Promise<string[][]> {
     return new Promise<string[][]>((resolve, reject) => {
       papaparse.parse(file, {
-        ...getParseOptions(columnMajor, resolve, reject)
+        ...getParseOptions(columnMajor, filterOutComments, resolve, reject)
       });
     });
   }
@@ -51,11 +53,12 @@ export default class Csv {
    */
   static parseUrl(
     url: string,
-    columnMajor: boolean = false
+    columnMajor: boolean = false,
+    filterOutComments: boolean = false
   ): Promise<string[][]> {
     return loadWithXhr({ url }).then(csv => {
       if (typeof csv === "string") {
-        return Csv.parseString(csv, columnMajor);
+        return Csv.parseString(csv, columnMajor, filterOutComments);
       } else {
         throw "Request failed";
       }
@@ -73,15 +76,17 @@ export default class Csv {
 
 function getParseOptions(
   columnMajor: boolean,
+  filterOutComments: boolean,
   resolve: (value: string[][]) => void,
   reject: (reason?: any) => void
 ): papaparse.ParseConfig {
   return columnMajor
-    ? getParseOptionsColumnMajor(resolve, reject)
-    : getParseOptionsRowMajor(resolve, reject);
+    ? getParseOptionsColumnMajor(filterOutComments, resolve, reject)
+    : getParseOptionsRowMajor(filterOutComments, resolve, reject);
 }
 
 function getParseOptionsRowMajor(
+  filterOutComments: boolean,
   resolve: (value: string[][]) => void,
   reject: (reason?: any) => void
 ): papaparse.ParseConfig {
@@ -89,6 +94,7 @@ function getParseOptionsRowMajor(
   let parser: any = null;
 
   return {
+    comments: filterOutComments,
     skipEmptyLines: true,
     worker: useWorker,
     chunk: function(results, p) {
@@ -111,6 +117,7 @@ function getParseOptionsRowMajor(
 }
 
 function getParseOptionsColumnMajor(
+  filterOutComments: boolean,
   resolve: (value: string[][]) => void,
   reject: (reason?: any) => void
 ): papaparse.ParseConfig {
@@ -118,6 +125,7 @@ function getParseOptionsColumnMajor(
   let parser: any = null;
 
   return {
+    comments: filterOutComments,
     skipEmptyLines: true,
     worker: useWorker,
     chunk: function(results, p) {

--- a/lib/Traits/CsvCatalogItemTraits.ts
+++ b/lib/Traits/CsvCatalogItemTraits.ts
@@ -55,6 +55,14 @@ export default class CsvCatalogItemTraits extends mixTraits(
   })
   csvString?: string;
 
+  @primitiveTrait({
+    name: "Ignore rows starting with comment",
+    description:
+      "Any rows of a CSV starting with '#' or '//' will be ignored. A value of `undefined` will be treated the same as `false`.",
+    type: "boolean"
+  })
+  ignoreRowsStartingWithComment?: boolean;
+
   @objectTrait({
     name: "Polling",
     description: "Polling configuration",

--- a/test/Table/CsvSpec.ts
+++ b/test/Table/CsvSpec.ts
@@ -1,14 +1,22 @@
 import Csv from "../../lib/Table/Csv";
 
 describe("Csv", function() {
+  function checkCsvParse(dataColumnMajor: string[][]) {
+    expect(dataColumnMajor.length).toEqual(2);
+    expect(dataColumnMajor[0][0]).toEqual("x");
+    expect(dataColumnMajor[0].slice(1)).toEqual(["1", "3", "4"]);
+    expect(dataColumnMajor[1][0]).toEqual("y");
+    expect(dataColumnMajor[1].slice(1)).toEqual(["5", "8", "-3"]);
+  }
+
   it("can read from csv string", function() {
     const csvString = "x,y\r\n1,5\r\n3,8\r\n4,-3\r\n";
-    return Csv.parseString(csvString, true).then(dataColumnMajor => {
-      expect(dataColumnMajor.length).toEqual(2);
-      expect(dataColumnMajor[0][0]).toEqual("x");
-      expect(dataColumnMajor[0].slice(1)).toEqual(["1", "3", "4"]);
-      expect(dataColumnMajor[1][0]).toEqual("y");
-      expect(dataColumnMajor[1].slice(1)).toEqual(["5", "8", "-3"]);
-    });
+    return Csv.parseString(csvString, true).then(checkCsvParse);
+  });
+
+  it("can read from csv string that includes comments", function() {
+    const csvString =
+      "x,y\r\n1,5\r\n3,8\r\n4,-3\r\n# this is a comment\n// and this\n";
+    return Csv.parseString(csvString, true).then(checkCsvParse);
   });
 });

--- a/test/Table/CsvSpec.ts
+++ b/test/Table/CsvSpec.ts
@@ -17,6 +17,6 @@ describe("Csv", function() {
   it("can read from csv string that includes comments", function() {
     const csvString =
       "x,y\r\n1,5\r\n3,8\r\n4,-3\r\n# this is a comment\n// and this\n";
-    return Csv.parseString(csvString, true).then(checkCsvParse);
+    return Csv.parseString(csvString, true, true).then(checkCsvParse);
   });
 });


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/de-australia-map/issues/71

Comments in CSV files will be ignored by papaparse when parsing.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
