### PR TITLE
Disable pedestrian mode in mobile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Move notification state change logic from ViewState into new class `NotificationState`
 * Catalog items can now show a disclaimer or message before loading through specifying `InitialMessageTraits`
 * Added Leaflet hack to remove white-gaps between tiles (https://github.com/Leaflet/Leaflet/issues/3575#issuecomment-688644225)
+* Disabled pedestrian mode in mobile view.
 * [The next improvement]
 
 #### 8.0.0-alpha.81

--- a/lib/ReactViews/Map/MapNavigation.jsx
+++ b/lib/ReactViews/Map/MapNavigation.jsx
@@ -141,6 +141,7 @@ class MapNavigation extends React.Component {
               <If
                 condition={
                   !this.props.terria.configParameters.disablePedestrianMode &&
+                  !this.props.viewState.useSmallScreenInterface &&
                   this.props.terria.currentViewer instanceof Cesium
                 }
               >


### PR DESCRIPTION
### What this PR does

Fixes #5511 

Disables pedestrian mode in mobile.

### Testing
* Go to http://ci.terria.io/next/
* Turn on mobile view from the dev panel in your browser
* You will see the pedestrian mode button 
![image](https://user-images.githubusercontent.com/1430/119581978-0aca2300-be07-11eb-91d1-b8ee78a180e8.png)
* Now visit http://ci.terria.io/disable-pedestrian-mode-in-mobile/
* Switch to mobile view
* You shouldn't see the pedestrian mode button


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
