### PR TITLE
lock i18next version till new version of i18next-http-backend is rele…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@ Change Log
 * Use `configParameters.cesiumIonAccessToken` in `IonImageryCatalogItem`
 * Added support for skipping comments in CSV files
 * Fix app crash when switching different tools.
+* Lock the version of i18next to 19.8.9 till new version of i18next-http-backend is available.
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "hammerjs": "^2.0.6",
     "hoist-non-react-statics": "^3.3.2",
     "html-to-react": "1.3.4",
-    "i18next": "^19.6.3",
+    "i18next": "~19.8.9",
     "i18next-browser-languagedetector": "^4.0.1",
     "i18next-http-backend": "^1.0.11",
     "imports-loader": "^0.8.0",


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

The latest release of i18next (19.9.0), done 1 hour ago is causing build issues. More specifically `i18next-http-backend` is failing which we are using for getting translations from TerriaMap. We need to lock the version of `i18next` to 19.8.9, and wait for an update and release of `i18next-http-backend`
This is picking up on the comment https://github.com/TerriaJS/terriajs/pull/5253#issuecomment-784910854

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist) - _*Build issues*_
-   [x] I've updated CHANGES.md with what I changed.
