### PR TITLE
Upgrade @babel/parser and eslint

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,22 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "corejs": 3,
+        "useBuiltIns": "usage"
+      }
+    ],
+    "@babel/preset-react",
+    ["@babel/typescript", {"allowNamespaces": true}]
+  ],
+  "plugins": [
+    "babel-plugin-jsx-control-statements",
+    "@babel/plugin-transform-modules-commonjs",
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/proposal-class-properties",
+    "@babel/proposal-object-rest-spread",
+    "babel-plugin-styled-components",
+    "@babel/plugin-syntax-dynamic-import"
+  ]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,9 +8,6 @@
         "jsx": true,
         "modules": true,
         "legacyDecorators": true
-      },
-      "babelOptions": {
-        "configFile": "terriajs/.babelrc"
       }
     },
     "env": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,18 @@
 {
     "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:jsx-control-statements/recommended"],
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
+    "parserOptions": {
+      "requireConfigFile": false,
+      "ecmaVersion": 2018,
+      "ecmaFeatures": {
+        "jsx": true,
+        "modules": true,
+        "legacyDecorators": true
+      },
+      "babelOptions": {
+        "configFile": "terriajs/.babelrc"
+      }
+    },
     "env": {
         "browser": true,
         "commonjs": true,

--- a/buildprocess/karma-browserstack.conf.js
+++ b/buildprocess/karma-browserstack.conf.js
@@ -1,6 +1,5 @@
 'use strict';
 
-/*global require*/
 var createKarmaBaseConfig = require('./createKarmaBaseConfig');
 
 module.exports = function(config) {

--- a/buildprocess/karma-firefox.conf.js
+++ b/buildprocess/karma-firefox.conf.js
@@ -1,6 +1,5 @@
 'use strict';
 
-/*global require*/
 var createKarmaBaseConfig = require('./createKarmaBaseConfig');
 
 module.exports = function(config) {

--- a/buildprocess/karma-local.conf.js
+++ b/buildprocess/karma-local.conf.js
@@ -1,6 +1,5 @@
 'use strict';
 
-/*global require*/
 var createKarmaBaseConfig = require('./createKarmaBaseConfig');
 
 module.exports = function(config) {

--- a/buildprocess/karma-saucelabs.conf.js
+++ b/buildprocess/karma-saucelabs.conf.js
@@ -1,6 +1,5 @@
 'use strict';
 
-/*global require*/
 var createKarmaBaseConfig = require('./createKarmaBaseConfig');
 
 module.exports = function(config) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,6 @@
 
 'use strict';
 
-/*global require*/
 
 // Every module required-in here must be a `dependency` in package.json, not just a `devDependency`,
 // so that our postinstall script (which runs `gulp post-npm-install`) is able to run without

--- a/lib/Charts/Scales.js
+++ b/lib/Charts/Scales.js
@@ -71,7 +71,7 @@ const Scales = {
         ];
       });
       for (const theseUnits in domain.y) {
-        if (domain.y.hasOwnProperty(theseUnits)) {
+        if (Object.prototype.hasOwnProperty.call(domain.y, theseUnits)) {
           const thisYDomain = domain.y[theseUnits];
           // If the y-domain is positive and could reasonably be expanded to include zero, do so.
           // (Eg. the range is 5 to 50, do it; if it is 5 to 8, do not. Set the boundary arbitrarily at 5 to 12.5, ie. 1:2.5.)
@@ -144,7 +144,7 @@ const Scales = {
 
       const yScales = {};
       for (const theseUnits in domain.y) {
-        if (domain.y.hasOwnProperty(theseUnits)) {
+        if (Object.prototype.hasOwnProperty.call(domain.y, theseUnits)) {
           const thisYDomain = domain.y[theseUnits];
           yScales[theseUnits] = d3ScaleLinear()
             .range([size.plotHeight, 0])

--- a/lib/Core/ConsoleAnalytics.js
+++ b/lib/Core/ConsoleAnalytics.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 const i18next = require("i18next").default;
 
@@ -21,8 +20,8 @@ ConsoleAnalytics.prototype.start = function(userParameters) {
     console.log(i18next.t("core.consoleAnalytics.started"));
     this.logToConsole = userParameters.logToConsole;
   } else if (
-    defined(userParameters.logToConsole) &&
-    userParameters.logToConsole
+    !defined(userParameters.logToConsole) ||
+    !userParameters.logToConsole
   ) {
     console.log(i18next.t("core.consoleAnalytics.startedNoLogToConsole"));
   }

--- a/lib/Core/GoogleAnalytics.js
+++ b/lib/Core/GoogleAnalytics.js
@@ -1,6 +1,6 @@
 "use strict";
 
-/*global require,ga*/
+/*global ga*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 const i18next = require("i18next").default;

--- a/lib/Core/ServerConfig.js
+++ b/lib/Core/ServerConfig.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const i18next = require("i18next").default;
-/*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var loadJson = require("./loadJson").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;

--- a/lib/Core/TerriaError.js
+++ b/lib/Core/TerriaError.js
@@ -1,5 +1,4 @@
 "use strict";
-/*global require*/
 
 var i18next = require("i18next").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;

--- a/lib/Core/containsAny.js
+++ b/lib/Core/containsAny.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 /**

--- a/lib/Core/formatNumberForLocale.js
+++ b/lib/Core/formatNumberForLocale.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,Intl*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 

--- a/lib/Core/formatPropertyValue.js
+++ b/lib/Core/formatPropertyValue.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var linkifyContent = require("./linkifyContent");
 var formatNumberForLocale = require("./formatNumberForLocale");
 

--- a/lib/Core/isCommonMobilePlatform.js
+++ b/lib/Core/isCommonMobilePlatform.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 /**

--- a/lib/Core/linkifyContent.js
+++ b/lib/Core/linkifyContent.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var linkify = require("linkify-it")();
 
 function linkifyContent(content) {

--- a/lib/Core/loadView.js
+++ b/lib/Core/loadView.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var getElement = require("terriajs-cesium/Source/Widgets/getElement").default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 

--- a/lib/Core/markdownToHtml.ts
+++ b/lib/Core/markdownToHtml.ts
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var MarkdownIt = require("markdown-it");
 var DOMPurify = require("dompurify/dist/purify");

--- a/lib/Core/overrideProperty.js
+++ b/lib/Core/overrideProperty.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 

--- a/lib/Core/pollToPromise.js
+++ b/lib/Core/pollToPromise.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var getTimestamp = require("terriajs-cesium/Source/Core/getTimestamp").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;

--- a/lib/Core/propertyGetTimeValues.js
+++ b/lib/Core/propertyGetTimeValues.js
@@ -20,7 +20,7 @@ function propertyGetTimeValues(properties, currentTime) {
     return properties.getValue(currentTime);
   }
   for (var key in properties) {
-    if (properties.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(properties, key)) {
       if (properties[key] && typeof properties[key].getValue === "function") {
         result[key] = properties[key].getValue(currentTime);
       } else {

--- a/lib/Core/readJson.js
+++ b/lib/Core/readJson.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 const json5 = require("json5");
 const readText = require("./readText");
 

--- a/lib/Core/readText.js
+++ b/lib/Core/readText.js
@@ -1,7 +1,6 @@
 "use strict";
 const i18next = require("i18next").default;
 
-/*global require*/
 const DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 

--- a/lib/Core/readXml.js
+++ b/lib/Core/readXml.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const i18next = require("i18next").default;
-/*global require*/
 var readText = require("./readText");
 
 var RuntimeError = require("terriajs-cesium/Source/Core/RuntimeError").default;

--- a/lib/Core/serializeToJson.js
+++ b/lib/Core/serializeToJson.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 
 /**
@@ -20,7 +19,7 @@ function serializeToJson(target, filterFunction, options) {
 
   for (var propertyName in target) {
     if (
-      target.hasOwnProperty(propertyName) &&
+      Object.prototype.hasOwnProperty.call(target, propertyName) &&
       propertyName.length > 0 &&
       propertyName[0] !== "_" &&
       propertyName !== "parent" &&

--- a/lib/Core/supportsWebGL.js
+++ b/lib/Core/supportsWebGL.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 var result;

--- a/lib/Core/updateFromJson.js
+++ b/lib/Core/updateFromJson.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
@@ -19,7 +18,7 @@ function updateFromJson(target, json, options) {
 
   for (var propertyName in target) {
     if (
-      target.hasOwnProperty(propertyName) &&
+      Object.prototype.hasOwnProperty.call(target, propertyName) &&
       shouldBeUpdated(target, propertyName, json)
     ) {
       if (target.updaters && target.updaters[propertyName]) {

--- a/lib/Map/AbsCode.js
+++ b/lib/Map/AbsCode.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 

--- a/lib/Map/AbsConcept.js
+++ b/lib/Map/AbsConcept.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var naturalSort = require("javascript-natural-sort");
 naturalSort.insensitive = true;
 

--- a/lib/Map/AddressGeocoder.js
+++ b/lib/Map/AddressGeocoder.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const i18next = require("i18next").default;
-/*global require*/
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;
 

--- a/lib/Map/CesiumDragPoints.js
+++ b/lib/Map/CesiumDragPoints.js
@@ -1,4 +1,3 @@
-/*global require*/
 "use strict";
 
 var defined = require("terriajs-cesium/Source/Core/defined").default;

--- a/lib/Map/Concept.js
+++ b/lib/Map/Concept.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 
 /**

--- a/lib/Map/DisplayVariablesConcept.js
+++ b/lib/Map/DisplayVariablesConcept.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const i18next = require("i18next").default;
-/*global require*/
 
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;

--- a/lib/Map/DragPoints.js
+++ b/lib/Map/DragPoints.js
@@ -1,4 +1,3 @@
-/*global require*/
 "use strict";
 
 var defined = require("terriajs-cesium/Source/Core/defined").default;

--- a/lib/Map/EarthGravityModel1996.js
+++ b/lib/Map/EarthGravityModel1996.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,Int16Array,Uint8Array,Int16Array*/
 var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var loadArrayBuffer = require("../Core/loadArrayBuffer");

--- a/lib/Map/GnafAddressGeocoder.js
+++ b/lib/Map/GnafAddressGeocoder.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const i18next = require("i18next").default;
-/*global require*/
 var VarType = require("./VarType");
 var AddressGeocoder = require("./AddressGeocoder");
 var BulkAddressGeocoderResult = require("./BulkAddressGeocoderResult");

--- a/lib/Map/ImageryProviderHooks.js
+++ b/lib/Map/ImageryProviderHooks.js
@@ -1,5 +1,4 @@
 "use strict";
-/* global require */
 const i18next = require("i18next").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;

--- a/lib/Map/LeafletDragPoints.js
+++ b/lib/Map/LeafletDragPoints.js
@@ -1,4 +1,3 @@
-/*global require*/
 "use strict";
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var Cartesian3 = require("terriajs-cesium/Source/Core/Cartesian3").default;

--- a/lib/Map/RegionProvider.js
+++ b/lib/Map/RegionProvider.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const i18next = require("i18next").default;
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")

--- a/lib/Map/RegionProviderList.js
+++ b/lib/Map/RegionProviderList.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var loadJson = require("../Core/loadJson").default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")

--- a/lib/Map/Reproject.js
+++ b/lib/Map/Reproject.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var proj4 = require("proj4").default;
 var loadText = require("../Core/loadText");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
@@ -69,7 +68,7 @@ var Reproject = {
    * @return {Promise} Eventually resolves to false if code wasn't there and wasn't able to be added
    */
   checkProjection: function(proj4ServiceBaseUrl, code) {
-    if (Proj4Definitions.hasOwnProperty(code)) {
+    if (Object.prototype.hasOwnProperty.call(Proj4Definitions, code)) {
       return true;
     }
 

--- a/lib/Map/SummaryConcept.js
+++ b/lib/Map/SummaryConcept.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 
 var inherit = require("../Core/inherit");

--- a/lib/Map/VariableConcept.js
+++ b/lib/Map/VariableConcept.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;

--- a/lib/Map/featureDataToGeoJson.js
+++ b/lib/Map/featureDataToGeoJson.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 import computeRingWindingOrder from "./computeRingWindingOrder";
 import defined from "terriajs-cesium/Source/Core/defined";
 import pointInPolygon from "point-in-polygon";

--- a/lib/Map/geoRssConvertor.js
+++ b/lib/Map/geoRssConvertor.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var geoJsonGeometryFromGeoRssSimpleGeometry = require("./geoJsonGeometryFromGeoRssSimpleGeometry");
 var geoJsonGeometryFromGmlGeometry = require("./geoJsonGeometryFromGmlGeometry");

--- a/lib/Map/gmlToGeoJson.js
+++ b/lib/Map/gmlToGeoJson.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var geoJsonGeometryFromGmlGeometry = require("./geoJsonGeometryFromGmlGeometry");
 var gmlNamespace = "http://www.opengis.net/gml";

--- a/lib/Map/unionRectangleArray.js
+++ b/lib/Map/unionRectangleArray.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var Rectangle = require("terriajs-cesium/Source/Core/Rectangle").default;
 var unionRectangles = require("./unionRectangles");

--- a/lib/Map/unionRectangles.js
+++ b/lib/Map/unionRectangles.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;

--- a/lib/Models/FunctionParameters/BooleanParameterGroup.js
+++ b/lib/Models/FunctionParameters/BooleanParameterGroup.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var BooleanParameter = require("./BooleanParameter");
 var FunctionParameter = require("../FunctionParameter");
 var inherit = require("../../Core/inherit");
@@ -92,7 +90,7 @@ inherit(FunctionParameter, BooleanParameterGroup);
 
 function isEmpty(obj) {
   for (var key in obj) {
-    if (obj.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
       return false;
     }
   }

--- a/lib/Models/FunctionParameters/RegionDataParameter.js
+++ b/lib/Models/FunctionParameters/RegionDataParameter.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
@@ -115,7 +114,7 @@ RegionDataParameter.prototype.getRegionDataValue = function() {
   var value = this.value;
 
   for (var columnName in value) {
-    if (value.hasOwnProperty(columnName)) {
+    if (Object.prototype.hasOwnProperty.call(value, columnName)) {
       columnData = value[columnName];
       if (!columnData || columnData.regionProvider !== regionProvider) {
         continue;

--- a/lib/Models/FunctionParameters/createParameterFromType.js
+++ b/lib/Models/FunctionParameters/createParameterFromType.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var TerriaError = require("../../Core/TerriaError");
 var i18next = require("i18next").default;

--- a/lib/Models/GoogleUrlShortener.js
+++ b/lib/Models/GoogleUrlShortener.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 

--- a/lib/Models/ImageryLayerFeatureInfo.js
+++ b/lib/Models/ImageryLayerFeatureInfo.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var ImageryLayerFeatureInfo = require("terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo")
   .default;
 var defined = require("terriajs-cesium/Source/Core/defined").default;
@@ -18,7 +17,7 @@ ImageryLayerFeatureInfo.prototype.configureDescriptionFromProperties = function(
   function describe(properties) {
     var html = '<table class="cesium-infoBox-defaultTable">';
     for (var key in properties) {
-      if (properties.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(properties, key)) {
         var value = properties[key];
         if (defined(value)) {
           if (typeof value === "object") {

--- a/lib/Models/ImageryLayerPreloadHelpers.js
+++ b/lib/Models/ImageryLayerPreloadHelpers.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 function setOpacity(catalogItem, layer, opacity) {

--- a/lib/Models/Metadata.js
+++ b/lib/Models/Metadata.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var MetadataItem = require("./MetadataItem");
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 

--- a/lib/Models/MetadataItem.js
+++ b/lib/Models/MetadataItem.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 
 /**

--- a/lib/Models/createCatalogMemberFromType.js
+++ b/lib/Models/createCatalogMemberFromType.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 var TerriaError = require("../Core/TerriaError");

--- a/lib/Models/createRegexDeserializer.js
+++ b/lib/Models/createRegexDeserializer.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 /**

--- a/lib/Models/createRegexSerializer.js
+++ b/lib/Models/createRegexSerializer.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 /**

--- a/lib/Models/extendLoad.js
+++ b/lib/Models/extendLoad.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 /**

--- a/lib/Models/invokeTerriaAnalyticsService.js
+++ b/lib/Models/invokeTerriaAnalyticsService.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var ResultPendingCatalogItem = require("./ResultPendingCatalogItem");
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;

--- a/lib/Models/raiseErrorOnRejectedPromise.js
+++ b/lib/Models/raiseErrorOnRejectedPromise.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;

--- a/lib/Models/raiseErrorToUser.js
+++ b/lib/Models/raiseErrorToUser.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var i18next = require("i18next").default;
 var TerriaError = require("../Core/TerriaError");
 

--- a/lib/Models/registerAnalytics.js
+++ b/lib/Models/registerAnalytics.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var createCatalogMemberFromType = require("./createCatalogMemberFromType");
 var PlacesLikeMeCatalogFunction = require("./PlacesLikeMeCatalogFunction");
 var SpatialDetailingCatalogFunction = require("./SpatialDetailingCatalogFunction");

--- a/lib/Models/sendFeedback.js
+++ b/lib/Models/sendFeedback.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var DeveloperError = require("terriajs-cesium/Source/Core/DeveloperError")
   .default;

--- a/lib/Models/setClockCurrentTime.js
+++ b/lib/Models/setClockCurrentTime.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;

--- a/lib/Models/updateRectangleFromRegion.js
+++ b/lib/Models/updateRectangleFromRegion.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var GeoJsonCatalogItem = require("./GeoJsonCatalogItem");
 

--- a/lib/ReactViewModels/HelpScreen.js
+++ b/lib/ReactViewModels/HelpScreen.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 

--- a/lib/ReactViewModels/HelpSequences.js
+++ b/lib/ReactViewModels/HelpSequences.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defaultValue = require("terriajs-cesium/Source/Core/defaultValue").default;
 
 /**

--- a/lib/ReactViewModels/HelpViewState.js
+++ b/lib/ReactViewModels/HelpViewState.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var knockout = require("terriajs-cesium/Source/ThirdParty/knockout").default;
 
 // Position of HelpScreen relative to highlighted element.

--- a/lib/ReactViews/.eslintrc
+++ b/lib/ReactViews/.eslintrc
@@ -1,6 +1,17 @@
 {
-  "parser": "babel-eslint",
-
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "requireConfigFile": false,
+    "ecmaVersion": 2018,
+    "ecmaFeatures": {
+      "jsx": true,
+      "modules": true,
+      "legacyDecorators": true
+    },
+    "babelOptions": {
+      "configFile": "terriajs/.babelrc"
+    }
+  },
   "env": {
     "browser": true,
     "commonjs": true

--- a/lib/ReactViews/.eslintrc
+++ b/lib/ReactViews/.eslintrc
@@ -7,9 +7,6 @@
       "jsx": true,
       "modules": true,
       "legacyDecorators": true
-    },
-    "babelOptions": {
-      "configFile": "terriajs/.babelrc"
     }
   },
   "env": {

--- a/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
@@ -63,7 +63,10 @@ const RegionDataParameterEditor = createReactClass({
       // If only one dataset can be active at a time, deactivate all others.
       if (this.props.parameter.singleSelect) {
         for (const columnName in value) {
-          if (value.hasOwnProperty(columnName) && columnName !== column.name) {
+          if (
+            Object.prototype.hasOwnProperty.call(value, columnName) &&
+            columnName !== column.name
+          ) {
             value[columnName] = false;
           }
         }

--- a/lib/ReactViews/Custom/Chart/downloadHrefWorker.js
+++ b/lib/ReactViews/Custom/Chart/downloadHrefWorker.js
@@ -1,4 +1,3 @@
-/* global onmessage:true */
 import defined from "terriajs-cesium/Source/Core/defined";
 import sortedIndices from "../../../Core/sortedIndices";
 

--- a/lib/ReactViews/Custom/registerCustomComponentTypes.js
+++ b/lib/ReactViews/Custom/registerCustomComponentTypes.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/* global require */
-
 import CollapsibleCustomComponent from "./CollapsibleCustomComponent";
 import CustomComponent from "./CustomComponent";
 import SOSChartCustomComponent from "./SOSChartCustomComponent";

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -469,7 +469,7 @@ function parseValues(properties) {
   // JSON.parse property values that look like arrays or objects
   const result = {};
   for (const key in properties) {
-    if (properties.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(properties, key)) {
       let val = properties[key];
       if (
         val &&
@@ -495,7 +495,7 @@ function parseValues(properties) {
 function applyFormatsInPlace(properties, formats) {
   // Optionally format each property. Updates properties in place, returning nothing.
   for (const key in formats) {
-    if (properties.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(properties, key)) {
       // Default type if not provided is number.
       if (
         !defined(formats[key].type) ||
@@ -534,7 +534,7 @@ function replaceBadKeyCharacters(properties) {
   }
   const result = {};
   for (const key in properties) {
-    if (properties.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(properties, key)) {
       const cleanKey = key.replace(/[.#]/g, "_");
       result[cleanKey] = replaceBadKeyCharacters(properties[key]);
     }
@@ -556,7 +556,7 @@ function areAllPropertiesConstant(properties) {
     return properties.isConstant;
   }
   for (const key in properties) {
-    if (properties.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(properties, key)) {
       result =
         result &&
         defined(properties[key]) &&
@@ -730,7 +730,7 @@ function describeFromProperties(
   }
   if (typeof properties === "object") {
     for (const key in properties) {
-      if (properties.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(properties, key)) {
         if (simpleStyleIdentifiers.indexOf(key) !== -1) {
           continue;
         }

--- a/lib/ReactViews/ObserveModelMixin.js
+++ b/lib/ReactViews/ObserveModelMixin.js
@@ -59,7 +59,7 @@ const ObserveModelMixin = {
         // even if the array is used in rendering.  This is because Knockout observable arrays don't note a
         // dependency when accessing individual elements of the array.
         for (const prop in that.props) {
-          if (that.props.hasOwnProperty(prop)) {
+          if (Object.prototype.hasOwnProperty.call(that.props, prop)) {
             if (
               defined(that.props[prop]) &&
               defined(that.props[prop].__knockoutSubscribable)

--- a/lib/ReactViews/Workbench/Controls/ConceptViewer.jsx
+++ b/lib/ReactViews/Workbench/Controls/ConceptViewer.jsx
@@ -22,7 +22,7 @@ const ConceptViewer = createReactClass({
     const nonSummaryConcept = this.props.item.concepts.filter(
       concept =>
         concept.isVisible &&
-        !SummaryConceptModel.prototype.isPrototypeOf(concept)
+        Object.prototype.isPrototypeOf.call(!SummaryConceptModel, concept)
     );
 
     return (
@@ -47,7 +47,7 @@ const ConceptViewer = createReactClass({
           of={this.props.item.concepts.filter(
             concept =>
               concept.isVisible &&
-              SummaryConceptModel.prototype.isPrototypeOf(concept)
+              Object.prototype.isPrototypeOf.call(SummaryConceptModel, concept)
           )}
         >
           <div className={Styles.section} key={i}>

--- a/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
+++ b/lib/ViewModels/CatalogItemNameSearchProviderViewModel.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var inherit = require("../Core/inherit");
 var runLater = require("../Core/runLater");
 var SearchProvider = require("../Models/SearchProvider").default;

--- a/lib/ViewModels/GazetteerSearchProviderViewModel.js
+++ b/lib/ViewModels/GazetteerSearchProviderViewModel.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var inherit = require("../Core/inherit");
 var SearchProviderViewModel = require("./SearchProviderViewModel");
 var SearchResultViewModel = require("../Models/SearchResultViewModel");

--- a/lib/ViewModels/GnafSearchProviderViewModel.js
+++ b/lib/ViewModels/GnafSearchProviderViewModel.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var inherit = require("../Core/inherit");
 var SearchProviderViewModel = require("./SearchProviderViewModel");
 var SearchResultViewModel = require("../Models/SearchResultViewModel");

--- a/lib/ViewModels/NominatimSearchProviderViewModel.js
+++ b/lib/ViewModels/NominatimSearchProviderViewModel.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var inherit = require("../Core/inherit");
 var SearchProviderViewModel = require("./SearchProviderViewModel");
 var SearchResultViewModel = require("../Models/SearchResultViewModel");

--- a/lib/ViewModels/createAustraliaBaseMapOptions.js
+++ b/lib/ViewModels/createAustraliaBaseMapOptions.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var ArcGisMapServerCatalogItem = require("../Models/ArcGisMapServerCatalogItem");
 var BaseMapViewModel = require("./BaseMapViewModel");
 

--- a/lib/ViewModels/createGlobalBaseMapOptions.ts
+++ b/lib/ViewModels/createGlobalBaseMapOptions.ts
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 import WebMapServiceCatalogItem from "../Models/WebMapServiceCatalogItem";
 import CommonStrata from "../Models/CommonStrata";
 import Terria from "../Models/Terria";

--- a/lib/ViewModels/selectBaseMap.js
+++ b/lib/ViewModels/selectBaseMap.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 /**

--- a/lib/ViewModels/updateApplicationOnHashChange.js
+++ b/lib/ViewModels/updateApplicationOnHashChange.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var raiseErrorToUser = require("../Models/raiseErrorToUser");
 
 /**

--- a/lib/ViewModels/updateApplicationOnMessageFromParentWindow.js
+++ b/lib/ViewModels/updateApplicationOnMessageFromParentWindow.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 var raiseErrorToUser = require("../Models/raiseErrorToUser");
 

--- a/package.json
+++ b/package.json
@@ -154,10 +154,11 @@
     "worker-loader": "^2.0.0"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.12.16",
+    "@babel/plugin-proposal-decorators": "^7.12.13",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "babel-eslint": "^10.0.1",
     "babel-plugin-styled-components": "^1.10.7",
-    "eslint": "^5.14.1",
+    "eslint": "^7.20.0",
     "eslint-plugin-jsx-control-statements": "^2.2.1",
     "eslint-plugin-react": "^7.19.0",
     "fork-ts-checker-notifier-webpack-plugin": "^3.0.0",

--- a/test/Core/CorsProxySpec.js
+++ b/test/Core/CorsProxySpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var CorsProxy = require("../../lib/Core/CorsProxy");
 var when = require("when");
 

--- a/test/Core/arrayProductSpec.js
+++ b/test/Core/arrayProductSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require, fail*/
 var arrayProduct = require("../../lib/Core/arrayProduct");
 
 describe("arrayProduct", function() {

--- a/test/Core/combineDataSpec.js
+++ b/test/Core/combineDataSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect*/
 var combineData = require("../../lib/Core/combineData");
 
 describe("combineData", function() {

--- a/test/Core/formatNumberForLocaleSpec.js
+++ b/test/Core/formatNumberForLocaleSpec.js
@@ -1,6 +1,6 @@
+/* eslint-disable no-native-reassign */
 "use strict";
 
-/*global require,Intl:true*/
 var formatNumberForLocale = require("../../lib/Core/formatNumberForLocale");
 
 describe("formatNumberForLocale", function() {
@@ -111,12 +111,14 @@ describe("formatNumberForLocale", function() {
     beforeEach(function() {
       if (typeof Intl === "object") {
         realIntl = Intl;
+        // eslint-disable-next-line no-global-assign
         Intl = undefined;
       }
     });
 
     afterEach(function() {
       if (realIntl) {
+        // eslint-disable-next-line no-global-assign
         Intl = realIntl;
       }
     });

--- a/test/Core/sortedIndicesSpec.js
+++ b/test/Core/sortedIndicesSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect*/
 var sortedIndices = require("../../lib/Core/sortedIndices");
 
 describe("sortedIndices", function() {

--- a/test/Data/RegionMappingJsonSpec.js
+++ b/test/Data/RegionMappingJsonSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach,fail*/
-
 // tests will not build if this require statement is not valid
 var RegionMappingJson = require("../../wwwroot/data/regionMapping.json");
 

--- a/test/Map/DragPointsSpec.js
+++ b/test/Map/DragPointsSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect*/
 var DragPoints = require("../../lib/Map/DragPoints");
 var Terria = require("../../lib/Models/Terria");
 var ViewerMode = require("../../lib/Models/ViewerMode");

--- a/test/Map/EarthGravityModel1996Spec.js
+++ b/test/Map/EarthGravityModel1996Spec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,xdescribe,it,expect,beforeAll*/
 var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;
 var EarthGravityModel1996 = require("../../lib/Map/EarthGravityModel1996");
 

--- a/test/Map/ReprojectSpec.js
+++ b/test/Map/ReprojectSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect*/
 var Reproject = require("../../lib/Map/Reproject");
 
 describe("Reproject", function() {

--- a/test/Map/TableColumnSpec.js
+++ b/test/Map/TableColumnSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect*/
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
 var TableColumn = require("../../lib/Map/TableColumn");
 var VarType = require("../../lib/Map/VarType");

--- a/test/Map/TableStructureSpec.js
+++ b/test/Map/TableStructureSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect*/
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
 var TableStructure = require("../../lib/Map/TableStructure");
 var TimeInterval = require("terriajs-cesium/Source/Core/TimeInterval").default;

--- a/test/Map/featureDataToGeoJsonSpec.js
+++ b/test/Map/featureDataToGeoJsonSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect*/
 const featureDataToGeoJson = require("../../lib/Map/featureDataToGeoJson");
 
 describe("featureDataToGeoJson", function() {

--- a/test/Map/unionRectanglesSpec.js
+++ b/test/Map/unionRectanglesSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect*/
-
 var Rectangle = require("terriajs-cesium/Source/Core/Rectangle").default;
 
 var unionRectangles = require("../../lib/Map/unionRectangles");

--- a/test/Models/AbsIttCatalogItemSpec.js
+++ b/test/Models/AbsIttCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require, fail*/
 var Rectangle = require("terriajs-cesium/Source/Core/Rectangle").default;
 
 var Terria = require("../../lib/Models/Terria");

--- a/test/Models/ArcGisMapServerCatalogItemSpec.js
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach*/
-
 var Terria = require("../../lib/Models/Terria");
 var Legend = require("../../lib/Map/Legend");
 var loadWithXhr = require("../../lib/Core/loadWithXhr");

--- a/test/Models/CameraViewSpec.js
+++ b/test/Models/CameraViewSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var CameraView = require("../../lib/Models/CameraView");
 var Cartesian3 = require("terriajs-cesium/Source/Core/Cartesian3").default;
 var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;

--- a/test/Models/CatalogGroupSpec.js
+++ b/test/Models/CatalogGroupSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach*/
 var CatalogGroup = require("../../lib/Models/CatalogGroup");
 var CatalogItem = require("../../lib/Models/CatalogItem");
 var createCatalogMemberFromType = require("../../lib/Models/createCatalogMemberFromType");

--- a/test/Models/CatalogItemSpec.js
+++ b/test/Models/CatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var Rectangle = require("terriajs-cesium/Source/Core/Rectangle").default;
 
 var CatalogItem = require("../../lib/Models/CatalogItem");

--- a/test/Models/CatalogMemberSpec.js
+++ b/test/Models/CatalogMemberSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var CatalogMember = require("../../lib/Models/CatalogMember");
 var Terria = require("../../lib/Models/Terria");
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;

--- a/test/Models/CatalogSpec.js
+++ b/test/Models/CatalogSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach*/
 var Terria = require("../../lib/Models/Terria");
 var loadJson = require("../../lib/Core/loadJson").default;
 var CHART_DATA_CATEGORY_NAME = require("../../lib/Core/addedForCharts")

--- a/test/Models/CesiumSpec.js
+++ b/test/Models/CesiumSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,xdescribe,it,expect,beforeEach*/
 var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;
 var Cesium = require("../../lib/Models/Cesium");
 var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;

--- a/test/Models/CesiumTerrainCatalogItemSpec.js
+++ b/test/Models/CesiumTerrainCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var CesiumTerrainCatalogItem = require("../../lib/Models/CesiumTerrainCatalogItem");
 var CesiumTerrainProvider = require("terriajs-cesium/Source/Core/CesiumTerrainProvider")
   .default;

--- a/test/Models/CkanCatalogItemSpec.js
+++ b/test/Models/CkanCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var CkanCatalogItem = require("../../lib/Models/CkanCatalogItem");
 var loadText = require("../../lib/Core/loadText");
 var Terria = require("../../lib/Models/Terria");

--- a/test/Models/CsvCatalogItemSpec.js
+++ b/test/Models/CsvCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach,fail*/
 var clone = require("terriajs-cesium/Source/Core/clone").default;
 var Color = require("terriajs-cesium/Source/Core/Color").default;
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;

--- a/test/Models/CswCatalogGroupSpec.js
+++ b/test/Models/CswCatalogGroupSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect*/
 var CswCatalogGroup = require("../../lib/Models/CswCatalogGroup");
 var loadText = require("../../lib/Core/loadText");
 var Terria = require("../../lib/Models/Terria");

--- a/test/Models/CzmlCatalogItemSpec.js
+++ b/test/Models/CzmlCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach*/
 var CzmlCatalogItem = require("../../lib/Models/CzmlCatalogItem");
 var TerriaError = require("../../lib/Core/TerriaError");
 var Terria = require("../../lib/Models/Terria");

--- a/test/Models/ImageryLayerCatalogItemSpec.js
+++ b/test/Models/ImageryLayerCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,beforeEach*/
 const CesiumEvent = require("terriajs-cesium/Source/Core/Event").default;
 const ImageryLayer = require("terriajs-cesium/Source/Scene/ImageryLayer")
   .default;

--- a/test/Models/KmlCatalogItemSpec.js
+++ b/test/Models/KmlCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach*/
 var KmlCatalogItem = require("../../lib/Models/KmlCatalogItem");
 var TerriaError = require("../../lib/Core/TerriaError");
 var Terria = require("../../lib/Models/Terria");

--- a/test/Models/LeafletSpec.js
+++ b/test/Models/LeafletSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach*/
 var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;
 var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
 var CesiumTileLayer = require("../../lib/Map/CesiumTileLayer");

--- a/test/Models/MapboxMapCatalogItemSpec.js
+++ b/test/Models/MapboxMapCatalogItemSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach*/
-
 var Terria = require("../../lib/Models/Terria");
 var ImageryLayerCatalogItem = require("../../lib/Models/ImageryLayerCatalogItem");
 var MapboxMapCatalogItem = require("../../lib/Models/MapboxMapCatalogItem");

--- a/test/Models/NowViewingSpec.js
+++ b/test/Models/NowViewingSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,xdescribe,it,expect,beforeEach*/
 var NowViewing = require("../../lib/Models/NowViewing");
 var Terria = require("../../lib/Models/Terria");
 var Cesium = require("../../lib/Models/Cesium");

--- a/test/Models/RegionProviderListSpec.js
+++ b/test/Models/RegionProviderListSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach,fail*/
-
 var RegionProviderList = require("../../lib/Map/RegionProviderList");
 var RegionProvider = require("../../lib/Map/RegionProvider");
 var TableStructure = require("../../lib/Map/TableStructure");

--- a/test/Models/RegionProviderSpec.js
+++ b/test/Models/RegionProviderSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach,fail*/
-
 var RegionProvider = require("../../lib/Map/RegionProvider");
 var CorsProxy = require("../../lib/Core/CorsProxy");
 

--- a/test/Models/SdmxJsonCatalogItemSpec.js
+++ b/test/Models/SdmxJsonCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require, fail*/
 var loadText = require("../../lib/Core/loadText");
 var Rectangle = require("terriajs-cesium/Source/Core/Rectangle").default;
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;

--- a/test/Models/SensorObservationServiceCatalogItemSpec.js
+++ b/test/Models/SensorObservationServiceCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require, fail*/
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
 var loadText = require("../../lib/Core/loadText");
 var Rectangle = require("terriajs-cesium/Source/Core/Rectangle").default;

--- a/test/Models/TerrainCatalogItemSpec.js
+++ b/test/Models/TerrainCatalogItemSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var CompositeCatalogItem = require("../../lib/Models/CompositeCatalogItem");
 var TerrainCatalogItem = require("../../lib/Models/TerrainCatalogItem");
 var Terria = require("../../lib/Models/Terria");

--- a/test/Models/TimeSeriesStackSpec.js
+++ b/test/Models/TimeSeriesStackSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var TimelineStack = require("../../lib/Models/TimelineStack");
 var CatalogItem = require("../../lib/Models/CatalogItem");
 var Terria = require("../../lib/Models/Terria");

--- a/test/Models/UrlTemplateCatalogItemSpec.js
+++ b/test/Models/UrlTemplateCatalogItemSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach*/
-
 var Terria = require("../../lib/Models/Terria");
 var ImageryLayerCatalogItem = require("../../lib/Models/ImageryLayerCatalogItem");
 var NeverTileDiscardPolicy = require("terriajs-cesium/Source/Scene/NeverTileDiscardPolicy")

--- a/test/Models/WebMapTileServiceCatalogItemSpec.js
+++ b/test/Models/WebMapTileServiceCatalogItemSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach,fail*/
-
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
 var Rectangle = require("terriajs-cesium/Source/Core/Rectangle").default;
 var TimeInterval = require("terriajs-cesium/Source/Core/TimeInterval").default;

--- a/test/Models/WfsFeaturesCatalogGroupSpec.js
+++ b/test/Models/WfsFeaturesCatalogGroupSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require*/
-
 var Terria = require("../../lib/Models/Terria");
 var WfsFeaturesCatalogGroup = require("../../lib/Models/WfsFeaturesCatalogGroup");
 

--- a/test/Models/calculateImageryLayerIntervalsSpec.js
+++ b/test/Models/calculateImageryLayerIntervalsSpec.js
@@ -1,7 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach,fail*/
-
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
 var calculateImageryLayerIntervals = require("../../lib/Models/calculateImageryLayerIntervals");
 var TimeInterval = require("terriajs-cesium/Source/Core/TimeInterval").default;

--- a/test/Models/parseCustomHtmlToReactSpec.js
+++ b/test/Models/parseCustomHtmlToReactSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require, fail*/
 import Chart from "../../lib/ReactViews/Custom/Chart/Chart";
 import Collapsible from "../../lib/ReactViews/Custom/Collapsible/Collapsible";
 import parseCustomHtmlToReact from "../../lib/ReactViews/Custom/parseCustomHtmlToReact";

--- a/test/Models/setClockCurrentTimeSpec.js
+++ b/test/Models/setClockCurrentTimeSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,beforeEach*/
 var JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
 var DataSourceClock = require("terriajs-cesium/Source/DataSources/DataSourceClock")
   .default;

--- a/test/ReactViews/ChartSpec.jsx
+++ b/test/ReactViews/ChartSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global expect,fail*/
 import React from "react";
 import { getMountedInstance } from "./MoreShallowTools";
 

--- a/test/ReactViews/FeatureInfoPanelSpec.jsx
+++ b/test/ReactViews/FeatureInfoPanelSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,expect*/
 // import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import React from "react";
 import { findWithType } from "react-shallow-testutils";

--- a/test/ReactViews/FeatureInfoSectionSpec.jsx
+++ b/test/ReactViews/FeatureInfoSectionSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,expect*/
 // import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import React from "react";
 import {

--- a/test/ReactViews/MeasureToolSpec.jsx
+++ b/test/ReactViews/MeasureToolSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,expect*/
 // import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import React from "react";
 import Terria from "../../lib/Models/Terria";

--- a/test/ReactViews/MoreShallowTools.js
+++ b/test/ReactViews/MoreShallowTools.js
@@ -1,6 +1,5 @@
 "use strict";
 
-//*global require,expect*/
 import { createRenderer } from "react-test-renderer/shallow";
 import { findAll } from "react-shallow-testutils";
 

--- a/test/ReactViews/ScalesSpec.jsx
+++ b/test/ReactViews/ScalesSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global expect,fail*/
 import React from "react";
 import { getMountedInstance } from "./MoreShallowTools";
 

--- a/test/ReactViews/StandardUserInterfaceSpec.jsx
+++ b/test/ReactViews/StandardUserInterfaceSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,expect*/
 import React from "react";
 import { findWithClass } from "react-shallow-testutils";
 import { getShallowRenderedOutput } from "./MoreShallowTools";

--- a/test/ReactViews/TimelineSpec.jsx
+++ b/test/ReactViews/TimelineSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,expect*/
 // import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import React from "react";
 import { getMountedInstance } from "./MoreShallowTools";

--- a/test/ReactViews/renderAndSubscribeSpec.js
+++ b/test/ReactViews/renderAndSubscribeSpec.js
@@ -1,7 +1,6 @@
 // 'use strict';
 
-// /*global require*/
-// var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
+// // var knockout = require('terriajs-cesium/Source/ThirdParty/knockout');
 // var renderAndSubscribe = require('../../lib/ReactViews/renderAndSubscribe');
 
 // describe('renderAndSubscribe', function() {

--- a/test/SpecMain.ts
+++ b/test/SpecMain.ts
@@ -1,4 +1,3 @@
-/*global require*/
 /// <reference types="jasmine" />
 import "../lib/Core/prerequisites";
 import "jasmine-ajax";

--- a/test/Utility/CustomMatchers.js
+++ b/test/Utility/CustomMatchers.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var defined = require("terriajs-cesium/Source/Core/defined").default;
 
 function equals(util, customEqualityTesters, a, b) {

--- a/test/Utility/loadAndStubTextResources.js
+++ b/test/Utility/loadAndStubTextResources.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var loadText = require("../../lib/Core/loadText");
 var when = require("terriajs-cesium/Source/ThirdParty/when").default;
 

--- a/test/ViewModels/CatalogItemNameSearchProviderViewModelSpec.js
+++ b/test/ViewModels/CatalogItemNameSearchProviderViewModelSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require,describe,it,expect,beforeEach*/
 var CatalogGroup = require("../../lib/Models/CatalogGroup");
 var CatalogItem = require("../../lib/Models/CatalogItem");
 var WebMapServiceCatalogItem = require("../../lib/Models/WebMapServiceCatalogItem");

--- a/test/ViewModels/NominatimSearchProviderViewModelSpec.js
+++ b/test/ViewModels/NominatimSearchProviderViewModelSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var CatalogItem = require("../../lib/Models/CatalogItem");
 var NominatimSearchProviderViewModel = require("../../lib/ViewModels/NominatimSearchProviderViewModel");
 var Terria = require("../../lib/Models/Terria");

--- a/test/ViewModels/updateApplicationOnMessageFromParentWindowSpec.js
+++ b/test/ViewModels/updateApplicationOnMessageFromParentWindowSpec.js
@@ -1,6 +1,5 @@
 "use strict";
 
-/*global require*/
 var CatalogGroup = require("../../lib/Models/CatalogGroup");
 var createCatalogMemberFromType = require("../../lib/Models/createCatalogMemberFromType");
 var Terria = require("../../lib/Models/Terria");


### PR DESCRIPTION
### What this PR does

Fixes 
Upgrade `babel-eslint` to `@babel/eslint-parser` and new version of `eslint`. There was a bunch of unexpected token errors/warnings in vscode due to some changes in used babel modules.
Most of the changes are regarding
```
warning  'require' is already defined as a built-in global variable  no-redeclare
```
otherwise, this would be really in-place upgrade.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
