### PR TITLE
Remove table style `SelectableDimension` from SDMX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 #### next release (8.0.0-alpha.85)
 
+* Remove table style `SelectableDimension` from SDMX
 * [The next improvement]
 
 #### 8.0.0-alpha.84

--- a/lib/Models/SdmxJson/SdmxJsonCatalogItem.ts
+++ b/lib/Models/SdmxJson/SdmxJsonCatalogItem.ts
@@ -96,7 +96,9 @@ export default class SdmxJsonCatalogItem
   @computed
   get selectableDimensions(): SelectableDimension[] {
     return filterOutUndefined([
-      ...super.selectableDimensions,
+      ...super.selectableDimensions.filter(
+        d => d.id !== this.styleDimensions?.id
+      ),
       ...this.sdmxSelectableDimensions,
       this.regionColumnDimensions,
       this.regionProviderDimensions


### PR DESCRIPTION
### Remove table style `SelectableDimension` from SDMX

We don't need the "Display Variable"  `SelectableDimension` for SDMX

![image](https://user-images.githubusercontent.com/6187649/121629384-6579a500-cabe-11eb-8acd-673e410ea92d.png)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
