### PR TITLE
Add custom request limits per domain and publish alpha 76

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### next release (8.0.0-alpha.76)
 
+* Added support for setting custom concurrent request limits per domain through `configParameters.customRequestSchedulerLimits`.
 * [The next improvement]
 
 #### 8.0.0-alpha.75

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,14 +3,18 @@ Change Log
 
 ### MobX Development
 
-#### next release (8.0.0-alpha.76)
+#### next release (8.0.0-alpha.77)
+
+* [The next improvement]
+
+
+#### 8.0.0-alpha.76
 
 * Added support for setting custom concurrent request limits per domain through `configParameters.customRequestSchedulerLimits`.
 * Added `momentChart` to region-mapped timeseries
 * Add time-series chart (in FeatureInfo) for region-mapped timeseries
 * Only show `TableMixin` chart if it has more than one
 * Add `TableChartStyle` name trait.
-* [The next improvement]
 
 #### 8.0.0-alpha.75
 

--- a/doc/customizing/client-side-config.md
+++ b/doc/customizing/client-side-config.md
@@ -78,6 +78,9 @@ Specifies various options for configuring TerriaJS:
 |`helpContent`|no|**[HelpContentItem](#HelpContentItem)**|`[]`|The content to be displayed in the help panel.|
 |`helpContentTerms`|no|**[Term](#Term)**|||
 |`languageConfiguration`|no|**[LanguageConfiguration](#LanguageConfiguration)**|undefined|Language configuration of TerriaJS.|
+|`customRequestSchedulerLimits`|no|**object**|undefined|Custom concurrent request limits for domains in Cesium's RequestScheduler.|
+|`persistViewerMode`|no|**boolean**|`true`|Whether to load persisted viewer mode from local storage.|
+|`openAddData`|no|**boolean**|`false`|Whether to open the add data explorer panel on load.|
 
 ### MagdaReferenceHeaders
 

--- a/doc/customizing/client-side-config.md
+++ b/doc/customizing/client-side-config.md
@@ -78,7 +78,7 @@ Specifies various options for configuring TerriaJS:
 |`helpContent`|no|**[HelpContentItem](#HelpContentItem)**|`[]`|The content to be displayed in the help panel.|
 |`helpContentTerms`|no|**[Term](#Term)**|||
 |`languageConfiguration`|no|**[LanguageConfiguration](#LanguageConfiguration)**|undefined|Language configuration of TerriaJS.|
-|`customRequestSchedulerLimits`|no|**object**|undefined|Custom concurrent request limits for domains in Cesium's RequestScheduler.|
+|`customRequestSchedulerLimits`|no|**[RequestScheduler](https://cesium.com/docs/cesiumjs-ref-doc/RequestScheduler.html#.requestsByServer)**|undefined|Custom concurrent request limits for domains in Cesium's RequestScheduler.|
 |`persistViewerMode`|no|**boolean**|`true`|Whether to load persisted viewer mode from local storage.|
 |`openAddData`|no|**boolean**|`false`|Whether to open the add data explorer panel on load.|
 

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -34,6 +34,7 @@ import { isLatLonHeight } from "../Core/LatLonHeight";
 import loadJson5 from "../Core/loadJson5";
 import ServerConfig from "../Core/ServerConfig";
 import TerriaError from "../Core/TerriaError";
+import { Complete } from "../Core/TypeModifiers";
 import { getUriWithoutPath } from "../Core/uriHelpers";
 import PickedFeatures, {
   featureBelongsToCatalogItem,
@@ -213,17 +214,17 @@ interface ConfigParameters {
    */
   languageConfiguration?: LanguageConfiguration;
   /**
-   * Custom concurrent request limits for domains in Cesium's RequestScheduler. Cesium's default is 6 per domain (the maximum allowed by browsers unless the server supports http2). For servers supporting http2 try 12-24 to have more parallel requests. Setting this too high will undermine Cesium's prioritised request scheduling and important data may load slower. Format is {"domain_without_protocol:port": number}
+   * Custom concurrent request limits for domains in Cesium's RequestScheduler. Cesium's default is 6 per domain (the maximum allowed by browsers unless the server supports http2). For servers supporting http2 try 12-24 to have more parallel requests. Setting this too high will undermine Cesium's prioritised request scheduling and important data may load slower. Format is {"domain_without_protocol:port": number}.
    */
   customRequestSchedulerLimits?: Record<string, number>;
 
   /**
-   * Whether to load persisted viewer mode from local storage
+   * Whether to load persisted viewer mode from local storage.
    */
   persistViewerMode?: boolean;
 
   /**
-   * Whether to open the add data explorer panel on load
+   * Whether to open the add data explorer panel on load.
    */
   openAddData?: boolean;
 }
@@ -323,7 +324,7 @@ export default class Terria {
   readonly timelineStack = new TimelineStack(this.timelineClock);
 
   @observable
-  readonly configParameters: ConfigParameters = {
+  readonly configParameters: Complete<ConfigParameters> = {
     appName: "TerriaJS App",
     supportEmail: "info@terria.io",
     defaultMaximumShownFeatureInfos: 100,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.0.0-alpha.75",
+  "version": "8.0.0-alpha.76",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -1,4 +1,5 @@
 import { action, runInAction } from "mobx";
+import RequestScheduler from "terriajs-cesium/Source/Core/RequestScheduler";
 import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSource";
 import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import ImagerySplitDirection from "terriajs-cesium/Source/Scene/ImagerySplitDirection";
@@ -979,5 +980,19 @@ describe("Terria", function() {
       expect(terria.selectedFeature).toBeDefined();
       expect(terria.selectedFeature?.name).toBe("foo");
     });
+  });
+  it("customRequestSchedulerLimits sets RequestScheduler limits for domains", async function() {
+    const configUrl = `data:application/json;base64,${btoa(
+      JSON.stringify({
+        initializationUrls: [],
+        parameters: {
+          customRequestSchedulerLimits: {
+            "test.domain:333": 12
+          }
+        }
+      })
+    )}`;
+    await terria.start({ configUrl, i18nOptions });
+    expect(RequestScheduler.requestsByServer["test.domain:333"]).toBe(12);
   });
 });


### PR DESCRIPTION
### What this PR does

Allows setting custom request limits per domain. This was trialled in https://github.com/TerriaJS/de-australia-map and worked well, however using a limit of 64 is probably too high and will interfere with Cesium's request prioritisation. Values from 12-24 should be the sweet spot for significantly improving performance where parallel requests are the limiting factor.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
