### PR TITLE
Hide basemap entry in basemap menu 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.70)
+* Add `hideInBaseMapMenu` option to `BaseMapModel`.
 * Change default basemap images to relative paths.
 * Add `tileWidth` and `tileHeight` traits to `WebMapServiceCatalogItem`.
 * [The next improvement]

--- a/doc/customizing/initialization-files.md
+++ b/doc/customizing/initialization-files.md
@@ -234,6 +234,7 @@ Definition of the baseMap model.
 |----|--------|----|-------|-----------|
 |item|yes|[**Catalog Item**](../connecting-to-data/catalog-items.md)||Catalog item defition to be used for the base map|
 |image|yes|**string**||Path to an image file of the baseMap image to be shown in Map Settings|
+|hideInBaseMapMenu|no|**boolean**|`false`|Useful for eg, when a basemap entry is only meant to be used as a member of a composite basemap and must be hidden from the basemap listing|
 
 ### Cartesian 3
 |Name|Required|Type|Default|Description|

--- a/lib/Models/BaseMaps/BaseMapModel.ts
+++ b/lib/Models/BaseMaps/BaseMapModel.ts
@@ -13,7 +13,7 @@ export interface BaseMapModel {
   item: BaseModel;
   // Useful for eg, when a basemap entry is only meant to be used as a member
   // of a composite basemap and must be hidden from the basemap listing
-  hideInBaseMapListing?: boolean;
+  hideInBaseMapMenu?: boolean;
 }
 
 export function processBaseMaps(newBaseMaps: BaseMapModel[], terria: Terria) {
@@ -46,7 +46,7 @@ export function processBaseMaps(newBaseMaps: BaseMapModel[], terria: Terria) {
     );
     if (MappableMixin.isMixedInto(model)) {
       if (CatalogMemberMixin.isMixedInto(model)) model.loadMetadata();
-      if (newBaseMap.hideInBaseMapListing !== true) {
+      if (newBaseMap.hideInBaseMapMenu !== true) {
         terria.baseMaps.push(new BaseMapViewModel(model, newBaseMap.image));
       }
     }

--- a/lib/Models/BaseMaps/BaseMapModel.ts
+++ b/lib/Models/BaseMaps/BaseMapModel.ts
@@ -11,6 +11,9 @@ import MappableMixin from "../../ModelMixins/MappableMixin";
 export interface BaseMapModel {
   image: string;
   item: BaseModel;
+  // Useful for eg, when a basemap entry is only meant to be used as a member
+  // of a composite basemap and must be hidden from the basemap listing
+  hideInBaseMapListing?: boolean;
 }
 
 export function processBaseMaps(newBaseMaps: BaseMapModel[], terria: Terria) {
@@ -43,7 +46,9 @@ export function processBaseMaps(newBaseMaps: BaseMapModel[], terria: Terria) {
     );
     if (MappableMixin.isMixedInto(model)) {
       if (CatalogMemberMixin.isMixedInto(model)) model.loadMetadata();
-      terria.baseMaps.push(new BaseMapViewModel(model, newBaseMap.image));
+      if (newBaseMap.hideInBaseMapListing !== true) {
+        terria.baseMaps.push(new BaseMapViewModel(model, newBaseMap.image));
+      }
     }
   });
 }


### PR DESCRIPTION
### What this PR does

Added option `hideInBaseMapMenu` to hide basemap entry in basemap listing.

### Why we need this? 
Some of our basemaps are composite catalog items combining multiple base maps. For this use-case we need to add base map entries as member of the composite map item, but the member itself should not be listed in the base map menu. This option can be used to hide the composite member from the basemap menu.

```
"baseMaps": [
...
{
      "item": {
        "id": "basemap-topographic-member",
        "type": "wms",
        "url": "https://base.maps.someservice.com/service?service=wms",
        "layers":"SOME_LAYER",
        "tileWidth": 512,
        "tileHeight": 512
      },
      "image": "images/basemaps/topographic.png",
      "hideInBaseMapMenu": true
    },
  {
      "item": {
        "id": "basemap-topographic",
        "name": "VIC Topographic",
        "type": "composite",
        "members": ["basemap-topographic-member", "basemap-bing-roads"]
      },
      "image": "images/basemaps/topographic.png"
    }
]
```

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
