### PR TITLE
Fix references to old viewState.notification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Change Log
 * Added Leaflet hack to remove white-gaps between tiles (https://github.com/Leaflet/Leaflet/issues/3575#issuecomment-688644225)
 * Disabled pedestrian mode in mobile view.
 * Pedestrian mode will no longer respond to "wasd" keys when the user is typing in some input field.
+* Fix references to old `viewState.notification`.
 * [The next improvement]
 
 #### 8.0.0-alpha.81

--- a/lib/ReactViewModels/DisclaimerHandler.js
+++ b/lib/ReactViewModels/DisclaimerHandler.js
@@ -86,7 +86,7 @@ export default class DisclaimerHandler {
    * @private
    */
   _openConfirmationModal(catalogItem, callback) {
-    this.viewState.notifications.push(
+    this.viewState.terria.notificationState.addNotificationToQueue(
       combine(
         {
           confirmAction: callback
@@ -97,7 +97,7 @@ export default class DisclaimerHandler {
   }
 
   _openNotificationModel(catalogItem) {
-    this.viewState.notifications.push(
+    this.viewState.terria.notificationState.addNotificationToQueue(
       DisclaimerHandler._generateOptions(catalogItem)
     );
   }

--- a/lib/ReactViews/Map/Navigation/AugmentedVirtualityTool.jsx
+++ b/lib/ReactViews/Map/Navigation/AugmentedVirtualityTool.jsx
@@ -72,7 +72,7 @@ class AugmentedVirtualityTool extends React.Component {
     ) {
       this.experimentalWarningShown = true;
       const { t } = this.props;
-      this.props.viewState.notifications.push({
+      this.props.viewState.terria.notificationState.addNotificationToQueue({
         title: t("AR.title"),
         message: t("AR.experimentalFeatureMessage"),
         confirmText: t("AR.confirmText")
@@ -86,7 +86,7 @@ class AugmentedVirtualityTool extends React.Component {
     if (!this.realignHelpShown) {
       this.realignHelpShown = true;
       const { t } = this.props;
-      this.props.viewState.notifications.push({
+      this.props.viewState.terria.notificationState.addNotificationToQueue({
         title: t("AR.manualAlignmentTitle"),
         message: t("AR.manualAlignmentMessage", {
           img:
@@ -104,7 +104,7 @@ class AugmentedVirtualityTool extends React.Component {
     if (!this.resetRealignHelpShown) {
       this.resetRealignHelpShown = true;
       const { t } = this.props;
-      this.props.viewState.notifications.push({
+      this.props.viewState.terria.notificationState.addNotificationToQueue({
         title: t("AR.resetAlignmentTitle"),
         message: t("AR.resetAlignmentMessage"),
         confirmText: t("AR.confirmText")

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -183,7 +183,7 @@ const StandardUserInterface = observer(
         this.props.terria.stories.length &&
         !this.props.viewState.storyShown
       ) {
-        this.props.viewState.notifications.push({
+        this.props.viewState.terria.notificationState.addNotificationToQueue({
           title: t("sui.notifications.title"),
           message: t("sui.notifications.message"),
           confirmText: t("sui.notifications.confirmText"),


### PR DESCRIPTION
### Fix references to old viewState.notification

Fixes https://github.com/TerriaJS/terriajs/issues/5515

### To test

- http://ci.terria.io/next/#share=s-lk9pQX3Yx6W8rl8Rj2OsetkWumA
- http://ci.terria.io/fix-notification/#share=s-lk9pQX3Yx6W8rl8Rj2OsetkWumA

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
