### PR TITLE
Fix new starter issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
   
 * Updated terriajs-cesium to version 1.79.1
 * Make base maps configurable from init files and update documentation for init files [#5140](https://github.com/TerriaJS/terriajs/pull/5140).
+* Fixed missing dependency issue for a fresh build
 
 #### 8.0.0-alpha.68
 * Remove points from rectangle `UserDrawing`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ Change Log
   
 * Updated terriajs-cesium to version 1.79.1
 * Make base maps configurable from init files and update documentation for init files [#5140](https://github.com/TerriaJS/terriajs/pull/5140).
-* Fixed missing dependency issue for a fresh build
+* Updated getting-started guide with npm build task
 
 #### 8.0.0-alpha.68
 * Remove points from rectangle `UserDrawing`

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -37,7 +37,7 @@ git clone https://github.com/TerriaJS/terriajs.git
 cd ..
 ```
 
-This will give you the `master` branch of TerriaJS.  While we strive to keep `master` stable and usable at all times, you must be aware that `master` is less tested than actual releases, and it may not be commpatible with the `master` branch of TerriaMap.  So, you may want to check out the actual version of TerriaJS that you're using before you start making changes.  To do that:
+This will give you the `master` branch of TerriaJS.  While we strive to keep `master` stable and usable at all times, you must be aware that `master` is less tested than actual releases, and it may not be compatible with the `master` branch of TerriaMap.  So, you may want to check out the actual version of TerriaJS that you're using before you start making changes.  To do that:
 
 ```
 grep terriajs package.json

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -13,7 +13,7 @@ git clone https://github.com/TerriaJS/TerriaMap.git --branch next
 
 cd TerriaMap
 
-npm install && npm run gulp && npm start
+npm install && npm run build && npm start
 
 # Open at http://localhost:3001
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,5 +183,5 @@ gulp.task('docs', gulp.series('user-guide', function docs(done) {
 gulp.task('build', gulp.series('copy-cesium-assets', 'build-specs'));
 gulp.task('release', gulp.series('copy-cesium-assets', 'release-specs'));
 gulp.task('watch', gulp.series('copy-cesium-assets', 'watch-specs'));
-gulp.task('post-npm-install', gulp.series('build'));
+gulp.task('post-npm-install', gulp.series('copy-cesium-assets'));
 gulp.task('default', gulp.series('lint', 'build'));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,5 +183,5 @@ gulp.task('docs', gulp.series('user-guide', function docs(done) {
 gulp.task('build', gulp.series('copy-cesium-assets', 'build-specs'));
 gulp.task('release', gulp.series('copy-cesium-assets', 'release-specs'));
 gulp.task('watch', gulp.series('copy-cesium-assets', 'watch-specs'));
-gulp.task('post-npm-install', gulp.series('copy-cesium-assets'));
+gulp.task('post-npm-install', gulp.series('build'));
 gulp.task('default', gulp.series('lint', 'build'));

--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "postpublish": "bash -c \"if [ -z \"$GITHUB_ACTION\" ]; then git tag -a ${npm_package_version} -m \"${npm_package_version}\" && git push origin ${npm_package_version}; fi \"",
     "postinstall": "gulp post-npm-install",
     "gulp": "gulp",
+    "build": "gulp build",
     "make-schema": "gulp make-schema",
     "start": "terriajs-server --port 3002",
     "dev": "webpack-dev-server --inline --config buildprocess/webpack.config.dev.js --host 0.0.0.0",


### PR DESCRIPTION
### What this PR does

Fixes missing linting dependencies when following the getting-started.md instructions for the first time.
Running the default `gulp` task for the first time after a fresh `npm install` fails as it is missing the lint dependencies.
This change makes it so that gulp build will be run as a npm post-install task.

Also fixes a typo in the docs

### Checklist

-   No unit tests as there are no source code changes
-   [ x] I've updated CHANGES.md with what I changed.
