### PR TITLE
Add basemap URL parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.70)
+* Fix load of persisted basemap
+* Fix sharing of base map
 * [The next improvement]
 
 #### 8.0.0-alpha.69

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 #### next release (8.0.0-alpha.70)
 * Fix load of persisted basemap
 * Fix sharing of base map
+* Add `baseMapId` URL parameter to allow setting of basemap
 * [The next improvement]
 
 #### 8.0.0-alpha.69

--- a/doc/deploying/controlling-with-url-parameters.md
+++ b/doc/deploying/controlling-with-url-parameters.md
@@ -22,6 +22,7 @@ Parameter      | Meaning
 `start=`...      | Load a map view previously saved without URL shortening. The argument is a URL-encoded JSON structure defined using an internal format described below.
 `<initfile>`     | Load catalog file as described below.
 `hideWelcomeMessage` | Forces the welcome message not to be displayed.
+`baseMapId`=...  | Use the specified basemap, instead of the default.
 
 ### Catalog files (init files)
 
@@ -73,7 +74,7 @@ The `start=` parameter essentially embeds an entire catalog file in the URL. The
                 "east": ...,
                 "north": -...
             },
-            "baseMapName": "Positron (Light)",
+            "baseMapId": "basemap-positron",
             "viewerMode": "3d"
         }
     ]

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -680,23 +680,44 @@ export default class Terria {
     }
   }
 
+  /**
+   * Loading of basemap is done in the following order
+   * - first try to load basemap set in the URL parameter `baseMapId`
+   * - if it is not defined try to load persisted basemap
+   * - lastly try to load init basemap
+   */
   @action
   loadPersistedOrInitBaseMap(): void {
-    const persistedBaseMapId = this.getLocalProperty("basemap");
-    const baseMapSearch = this.baseMaps.find(
-      baseMap => baseMap.mappable.uniqueId === persistedBaseMapId
-    );
-    if (baseMapSearch) {
-      this.mainViewer.baseMap = baseMapSearch.mappable;
-    } else {
-      console.error(
-        `Couldn't find a basemap for unique id ${persistedBaseMapId}. Trying to load init base map.`
-      );
+    const baseMapId = this.userProperties.get("baseMapId");
+    if (baseMapId) {
       const baseMapSearch = this.baseMaps.find(
-        baseMap => baseMap.mappable.uniqueId === this.initBaseMapId
+        baseMap => baseMap.mappable.uniqueId === baseMapId
       );
       if (baseMapSearch) {
         this.mainViewer.baseMap = baseMapSearch.mappable;
+      } else {
+        console.error(
+          `Couldn't find a basemap for unique id ${baseMapId}. Trying to load persisted base map.`
+        );
+      }
+    }
+    if (!isDefined(this.mainViewer.baseMap)) {
+      const persistedBaseMapId = this.getLocalProperty("basemap");
+      const baseMapSearch = this.baseMaps.find(
+        baseMap => baseMap.mappable.uniqueId === persistedBaseMapId
+      );
+      if (baseMapSearch) {
+        this.mainViewer.baseMap = baseMapSearch.mappable;
+      } else {
+        console.error(
+          `Couldn't find a basemap for unique id ${persistedBaseMapId}. Trying to load init base map.`
+        );
+        const baseMapSearch = this.baseMaps.find(
+          baseMap => baseMap.mappable.uniqueId === this.initBaseMapId
+        );
+        if (baseMapSearch) {
+          this.mainViewer.baseMap = baseMapSearch.mappable;
+        }
       }
     }
   }

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -673,13 +673,6 @@ export default class Terria {
     }
   }
 
-  setBaseMaps(baseMaps: BaseMapModel[]): void {
-    processBaseMaps(baseMaps, this);
-    if (!this.mainViewer.baseMap) {
-      this.loadPersistedOrInitBaseMap();
-    }
-  }
-
   @action
   loadPersistedOrInitBaseMap(): void {
     const persistedBaseMapId = this.getLocalProperty("basemap");
@@ -775,6 +768,10 @@ export default class Terria {
 
     if (this.baseMaps.length === 0) {
       processBaseMaps(defaultBaseMaps(this), this);
+    }
+
+    if (!this.mainViewer.baseMap) {
+      this.loadPersistedOrInitBaseMap();
     }
   }
 
@@ -952,7 +949,7 @@ export default class Terria {
       Array.isArray(initData.baseMaps) &&
       initData.baseMaps.length > 0
     ) {
-      this.setBaseMaps(<BaseMapModel[]>(<unknown>initData.baseMaps));
+      processBaseMaps(<BaseMapModel[]>(<unknown>initData.baseMaps), this);
     }
 
     if (isJsonObject(initData.homeCamera)) {

--- a/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
+++ b/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
@@ -316,7 +316,10 @@ function addViewSettings(terria, viewState, initSource) {
     .toJson();
   initSource.homeCamera = terria.mainViewer.homeCamera.toJson();
   if (viewer.baseMap !== undefined) {
-    initSource.baseMapName = viewer.baseMap.name;
+    initSource.baseMapId = viewer.baseMap.uniqueId;
+  }
+  if (terria.previewBaseMapId !== undefined) {
+    initSource.previewBaseMapId = terria.previewBaseMapId;
   }
   initSource.viewerMode = viewerMode;
   initSource.currentTime = time;


### PR DESCRIPTION
### What this PR does

Fixes #5347

Implements the `baseMapId` URL parameter which can be used to set the basemap. Continues the work from #5353. 
Loading of basemap is done in the following order
 - first, try to load basemap set in the URL parameter `baseMapId`
 - if it is not defined try to load persisted basemap
 - lastly, try to load init basemap

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
