### PR TITLE
Fixes a bug with numeric item search where it sometimes fails to return all matching values.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### MobX Development
 
 #### next release (8.0.0-alpha.88)
+* Fixed a bug with numeric item search where it sometimes fails to return all matching values.
 * [The next improvement]
 #### 8.0.0-alpha.87
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,6 @@ Change Log
 
 #### next release (8.0.0-alpha.88)
 * Fixed a bug with numeric item search where it sometimes fails to return all matching values.
-
 * Fix datetime button margin with scroll in workbench.
 * Fix checkbox when click happen on svg icon. (#5550)
 * [The next improvement]

--- a/lib/Models/ItemSearchProviders/NumericIndex.ts
+++ b/lib/Models/ItemSearchProviders/NumericIndex.ts
@@ -21,7 +21,7 @@ type NumericSearchQuery = {
 export default class NumericIndex implements IndexBase<NumericSearchQuery> {
   readonly type = IndexType.numeric;
 
-  private idValuePairs?: Promise<{ dataRowId: number; value: number }[]>;
+  idValuePairs?: Promise<{ dataRowId: number; value: number }[]>;
 
   /**
    * Constructs a NumericIndex.
@@ -73,8 +73,12 @@ export default class NumericIndex implements IndexBase<NumericSearchQuery> {
       { value: endValue },
       (a, b) => a.value - b.value
     );
-    const startIndex = i < 0 ? ~i : i;
-    const endIndex = j < 0 ? ~j : j;
+    let startIndex = i < 0 ? ~i : i;
+    let endIndex = j < 0 ? ~j : j;
+    // iterate startIndex backward till we find the first matching value
+    while (idValuePairs[startIndex - 1]?.value === value.start) startIndex -= 1;
+    // iterate endIndex forward till we find the last matching value
+    while (idValuePairs[endIndex + 1]?.value === value.end) endIndex += 1;
     const matchingIds = idValuePairs
       .slice(startIndex, endIndex + 1)
       .map(({ dataRowId }) => dataRowId);

--- a/lib/Models/ItemSearchProviders/NumericIndex.ts
+++ b/lib/Models/ItemSearchProviders/NumericIndex.ts
@@ -69,14 +69,13 @@ export default class NumericIndex implements IndexBase<NumericSearchQuery> {
       { dataRowId: 0, value: startValue },
       entry => entry.value
     );
-    const endIndex =
-      sortedLastIndexBy(
-        idValuePairs,
-        { dataRowId: 0, value: endValue },
-        entry => entry.value
-      ) - 1;
+    const endIndex = sortedLastIndexBy(
+      idValuePairs,
+      { dataRowId: 0, value: endValue },
+      entry => entry.value
+    );
     const matchingIds = idValuePairs
-      .slice(startIndex, endIndex + 1)
+      .slice(startIndex, endIndex)
       .map(({ dataRowId }) => dataRowId);
     return new Set(matchingIds);
   }

--- a/test/Models/ItemSearchProviders/NumericIndexSpec.ts
+++ b/test/Models/ItemSearchProviders/NumericIndexSpec.ts
@@ -1,0 +1,23 @@
+import NumericIndex from "../../../lib/Models/ItemSearchProviders/NumericIndex";
+
+describe("NumericIndex", function() {
+  describe("search", function() {
+    it("should return all matching IDs when the start and end values are the same", async function() {
+      const index = new NumericIndex("", { min: 0, max: 10 });
+      index.idValuePairs = Promise.resolve([
+        { dataRowId: 0, value: 0 },
+        { dataRowId: 1, value: 1 },
+        { dataRowId: 2, value: 2 },
+        { dataRowId: 3, value: 3 },
+        { dataRowId: 4, value: 3 },
+        { dataRowId: 5, value: 3 },
+        { dataRowId: 6, value: 3 },
+        { dataRowId: 7, value: 3 },
+        { dataRowId: 8, value: 9 },
+        { dataRowId: 9, value: 10 }
+      ]);
+      const ids = await index.search({ start: 3, end: 3 });
+      expect([...ids]).toEqual([3, 4, 5, 6, 7]);
+    });
+  });
+});

--- a/test/Models/ItemSearchProviders/NumericIndexSpec.ts
+++ b/test/Models/ItemSearchProviders/NumericIndexSpec.ts
@@ -2,7 +2,7 @@ import NumericIndex from "../../../lib/Models/ItemSearchProviders/NumericIndex";
 
 describe("NumericIndex", function() {
   describe("search", function() {
-    it("returns all matching IDs", async function() {
+    it("returns all matching IDs when the search query is within the index range", async function() {
       const index = new NumericIndex("", { min: 0, max: 10 });
       index.idValuePairs = Promise.resolve([
         { dataRowId: 0, value: 0 },
@@ -18,6 +18,24 @@ describe("NumericIndex", function() {
       ]);
       const ids = await index.search({ start: 1, end: 9 });
       expect([...ids]).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    });
+
+    it("returns all matching IDs when the end value of the search query is outside the index range", async function() {
+      const index = new NumericIndex("", { min: 0, max: 10 });
+      index.idValuePairs = Promise.resolve([
+        { dataRowId: 0, value: 0 },
+        { dataRowId: 1, value: 1 },
+        { dataRowId: 2, value: 2 },
+        { dataRowId: 3, value: 3 },
+        { dataRowId: 4, value: 3 },
+        { dataRowId: 5, value: 3 },
+        { dataRowId: 6, value: 3 },
+        { dataRowId: 7, value: 3 },
+        { dataRowId: 8, value: 9 },
+        { dataRowId: 9, value: 10 }
+      ]);
+      const ids = await index.search({ start: 1, end: 100 });
+      expect([...ids]).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
     });
 
     it("returns all matching IDs when the start and end values are the same", async function() {

--- a/test/Models/ItemSearchProviders/NumericIndexSpec.ts
+++ b/test/Models/ItemSearchProviders/NumericIndexSpec.ts
@@ -2,7 +2,25 @@ import NumericIndex from "../../../lib/Models/ItemSearchProviders/NumericIndex";
 
 describe("NumericIndex", function() {
   describe("search", function() {
-    it("should return all matching IDs when the start and end values are the same", async function() {
+    it("returns all matching IDs", async function() {
+      const index = new NumericIndex("", { min: 0, max: 10 });
+      index.idValuePairs = Promise.resolve([
+        { dataRowId: 0, value: 0 },
+        { dataRowId: 1, value: 1 },
+        { dataRowId: 2, value: 2 },
+        { dataRowId: 3, value: 3 },
+        { dataRowId: 4, value: 3 },
+        { dataRowId: 5, value: 3 },
+        { dataRowId: 6, value: 3 },
+        { dataRowId: 7, value: 3 },
+        { dataRowId: 8, value: 9 },
+        { dataRowId: 9, value: 10 }
+      ]);
+      const ids = await index.search({ start: 1, end: 9 });
+      expect([...ids]).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    });
+
+    it("returns all matching IDs when the start and end values are the same", async function() {
       const index = new NumericIndex("", { min: 0, max: 10 });
       index.idValuePairs = Promise.resolve([
         { dataRowId: 0, value: 0 },
@@ -18,6 +36,26 @@ describe("NumericIndex", function() {
       ]);
       const ids = await index.search({ start: 3, end: 3 });
       expect([...ids]).toEqual([3, 4, 5, 6, 7]);
+    });
+
+    it("returns an empty set when the start and end values are outside the range of the index", async function() {
+      const index = new NumericIndex("", { min: 0, max: 10 });
+      index.idValuePairs = Promise.resolve([
+        { dataRowId: 0, value: 0 },
+        { dataRowId: 1, value: 1 },
+        { dataRowId: 2, value: 2 },
+        { dataRowId: 3, value: 3 },
+        { dataRowId: 4, value: 3 },
+        { dataRowId: 5, value: 3 },
+        { dataRowId: 6, value: 3 },
+        { dataRowId: 7, value: 3 },
+        { dataRowId: 8, value: 9 },
+        { dataRowId: 9, value: 10 }
+      ]);
+      let ids = await index.search({ start: 30, end: 40 });
+      expect(ids.size).toBe(0);
+      ids = await index.search({ start: -10, end: -20 });
+      expect(ids.size).toBe(0);
     });
   });
 });


### PR DESCRIPTION
### What this PR does

Fixes #5562 

Basically if a numeric index has multiple repeating values, currently the search might not return all the matching results.


### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
