### PR TITLE
Quaterly dates support (eg 2020-Q1)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 #### next release (8.0.0-alpha.68)
 * Remove points from rectangle `UserDrawing`
 * Fix clipboard typing error. 
+* Add support for TableColumn quarterly dates in the format yyyy-Qx (eg 2020-Q1).
 * [The next improvement]
 
 #### 8.0.0-alpha.67

--- a/lib/Table/TableColumn.ts
+++ b/lib/Table/TableColumn.ts
@@ -252,6 +252,30 @@ export default class TableColumn {
       }
     };
 
+    let yyyyQQ: StringToDateFunction = value => {
+      // Is it quarterly data in the format yyyy-Qx ? (Ignoring null values, and failing on any purely numeric values)
+      if (value.indexOf("-Q") === 4) {
+        var year = value.slice(0, 4);
+        var quarter = value.slice(6);
+        var monthString;
+        if (quarter === "1") {
+          monthString = "01/01";
+        } else if (quarter === "2") {
+          monthString = "04/01";
+        } else if (quarter === "3") {
+          monthString = "07/01";
+        } else if (quarter === "4") {
+          monthString = "10/01";
+        } else {
+          parsingFailed = true;
+          return null;
+        }
+        return new Date(year + "/" + monthString);
+      }
+      parsingFailed = true;
+      return null;
+    };
+
     let dateConstructor: StringToDateFunction = value => {
       const ms = Date.parse(value);
       if (!Number.isNaN(ms)) {
@@ -313,6 +337,10 @@ export default class TableColumn {
       if (!parsingFailed) return result;
       parsingFailed = false;
     }
+    result = convertValuesToDates(this.values, yyyyQQ);
+    if (!parsingFailed) return result;
+    parsingFailed = false;
+
     return convertValuesToDates(this.values, dateConstructor);
   }
 

--- a/lib/Table/TableColumn.ts
+++ b/lib/Table/TableColumn.ts
@@ -254,10 +254,14 @@ export default class TableColumn {
 
     let yyyyQQ: StringToDateFunction = value => {
       // Is it quarterly data in the format yyyy-Qx ? (Ignoring null values, and failing on any purely numeric values)
-      if (value.indexOf("-Q") === 4) {
-        var year = value.slice(0, 4);
-        var quarter = value.slice(6);
-        var monthString;
+      if (value[4] === "-" && value[5] === "Q") {
+        const year = +value.slice(0, 4);
+        if (!Number.isInteger(year)) {
+          parsingFailed = true;
+          return null;
+        }
+        const quarter = value.slice(6);
+        let monthString: string;
         if (quarter === "1") {
           monthString = "01/01";
         } else if (quarter === "2") {
@@ -270,7 +274,7 @@ export default class TableColumn {
           parsingFailed = true;
           return null;
         }
-        return new Date(year + "/" + monthString);
+        return new Date(centuryFix(year) + "/" + monthString);
       }
       parsingFailed = true;
       return null;

--- a/test/Table/TableColumnSpec.ts
+++ b/test/Table/TableColumnSpec.ts
@@ -121,6 +121,30 @@ describe("TableColumn", function() {
       );
     });
 
+    it("can convert yyyy-Qx dates", async function() {
+      tableModel.setTrait(
+        CommonStrata.user,
+        "csvString",
+        "TIME_PERIOD,OBS_VALUE\n1983-Q2,-0.6\n1983-Q3,-3.2\n1983-Q4,0.9\n1984-Q1,-1.7\n1984-Q2,3.6\n1984-Q3,-1.1\n1984-Q4,3\n1985-Q1,1.1"
+      );
+      await tableModel.loadChartItems();
+      const tableColumn1 = new TableColumn(tableModel, 0);
+      expect(
+        tableColumn1.valuesAsDates.values.map(d => d && d.toISOString())
+      ).toEqual(
+        [
+          new Date("1983/04/01"),
+          new Date("1983/07/01"),
+          new Date("1983/10/01"),
+          new Date("1984/01/01"),
+          new Date("1984/04/01"),
+          new Date("1984/07/01"),
+          new Date("1984/10/01"),
+          new Date("1985/01/01")
+        ].map(d => d.toISOString())
+      );
+    });
+
     it("attempts to convert all dates using new Date if one date fails parsing with dd/mm/yyyy and mm/dd/yyyy", async function() {
       tableModel.setTrait(
         CommonStrata.user,


### PR DESCRIPTION
Add support for TableColumn quarterly dates in the format yyyy-Qx (eg 2020-Q1)

Test CSV https://gist.githubusercontent.com/nf-s/c7968085cf15db1a32d130d77fbb9110/raw/618037a0a3ccd39c9e3a422b6f01476e75ee387c/yyyy-Qx.csv

### Checklist

-   [x] There are unit tests to verify my changes are correct
-   [x] I've updated CHANGES.md with what I changed.
