### PR TITLE
Update catalog-converter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 #### next release (8.0.0-alpha.67)
 * TSify `Loader` function.
 * Added walking mode to pedestrian mode which clamps the pedestrain to a fixed height above the surface.
+* Upgraded catalog-converter and ensure that all imports are async to reduce main bundle size.
 * [The next improvement]
 
 #### 8.0.0-alpha.66

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -564,7 +564,7 @@ export default class Terria {
           .filter((v7initUrl: any) => isJsonString(v7initUrl))
           .map(async (v7initUrl: string) => {
             const catalog = await loadJson5(v7initUrl);
-            const convert = convertCatalog(catalog);
+            const convert = convertCatalog(catalog, { generateIds: false });
             console.log(
               `WARNING: ${v7initUrl} is a v7 catalog - it has been upgraded to v8\nMessages:\n`
             );

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@vx/tooltip": "^0.0.193-alpha.2",
     "babel-loader": "^8.0.5",
     "babel-plugin-jsx-control-statements": "^4.0.0",
-    "catalog-converter": "^0.0.2-alpha.4",
+    "catalog-converter": "^0.0.4",
     "class-list": "^0.1.1",
     "classnames": "^2.2.3",
     "clipboard": "^2.0.0",

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -176,7 +176,9 @@ describe("Terria", function() {
         );
         if (isInitDataPromise(terria.initSources[0])) {
           const data = await terria.initSources[0];
-          expect(data.data.catalog).toEqual([
+          // JSON parse & stringify to avoid a problem where I think catalog-converter
+          //  can return {"id": undefined} instead of no "id"
+          expect(JSON.parse(JSON.stringify(data.data.catalog))).toEqual([
             {
               name: groupName,
               type: "group",


### PR DESCRIPTION
### What this PR does

Update catalog-converter to latest published version. The default options have changed with this version so that the CLI and exported functions use the same conversion options by default.