### PR TITLE
Don't render help panel on init

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.77)
-
+* Stopped rendering help panel when it is closed.
 * [The next improvement]
 
 

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -454,7 +454,9 @@ const StandardUserInterface = observer(
                   animationDuration={animationDuration}
                 />
               )}
-            <HelpPanel terria={terria} viewState={this.props.viewState} />
+            {this.props.viewState.showHelpMenu && (
+              <HelpPanel terria={terria} viewState={this.props.viewState} />
+            )}
             <Disclaimer viewState={this.props.viewState} />
           </div>
         </ThemeProvider>


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Currently we are rendering entire help panel at the start although it is not visible, and it might also fix #4670. Profiler is reporting significant increase of the initial rendering time. 
before this change
![image](https://user-images.githubusercontent.com/19208948/115154709-8dc7c300-a07c-11eb-8e86-9896abd11d54.png)

after this change
![image](https://user-images.githubusercontent.com/19208948/115154729-a46e1a00-a07c-11eb-8ce7-c3cf53864112.png)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist) - small UI change
-   [ ] I've updated CHANGES.md with what I changed.
