### PR TITLE
Move metadataurls up in Description

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,7 @@ Change Log
 * Fix app crash when switching different tools.
 * Create `merge` `TraitsOption` for `objectArrayTrait`
 * Lock the version of i18next to 19.8.9 till new version of i18next-http-backend is available.
+* Move `Description` `metadataUrls` above `infoSections`.
 * [The next improvement]
 
 #### 8.0.0-alpha.65

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,7 +50,6 @@ Change Log
 * Fix `DiffTool` date-picker label `dateComparisonB`
 * Fix app crash when switching different tools.
 * Create `merge` `TraitsOption` for `objectArrayTrait`
-* Lock the version of i18next to 19.8.9 till new version of i18next-http-backend is available.
 * Move `Description` `metadataUrls` above `infoSections`.
 * Upgraded i18next and i18next-http-backend to fix incompatibility.
 * Added support for dd/mm/yyyy, dd-mm-yyyy and mm-dd-yyyy date formats.

--- a/lib/ReactViews/Preview/Description.jsx
+++ b/lib/ReactViews/Preview/Description.jsx
@@ -91,6 +91,28 @@ const Description = observer(
             <p>{t("description.dataNotLocal")}</p>
           </If>
 
+          <If condition={metadataUrls && metadataUrls.length > 0}>
+            <h4 className={Styles.h4}>{t("description.metadataUrls")}</h4>
+            <For each="metadataUrl" index="i" of={metadataUrls}>
+              <Box paddedVertically key={metadataUrl.url}>
+                <a
+                  href={metadataUrl.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`${Styles.link} description-metadataUrls`}
+                  css={`
+                    color: ${p => p.theme.colorPrimary};
+                  `}
+                >
+                  <If condition={metadataUrl.title}>
+                    <Button primary={true}>{metadataUrl.title}</Button>
+                  </If>
+                  <If condition={!metadataUrl.title}>{metadataUrl.url}</If>
+                </a>
+              </Box>
+            </For>
+          </If>
+
           <DataPreviewSections metadataItem={catalogItem} />
 
           <If
@@ -187,27 +209,6 @@ const Description = observer(
               </Choose>
             </If>
 
-            <If condition={metadataUrls && metadataUrls.length > 0}>
-              <h4 className={Styles.h4}>{t("description.metadataUrls")}</h4>
-              <For each="metadataUrl" index="i" of={metadataUrls}>
-                <Box paddedVertically key={metadataUrl.url}>
-                  <a
-                    href={metadataUrl.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`${Styles.link} description-metadataUrls`}
-                    css={`
-                      color: ${p => p.theme.colorPrimary};
-                    `}
-                  >
-                    <If condition={metadataUrl.title}>
-                      <Button primary={true}>{metadataUrl.title}</Button>
-                    </If>
-                    <If condition={!metadataUrl.title}>{metadataUrl.url}</If>
-                  </a>
-                </Box>
-              </For>
-            </If>
             <If
               condition={
                 catalogItem.dataUrlType &&


### PR DESCRIPTION
### What this PR does

Move new `metadataUrl` buttons above `infoSections`.

This is temporary until we add some method of ordering all sections in `Description` - like how we deal have `infoSectionOrder` - https://github.com/TerriaJS/terriajs/issues/5143

### After changes

http://ci.terria.io/move-metadataurls-up/#clean&https://raw.githubusercontent.com/TerriaJS/saas-catalogs-public/main/kaleidoscope/dev.json

![image](https://user-images.githubusercontent.com/6187649/109251887-630d7b00-7840-11eb-9094-5471845282d5.png)

### Before changes

http://ci.terria.io/next/#clean&https://raw.githubusercontent.com/TerriaJS/saas-catalogs-public/main/kaleidoscope/dev.json

![image](https://user-images.githubusercontent.com/6187649/109251970-8a644800-7840-11eb-86c5-b7bfc8c52c7f.png)

### Checklist

-   [x] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [x] I've updated CHANGES.md with what I changed.
