### PR TITLE
WMS tileWidth and tileHeight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### next release (8.0.0-alpha.70)
 * Change default basemap images to relative paths.
+* Add `tileWidth` and `tileHeight` traits to `WebMapServiceCatalogItem`.
 * [The next improvement]
 
 #### 8.0.0-alpha.69

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -1149,6 +1149,8 @@ class WebMapServiceCatalogItem
           ...dimensionParameters,
           styles: this.styles === undefined ? "" : this.styles
         },
+        tileWidth: this.tileWidth,
+        tileHeight: this.tileHeight,
         tilingScheme: /*defined(this.tilingScheme) ? this.tilingScheme :*/ new WebMercatorTilingScheme(),
         maximumLevel: maximumLevel,
         rectangle: rectangle,

--- a/lib/Traits/WebMapServiceCatalogItemTraits.ts
+++ b/lib/Traits/WebMapServiceCatalogItemTraits.ts
@@ -205,6 +205,22 @@ export default class WebMapServiceCatalogItemTraits extends mixTraits(
 
   @primitiveTrait({
     type: "number",
+    name: "Tile width (in pixels)",
+    description:
+      "Tile width in pixels. This will be added to `GetMap` requests for map tiles using the `width` parameter. Default value is 256 pixels"
+  })
+  tileWidth: number = 256;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Tile height (in pixels)",
+    description:
+      "Tile height in pixels. This will be added to `GetMap` requests for map tiles using the `height` parameter. Default value is 256 pixels"
+  })
+  tileHeight: number = 256;
+
+  @primitiveTrait({
+    type: "number",
     name: "Minimum Scale Denominator",
     description:
       "The denominator of the largest scale (smallest denominator) for which tiles should be requested. " +

--- a/test/Models/WebMapServiceCatalogItemSpec.ts
+++ b/test/Models/WebMapServiceCatalogItemSpec.ts
@@ -91,6 +91,8 @@ describe("WebMapServiceCatalogItem", function() {
         expect(mapItems[0].imageryProvider.url).toBe(
           "test/WMS/single_metadata_url.xml"
         );
+        expect(mapItems[0].imageryProvider.tileHeight).toBe(256);
+        expect(mapItems[0].imageryProvider.tileWidth).toBe(256);
       }
     } finally {
       cleanup();
@@ -117,6 +119,38 @@ describe("WebMapServiceCatalogItem", function() {
       await wms.loadMetadata();
       //@ts-ignore
       expect(mapItems[0].imageryProvider.layers).toBe("landsat_barest_earth");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("uses tileWidth and tileHeight", async function() {
+    let wms: WebMapServiceCatalogItem;
+    const terria = new Terria();
+    wms = new WebMapServiceCatalogItem("test", terria);
+    runInAction(() => {
+      wms.setTrait("definition", "url", "test/WMS/single_metadata_url.xml");
+      wms.setTrait(
+        "definition",
+        "layers",
+        "mobile-black-spot-programme:funded-base-stations-group"
+      );
+      wms.setTrait("definition", "tileWidth", 512);
+      wms.setTrait("definition", "tileHeight", 512);
+    });
+    let mapItems: ImageryParts[] = [];
+    const cleanup = autorun(() => {
+      mapItems = wms.mapItems.slice();
+    });
+    try {
+      await wms.loadMetadata();
+      expect(
+        mapItems[0].imageryProvider instanceof WebMapServiceImageryProvider
+      ).toBeTruthy();
+      if (mapItems[0].imageryProvider instanceof WebMapServiceImageryProvider) {
+        expect(mapItems[0].imageryProvider.tileHeight).toBe(512);
+        expect(mapItems[0].imageryProvider.tileWidth).toBe(512);
+      }
     } finally {
       cleanup();
     }


### PR DESCRIPTION
### What this PR does

All this PR does is add `tileWidth` and `tileHeight` traits to `WebMapServiceCatalogItemTraits`, and add the traits to `WebMapServiceImageryProviderOptions`

### To Test

Select one of the Web Mercator layers - not VicGrid94.

http://ci.terria.io/wms-tilewidthheight/#clean&https://gist.githubusercontent.com/nf-s/49949c938a81469bfd442b535ff3bd7b/raw/03096be7b1b2d43e06ec2dbca62ab919fc1ee87b/wms-tilewidth-tileheight.json

### Example catalog

https://gist.githubusercontent.com/nf-s/49949c938a81469bfd442b535ff3bd7b/raw/dfc0c4130d5cec9e66ba70ff29076282b4e5db06/wms-tilewidth-tileheight

```json
{
  "homeCamera": {
    "north": -8,
    "east": 158,
    "south": -45,
    "west": 109
  },
  "catalog": [
    {
      "type": "wms-group",
      "url": "https://base.maps.vic.gov.au/service?service=WMS&request=GetCapabilities&version=1.3.0",
      "name": "Vic Map",
      "itemProperties": {
        "tileWidth": 512,
        "tileHeight": 512,
        "opacity": 1
      }
    },
  ]
}
```

### Checklist

-   [x] Added test
-   [x] I've updated CHANGES.md with what I changed.
