### PR TITLE
Fix init docs formatting

### DIFF
--- a/doc/customizing/initialization-files.md
+++ b/doc/customizing/initialization-files.md
@@ -77,7 +77,7 @@ Catalog files can be edited two ways:
 |viewerMode|no|**"3d"** or **"3dSmooth"** or **"2D"** |"3d"|The id of the viewer mode to be shown initialy.|
 |homeCamera|yes|[**CameraPosition**](#CameraPosition)||Where the camera goes when you click the "home" button between the zoom-in and zoom-out buttons.|
 |<a id="base-maps"></a>baseMaps|no|[**`baseMaps`**](#baseMaps)|[default list of basemaps](https://github.com/TerriaJS/terriajs/blob/next/lib/Models/BaseMaps/defaultBaseMaps.ts)|The array of the base maps to be shown to the user.|
-|<a id="base-map-id"></a>baseMapId|no|**string**||The id of the baseMap user will see on the first mapLoad. The value must be an id of the catalog item from the [`baseMaps`](#basemaps) array|
+|<a id="base-map-id"></a>baseMapId|no|**string**||The id of the baseMap user will see on the first mapLoad. The value must be an id of the catalog item from the [`baseMaps`](#base-maps) array|
 |previewBaseMapId|no|**string**|[`baseMapId`](#base-map-id)|The id of the baseMap to be used as the base map in data preview. The value must be an id of the catalog item from the [`baseMaps`](#base-maps) array.|
 |showSplitter|no|**boolean**|false|Show splitter initally.|
 |splitPosition|no|**number**|0.5|The position of splitter.|

--- a/doc/customizing/initialization-files.md
+++ b/doc/customizing/initialization-files.md
@@ -77,7 +77,7 @@ Catalog files can be edited two ways:
 |viewerMode|no|**"3d"** or **"3dSmooth"** or **"2D"** |"3d"|The id of the viewer mode to be shown initialy.|
 |homeCamera|yes|[**CameraPosition**](#CameraPosition)||Where the camera goes when you click the "home" button between the zoom-in and zoom-out buttons.|
 |<a id="base-maps"></a>baseMaps|no|[**`baseMaps`**](#baseMaps)|[default list of basemaps](../../lib/Models/BaseMaps/defaultBaseMaps.ts)|The array of the base maps to be shown to the user.|
-|<a id="base-map-id"></a>baseMapId|no|**string**||The id of the baseMap user will see on the first mapLoad. The value must be an id of the catalog item from the [`baseMaps`](#base-maps) array|
+|<a id="base-map-id"></a>baseMapId|no|**string**||The id of the baseMap user will see on the first mapLoad. The value must be an id of the catalog item from the [`baseMaps`](#basemaps) array|
 |previewBaseMapId|no|**string**|[`baseMapId`](#base-map-id)|The id of the baseMap to be used as the base map in data preview. The value must be an id of the catalog item from the [`baseMaps`](#base-maps) array.|
 |showSplitter|no|**boolean**|false|Show splitter initally.|
 |splitPosition|no|**number**|0.5|The position of splitter.|
@@ -90,6 +90,7 @@ Catalog files can be edited two ways:
 The bounding box method uses `north`, `east `,`south`, and `west`, in lat/lng decimal degrees.  The camera will be positioned in the center point of those bounds, looking toward the Earth's center, zoomed back enough to see to the edges of the bounds.
 
 This is the only mode supported in 2D mode (Leaflet). Therefore, you should always include a bounding box, even if you also use another mode.
+
 |Name|Required|Type|Default|Description|
 |----|--------|----|-------|-----------|
 |north|yes|**number**|||
@@ -228,8 +229,9 @@ Definition of the story. This can be pretty complex to define for the standard u
 |version|yes|string|"8.0.0"|The version of share data.|
 |initSources|yes|[**CatalogFileProperties**](#catalog-file-properties)
 
-### `baseMaps`
+### baseMaps
 Definition of the baseMap model.
+
 |Name|Required|Type|Default|Description|
 |----|--------|----|-------|-----------|
 |item|yes|[**Catalog Item**](../connecting-to-data/catalog-items.md)||Catalog item defition to be used for the base map|

--- a/doc/customizing/initialization-files.md
+++ b/doc/customizing/initialization-files.md
@@ -76,7 +76,7 @@ Catalog files can be edited two ways:
 |stories|no|[**Story[]**](#story)||An array of stories to be loaded.|
 |viewerMode|no|**"3d"** or **"3dSmooth"** or **"2D"** |"3d"|The id of the viewer mode to be shown initialy.|
 |homeCamera|yes|[**CameraPosition**](#CameraPosition)||Where the camera goes when you click the "home" button between the zoom-in and zoom-out buttons.|
-|<a id="base-maps"></a>baseMaps|no|[**`baseMaps`**](#baseMaps)|[default list of basemaps](../../lib/Models/BaseMaps/defaultBaseMaps.ts)|The array of the base maps to be shown to the user.|
+|<a id="base-maps"></a>baseMaps|no|[**`baseMaps`**](#baseMaps)|[default list of basemaps](https://github.com/TerriaJS/terriajs/blob/next/lib/Models/BaseMaps/defaultBaseMaps.ts)|The array of the base maps to be shown to the user.|
 |<a id="base-map-id"></a>baseMapId|no|**string**||The id of the baseMap user will see on the first mapLoad. The value must be an id of the catalog item from the [`baseMaps`](#basemaps) array|
 |previewBaseMapId|no|**string**|[`baseMapId`](#base-map-id)|The id of the baseMap to be used as the base map in data preview. The value must be an id of the catalog item from the [`baseMaps`](#base-maps) array.|
 |showSplitter|no|**boolean**|false|Show splitter initally.|


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Fix formatting of doc for init files, some line breaks were missing.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist) - **_only docs change_**
-   [ ] I've updated CHANGES.md with what I changed.
