### PR TITLE
fix setting previewedItemId from initData

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.72)
+* Fix sharing preview item.
 * [The next improvement]
 
 #### 8.0.0-alpha.71

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -994,6 +994,7 @@ export default class Terria {
       ? initData.timeline.slice()
       : [];
 
+    // NOTE: after this Promise, this function is no longer an `@action`
     const models = initData.models;
     if (isJsonObject(models)) {
       await Promise.all(
@@ -1014,9 +1015,11 @@ export default class Terria {
       );
     }
 
-    if (isJsonString(initData.previewedItemId)) {
-      this.previewedItemId = initData.previewedItemId;
-    }
+    runInAction(() => {
+      if (isJsonString(initData.previewedItemId)) {
+        this.previewedItemId = initData.previewedItemId;
+      }
+    });
 
     // Set the new contents of the workbench.
     const newItems = filterOutUndefined(


### PR DESCRIPTION
### fix setting `previewedItemId` from `initData`

Shares of preview items were broken:

- http://ci.terria.io/next/#share=s-dm0YV80UAlujq5LSpbQYVGPT9iZ
- http://ci.terria.io/fix-preview-share/#share=s-dm0YV80UAlujq5LSpbQYVGPT9iZ

### Checklist

-   [x] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [x] I've updated CHANGES.md with what I changed.
