### PR TITLE
Nudge x-axis tick labels in feature info panel a bit to the left.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@ Change Log
 * GeoJSON Mixin based catalog items can now call an API to retrieve their data as well as fetching it from a url.
 * Changes to loadJson and loadJsonBlob to POST a request body rather than always make a GET request.
 * Added ApiRequestTraits, and refactor ApiTableCatalogItemTraits to use it. `apiUrl` is now `url`.
+* Adjusted styling of x-axis labels in feature info panel to prevent its clipping.
 * [The next improvement]
 
 #### 8.0.0-alpha.81

--- a/lib/ReactViews/Custom/Chart/FeatureInfoPanelChart.jsx
+++ b/lib/ReactViews/Custom/Chart/FeatureInfoPanelChart.jsx
@@ -142,7 +142,12 @@ class Chart extends React.Component {
             numTicks={2}
             stroke="none"
             tickStroke="none"
-            tickLabelProps={() => textStyle}
+            tickLabelProps={() => ({
+              ...textStyle,
+              // nudge the tick label a bit to the left so that we can fit
+              // values up to 8 chars long without getting clipped
+              dx: "-2em"
+            })}
             label={this.props.xAxisLabel}
             labelOffset={3}
             labelProps={textStyle}


### PR DESCRIPTION
### What this PR does

Nudge x-axis tick labels in feature info panel a bit to the left. This is to prevent the rightmost label from getting clipped. It works for labels up to 8 characters long.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
