### PR TITLE
Configurable credit links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Fixed point entity creation for TableMixin where different columns are used for point size and colour.
 * Changed MappableMixin's initialMessage to show while map items are loaded. Map items could be displayed behind the disclaimer before a user accepts the disclaimer.
 * Fixed a cyclic dependency between initialMessage and app spinner (globe gif greysreen) that caused the app spinner to be present forever when loading a share link.
+* Removed hardcoded credit links and made it configurable via terria config parameters.
 * [The next improvement]
 
 #### 8.0.0-alpha.86

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -787,6 +787,11 @@
       "csvRegionMappingMessageZeroFound": "Zero region names found for region type {{regionType}}",
       "csvRegionMappingMessageZeroBoundariesFound": "Zero region boundaries found for region {{regionName}}",
       "csvRegionMappingMessageLoadError": "Couldn't load region boundaries for region {{regionName}} {{exception}}"
+    },
+    "extraCreditLinks": {
+      "dataAttribution": "Data attribution",
+      "disclaimer": "Disclaimer",
+      "basemap": "Basemap"
     }
   },
   "models": {

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -243,14 +243,16 @@ export default class Cesium extends GlobeOrMap {
           ?.reverse()
           .forEach(({ url, text }) => {
             // Create a link and insert it after the logo node
+            // Defaults to the given text if no translation is provided
+            const translatedText = i18next.t(text);
             const el = document.createElement("div");
-            el.innerHTML = `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+            el.innerHTML = `<a href="${url}" target="_blank" rel="noopener noreferrer">${translatedText}</a>`;
             const linkNode = el.firstChild as Element | null;
             if (linkNode) {
               logoContainer?.insertAdjacentElement("afterend", linkNode);
             }
           });
-        expandLink.innerText = "Basemap";
+        expandLink.innerText = i18next.t("map.extraCreditLinks.basemap");
       }
     }
 

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -245,12 +245,12 @@ export default class Cesium extends GlobeOrMap {
             // Create a link and insert it after the logo node
             // Defaults to the given text if no translation is provided
             const translatedText = i18next.t(text);
-            const el = document.createElement("div");
-            el.innerHTML = `<a href="${url}" target="_blank" rel="noopener noreferrer">${translatedText}</a>`;
-            const linkNode = el.firstChild as Element | null;
-            if (linkNode) {
-              logoContainer?.insertAdjacentElement("afterend", linkNode);
-            }
+            const a = document.createElement("a");
+            a.href = url;
+            a.target = "_blank";
+            a.rel = "noopener noreferrer";
+            a.innerText = translatedText;
+            logoContainer?.insertAdjacentElement("afterend", a);
           });
         expandLink.innerText = i18next.t("map.extraCreditLinks.basemap");
       }

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -240,7 +240,8 @@ export default class Cesium extends GlobeOrMap {
       }
       if (expandLink) {
         this.terria.configParameters.extraCreditLinks
-          ?.reverse()
+          ?.slice()
+          .reverse()
           .forEach(({ url, text }) => {
             // Create a link and insert it after the logo node
             // Defaults to the given text if no translation is provided

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -239,27 +239,17 @@ export default class Cesium extends GlobeOrMap {
         );
       }
       if (expandLink) {
-        let attributionToAboutPage = document.createElement("div");
-        attributionToAboutPage.innerHTML = `<a href="about.html#data-attribution" target="_blank" rel="noopener noreferrer">Data attribution</a>`;
-        let disclaimerToAboutPage = document.createElement("div");
-        disclaimerToAboutPage.innerHTML = `<a href="about.html#disclaimer" target="_blank" rel="noopener noreferrer">Disclaimer</a>`;
-
-        if (logoContainer && logoContainer.parentNode) {
-          if (disclaimerToAboutPage && disclaimerToAboutPage.firstChild) {
-            logoContainer.parentNode.insertBefore(
-              disclaimerToAboutPage.firstChild,
-              logoContainer.nextSibling
-            );
-          }
-
-          if (attributionToAboutPage && attributionToAboutPage.firstChild) {
-            logoContainer.parentNode.insertBefore(
-              attributionToAboutPage.firstChild,
-              logoContainer.nextSibling
-            );
-          }
-        }
-
+        this.terria.configParameters.extraCreditLinks
+          ?.reverse()
+          .forEach(({ url, text }) => {
+            // Create a link and insert it after the logo node
+            const el = document.createElement("div");
+            el.innerHTML = `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+            const linkNode = el.firstChild as Element | null;
+            if (linkNode) {
+              logoContainer?.insertAdjacentElement("afterend", linkNode);
+            }
+          });
         expandLink.innerText = "Basemap";
       }
     }

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -423,9 +423,12 @@ export default class Terria {
     feedbackPreamble: "feedback.feedbackPreamble",
     feedbackMinLength: 0,
     extraCreditLinks: [
-      // Default credit links (currently shown at the bottom of the Cesium map)
-      { text: "Data attribution", url: "about.html#data-attribution" },
-      { text: "Disclaimer", url: "about.html#disclaimer" }
+      // Default credit links (shown at the bottom of the Cesium map)
+      {
+        text: "map.extraCreditLinks.dataAttribution",
+        url: "about.html#data-attribution"
+      },
+      { text: "map.extraCreditLinks.disclaimer", url: "about.html#disclaimer" }
     ]
   };
 

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -255,6 +255,9 @@ interface ConfigParameters {
    */
   feedbackMinLength?: number;
 
+  /**
+   * Extra links to show in the credit line at the bottom of the map (currently only the Cesium map).
+   */
   extraCreditLinks?: { url: string; text: string }[];
 }
 

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -254,6 +254,8 @@ interface ConfigParameters {
    * Minimum length of feedback comment.
    */
   feedbackMinLength?: number;
+
+  extraCreditLinks?: { url: string; text: string }[];
 }
 
 interface StartOptions {
@@ -416,7 +418,12 @@ export default class Terria {
     persistViewerMode: true,
     openAddData: false,
     feedbackPreamble: "feedback.feedbackPreamble",
-    feedbackMinLength: 0
+    feedbackMinLength: 0,
+    extraCreditLinks: [
+      // Default credit links (currently shown at the bottom of the Cesium map)
+      { text: "Data attribution", url: "about.html#data-attribution" },
+      { text: "Disclaimer", url: "about.html#disclaimer" }
+    ]
   };
 
   @observable


### PR DESCRIPTION
### What this PR does

Replaces the hardcoded credit links with links configurable via config parameters.

This is required especially for maps that have about pages that are not located at the hardcoded locations.

### Testing

* Visit the [ci link](http://ci.terria.io/custom-credit-links/#configUrl=https://gist.githubusercontent.com/na9da/6c5c76313faae147c2589de3069fe046/raw/0be24f0807aad0852094835147aab321373b9e16/custom-credit-links.json).
* Check out the 3 links at the bottom credit line that configured via the config parameters.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
