### PR TITLE
Change behaviour of Disclaimer to only render deny button if there is a denyAction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Add `cesiumTerrainAssetId` to config.json to allow configuring default terrain.
 * Added in language toggle and first draft of french translation.json
   * This is enabled via language languageConfiguration.enabled inside config.json and relies on the language being both enumerated inside languageConfiguration.langagues and availble under {code}/translation.json
+* Removed `Disclaimer` deny or cancel button when there is no `denyAction` associated with it.
 * [The next improvement]
 
 #### 8.0.0-alpha.78

--- a/lib/ReactViews/Disclaimer.jsx
+++ b/lib/ReactViews/Disclaimer.jsx
@@ -79,6 +79,7 @@ class Disclaimer extends React.Component {
       disclaimer?.message || "Disclaimer text goes here";
     const useSmallScreenInterface = this.props.viewState
       .useSmallScreenInterface;
+    const renderDenyButton = !!disclaimer.denyAction;
     return disclaimer ? (
       <FadeIn isVisible={this.props.viewState.disclaimerVisible}>
         <TopElementBox position="absolute" fullWidth fullHeight centered>
@@ -133,13 +134,15 @@ class Disclaimer extends React.Component {
               centered
               displayInlineBlock={useSmallScreenInterface}
             >
-              <DisclaimerButton
-                denyButton
-                onClick={() => this.deny(disclaimer.denyAction)}
-                fullWidth={useSmallScreenInterface}
-              >
-                {disclaimerDeny}
-              </DisclaimerButton>
+              {renderDenyButton && (
+                <DisclaimerButton
+                  denyButton
+                  onClick={() => this.deny(disclaimer.denyAction)}
+                  fullWidth={useSmallScreenInterface}
+                >
+                  {disclaimerDeny}
+                </DisclaimerButton>
+              )}
               <Choose>
                 <When condition={useSmallScreenInterface}>
                   <Spacing bottom={3} />
@@ -150,7 +153,7 @@ class Disclaimer extends React.Component {
               </Choose>
               <DisclaimerButton
                 onClick={() => this.confirm(disclaimer.confirmAction)}
-                fullWidth={useSmallScreenInterface}
+                fullWidth={useSmallScreenInterface || !renderDenyButton}
                 primary
               >
                 {disclaimerConfirm}

--- a/lib/ReactViews/Disclaimer.jsx
+++ b/lib/ReactViews/Disclaimer.jsx
@@ -79,7 +79,7 @@ class Disclaimer extends React.Component {
       disclaimer?.message || "Disclaimer text goes here";
     const useSmallScreenInterface = this.props.viewState
       .useSmallScreenInterface;
-    const renderDenyButton = !!disclaimer.denyAction;
+    const renderDenyButton = !!disclaimer?.denyAction;
     return disclaimer ? (
       <FadeIn isVisible={this.props.viewState.disclaimerVisible}>
         <TopElementBox position="absolute" fullWidth fullHeight centered>


### PR DESCRIPTION
### What this PR does

For https://github.com/TerriaJS/drought-map/issues/235.

Rather than show a useless cancel button this PR now hides that button unless it does something.

In most cases with sites derived from v8 TerriaMap the denyAction is a redirect to a site, by default https://terria.io. Maybe there should be a follow up PR to remove that default and default to no cancel button when a custom site is not provided. @nf-s what do you think? 

### Checklist

-   [x] Small UI change, no tests
-   [x] I've updated CHANGES.md with what I changed.
