### PR TITLE
Fix Cesium rendering crash when clipping rectangle is not within tiling scheme rectangle

### DIFF
--- a/lib/ModelMixins/MappableMixin.ts
+++ b/lib/ModelMixins/MappableMixin.ts
@@ -1,3 +1,5 @@
+import { computed } from "mobx";
+import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import TerrainProvider from "terriajs-cesium/Source/Core/TerrainProvider";
 import DataSource from "terriajs-cesium/Source/DataSources/DataSource";
 import Cesium3DTileset from "terriajs-cesium/Source/Scene/Cesium3DTileset";
@@ -17,12 +19,10 @@ export type MapItem =
 
 // Shouldn't this be a class?
 export interface ImageryParts {
-  // TODO
   alpha: number;
-  // wms: boolean;
-  // isGeoServer: boolean;
-  show: boolean;
+  clippingRectangle: Rectangle | undefined;
   imageryProvider: ImageryProvider;
+  show: boolean;
 }
 
 // This discriminator only discriminates between ImageryParts and DataSource
@@ -52,6 +52,25 @@ function MappableMixin<T extends Constructor<Model<MappableTraits>>>(Base: T) {
   abstract class MappableMixin extends Base {
     get isMappable() {
       return true;
+    }
+
+    @computed
+    get cesiumRectangle() {
+      if (
+        this.rectangle !== undefined &&
+        this.rectangle.east !== undefined &&
+        this.rectangle.west !== undefined &&
+        this.rectangle.north !== undefined &&
+        this.rectangle.south !== undefined
+      ) {
+        return Rectangle.fromDegrees(
+          this.rectangle.west,
+          this.rectangle.south,
+          this.rectangle.east,
+          this.rectangle.north
+        );
+      }
+      return undefined;
     }
 
     private _mapItemsLoader = new AsyncLoader(

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -40,7 +40,7 @@ import DiscretelyTimeVaryingMixin, {
   DiscreteTimeAsJS
 } from "./DiscretelyTimeVaryingMixin";
 import ExportableMixin, { ExportData } from "./ExportableMixin";
-import MappableMixin, { ImageryParts } from "./MappableMixin";
+import { ImageryParts } from "./MappableMixin";
 
 // TypeScript 3.6.3 can't tell JSRegionProviderList is a class and reports
 //   Cannot use namespace 'JSRegionProviderList' as a type.ts(2709)
@@ -715,7 +715,10 @@ function TableMixin<T extends Constructor<Model<TableTraits>>>(Base: T) {
               return undefined;
             }
           }),
-          show: this.show
+          show: this.show,
+          clippingRectangle: this.clipToRectangle
+            ? this.cesiumRectangle
+            : undefined
         };
       }
     );

--- a/lib/ModelMixins/TileErrorHandlerMixin.ts
+++ b/lib/ModelMixins/TileErrorHandlerMixin.ts
@@ -14,13 +14,15 @@ import CommonStrata from "../Models/CommonStrata";
 import CompositeCatalogItem from "../Models/CompositeCatalogItem";
 import Model from "../Models/Model";
 import CatalogMemberTraits from "../Traits/CatalogMemberTraits";
-import MappableTraits, { RectangleTraits } from "../Traits/MappableTraits";
+import MappableTraits from "../Traits/MappableTraits";
 import RasterLayerTraits from "../Traits/RasterLayerTraits";
 import DiscretelyTimeVaryingMixin from "./DiscretelyTimeVaryingMixin";
+import MappableMixin from "./MappableMixin";
 
 type ModelType = Model<
   MappableTraits & RasterLayerTraits & CatalogMemberTraits
