### PR TITLE
Fix tool switching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ Change Log
 * Fix hard-coded colour value in Story
 * Use `configParameters.cesiumIonAccessToken` in `IonImageryCatalogItem`
 * Added support for skipping comments in CSV files
+* Fix app crash when switching different tools.
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -712,7 +712,7 @@ export default class ViewState {
 
 interface Tool {
   toolName: string;
-  getToolComponent: () => React.Component | Promise<React.Component>;
+  getToolComponent: () => React.ComponentType | Promise<React.ComponentType>;
   showCloseButton: boolean;
   params?: any;
 }

--- a/lib/ReactViews/BottomDock/Timeline/DateTimePicker.tsx
+++ b/lib/ReactViews/BottomDock/Timeline/DateTimePicker.tsx
@@ -216,7 +216,7 @@ class DateTimePicker extends React.Component<PropsType> {
       granularity: defaultGranularity
     };
 
-    window.addEventListener("click", this.closePickerEventHandler.bind(this));
+    window.addEventListener("click", this.closePickerEventHandler);
 
     // Update currentDateIndice when currentDate changes
     this.currentDateAutorunDisposer = reaction(
@@ -248,11 +248,10 @@ class DateTimePicker extends React.Component<PropsType> {
 
   componentWillUnmount() {
     this.currentDateAutorunDisposer && this.currentDateAutorunDisposer();
-    window.removeEventListener("click", () =>
-      this.closePickerEventHandler.bind(this)
-    );
+    window.removeEventListener("click", this.closePickerEventHandler);
   }
 
+  @action.bound
   closePickerEventHandler() {
     this.closePicker();
   }

--- a/lib/ReactViews/Tool.tsx
+++ b/lib/ReactViews/Tool.tsx
@@ -28,9 +28,11 @@ const Tool: React.FC<ToolProps> = props => {
   const { viewState, getToolComponent, params, toolName } = props;
   const [t] = useTranslation();
 
-  const [tool, setTool] = useState<any>(undefined);
+  // Track the tool component & props together so that we always
+  // pass the right props to the right tool.
+  const [toolAndProps, setToolAndProps] = useState<any>(undefined);
   useEffect(() => {
-    setTool([
+    setToolAndProps([
       React.lazy(() =>
         Promise.resolve(getToolComponent()).then(c => ({ default: c }))
       ),
@@ -38,12 +40,9 @@ const Tool: React.FC<ToolProps> = props => {
     ]);
   }, [getToolComponent]);
 
-  // If the user tries to reload the tool after an error we want to re-render
-  // whole ToolErrorBoundary and its children so increment the key when
-  // getToolComponent changes.
   let ToolComponent;
   let toolProps;
-  if (tool !== undefined) [ToolComponent, toolProps] = tool;
+  if (toolAndProps !== undefined) [ToolComponent, toolProps] = toolAndProps;
   return (
     <ToolErrorBoundary t={t} toolName={toolName} terria={viewState.terria}>
       <Suspense fallback={<div>Loading...</div>}>

--- a/test/Models/UserDrawingSpec.ts
+++ b/test/Models/UserDrawingSpec.ts
@@ -56,7 +56,9 @@ describe("UserDrawing", function() {
     var userDrawing = new UserDrawing(options);
 
     expect(userDrawing.getDialogMessage()).toEqual(
-      "<div><strong>models.userDrawing.messageHeader</strong></br><i>models.userDrawing.clickToAddFirstPoint</i></div>"
+      `<div><strong>${i18next.t(
+        "models.userDrawing.messageHeader"
+      )}</strong></br><i>models.userDrawing.clickToAddFirstPoint</i></div>`
     );
   });
 
@@ -70,7 +72,9 @@ describe("UserDrawing", function() {
     var userDrawing = new UserDrawing(options);
 
     expect(userDrawing.getDialogMessage()).toEqual(
-      "<div><strong>models.userDrawing.messageHeader</strong></br>HELLO</br><i>models.userDrawing.clickToAddFirstPoint</i></div>"
+      `<div><strong>${i18next.t(
+        "models.userDrawing.messageHeader"
+      )}</strong></br>HELLO</br><i>models.userDrawing.clickToAddFirstPoint</i></div>`
     );
   });
 

--- a/test/Models/UserDrawingSpec.ts
+++ b/test/Models/UserDrawingSpec.ts
@@ -58,7 +58,9 @@ describe("UserDrawing", function() {
     expect(userDrawing.getDialogMessage()).toEqual(
       `<div><strong>${i18next.t(
         "models.userDrawing.messageHeader"
-      )}</strong></br><i>models.userDrawing.clickToAddFirstPoint</i></div>`
+      )}</strong></br><i>${i18next.t(
+        "models.userDrawing.clickToAddFirstPoint"
+      )}</i></div>`
     );
   });
 
@@ -74,7 +76,9 @@ describe("UserDrawing", function() {
     expect(userDrawing.getDialogMessage()).toEqual(
       `<div><strong>${i18next.t(
         "models.userDrawing.messageHeader"
-      )}</strong></br>HELLO</br><i>models.userDrawing.clickToAddFirstPoint</i></div>`
+      )}</strong></br>HELLO</br><i>${i18next.t(
+        "models.userDrawing.clickToAddFirstPoint"
+      )}</i></div>`
     );
   });
 

--- a/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
+++ b/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
@@ -24,6 +24,7 @@ import SearchForm from "../../../../lib/ReactViews/Tools/ItemSearchTool/SearchFo
 import SearchResults from "../../../../lib/ReactViews/Tools/ItemSearchTool/SearchResults";
 import { withThemeContext } from "../../withThemeContext";
 import MockSearchableItem from "./MockSearchableItem";
+import i18next from "i18next";
 
 class TestItemSearchProvider extends ItemSearchProvider {
   async initialize(): Promise<void> {
@@ -106,7 +107,9 @@ describe("ItemSearchTool", function() {
       });
       const progressText = rendered.root.findByType(Loading);
       expect(progressText).toBeDefined();
-      expect(progressText.props.children).toEqual("itemSearchTool.loading");
+      expect(progressText.props.children).toEqual(
+        i18next.t("itemSearchTool.loading")
+      );
     });
 
     it("shows an error message on load error", async function() {
@@ -122,7 +125,9 @@ describe("ItemSearchTool", function() {
 
       const error = rendered.root.findByType(ErrorComponent);
       expect(error).toBeDefined();
-      expect(error.props.children).toEqual("itemSearchTool.loadError");
+      expect(error.props.children).toEqual(
+        i18next.t("itemSearchTool.loadError")
+      );
     });
 
     it("shows a search from on successful load", async function() {

--- a/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
+++ b/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
@@ -1,3 +1,4 @@
+import "../../../SpecMain";
 import React from "react";
 import {
   act,

--- a/test/ReactViews/Tools/ItemSearchTool/MockSearchableItem.ts
+++ b/test/ReactViews/Tools/ItemSearchTool/MockSearchableItem.ts
@@ -8,10 +8,10 @@ import ShowableTraits from "../../../../lib/Traits/ShowableTraits";
 export default class MockSearchableItem extends SearchableItemMixin(
   CreateModel(mixTraits(SearchableItemTraits, ShowableTraits))
 ) {
-  highlightItemSearchResults(results: ItemSearchResult[]) {
+  highlightFeaturesFromItemSearchResults(results: ItemSearchResult[]) {
     return () => {};
   }
-  hideItemSearchResults(results: ItemSearchResult[]) {
+  hideFeaturesNotInItemSearchResults(results: ItemSearchResult[]) {
     return () => {};
   }
 }


### PR DESCRIPTION
### What this PR does

Merge after #5232

Fixes app crash when switching between multiple tools.

eg: Open item search tool, then open pedestrian mode tool, witness the app crash :boom: 

Tool mode uses [SplitPoint](https://github.com/TerriaJS/terriajs/blob/cc0db318b94b75f6b12abf518db129deb0a4f268/lib/ReactViews/SplitPoint.jsx#L21) for lazy loading tool components. 

SplitPoint uses react state variable to track the loaded component and during render it gets forwarded the latest props. 

This works fine when opening/re-opening the same tool component. But when opening a new tool, since react state updates lags behind `render()` the old component will receive the new props meant for the new component. This causes the app to crash.

I have re-written `Tool` component using react-lazy and ErrorBoundary also fixing the original problem.

### Checklist

-   ~[ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [x] I've updated CHANGES.md with what I changed.
