### PR TITLE
GeoJSON CZML template

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 * Added support for `OpenDataSoft` - only point or region based features + timeseries
 * [The next improvement]
 * `GeoJsonMixin`-based catalog items with polygon features can be extruded if a `heightProperty` is specified.
+* Add `czmlTemplate` to `GeoJsonTraits` - it can be used to replace GeoJSON Point features with a CZML packet.
 * [The next improvement]
 
 #### 8.0.0-alpha.85

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -1,7 +1,8 @@
-import { Feature, FeatureCollection, GeoJsonObject } from "geojson";
+import { Feature, FeatureCollection, GeoJsonObject, Point } from "geojson";
 import i18next from "i18next";
-import { action, computed, observable, runInAction } from "mobx";
+import { action, computed, observable, runInAction, toJS } from "mobx";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import clone from "terriajs-cesium/Source/Core/clone";
 import Color from "terriajs-cesium/Source/Core/Color";
 import defaultValue from "terriajs-cesium/Source/Core/defaultValue";
 import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
@@ -13,6 +14,7 @@ import TimeIntervalCollection from "terriajs-cesium/Source/Core/TimeIntervalColl
 import BillboardGraphics from "terriajs-cesium/Source/DataSources/BillboardGraphics";
 import ColorMaterialProperty from "terriajs-cesium/Source/DataSources/ColorMaterialProperty";
 import ConstantProperty from "terriajs-cesium/Source/DataSources/ConstantProperty";
+import CzmlDataSource from "terriajs-cesium/Source/DataSources/CzmlDataSource";
 import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import EntityCollection from "terriajs-cesium/Source/DataSources/EntityCollection";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
@@ -66,7 +68,7 @@ export default function GeoJsonMixin<
 
     readonly canZoomTo = true;
 
-    private _dataSource: GeoJsonDataSource | undefined;
+    private _dataSource: CzmlDataSource | GeoJsonDataSource | undefined;
     protected _file?: File;
 
     @observable private _readyData?: JsonObject;
@@ -112,51 +114,51 @@ export default function GeoJsonMixin<
       return Promise.resolve();
     }
 
