### PR TITLE
Apply new Result/TerriaError pattern to traits.fromJson()

### DIFF
--- a/lib/Core/TerriaError.ts
+++ b/lib/Core/TerriaError.ts
@@ -88,7 +88,7 @@ export default class TerriaError {
     }
 
     return new TerriaError({
-      title: { key: "models.raiseError.errorTitle" },
+      title: { key: "core.terriaError.defaultTitle" },
       message,
       originalError: error instanceof Error ? error : undefined,
       ...overrides
@@ -110,8 +110,8 @@ export default class TerriaError {
     }
     return new TerriaError({
       // Set default title and message
-      title: { key: "models.raiseError.errorMultipleTitle" },
-      message: { key: "models.raiseError.errorMultipleMessage" },
+      title: { key: "core.terriaError.defaultCombineTitle" },
+      message: { key: "core.terriaError.defaultCombineMessage" },
 
       // Add original errors and overrides
       originalError: errors,
@@ -121,7 +121,7 @@ export default class TerriaError {
 
   constructor(options: TerriaErrorOptions) {
     this._message = options.message;
-    this._title = options.title ?? { key: "core.terriaError.defaultValue" };
+    this._title = options.title ?? { key: "core.terriaError.defaultTitle" };
     this.sender = options.sender;
     this._raisedToUser = options.raisedToUser ?? false;
 

--- a/lib/Core/TerriaError.ts
+++ b/lib/Core/TerriaError.ts
@@ -3,6 +3,8 @@
 import i18next from "i18next";
 import { Notification } from "../ReactViewModels/ViewState";
 import { terriaErrorNotification } from "../ReactViews/Notification/terriaErrorNotification";
+import filterOutUndefined from "./filterOutUndefined";
+import flatten from "./flatten";
 import isDefined from "./isDefined";
 
 /** This is used for I18n translation strings so we can "resolve" them when the Error is displayed to the user.
@@ -181,5 +183,18 @@ export default class TerriaError {
       },
       ...overrides
     });
+  }
+
+  flatten(): TerriaError[] {
+    return filterOutUndefined([
+      this,
+      ...flatten(
+        this.originalError
+          ? this.originalError.map(error =>
+              error instanceof TerriaError ? error.flatten() : []
+            )
+          : []
+      )
+    ]);
   }
 }

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -709,7 +709,9 @@
       "failedToGet": "Failed to get server config from {{serverConfigUrl}}. This means services such as proxy, convert and URL shortening may not work."
     },
     "terriaError": {
-      "defaultValue": "An error occurred"
+      "defaultTitle": "An error occurred",
+      "defaultCombineTitle": "Multiple errors occurred",
+      "defaultCombineMessage": "Details of the errors are below"
     }
   },
   "map": {
@@ -1164,8 +1166,6 @@
     },
     "raiseError": {
       "errorTitle": "An error occurred",
-      "errorMultipleTitle": "Multiple errors occurred",
-      "errorMultipleMessage": "Details of the errors are below",
       "notificationFeedback": "To send the error to the developers, click here.",
       "developerDetails": "Developer details"
     },

--- a/lib/Models/Group.ts
+++ b/lib/Models/Group.ts
@@ -1,5 +1,6 @@
-import { BaseModel } from "./Model";
+import Result from "../Core/Result";
 import ModelReference from "../Traits/ModelReference";
+import { BaseModel } from "./Model";
 
 export default interface Group {
   readonly isGroup: boolean;
@@ -12,7 +13,7 @@ export default interface Group {
   loadMembers(): Promise<void>;
   refreshKnownContainerUniqueIds(uniqueId: string | undefined): void;
   add(stratumId: string, member: BaseModel): void;
-  addMembersFromJson(stratumId: string, members: any): void;
+  addMembersFromJson(stratumId: string, members: any): Result;
   remove(stratumId: string, member: BaseModel): void;
   moveMemberToIndex(
     stratumId: string,

--- a/lib/Models/MagdaReference.ts
+++ b/lib/Models/MagdaReference.ts
@@ -525,11 +525,14 @@ export default class MagdaReference extends AccessControlMixin(
       if (stratum === "id" || stratum === "type" || stratum === "shareKeys") {
         return;
       }
-      try {
-        updateModelFromJson(result, stratum, terriaAspect[stratum], true);
-      } catch (err) {
-        result.setTrait(CommonStrata.underride, "isExperiencingIssues", true);
-      }
+      updateModelFromJson(
+        result,
+        stratum,
+        terriaAspect[stratum],
+        true
+      ).catchError(error =>
+        result.setTrait(CommonStrata.underride, "isExperiencingIssues", true)
+      );
     });
 
     if (override) {

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1041,21 +1041,21 @@ export default class Terria {
       }
 
       if (isDefined(loadedModel.target)) {
-        try {
-          updateModelFromJson(
-            loadedModel.target,
-            stratumId,
-            dereferenced || {},
-            replaceStratum
-          );
-        } catch (e) {
+        updateModelFromJson(
+          loadedModel.target,
+          stratumId,
+          dereferenced || {},
+          replaceStratum
+        ).catchError(e =>
           errors.push(
             TerriaError.from(
               e,
-              `Failed to update model from JSON: ${loadedModel.target.uniqueId}`
+              `Failed to update model from JSON: ${
+                loadedModel.target!.uniqueId
+              }`
             )
-          );
-        }
+          )
+        );
       }
     } else if (dereferenced) {
       throw new TerriaError({
@@ -1114,7 +1114,11 @@ export default class Terria {
     }
 
     if (initData.catalog !== undefined) {
-      this.catalog.group.addMembersFromJson(stratumId, initData.catalog);
+      this.catalog.group
+        .addMembersFromJson(stratumId, initData.catalog)
+        .catchError(error => {
+          errors.push(error);
+        });
     }
 
     if (isJsonObject(initData.elements)) {

--- a/lib/Models/WebProcessingServiceCatalogFunctionJob.ts
+++ b/lib/Models/WebProcessingServiceCatalogFunctionJob.ts
@@ -436,7 +436,7 @@ export default class WebProcessingServiceCatalogFunctionJob extends XmlRequestMi
       {
         addModelToTerria: false
       }
-    );
+    ).throwIfError();
     return catalogItem;
   }
 }

--- a/lib/Models/addUserFiles.ts
+++ b/lib/Models/addUserFiles.ts
@@ -42,10 +42,13 @@ export default async function addUserFiles(
   }
 
   function loadInitData(initData: { catalog: any }) {
-    terria.catalog.group.addMembersFromJson(
-      CommonStrata.user,
-      initData.catalog
-    );
+    terria.catalog.group
+      .addMembersFromJson(CommonStrata.user, initData.catalog)
+      .catchError(error => {
+        terria.raiseErrorToUser(
+          TerriaError.from(error, "Failed to load catalog from file")
+        );
+      });
   }
 
   for (let i = 0; i < files.length; i++) {

--- a/lib/Models/upsertModelFromJson.ts
+++ b/lib/Models/upsertModelFromJson.ts
@@ -108,16 +108,20 @@ export default function upsertModelFromJson(
     }
   }
 
-  try {
-    updateModelFromJson(model, stratumName, json, options.replaceStratum);
-  } catch (error) {
+  updateModelFromJson(
+    model,
+    stratumName,
+    json,
+    options.replaceStratum
+  ).catchError(error => {
     errors.push(
       TerriaError.from(error, {
-        message: `Error updating model from JSON: ${model.uniqueId}`
+        message: `Error updating model from JSON: ${model!.uniqueId}`
       })
     );
-    model.setTrait(CommonStrata.underride, "isExperiencingIssues", true);
-  }
+    model!.setTrait(CommonStrata.underride, "isExperiencingIssues", true);
+  });
+
   return new Result(
     model,
     TerriaError.combine(errors, `Error upserting model JSON: ${uniqueId}`)

--- a/lib/Traits/Trait.ts
+++ b/lib/Traits/Trait.ts
@@ -1,4 +1,4 @@
-import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
+import Result from "../Core/Result";
 import { BaseModel } from "../Models/Model";
 
 export interface TraitOptions {
@@ -19,7 +19,11 @@ export default abstract class Trait {
   }
 
   abstract getValue(model: BaseModel): any;
-  abstract fromJson(model: BaseModel, stratumName: string, jsonValue: any): any;
+  abstract fromJson(
+    model: BaseModel,
+    stratumName: string,
+    jsonValue: any
+  ): Result<any | undefined>;
   abstract toJson(value: any): any;
 
   abstract isSameType(trait: Trait): boolean;

--- a/lib/Traits/anyTrait.ts
+++ b/lib/Traits/anyTrait.ts
@@ -1,3 +1,4 @@
+import Result from "../Core/Result";
 import { BaseModel } from "../Models/Model";
 import Trait, { TraitOptions } from "./Trait";
 
@@ -28,8 +29,8 @@ export class AnyTrait extends Trait {
     return undefined;
   }
 
-  fromJson(model: BaseModel, stratumName: string, jsonValue: any): any {
-    return jsonValue;
+  fromJson(model: BaseModel, stratumName: string, jsonValue: any): Result<any> {
+    return Result.return(jsonValue);
   }
 
   toJson(value: any): any {

--- a/lib/Traits/modelReferenceArrayTrait.ts
+++ b/lib/Traits/modelReferenceArrayTrait.ts
@@ -1,13 +1,13 @@
 import { computed } from "mobx";
+import isDefined from "../Core/isDefined";
+import Result from "../Core/Result";
 import TerriaError from "../Core/TerriaError";
+import createStubCatalogItem from "../Models/createStubCatalogItem";
 import { BaseModel } from "../Models/Model";
 import ModelFactory from "../Models/ModelFactory";
 import upsertModelFromJson from "../Models/upsertModelFromJson";
 import ModelReference from "./ModelReference";
-import filterOutUndefined from "../Core/filterOutUndefined";
 import Trait, { TraitOptions } from "./Trait";
-import StubCatalogItem from "../Models/StubCatalogItem";
-import createStubCatalogItem from "../Models/createStubCatalogItem";
 
 export interface ModelArrayTraitOptions extends TraitOptions {
   factory?: ModelFactory;
@@ -79,11 +79,11 @@ export class ModelReferenceArrayTrait extends Trait {
     model: BaseModel,
     stratumName: string,
     jsonValue: any
-  ): ReadonlyArray<ModelReference> {
+  ): Result<ReadonlyArray<ModelReference> | undefined> {
     // TODO: support removals
 
     if (!Array.isArray(jsonValue)) {
-      throw new TerriaError({
+      return Result.error({
         title: "Invalid property",
         message: `Property ${
           this.id
@@ -91,18 +91,23 @@ export class ModelReferenceArrayTrait extends Trait {
       });
     }
 
-    const result = jsonValue.map(jsonElement => {
-      if (typeof jsonElement === "string") {
-        return jsonElement;
-      } else if (typeof jsonElement === "object") {
-        if (this.factory === undefined) {
-          throw new TerriaError({
-            title: "Cannot create Model",
-            message:
-              "A modelReferenceArrayTrait does not have a factory but it contains an embedded model that does not yet exist."
-          });
-        }
-        try {
+    const errors: TerriaError[] = [];
+
+    const result = jsonValue
+      .map(jsonElement => {
+        if (typeof jsonElement === "string") {
+          return jsonElement;
+        } else if (typeof jsonElement === "object") {
+          if (this.factory === undefined) {
+            errors.push(
+              new TerriaError({
+                title: "Cannot create Model",
+                message:
+                  "A modelReferenceArrayTrait does not have a factory but it contains an embedded model that does not yet exist."
+              })
+            );
+            return;
+          }
           const nestedModel = upsertModelFromJson(
             this.factory,
             model.terria,
@@ -110,22 +115,36 @@ export class ModelReferenceArrayTrait extends Trait {
             stratumName,
             jsonElement,
             {}
-          ).throwIfUndefined();
-          return nestedModel.uniqueId!;
-        } catch {
-          const stub = createStubCatalogItem(model.terria);
-          return stub.uniqueId!;
+          ).catchError(error => errors.push(error));
+
+          // Maybe this should throw if undefined?
+          return (
+            nestedModel?.uniqueId ??
+            createStubCatalogItem(model.terria).uniqueId!
+          );
+        } else {
+          errors.push(
+            new TerriaError({
+              title: "Invalid property",
+              message: `Elements of ${
+                this.id
+              } are expected to be strings or objects but instead are of type ${typeof jsonElement}.`
+            })
+          );
         }
-      } else {
-        throw new TerriaError({
-          title: "Invalid property",
-          message: `Elements of ${
-            this.id
-          } are expected to be strings or objects but instead are of type ${typeof jsonElement}.`
-        });
-      }
-    });
-    return result;
+      })
+      .filter(isDefined);
+    return Result.return(
+      result,
+      TerriaError.combine(
+        errors,
+        `Error${
+          errors.length !== 1 ? "s" : ""
+        } occurred while updating modelReferenceArrayTrait model "${
+          model.uniqueId
+        }" from JSON`
+      )
+    );
   }
 
   toJson(value: ReadonlyArray<ModelReference> | undefined): any {

--- a/lib/Traits/objectTrait.ts
+++ b/lib/Traits/objectTrait.ts
@@ -1,4 +1,5 @@
 import { computed } from "mobx";
+import Result from "../Core/Result";
 import TerriaError from "../Core/TerriaError";
 import createStratumInstance from "../Models/createStratumInstance";
 import Model, { BaseModel, ModelConstructor } from "../Models/Model";
@@ -55,32 +56,48 @@ export class ObjectTrait<T extends ModelTraits> extends Trait {
     model: BaseModel,
     stratumName: string,
     jsonValue: any
-  ): StratumFromTraits<T> {
+  ): Result<StratumFromTraits<T> | undefined> {
     const ResultType = this.type;
     const result: any = createStratumInstance(ResultType);
 
     if (this.isNullable && jsonValue === null) {
-      return jsonValue;
+      return Result.return(jsonValue);
     }
+
+    const errors: TerriaError[] = [];
 
     Object.keys(jsonValue).forEach(propertyName => {
       const trait = ResultType.traits[propertyName];
       if (trait === undefined) {
-        throw new TerriaError({
-          title: "Unknown property",
-          message: `${propertyName} is not a valid sub-property of ${this.id}.`
-        });
+        errors.push(
+          new TerriaError({
+            title: "Unknown property",
+            message: `${propertyName} is not a valid sub-property of ${this.id}.`
+          })
+        );
       }
 
       const subJsonValue = jsonValue[propertyName];
       if (subJsonValue === undefined) {
         result[propertyName] = undefined;
       } else {
-        result[propertyName] = trait.fromJson(model, stratumName, subJsonValue);
+        result[propertyName] = trait
+          .fromJson(model, stratumName, subJsonValue)
+          .catchError(error => errors.push(error));
       }
     });
 
-    return result;
+    return Result.return(
+      result,
+      TerriaError.combine(
+        errors,
+        `Error${
+          errors.length !== 1 ? "s" : ""
+        } occurred while updating objectTrait model "${
+          model.uniqueId
+        }" from JSON`
+      )
+    );
   }
 
   toJson(value: StratumFromTraits<T> | undefined): any {

--- a/lib/Traits/primitiveArrayTrait.ts
+++ b/lib/Traits/primitiveArrayTrait.ts
@@ -1,4 +1,4 @@
-import TerriaError from "../Core/TerriaError";
+import Result from "../Core/Result";
 import { BaseModel } from "../Models/Model";
 import Trait, { TraitOptions } from "./Trait";
 
@@ -46,15 +46,19 @@ export class PrimitiveArrayTrait<T> extends Trait {
     return undefined;
   }
 
-  fromJson(model: BaseModel, stratumName: string, jsonValue: any): T[] {
+  fromJson(
+    model: BaseModel,
+    stratumName: string,
+    jsonValue: any
+  ): Result<T[] | undefined> {
     if (!this.isValidJson(jsonValue)) {
-      throw new TerriaError({
+      return Result.error({
         title: "Invalid property",
         message: `Property ${this.id} is expected to be of type ${this.type}[].`
       });
     }
 
-    return jsonValue;
+    return Result.return(jsonValue);
   }
 
   toJson(value: T[]): any {

--- a/lib/Traits/primitiveTrait.ts
+++ b/lib/Traits/primitiveTrait.ts
@@ -1,4 +1,4 @@
-import TerriaError from "../Core/TerriaError";
+import Result from "../Core/Result";
 import { BaseModel } from "../Models/Model";
 import Trait, { TraitOptions } from "./Trait";
 
@@ -41,12 +41,16 @@ export class PrimitiveTrait<T> extends Trait {
     return undefined;
   }
 
-  fromJson(model: BaseModel, stratumName: string, jsonValue: any): T {
+  fromJson(
+    model: BaseModel,
+    stratumName: string,
+    jsonValue: any
+  ): Result<T | undefined> {
     if (
       typeof jsonValue !== this.type &&
       (!this.isNullable || jsonValue !== null)
     ) {
-      throw new TerriaError({
+      return Result.error({
         title: "Invalid property",
         message: `Property ${this.id} is expected to be of type ${
           this.type
@@ -54,7 +58,7 @@ export class PrimitiveTrait<T> extends Trait {
       });
     }
 
-    return jsonValue;
+    return Result.return(jsonValue);
   }
 
   toJson(value: T): any {

--- a/test/Core/ResultSpec.ts
+++ b/test/Core/ResultSpec.ts
@@ -1,0 +1,73 @@
+import TerriaError from "../../lib/Core/TerriaError";
+import Result from "../../lib/Core/Result";
+
+describe("Result", function() {
+  beforeEach(function() {});
+
+  it("Can create Result without error", function() {
+    const result = new Result("what");
+
+    expect(result.ignoreError()).toBe("what");
+    expect(result.throwIfError()).toBe("what");
+    expect(result.throwIfUndefined()).toBe("what");
+    expect(result.error).toBeUndefined();
+
+    let caughtError = false;
+    expect(
+      result.catchError(() => {
+        caughtError = true;
+      })
+    ).toBe("what");
+    expect(caughtError).toBeFalsy();
+
+    const result2 = Result.return("what");
+
+    expect(result2.ignoreError()).toBe("what");
+    expect(result2.throwIfError()).toBe("what");
+    expect(result2.throwIfUndefined()).toBe("what");
+    expect(result.error).toBeUndefined();
+
+    let caughtError2 = false;
+    expect(
+      result2.catchError(() => {
+        caughtError2 = true;
+      })
+    ).toBe("what");
+    expect(caughtError2).toBeFalsy();
+  });
+
+  it("Can create Result with error", function() {
+    const result = new Result(
+      "what",
+      new TerriaError({ message: "some error" })
+    );
+
+    expect(result.ignoreError()).toBe("what");
+    expect(result.throwIfError).toThrow();
+    expect(result.throwIfUndefined).toThrow();
+    expect(result.error?.message).toBe("some error");
+
+    let caughtError = false;
+    expect(
+      result.catchError(() => {
+        caughtError = true;
+      })
+    ).toBe("what");
+    expect(caughtError).toBeTruthy();
+
+    const result2 = Result.return("what", { message: "some error" });
+
+    expect(result2.ignoreError()).toBe("what");
+    expect(result2.throwIfError).toThrow();
+    expect(result2.throwIfUndefined).toThrow();
+    expect(result2.error?.message).toBe("some error");
+
+    let caughtError2 = false;
+    expect(
+      result2.catchError(() => {
+        caughtError2 = true;
+      })
+    ).toBe("what");
+    expect(caughtError2).toBeTruthy();
+  });
+});

--- a/test/Core/TerriaErrorSpec.ts
+++ b/test/Core/TerriaErrorSpec.ts
@@ -1,0 +1,86 @@
+import TerriaError from "../../lib/Core/TerriaError";
+
+describe("TerriaError", function() {
+  beforeEach(function() {});
+
+  it("Can create TerriaError", function() {
+    const test = new TerriaError({ message: "some message" });
+    expect(test.message).toBe("some message");
+    expect(test.title).toBe("core.terriaError.defaultTitle");
+  });
+
+  it("Can create TerriaError from string", function() {
+    const test = TerriaError.from("What what");
+    expect(test.message).toBe("What what");
+    expect(test.title).toBe("core.terriaError.defaultTitle");
+
+    const test2 = TerriaError.from("What what", { title: "Some title" });
+    expect(test2.message).toBe("What what");
+    expect(test2.title).toBe("Some title");
+  });
+
+  it("Can create TerriaError from Error", function() {
+    const error = new Error("What what what");
+    const test = TerriaError.from(error);
+    expect(test.message).toBe("What what what");
+    expect(test.title).toBe("core.terriaError.defaultTitle");
+    expect(test.originalError?.[0]).toBe(error);
+
+    const error2 = new Error("What 2 what");
+    const test2 = TerriaError.from(error2, { title: "Some better title" });
+    expect(test2.message).toBe("What 2 what");
+    expect(test2.title).toBe("Some better title");
+    expect(test2.originalError?.[0]).toBe(error2);
+  });
+
+  it("Can create TerriaError from Object", function() {
+    const error = new Object("some stringy object");
+    const test = TerriaError.from(error);
+    expect(test.message).toBe("some stringy object");
+    expect(test.title).toBe("core.terriaError.defaultTitle");
+    expect(test.originalError?.[0]).toBeUndefined();
+  });
+
+  it("Can create chain of TerriaErrors and combine them", function() {
+    const error = new TerriaError({ message: "some message" });
+    const test = TerriaError.from(error);
+    expect(test).toBe(error);
+
+    const error2 = new TerriaError({ message: "some message" });
+    const test2 = TerriaError.from(error2, "Some other message");
+    expect(test2.message).toBe("Some other message");
+    expect(test2.originalError?.[0].message).toBe("some message");
+
+    const test3 = TerriaError.from(test2, { title: "A title" });
+    expect(test3.message).toBe(test2.message);
+    expect(test3.title).toBe("A title");
+    expect((test3.originalError?.[0] as TerriaError).title).toBe(
+      "core.terriaError.defaultTitle"
+    );
+    const errors = test3.flatten();
+    expect(errors[0].message).toBe(
+      ["Some other message", "Some other message", "some message"][0]
+    );
+    expect(errors[1].message).toBe(
+      ["Some other message", "Some other message", "some message"][1]
+    );
+    expect(errors[2].message).toBe(
+      ["Some other message", "Some other message", "some message"][2]
+    );
+
+    const combined = TerriaError.combine(errors, "A big error");
+    expect(combined?.message).toBe("A big error");
+    expect(combined?.title).toBe("core.terriaError.defaultCombineTitle");
+    expect(combined?.originalError?.length).toBe(3);
+    expect(
+      (combined?.originalError?.[0] as TerriaError).originalError?.length
+    ).toBe(1);
+    expect(
+      (combined?.originalError?.[1] as TerriaError).originalError?.length
+    ).toBe(1);
+    expect(
+      (combined?.originalError?.[2] as TerriaError).originalError?.length
+    ).toBe(0);
+    expect(combined?.flatten().length).toBe(7);
+  });
+});

--- a/test/ModelMixins/TileErrorHandlerMixinSpec.ts
+++ b/test/ModelMixins/TileErrorHandlerMixinSpec.ts
@@ -177,7 +177,7 @@ describe("TileErrorHandlerMixin", function() {
     let raiseEvent: jasmine.Spy;
 
     beforeEach(function() {
-      raiseEvent = spyOn(item.terria.error, "raiseEvent");
+      raiseEvent = spyOn(item.terria, "raiseErrorToUser");
       item.tileErrorHandlingOptions.setTrait(
         CommonStrata.user,
         "thresholdBeforeDisablingItem",
@@ -282,7 +282,7 @@ describe("TileErrorHandlerMixin", function() {
     });
 
     it("reports the last error to the user", async function() {
-      spyOn(item.terria.error, "raiseEvent");
+      spyOn(item.terria, "raiseErrorToUser");
       try {
         await onTileLoadError(item, newError(undefined));
       } catch {}

--- a/test/Models/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/ArcGisMapServerCatalogItemSpec.ts
@@ -216,7 +216,7 @@ describe("ArcGisMapServerCatalogItem", function() {
         });
 
         it("raise an error if requested level is above maximumScaleBeforeMessage", function() {
-          spyOn(item.terria.error, "raiseEvent");
+          spyOn(item.terria, "raiseErrorToUser");
           imageryProvider.requestImage(0, 0, 100);
           expect(item.terria.raiseErrorToUser).toHaveBeenCalled();
         });

--- a/test/Models/CatalogGroupSpec.ts
+++ b/test/Models/CatalogGroupSpec.ts
@@ -40,7 +40,7 @@ describe("CatalogGroup", function() {
         "definition",
         json,
         {}
-      ).throwIfUndefined().result
+      ).throwIfUndefined()
     );
   });
 

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -176,10 +176,12 @@ describe("Terria", function() {
           "Expected initSources[0] to be an InitDataPromise"
         );
         if (isInitDataPromise(terria.initSources[0])) {
-          const data = await terria.initSources[0];
+          const data = await terria.initSources[0].data;
           // JSON parse & stringify to avoid a problem where I think catalog-converter
           //  can return {"id": undefined} instead of no "id"
-          expect(JSON.parse(JSON.stringify(data.data.catalog))).toEqual([
+          expect(
+            JSON.parse(JSON.stringify(data.ignoreError()?.data.catalog))
+          ).toEqual([
             {
               name: groupName,
               type: "group",

--- a/test/Models/updateModelFromJsonSpec.ts
+++ b/test/Models/updateModelFromJsonSpec.ts
@@ -1,10 +1,9 @@
 import { runInAction } from "mobx";
-import Terria from "../../lib/Models/Terria";
-import WebMapServiceCatalogItem from "../../lib/Models/WebMapServiceCatalogItem";
-import updateModelFromJson from "../../lib/Models/updateModelFromJson";
-import { BaseModel } from "../../lib/Models/Model";
 import CommonStrata from "../../lib/Models/CommonStrata";
-import CatalogGroup from "../../lib/Models/CatalogGroupNew";
+import { BaseModel } from "../../lib/Models/Model";
+import Terria from "../../lib/Models/Terria";
+import updateModelFromJson from "../../lib/Models/updateModelFromJson";
+import WebMapServiceCatalogItem from "../../lib/Models/WebMapServiceCatalogItem";
 
 describe("updateModelFromJson", function() {
   let model: BaseModel;
@@ -162,7 +161,26 @@ describe("updateModelFromJson", function() {
       expect("someTrait" in model).toBeFalsy();
       expect("someOtherTrait" in model).toBeFalsy();
       expect(result.error).toBeDefined();
-      expect(result.error?.originalError?.length).toBe(2);
+      expect(result.error?.originalError?.length).toBe(1);
+
+      expect(
+        result.error
+          ?.flatten()
+          .find(
+            error =>
+              error.message ===
+              "The property someTrait is not valid for type wms."
+          )
+      ).toBeDefined();
+      expect(
+        result.error
+          ?.flatten()
+          .find(
+            error =>
+              error.message ===
+              "The property someOtherTrait is not valid for type wms."
+          )
+      ).toBeDefined();
     });
   });
 });

--- a/test/Models/updateModelFromJsonSpec.ts
+++ b/test/Models/updateModelFromJsonSpec.ts
@@ -128,5 +128,41 @@ describe("updateModelFromJson", function() {
         newJson.description
       );
     });
+
+    it("will ignore trait which doesn't exist in model", function() {
+      const model = terria.getModelById(BaseModel, "testgroup")!;
+      const newJson: any = {
+        name: "NewTestGroup",
+        type: "group",
+        id: "testgroup",
+        description: "This is another test group",
+        members: [
+          {
+            id: "3",
+            name: "TestWMS3",
+            type: "wms",
+            url: "test/WMS/single_metadata_url.xml",
+            someTrait: "What what",
+            someOtherTrait: "What what what?"
+          }
+        ]
+      };
+      const result = updateModelFromJson(
+        model,
+        CommonStrata.definition,
+        newJson
+      );
+      expect(model.getTrait(CommonStrata.definition, "name")).toBe(
+        newJson.name
+      );
+      expect(model.getTrait(CommonStrata.definition, "description")).toBe(
+        newJson.description
+      );
+
+      expect("someTrait" in model).toBeFalsy();
+      expect("someOtherTrait" in model).toBeFalsy();
+      expect(result.error).toBeDefined();
+      expect(result.error?.originalError?.length).toBe(2);
+    });
   });
 });

--- a/test/Models/upsertModelFromJsonSpec.ts
+++ b/test/Models/upsertModelFromJsonSpec.ts
@@ -24,7 +24,7 @@ describe("upsertModelFromJson", function() {
       "definition",
       json,
       {}
-    ).throwIfUndefined().result;
+    ).throwIfUndefined();
     expect(model instanceof WebMapServiceCatalogItem).toBe(true);
     expect(model.type).toBe("wms");
 
@@ -59,7 +59,7 @@ describe("upsertModelFromJson", function() {
         "definition",
         json,
         {}
-      ).throwIfUndefined().result;
+      ).throwIfUndefined();
       expect(model instanceof WebMapServiceCatalogGroup).toBe(true);
       expect(model.type).toBe("wms-group");
       return model;
@@ -122,7 +122,7 @@ describe("upsertModelFromJson", function() {
       "definition",
       json,
       {}
-    ).throwIfUndefined().result;
+    ).throwIfUndefined();
     expect(model instanceof WebMapServiceCatalogItem).toBe(true);
     expect(model.type).toBe("wms");
 
@@ -139,7 +139,7 @@ describe("upsertModelFromJson", function() {
         replaceStratum: false,
         matchByShareKey: true
       }
-    ).throwIfUndefined().result;
+    ).throwIfUndefined();
     expect(model).toBe(model2, "Failed to match model by shareKey");
 
     const wms = <WebMapServiceCatalogItem>model;


### PR DESCRIPTION
### Apply new `Result`/`TerriaError` pattern to `traits.fromJson()`

This depends on https://github.com/TerriaJS/terriajs/pull/5429

This makes some changes to how we handle errors update/upserting JSON into the model. If an error is occurred while updating a trait in a model (for example, a trait doesn't exist) it **will not interrupt** updating the model &mdash; it will just add an error message and continue.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
