### PR TITLE
Disable pedestrian mode keybindings when entering input in other text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Move notification state change logic from ViewState into new class `NotificationState`
 * Catalog items can now show a disclaimer or message before loading through specifying `InitialMessageTraits`
 * Added Leaflet hack to remove white-gaps between tiles (https://github.com/Leaflet/Leaflet/issues/3575#issuecomment-688644225)
+* Pedestrian mode will no longer respond to "wasd" keys when the user is typing in some input field.
 * [The next improvement]
 
 #### 8.0.0-alpha.81

--- a/lib/ReactViews/Tools/PedestrianMode/MovementsController.ts
+++ b/lib/ReactViews/Tools/PedestrianMode/MovementsController.ts
@@ -365,8 +365,8 @@ export default class MovementsController {
         this.activeMovements.delete(KeyMap[ev.code]);
     };
 
-    document.addEventListener("keydown", onKeyDown);
-    document.addEventListener("keyup", onKeyUp);
+    document.addEventListener("keydown", excludeInputEvents(onKeyDown), true);
+    document.addEventListener("keyup", excludeInputEvents(onKeyUp), true);
 
     const keyMapDestroyer = () => {
       document.removeEventListener("keydown", onKeyDown);
@@ -569,4 +569,25 @@ function rotateVectorAboutAxis(
     vector.clone()
   );
   return rotatedVector;
+}
+
+// A regex matching input tag names
+const inputNodeRe = /input|textarea|select/i;
+
+function excludeInputEvents(
+  handler: (ev: KeyboardEvent) => void
+): (ev: KeyboardEvent) => void {
+  return ev => {
+    const target = ev.target;
+    if (target !== null) {
+      const nodeName = (target as any).nodeName;
+      const isContentEditable = (target as any).getAttribute?.(
+        "contenteditable"
+      );
+      if (isContentEditable || inputNodeRe.test(nodeName)) {
+        return;
+      }
+    }
+    handler(ev);
+  };
 }


### PR DESCRIPTION
### What this PR does

Disables pedestrian mode keybindings when typing input in text fields.

### Testing 
* Visit http://ci.terria.io/disable-pedestrian-mode-key-when-entering-text-input/
* Turn on pedestrian mode. Start typing "wasd" keys in any input field (eg. story builder input fields). The map shouldn't animate when doing this. When the focus is removed from the input field, the map should respond correctly to "wasd" keys.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
