### PR TITLE
Modify story scene transition to support walk mode transition.

### DIFF
--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -85,6 +85,7 @@ export default class ViewState {
   @observable topElement: string = "FeatureInfo";
   @observable lastUploadedFiles: any[] = [];
   @observable storyBuilderShown: boolean = false;
+  @observable isPedestrianWalkModeOn: boolean = false;
 
   // Flesh out later
   @observable showHelpMenu: boolean = false;

--- a/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
+++ b/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
@@ -336,6 +336,10 @@ function addViewSettings(terria, viewState, initSource) {
     if (viewState.explorerPanelIsVisible && itemIdToUse) {
       initSource.previewedItemId = itemIdToUse;
     }
+
+    if (viewState.isPedestrianWalkModeOn) {
+      initSource.isPedestrianWalkModeOn = viewState.isPedestrianWalkModeOn;
+    }
   }
 }
 

--- a/lib/ReactViews/Tools/PedestrianMode/MovementControls.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MovementControls.tsx
@@ -7,7 +7,7 @@ import Button from "../../../Styled/Button";
 import Spacing from "../../../Styled/Spacing";
 import Text from "../../../Styled/Text";
 import Icon, { StyledIcon } from "../../../Styled/Icon";
-import MovementsController from "./MovementsController";
+import MovementsController, { Mode } from "./MovementsController";
 
 const mouseControlsImage = require("../../../../wwwroot/images/mouse-control.svg");
 const wasdControlsImage = require("../../../../wwwroot/images/wasd.svg");
@@ -15,7 +15,7 @@ const heightControlsImage = require("../../../../wwwroot/images/height-controls.
 
 type MovementControlsProps = {
   cesium: Cesium;
-  onMove: () => void;
+  onMove: (mode: Mode) => void;
   pedestrianHeight: number;
   maxVerticalLookAngle: number;
 };

--- a/lib/ReactViews/Tools/PedestrianMode/MovementsController.ts
+++ b/lib/ReactViews/Tools/PedestrianMode/MovementsController.ts
@@ -61,7 +61,7 @@ export default class MovementsController {
 
   constructor(
     readonly cesium: Cesium,
-    readonly onMove: () => void,
+    readonly onMove: (mode: Mode) => void,
     readonly pedestrianHeight: number,
     readonly maxVerticalLookAngle: number
   ) {
@@ -326,7 +326,7 @@ export default class MovementsController {
     if (this.activeMovements.size > 0) {
       [...this.activeMovements].forEach(movement => this.move(movement));
       this.updateSurfaceHeightEstimate();
-      this.onMove();
+      this.onMove(this.mode);
 
       if (
         this.activeMovements.has("down") &&

--- a/lib/ReactViews/Tools/PedestrianMode/PedestrianMode.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/PedestrianMode.tsx
@@ -7,6 +7,7 @@ import PositionRightOfWorkbench from "../../Workbench/PositionRightOfWorkbench";
 import DropPedestrianToGround from "./DropPedestrianToGround";
 import MiniMap, { getViewFromScene, MiniMapView } from "./MiniMap";
 import MovementControls from "./MovementControls";
+import { Mode } from "./MovementsController";
 
 // The desired camera height measured from the surface in metres
 export const PEDESTRIAN_HEIGHT = 1.7;
@@ -25,13 +26,22 @@ const PedestrianMode: React.FC<PedestrianModeProps> = observer(props => {
   const [view, setView] = useState<MiniMapView | undefined>();
 
   const onDropCancelled = () => viewState.closeTool();
-  const updateView = () => setView(getViewFromScene(cesium.scene));
+  const updateView = (mode: Mode) => {
+    viewState.isPedestrianWalkModeOn = mode === "walk";
+    setView(getViewFromScene(cesium.scene));
+  };
 
   useEffect(function closeOnZoomTo() {
     const disposer = cesium.zoomToEvent.addEventListener(() =>
       viewState.closeTool()
     );
     return disposer;
+  }, []);
+
+  useEffect(function unsetViewStateFlagOnClose() {
+    return () => {
+      viewState.isPedestrianWalkModeOn = false;
+    };
   }, []);
 
   return (


### PR DESCRIPTION
### What this PR does

Fixes #5345 

- [ ] Fix key binding conflicts when activating both story mode and pedestrian mode together
- [x] Transition between story scenes captured in pedestrian "walk" mode should be linear and flat and less like flying.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
