### PR TITLE
Add theme config parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
   * `Text`'s `styledSize` has been removed. Use the `styledFontSize` prop.
   * `ButtonAsLabel` no longer accepts `dark`. A dark background is now used when `light` is false (or undefined).
 * Fixes CZML catalog item so that it appears on the timeline.
+* Enable `theme` config parameter. This can now be used to override theme properties.
 * [The next improvement]
 
 

--- a/doc/customizing/client-side-config.md
+++ b/doc/customizing/client-side-config.md
@@ -82,6 +82,7 @@ Specifies various options for configuring TerriaJS:
 |`customRequestSchedulerLimits`|no|**[RequestScheduler](https://cesium.com/docs/cesiumjs-ref-doc/RequestScheduler.html#.requestsByServer)**|undefined|Custom concurrent request limits for domains in Cesium's RequestScheduler.|
 |`persistViewerMode`|no|**boolean**|`true`|Whether to load persisted viewer mode from local storage.|
 |`openAddData`|no|**boolean**|`false`|Whether to open the add data explorer panel on load.|
+|`theme`|no|**any**|`{}`|An object used to override theme properties - for example `{"logoHeight": "70px"}`.|
 
 ### MagdaReferenceHeaders
 

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -200,6 +200,12 @@ interface ConfigParameters {
    * True to display welcome message on startup.
    */
   showWelcomeMessage?: boolean;
+
+  // TODO: make themeing TS
+  /** Theme overrides, this is applied in StandardUserInterface and merged in order of highest priority:
+   *  `StandardUserInterface.jsx` `themeOverrides` prop -> `theme` config parameter (this object) -> default `terriaTheme` (see `StandardTheme.jsx`)
+   */
+  theme?: any;
   /**
    * Video to show in welcome message.
    */
@@ -362,6 +368,7 @@ export default class Terria {
     googleAnalyticsKey: undefined,
     rollbarAccessToken: undefined,
     globalDisclaimer: undefined,
+    theme: {},
     showWelcomeMessage: false,
     welcomeMessageVideo: {
       videoTitle: "Getting started with the map",

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -226,7 +226,12 @@ const StandardUserInterface = observer(
 
     render() {
       const { t } = this.props;
-      const mergedTheme = combine(this.props.themeOverrides, terriaTheme, true);
+      // Merge theme in order of highest priority: themeOverrides props -> theme config parameter -> default terriaTheme
+      const mergedTheme = combine(
+        this.props.themeOverrides,
+        combine(this.props.terria.configParameters.theme, terriaTheme, true),
+        true
+      );
       const theme = mergedTheme;
 
       const customElements = processCustomElements(


### PR DESCRIPTION
### Add theme config parameter

Partially fixes https://github.com/TerriaJS/terriajs/issues/5169

Enable `theme` config parameter. This can now be used to override theme properties.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
