### PR TITLE
Add catalog-converter support for startData

### DIFF
--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1357,32 +1357,28 @@ function interpretHash(
       });
 
       if (isDefined(shareProps) && shareProps !== {}) {
-        // Convert shareProps to v8 if neccessary
-        const result = convertShare(shareProps);
-
-        // Show warning messages if converted
-        if (result.converted) {
-          terria.notification.raiseEvent({
-            title: i18next.t("share.convertNotificationTitle"),
-            message: shareConvertNotification(result.messages)
-          } as Notification);
-        }
-
-        if (result.result !== null) {
-          interpretStartData(terria, result.result);
-        }
+        interpretStartData(terria, shareProps);
       }
     });
   });
 }
 
-function interpretStartData(terria: Terria, startData: any) {
-  // TODO: version check, filtering, etc.
+function interpretStartData(terria: Terria, startData: unknown) {
+  // Convert startData to v8 if neccessary
+  const result = convertShare(startData);
 
-  if (startData.initSources) {
+  // Show warning messages if converted
+  if (result.converted) {
+    terria.notification.raiseEvent({
+      title: i18next.t("share.convertNotificationTitle"),
+      message: shareConvertNotification(result.messages)
+    } as Notification);
+  }
+
+  if (result.result?.initSources) {
     runInAction(() => {
       terria.initSources.push(
-        ...startData.initSources.map((initSource: any) => {
+        ...result.result!.initSources.map((initSource: any) => {
           return {
             data: initSource
           };
@@ -1390,6 +1386,8 @@ function interpretStartData(terria: Terria, startData: any) {
       );
     });
   }
+
+  // TODO: version check, filtering, etc.
 
   // if (defined(startData.version) && startData.version !== latestStartVersion) {
   //   adjustForBackwardCompatibility(startData);


### PR DESCRIPTION
### Add catalog-converter support for startData

Related to https://github.com/TerriaJS/terriajs/issues/4897

For example:

```
http://nationalmap.gov.au/#clean&hideExplorerPanel=1&start={"version":"0.0.03","initSources":[{"catalog":[{"type":"group","name":"User-Added Data","description":"The group for data that was added by the user via the Add Data panel.","isUserSupplied":true,"isOpen":true,"items":[{"type":"geojson","name":"User Data","isUserSupplied":true,"isOpen":true,"isEnabled":true,"url":"https://pacificdata.org/data/dataset/e04fe335-e679-4cf8-b67a-99d428496ac8/resource/808e22e1-9ec4-4179-a3f3-83dabf1abef7/download/as_counties_4326.geojson"}]}],"catalogIsUserSupplied":true,"homeCamera":{"west":186.2253093499468,"south":-17.555268752861593,"east":194.79916666680836,"north":-10.024476331617223}}]}
```

This link will add a geojson catalog item to the map. Currently, v8 will not convert the v7 JSON through `catalog-converter` for `start=` data.

There are a few issues with this PR:

- This is using `convertShare` for all `startData` (share JSON or catalog JSON).
  - This does a few weird things to groups in the `catalog` object - for example - we only convert groups related to User Added Data
  - Whereas, we should be treating the `catalog` object as an actual catalog - and using `convertCatalog` function 
  - `convertShare` was written pre v8 `shareKeys` support - which is why it is a bit hacky

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