-    protected forceLoadMapItems(): Promise<void> {
-      return new Promise<JsonValue | undefined>((resolve, reject) => {
-        this.customDataLoader(resolve, reject);
-        if (isDefined(this._file)) {
-          this.loadFromFile(this._file)
-            .then(resolve)
-            .catch(reject);
-        } else if (isDefined(this.url)) {
-          // try loading from a zip file url or a regular url
-          resolve(this.loadFromUrl(this.url));
-        } else {
-          throw new TerriaError({
-            sender: this,
-            title: i18next.t("models.geoJson.unableToLoadItemTitle"),
-            message: i18next.t("models.geoJson.unableToLoadItemMessage")
-          });
-        }
-      })
-        .then((geoJson: JsonValue | undefined) => {
-          if (!isJsonObject(geoJson)) {
-            throw new TerriaError({
-              title: i18next.t("models.geoJson.errorLoadingTitle"),
-              message: i18next.t("models.geoJson.errorParsingMessage")
-            });
+    protected async forceLoadMapItems(): Promise<void> {
+      try {
+        const geoJson = await new Promise<JsonValue | undefined>(
+          (resolve, reject) => {
+            this.customDataLoader(resolve, reject);
+            if (isDefined(this._file)) {
+              this.loadFromFile(this._file)
+                .then(resolve)
+                .catch(reject);
+            } else if (isDefined(this.url)) {
+              // try loading from a zip file url or a regular url
+              resolve(this.loadFromUrl(this.url));
+            } else {
+              throw new TerriaError({
+                sender: this,
+                title: i18next.t("models.geoJson.unableToLoadItemTitle"),
+                message: i18next.t("models.geoJson.unableToLoadItemMessage")
+              });
+            }
           }
-          return reprojectToGeographic(
-            geoJson,
-            this.terria.configParameters.proj4ServiceBaseUrl
-          );
-        })
-        .then((geoJsonWgs84: JsonObject) => {
-          runInAction(() => {
-            this._readyData = geoJsonWgs84;
-          });
-          return this.loadDataSource(geoJsonWgs84);
-        })
-        .then(dataSource => {
-          this._dataSource = dataSource;
-        })
-        .catch(e => {
-          throw TerriaError.from(e, {
+        );
+        if (!isJsonObject(geoJson)) {
+          throw new TerriaError({
             title: i18next.t("models.geoJson.errorLoadingTitle"),
             message: i18next.t("models.geoJson.errorParsingMessage")
           });
+        }
+        const geoJsonWgs84 = await reprojectToGeographic(
+          geoJson,
+          this.terria.configParameters.proj4ServiceBaseUrl
+        );
+        runInAction(() => {
+          this._readyData = geoJsonWgs84;
         });
+        if (isDefined(this.czmlTemplate)) {
+          this._dataSource = await this.loadCzmlDataSource(geoJsonWgs84);
+        } else {
+          this._dataSource = await this.loadGeoJsonDataSource(geoJsonWgs84);
+        }
+      } catch (e) {
+        throw TerriaError.from(e, {
+          title: i18next.t("models.geoJson.errorLoadingTitle"),
+          message: i18next.t("models.geoJson.errorParsingMessage")
+        });
+      }
     }
 
     @action
@@ -205,7 +207,62 @@ export default function GeoJsonMixin<
       }
     }
 
-    private loadDataSource(geoJson: JsonObject): Promise<GeoJsonDataSource> {
+    private async loadCzmlDataSource(
+      geoJson: JsonObject
+    ): Promise<CzmlDataSource> {
+      if (
+        geoJson.type !== "FeatureCollection" ||
+        !Array.isArray(geoJson.features)
+      ) {
+        throw TerriaError.from(
+          "CZML templating only supports GeoJSON FeatureCollections"
+        );
+      }
+
+      const czmlTemplate = toJS(this.czmlTemplate);
+      const czmlPackets = [];
+
+      // Create a czml packet for each geoJson Point feature
+      // Set czml position (cartographicDegrees) to point coordinates
+      // Set czml properties to feature properties
+      for (let i = 0; i < geoJson.features.length; i++) {
+        const feature = geoJson.features[i] as any;
+        if (feature !== null && feature.geometry?.type === "Point") {
+          const point = feature.geometry as Point;
+          const czml = clone(czmlTemplate ?? {}, true);
+          const coords = point.coordinates;
+          if (coords.length === 2) {
+            coords[2] = 0;
+          }
+          czml.position = {
+            cartographicDegrees: point.coordinates
+          };
+
+          if (feature.properties !== null) {
+            czml.properties = Object.assign(
+              czml.properties ?? {},
+              feature.properties
+            );
+          }
+
+          czmlPackets.push(czml);
+        }
+      }
+
+      const rootCzml = [
+        {
+          id: "document",
+          name: "CZML",
+          version: "1.0"
+        },
+        ...czmlPackets
+      ];
+      return CzmlDataSource.load(rootCzml);
+    }
+
+    private loadGeoJsonDataSource(
+      geoJson: JsonObject
+    ): Promise<GeoJsonDataSource | CzmlDataSource> {
       /* Style information is applied as follows, in decreasing priority:
              - simple-style properties set directly on individual features in the GeoJSON file
              - simple-style properties set as the 'Style' property on the catalog item

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -220,7 +220,14 @@ export default function GeoJsonMixin<
       }
 
       const czmlTemplate = toJS(this.czmlTemplate);
-      const czmlPackets = [];
+
+      const rootCzml = [
+        {
+          id: "document",
+          name: "CZML",
+          version: "1.0"
+        }
+      ];
 
       // Create a czml packet for each geoJson Point feature
       // Set czml position (cartographicDegrees) to point coordinates
@@ -245,18 +252,10 @@ export default function GeoJsonMixin<
             );
           }
 
-          czmlPackets.push(czml);
+          rootCzml.push(czml);
         }
       }
 
-      const rootCzml = [
-        {
-          id: "document",
-          name: "CZML",
-          version: "1.0"
-        },
-        ...czmlPackets
-      ];
       return CzmlDataSource.load(rootCzml);
     }
 

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -1179,7 +1179,7 @@ export default class Cesium extends GlobeOrMap {
       // Try to find catalogItem for picked feature, and use catalogItem.getFeaturesFromPickResult() if it exists - this is used by FeatureInfoMixin
       const catalogItem = picked?.primitive?._catalogItem ?? id?._catalogItem;
 
-      if (typeof catalogItem.getFeaturesFromPickResult === "function") {
+      if (typeof catalogItem?.getFeaturesFromPickResult === "function") {
         const result = catalogItem.getFeaturesFromPickResult.bind(catalogItem)(
           screenPosition,
           picked

--- a/lib/Traits/GeoJsonTraits.ts
+++ b/lib/Traits/GeoJsonTraits.ts
@@ -82,4 +82,31 @@ export class GeoJsonTraits extends mixTraits(
       "The property of each GeoJSON feature that specifies the height. If defined, polygons will be extruded to this property (in meters) above terrain."
   })
   heightProperty?: string;
+
+  @anyTrait({
+    name: "CZML template",
+    description: `CZML template to be used to replace each GeoJSON Point feature. Feature coordinates and properties will automatically be applied to CZML packet, so they can be used as references. If this is defined, \`clampToGround\`, \`style\`, \`perPropertyStyles\`, \`timeProperty\` and \`heightProperty\` will be ignored.
+
+    For example - this will render a cylinder for every point (and use the length and radius feature properties)
+      \`\`\`json
+      {
+        cylinder: {
+          length: {
+            reference: "#properties.length"
+          },
+          bottomRadius: {
+            reference: "#properties.radius"
+          },
+          material: {
+            solidColor: {
+              color: {
+                rgba: [0, 200, 0, 20]
+              }
+            }
+          }
+        }
+      }
+      \`\`\``
+  })
+  czmlTemplate?: JsonObject;
 }

--- a/lib/Traits/GeoJsonTraits.ts
+++ b/lib/Traits/GeoJsonTraits.ts
@@ -94,6 +94,9 @@ export class GeoJsonTraits extends mixTraits(
           length: {
             reference: "#properties.length"
           },
+          topRadius: {
+            reference: "#properties.radius"
+          },
           bottomRadius: {
             reference: "#properties.radius"
           },

--- a/test/Models/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/GeoJsonCatalogItemSpec.ts
@@ -418,6 +418,59 @@ describe("GeoJsonCatalogItem", function() {
     });
   });
 
+  describe("Support for czml templating", () => {
+    it("Sets polygon height properties correctly", async () => {
+      geojson.setTrait(CommonStrata.user, "url", "test/GeoJSON/points.geojson");
+      geojson.setTrait(CommonStrata.user, "czmlTemplate", {
+        cylinder: {
+          length: {
+            reference: "#properties.height"
+          },
+          topRadius: {
+            reference: "#properties.radius"
+          },
+          bottomRadius: {
+            reference: "#properties.radius"
+          },
+          material: {
+            solidColor: {
+              color: {
+                rgba: [0, 200, 0, 20]
+              }
+            }
+          }
+        }
+      });
+      await geojson.loadMapItems();
+
+      const entities = geojson.mapItems[0].entities.values;
+      console.log(entities);
+      expect(entities.length).toEqual(5);
+
+      const entity1 = entities[0];
+      expect(
+        entity1.cylinder?.length?.getValue(terria.timelineClock.currentTime)
+      ).toBe(10);
+      expect(
+        entity1.cylinder?.bottomRadius?.getValue(
+          terria.timelineClock.currentTime
+        )
+      ).toBe(10);
+      expect(entity1.properties?.someOtherProp?.getValue()).toBe("what");
+
+      const entity2 = entities[1];
+      expect(
+        entity2.cylinder?.length?.getValue(terria.timelineClock.currentTime)
+      ).toBe(20);
+      expect(
+        entity2.cylinder?.bottomRadius?.getValue(
+          terria.timelineClock.currentTime
+        )
+      ).toBe(5);
+      expect(entity2.properties?.someOtherProp?.getValue()).toBe("ok");
+    });
+  });
+
   describe("Per features styling", function() {
     it("Applies styles to features according to their properties, respecting string case", async function() {
       const name = "PETER FAGANS GRAVE";

--- a/wwwroot/test/GeoJSON/points.geojson
+++ b/wwwroot/test/GeoJSON/points.geojson
@@ -1,0 +1,77 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "height": 10,
+        "radius": 10,
+        "someOtherProp": "what"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          144.91734981536865,
+          -37.824700770115996
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "height": 20,
+        "radius": 5,
+        "someOtherProp": "ok"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          144.92305755615234,
+          -37.82453127776299
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "height": 5,
+        "radius": 20
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          144.92249965667725,
+          -37.82798884473596
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "height": 30,
+        "radius": 30
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          144.92855072021484,
+          -37.82537873563539
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "height": 25,
+        "radius": 15
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          144.91262912750244,
+          -37.827615977659555
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### What this PR does

CZML template to be used to replace each GeoJSON Point feature. Feature coordinates and properties will automatically be applied to CZML packet, so they can be used as references. If this is defined, `clampToGround`, `style`, `perPropertyStyles`, `timeProperty` and `heightProperty` will be ignored.

For example - this will render a green cylinder for every point (and use the length and radius feature properties)

http://ci.terria.io/geojson-czml-template/#clean&https://gist.githubusercontent.com/nf-s/327a06724f1f00aaafa2052036ed9243/raw/8779ecbcc18b29c827736084be7e54692d5a6cf0/czml-geojson.json

```json
{
      "name": "geojson-czml-test",
      "url": "build/TerriaJS/test/GeoJSON/points.geojson",
      "type": "geojson",
      "czmlTemplate": {
        "cylinder": {
          "length": {
            "reference": "#properties.height"
          },
          "topRadius": {
            "reference": "#properties.radius"
          },
          "bottomRadius": {
            "reference": "#properties.radius"
          },
          "material": {
            "solidColor": {
              "color": {
                "rgba": [
                  0,
                  200,
                  0,
                  255
                ]
              }
            }
          }
        }
      }
    },
```

![image](https://user-images.githubusercontent.com/6187649/123050380-fbf58100-d443-11eb-9d59-f4dcfe43d648.png)


### Checklist

-   [X] There are unit tests to verify my changes are correct
-   [X] I've updated CHANGES.md with what I changed.
