### PR TITLE
Publish alpha 80

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,13 @@ Change Log
 
 ### MobX Development
 
-#### next release (8.0.0-alpha.80)
+#### next release (8.0.0-alpha.81)
+
+* [The next improvement]
+
+#### 8.0.0-alpha.80
 
 * Removed `Disclaimer` deny or cancel button when there is no `denyAction` associated with it.
-* [The next improvement]
 
 #### 8.0.0-alpha.79
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.0.0-alpha.79",
+  "version": "8.0.0-alpha.80",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Publish terriajs@8.0.0-alpha.80.

The most recent build on `next` passes: https://github.com/TerriaJS/terriajs/commit/6f0e8544cdc0e7827c57db2f8fbb058429567389

Diff looks good: https://github.com/TerriaJS/terriajs/compare/8.0.0-alpha.79...publish-alpha-80