->;
+> &
+  MappableMixin.MappableMixin;
 
 /**
  * A mixin for handling tile errors in raster layers
@@ -95,7 +97,7 @@ function TileErrorHandlerMixin<T extends Constructor<ModelType>>(Base: T) {
       if (
         isTileOutsideExtent(
           tile,
-          runInAction(() => this.rectangle),
+          runInAction(() => this.cesiumRectangle),
           imageryProvider
         )
       ) {
@@ -339,25 +341,20 @@ function TileErrorHandlerMixin<T extends Constructor<ModelType>>(Base: T) {
 
   function isTileOutsideExtent(
     tile: { x: number; y: number; level: number },
-    rectangle: Model<RectangleTraits>,
+    rectangle: Rectangle | undefined,
     imageryProvider: ImageryProvider
-  ) {
-    const { west, south, east, north } = rectangle;
-    if ([west, south, east, north].some(x => x === undefined)) {
-      // If the rectangle is not full defined, assume the tile is inside.
+  ): boolean {
+    if (rectangle === undefined) {
+      // If the rectangle is not defined, assume the tile is inside.
       return false;
     }
-
     const tilingScheme = imageryProvider.tilingScheme;
     const tileExtent = tilingScheme.tileXYToRectangle(
       tile.x,
       tile.y,
       tile.level
     );
-    const intersection = Rectangle.intersection(
-      tileExtent,
-      Rectangle.fromDegrees(west, south, east, north)
-    );
+    const intersection = Rectangle.intersection(tileExtent, rectangle);
     return intersection === undefined;
   }
 

--- a/lib/Models/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/ArcGisMapServerCatalogItem.ts
@@ -2,7 +2,6 @@ import i18next from "i18next";
 import uniqWith from "lodash-es/uniqWith";
 import { computed, runInAction } from "mobx";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
-import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import WebMercatorTilingScheme from "terriajs-cesium/Source/Core/WebMercatorTilingScheme";
 import ArcGisMapServerImageryProvider from "terriajs-cesium/Source/Scene/ArcGisMapServerImageryProvider";
 import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
@@ -17,13 +16,13 @@ import TerriaError from "../Core/TerriaError";
 import proj4definitions from "../Map/Proj4Definitions";
 import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
 import DiscretelyTimeVaryingMixin from "../ModelMixins/DiscretelyTimeVaryingMixin";
+import MappableMixin, { ImageryParts } from "../ModelMixins/MappableMixin";
 import UrlMixin from "../ModelMixins/UrlMixin";
 import ArcGisMapServerCatalogItemTraits from "../Traits/ArcGisMapServerCatalogItemTraits";
 import { InfoSectionTraits } from "../Traits/CatalogMemberTraits";
 import DiscreteTimeTraits from "../Traits/DiscreteTimeTraits";
 import LegendTraits, { LegendItemTraits } from "../Traits/LegendTraits";
 import { RectangleTraits } from "../Traits/MappableTraits";
-import MappableMixin, { ImageryParts } from "../ModelMixins/MappableMixin";
 import CreateModel from "./CreateModel";
 import createStratumInstance from "./createStratumInstance";
 import getToken from "./getToken";
@@ -427,7 +426,8 @@ export default class ArcGisMapServerCatalogItem extends MappableMixin(
     return {
       imageryProvider,
       alpha: this.opacity,
-      show: this.show !== undefined ? this.show : true
+      show: this.show,
+      clippingRectangle: this.clipToRectangle ? this.cesiumRectangle : undefined
     };
   }
 
@@ -447,7 +447,10 @@ export default class ArcGisMapServerCatalogItem extends MappableMixin(
       return {
         imageryProvider,
         alpha: 0.0,
-        show: true
+        show: true,
+        clippingRectangle: this.clipToRectangle
+          ? this.cesiumRectangle
+          : undefined
       };
     } else {
       return undefined;
@@ -464,26 +467,6 @@ export default class ArcGisMapServerCatalogItem extends MappableMixin(
         return;
       }
 
-      let rectangle;
-
-      if (
-        this.clipToRectangle &&
-        this.rectangle !== undefined &&
-        this.rectangle.east !== undefined &&
-        this.rectangle.west !== undefined &&
-        this.rectangle.north !== undefined &&
-        this.rectangle.south !== undefined
-      ) {
-        rectangle = Rectangle.fromDegrees(
-          this.rectangle.west,
-          this.rectangle.south,
-          this.rectangle.east,
-          this.rectangle.north
-        );
-      } else {
-        rectangle = undefined;
-      }
-
       const params: any = Object.assign({}, this.parameters);
       if (time !== undefined) {
         params.time = time;
@@ -498,7 +481,6 @@ export default class ArcGisMapServerCatalogItem extends MappableMixin(
         tilingScheme: new WebMercatorTilingScheme(),
         maximumLevel: maximumLevel,
         parameters: params,
-        rectangle: rectangle,
         enablePickFeatures: this.allowFeaturePicking,
         usePreCachedTilesIfAvailable: !dynamicRequired,
         mapServerData: stratum.mapServerData,

--- a/lib/Models/BingMapsCatalogItem.ts
+++ b/lib/Models/BingMapsCatalogItem.ts
@@ -1,8 +1,8 @@
 import { computed } from "mobx";
 import Credit from "terriajs-cesium/Source/Core/Credit";
 import BingMapsImageryProvider from "terriajs-cesium/Source/Scene/BingMapsImageryProvider";
-import MappableMixin from "../ModelMixins/MappableMixin";
 import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
+import MappableMixin, { MapItem } from "../ModelMixins/MappableMixin";
 import BingMapsCatalogItemTraits from "../Traits/BingMapsCatalogItemTraits";
 import CreateModel from "./CreateModel";
 
@@ -19,13 +19,16 @@ export default class BingMapsCatalogItem extends MappableMixin(
     return Promise.resolve();
   }
 
-  @computed get mapItems() {
+  @computed get mapItems(): MapItem[] {
     const imageryProvider = this._createImageryProvider();
     return [
       {
         imageryProvider,
         show: this.show,
-        alpha: this.opacity
+        alpha: this.opacity,
+        clippingRectangle: this.clipToRectangle
+          ? this.cesiumRectangle
+          : undefined
       }
     ];
   }

--- a/lib/Models/IonImageryCatalogItem.ts
+++ b/lib/Models/IonImageryCatalogItem.ts
@@ -1,7 +1,7 @@
 import { computed } from "mobx";
 import IonImageryProvider from "terriajs-cesium/Source/Scene/IonImageryProvider";
 import isDefined from "../Core/isDefined";
-import MappableMixin from "../ModelMixins/MappableMixin";
+import MappableMixin, { MapItem } from "../ModelMixins/MappableMixin";
 import IonImageryCatalogItemTraits from "../Traits/IonImageryCatalogItemTraits";
 import CreateModel from "./CreateModel";
 
@@ -18,7 +18,7 @@ export default class IonImageryCatalogItem extends MappableMixin(
     return Promise.resolve();
   }
 
-  @computed get mapItems() {
+  @computed get mapItems(): MapItem[] {
     if (!isDefined(this.imageryProvider)) {
       return [];
     }
@@ -26,7 +26,10 @@ export default class IonImageryCatalogItem extends MappableMixin(
       {
         show: this.show,
         alpha: this.opacity,
-        imageryProvider: this.imageryProvider
+        imageryProvider: this.imageryProvider,
+        clippingRectangle: this.clipToRectangle
+          ? this.cesiumRectangle
+          : undefined
       }
     ];
   }

--- a/lib/Models/MapboxVectorTileCatalogItem.ts
+++ b/lib/Models/MapboxVectorTileCatalogItem.ts
@@ -2,12 +2,11 @@ import { VectorTileFeature } from "@mapbox/vector-tile";
 import i18next from "i18next";
 import { clone } from "lodash-es";
 import { action, computed, observable, runInAction } from "mobx";
-import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import ImageryLayerFeatureInfo from "terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo";
 import isDefined from "../Core/isDefined";
 import MapboxVectorTileImageryProvider from "../Map/MapboxVectorTileImageryProvider";
-import MappableMixin from "../ModelMixins/MappableMixin";
 import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
+import MappableMixin, { MapItem } from "../ModelMixins/MappableMixin";
 import UrlMixin from "../ModelMixins/UrlMixin";
 import LegendTraits, { LegendItemTraits } from "../Traits/LegendTraits";
 import MapboxVectorTileCatalogItemTraits from "../Traits/MapboxVectorTileCatalogItemTraits";
@@ -91,13 +90,6 @@ class MapboxVectorTileCatalogItem extends MappableMixin(
         lineJoin: "miter" as CanvasLineJoin,
         lineWidth: 1
       }))({ fillStyle: this.fillColor, strokeStyle: this.lineColor }),
-
-      rectangle: Rectangle.fromDegrees(
-        this.rectangle.west,
-        this.rectangle.south,
-        this.rectangle.east,
-        this.rectangle.north
-      ),
       minimumZoom: this.minimumZoom,
       maximumNativeZoom: this.maximumNativeZoom,
       maximumZoom: this.maximumZoom,
@@ -112,7 +104,7 @@ class MapboxVectorTileCatalogItem extends MappableMixin(
   }
 
   @computed
-  get mapItems() {
+  get mapItems(): MapItem[] {
     if (this.isLoadingMapItems || this.imageryProvider === undefined) {
       return [];
     }
@@ -122,7 +114,9 @@ class MapboxVectorTileCatalogItem extends MappableMixin(
         imageryProvider: this.imageryProvider,
         show: this.show,
         alpha: this.opacity,
-        canZoomTo: this.canZoomTo
+        clippingRectangle: this.clipToRectangle
+          ? this.cesiumRectangle
+          : undefined
       }
     ];
   }

--- a/lib/Models/OpenStreetMapCatalogItem.ts
+++ b/lib/Models/OpenStreetMapCatalogItem.ts
@@ -1,11 +1,10 @@
 import { computed } from "mobx";
-import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import UrlTemplateImageryProvider from "terriajs-cesium/Source/Scene/UrlTemplateImageryProvider";
 import URI from "urijs";
 import isDefined from "../Core/isDefined";
 import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
+import MappableMixin, { MapItem } from "../ModelMixins/MappableMixin";
 import OpenStreetMapCatalogItemTraits from "../Traits/OpenStreetMapCatalogItemTraits";
-import MappableMixin from "../ModelMixins/MappableMixin";
 import CreateModel from "./CreateModel";
 import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
 
@@ -22,7 +21,7 @@ export default class OpenStreetMapCatalogItem extends MappableMixin(
     return Promise.resolve();
   }
 
-  @computed get mapItems() {
+  @computed get mapItems(): MapItem[] {
     const imageryProvider = this.imageryProvider;
     if (!isDefined(imageryProvider)) {
       return [];
@@ -31,7 +30,10 @@ export default class OpenStreetMapCatalogItem extends MappableMixin(
       {
         show: this.show,
         alpha: this.opacity,
-        imageryProvider
+        imageryProvider,
+        clippingRectangle: this.clipToRectangle
+          ? this.cesiumRectangle
+          : undefined
       }
     ];
   }
@@ -41,24 +43,10 @@ export default class OpenStreetMapCatalogItem extends MappableMixin(
       return;
     }
 
-    let rectangle: Rectangle | undefined;
-    if (isDefined(this.rectangle)) {
-      const { west, south, east, north } = this.rectangle;
-      if (
-        isDefined(west) &&
-        isDefined(south) &&
-        isDefined(east) &&
-        isDefined(north)
-      ) {
-        rectangle = Rectangle.fromDegrees(west, south, east, north);
-      }
-    }
-
     return new UrlTemplateImageryProvider({
       url: cleanAndProxyUrl(this, this.templateUrl),
       subdomains: this.subdomains.slice(),
       credit: this.attribution,
-      rectangle: rectangle,
       maximumLevel: this.maximumLevel
     });
   }

--- a/lib/Models/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/WebMapTileServiceCatalogItem.ts
@@ -1,16 +1,15 @@
 import i18next from "i18next";
 import { computed, runInAction } from "mobx";
 import defined from "terriajs-cesium/Source/Core/defined";
-import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import WebMercatorTilingScheme from "terriajs-cesium/Source/Core/WebMercatorTilingScheme";
 import WebMapTileServiceImageryProvider from "terriajs-cesium/Source/Scene/WebMapTileServiceImageryProvider";
 import URI from "urijs";
 import containsAny from "../Core/containsAny";
 import isDefined from "../Core/isDefined";
 import TerriaError from "../Core/TerriaError";
-import MappableMixin from "../ModelMixins/MappableMixin";
 import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
 import GetCapabilitiesMixin from "../ModelMixins/GetCapabilitiesMixin";
+import MappableMixin, { MapItem } from "../ModelMixins/MappableMixin";
 import UrlMixin from "../ModelMixins/UrlMixin";
 import { InfoSectionTraits } from "../Traits/CatalogMemberTraits";
 import LegendTraits from "../Traits/LegendTraits";
@@ -23,6 +22,7 @@ import CreateModel from "./CreateModel";
 import createStratumInstance from "./createStratumInstance";
 import LoadableStratum from "./LoadableStratum";
 import { BaseModel } from "./Model";
+import { ServiceProvider } from "./OwsInterfaces";
 import proxyCatalogItemUrl from "./proxyCatalogItemUrl";
 import StratumFromTraits from "./StratumFromTraits";
 import WebMapTileServiceCapabilities, {
@@ -32,7 +32,6 @@ import WebMapTileServiceCapabilities, {
   WmtsCapabilitiesLegend,
   WmtsLayer
 } from "./WebMapTileServiceCapabilities";
-import { ServiceProvider } from "./OwsInterfaces";
 
 interface UsableTileMatrixSets {
   identifiers: string[];
@@ -534,26 +533,6 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
       return;
     }
 
-    let rectangle;
-
-    if (
-      this.clipToRectangle &&
-      this.rectangle !== undefined &&
-      this.rectangle.east !== undefined &&
-      this.rectangle.west !== undefined &&
-      this.rectangle.north !== undefined &&
-      this.rectangle.south !== undefined
-    ) {
-      rectangle = Rectangle.fromDegrees(
-        this.rectangle.west,
-        this.rectangle.south,
-        this.rectangle.east,
-        this.rectangle.north
-      );
-    } else {
-      rectangle = undefined;
-    }
-
     const imageryProvider = new WebMapTileServiceImageryProvider({
       url: proxyCatalogItemUrl(this, baseUrl),
       layer: layerIdentifier,
@@ -566,7 +545,6 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
       tileHeight: tileMatrixSet.tileHeight,
       tilingScheme: new WebMercatorTilingScheme(),
       format,
-      rectangle,
       credit: this.attribution
     });
     return imageryProvider;
@@ -651,13 +629,16 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
   }
 
   @computed
-  get mapItems() {
+  get mapItems(): MapItem[] {
     if (isDefined(this.imageryProvider)) {
       return [
         {
           alpha: this.opacity,
           show: this.show,
-          imageryProvider: this.imageryProvider
+          imageryProvider: this.imageryProvider,
+          clippingRectangle: this.clipToRectangle
+            ? this.cesiumRectangle
+            : undefined
         }
       ];
     }

--- a/test/Map/PickedFeaturesSpec.ts
+++ b/test/Map/PickedFeaturesSpec.ts
@@ -34,7 +34,9 @@ describe("featureBelongsToCatalogItem", function() {
     });
     feature.imageryLayer = new ImageryLayer(imageryProvider);
     expect(featureBelongsToCatalogItem(feature, item)).toBe(false);
-    item.mapItems = [{ imageryProvider, alpha: 0, show: false }];
+    item.mapItems = [
+      { imageryProvider, alpha: 0, show: false, clippingRectangle: undefined }
+    ];
     expect(featureBelongsToCatalogItem(feature, item)).toBe(true);
   });
 });

--- a/test/ModelMixins/TileErrorHandlerMixinSpec.ts
+++ b/test/ModelMixins/TileErrorHandlerMixinSpec.ts
@@ -4,6 +4,7 @@ import Resource from "terriajs-cesium/Source/Core/Resource";
 import TileProviderError from "terriajs-cesium/Source/Core/TileProviderError";
 import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
 import WebMapServiceImageryProvider from "terriajs-cesium/Source/Scene/WebMapServiceImageryProvider";
+import MappableMixin, { MapItem } from "../../lib/ModelMixins/MappableMixin";
 import TileErrorHandlerMixin from "../../lib/ModelMixins/TileErrorHandlerMixin";
 import CommonStrata from "../../lib/Models/CommonStrata";
 import CreateModel from "../../lib/Models/CreateModel";
@@ -16,13 +17,15 @@ import ShowableTraits from "../../lib/Traits/ShowableTraits";
 import UrlTraits from "../../lib/Traits/UrlTraits";
 
 class TestCatalogItem extends TileErrorHandlerMixin(
-  CreateModel(
-    mixTraits(
-      UrlTraits,
-      ShowableTraits,
-      RasterLayerTraits,
-      MappableTraits,
-      CatalogMemberTraits
+  MappableMixin(
+    CreateModel(
+      mixTraits(
+        UrlTraits,
+        ShowableTraits,
+        RasterLayerTraits,
+        MappableTraits,
+        CatalogMemberTraits
+      )
     )
   )
 ) {
@@ -41,8 +44,19 @@ class TestCatalogItem extends TileErrorHandlerMixin(
     };
   }
 
-  get mapItems() {
-    return [{ imageryProvider: this.imageryProvider }];
+  protected forceLoadMapItems(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  get mapItems(): MapItem[] {
+    return [
+      {
+        imageryProvider: this.imageryProvider,
+        show: true,
+        alpha: 1,
+        clippingRectangle: undefined
+      }
+    ];
   }
 }
 

--- a/test/Models/IonImageryCatalogItemSpec.ts
+++ b/test/Models/IonImageryCatalogItemSpec.ts
@@ -1,7 +1,8 @@
-import IonImageryCatalogItem from "../../lib/Models/IonImageryCatalogItem";
-import Terria from "../../lib/Models/Terria";
 import { runInAction } from "mobx";
 import IonImageryProvider from "terriajs-cesium/Source/Scene/IonImageryProvider";
+import { ImageryParts } from "../../lib/ModelMixins/MappableMixin";
+import IonImageryCatalogItem from "../../lib/Models/IonImageryCatalogItem";
+import Terria from "../../lib/Models/Terria";
 
 describe("IonImageryCatalogItem", function() {
   let item = new IonImageryCatalogItem("test", new Terria());
@@ -20,11 +21,17 @@ describe("IonImageryCatalogItem", function() {
     });
 
     it("correctly sets the `alpha` value", function() {
+      if (!ImageryParts.is(item.mapItems[0]))
+        throw new Error("Expected MapItem to be an ImageryParts");
+
       runInAction(() => item.setTrait("definition", "opacity", 0.42));
       expect(item.mapItems[0].alpha).toBe(0.42);
     });
 
     it("correctly sets `show`", function() {
+      if (!ImageryParts.is(item.mapItems[0]))
+        throw new Error("Expected MapItem to be an ImageryParts");
+
       runInAction(() => item.setTrait("definition", "show", false));
       expect(item.mapItems[0].show).toBe(false);
       runInAction(() => item.setTrait("definition", "show", true));
@@ -34,6 +41,8 @@ describe("IonImageryCatalogItem", function() {
 
   describe("imageryProvider", function() {
     it("should be a UrlTemplateImageryProvider", function() {
+      if (!ImageryParts.is(item.mapItems[0]))
+        throw new Error("Expected MapItem to be an ImageryParts");
       let imageryProvider = item.mapItems[0].imageryProvider;
       expect(imageryProvider instanceof IonImageryProvider).toBeTruthy();
     });

--- a/test/Models/MapboxVectorTileCatalogItemSpec.ts
+++ b/test/Models/MapboxVectorTileCatalogItemSpec.ts
@@ -1,5 +1,6 @@
 import { action } from "mobx";
 import MapboxVectorTileImageryProvider from "../../lib/Map/MapboxVectorTileImageryProvider";
+import { ImageryParts } from "../../lib/ModelMixins/MappableMixin";
 import CommonStrata from "../../lib/Models/CommonStrata";
 import MapboxVectorTileCatalogItem from "../../lib/Models/MapboxVectorTileCatalogItem";
 import Terria from "../../lib/Models/Terria";
@@ -23,6 +24,9 @@ describe("MapboxVectorTileCatalogItem", function() {
       mvt.setTrait(CommonStrata.user, "url", "http://test");
       mvt.setTrait(CommonStrata.user, "layer", "test-layer");
       await mvt.loadMapItems();
+      if (!ImageryParts.is(mvt.mapItems[0]))
+        throw new Error("Expected MapItem to be an ImageryParts");
+
       imageryProvider = mvt.mapItems[0]
         .imageryProvider as MapboxVectorTileImageryProvider;
     });


### PR DESCRIPTION
### What this PR does

Fixes #5396.

* Add computed cesiumRectangle and change all other places that use item.rectangle to create a Cesium Rectangle to use new computed.
* Move clipping rectangle from ImageryProviders to ImageryLayer creation points to match terriajs v7 and fix Cesium render crash bug
* Update tests affected by these changes
* Fix some type errors in tests. I've started experimenting with throwing exceptions in tests for assertions that help with ts types in the remainder of the test.

(example for last point - changing:
```js
expect(long.expression.to.derive(condition)).toBeTruthy();
if (long.expression.to.derive(condition)) {
  // Remainder of test can now execute and types will recognise that condition is true
}
```

to:

```js
if (!long.expression.to.derive(condition)) throw new Error("Expected <explain condition meaning here>");
// remainder of test will also recognise condition is true
```
which has less repetition and as long as the exception message starts with "Expected" or similar it'll still be clear that it's an expectation failure of sorts)


### Checklist

-   [ ] No tests exist yet for ImageryLayer creating in Cesium.ts
-   [x] I've updated CHANGES.md with what I changed.
