### PR TITLE
Changes styling of tool title bar to ellipsify overflow text & use

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 
 * Remove table style `SelectableDimension` from SDMX
 * `GyroscopeGuidance` can now be translated.
+* Wraps tool title bar text using `...`.
 * [The next improvement]
 
 #### 8.0.0-alpha.84

--- a/lib/ReactViews/Tools/ToolModal.tsx
+++ b/lib/ReactViews/Tools/ToolModal.tsx
@@ -119,6 +119,7 @@ const Title: React.FC<TitleProps> = props => {
         styledLineHeight="30px"
         overflowEllipsis
         overflowHide
+        noWrap
       >
         {props.title}
       </TitleText>
@@ -128,4 +129,5 @@ const Title: React.FC<TitleProps> = props => {
 
 const TitleText = styled(Text)`
   flex-grow: 2;
+  max-width: 220px;
 `;

--- a/lib/Sass/common/_variables.scss
+++ b/lib/Sass/common/_variables.scss
@@ -187,4 +187,4 @@ $legend-item-height: 16px;
 $legend-padding: $legend-item-height / 2;
 $legend-spacer-height: $legend-padding / 2;
 
-$tool-primary-color: $color-splitter;
+$tool-primary-color: $color-primary;


### PR DESCRIPTION
primary color as bg.

### What this PR does

1. Improves tool title bar styling for long text by truncating long titles using `...`
2. Changes the default color of title bar to primary color.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
