### PR TITLE
Show searchtool load progress

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 
 * Fix datetime button margin with scroll in workbench.
 * Fix checkbox when click happen on svg icon. (#5550)
+* Added progress indicator when loading item search tool.
 * [The next improvement]
 
 #### 8.0.0-alpha.87

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -1525,6 +1525,7 @@
     "missingContent": "missing content"
   },
   "itemSearchTool": {
+    "toolLoadError": "Error loading search tool.",
     "title": "Search {{itemName}}",
     "loading": "Loading search parameters",
     "loadError": "Error loading search parameters. Check console for detailed errors.",

--- a/lib/ReactViews/Errors/RaiseToUserErrorBoundary.tsx
+++ b/lib/ReactViews/Errors/RaiseToUserErrorBoundary.tsx
@@ -1,0 +1,29 @@
+import i18next from "i18next";
+import React, { ErrorInfo } from "react";
+import ViewState from "../../ReactViewModels/ViewState";
+
+/**
+ * An error boundary that raise the error to the user.
+ */
+export default class RaiseToUserErrorBoundary extends React.Component<{
+  viewState: ViewState;
+}> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(error: any) {
+    return {
+      hasError: true
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    const newError = new Error(i18next.t("itemSearchTool.toolLoadError"));
+    newError.name = error.name;
+    newError.stack = error.stack;
+    this.props.viewState.terria.raiseErrorToUser(newError);
+  }
+
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}

--- a/lib/ReactViews/Errors/RaiseToUserErrorBoundary.tsx
+++ b/lib/ReactViews/Errors/RaiseToUserErrorBoundary.tsx
@@ -3,7 +3,7 @@ import React, { ErrorInfo } from "react";
 import ViewState from "../../ReactViewModels/ViewState";
 
 /**
- * An error boundary that raise the error to the user.
+ * An error boundary that raises the error to the user.
  */
 export default class RaiseToUserErrorBoundary extends React.Component<{
   viewState: ViewState;

--- a/lib/ReactViews/Errors/RaiseToUserErrorBoundary.tsx
+++ b/lib/ReactViews/Errors/RaiseToUserErrorBoundary.tsx
@@ -1,13 +1,19 @@
-import i18next from "i18next";
 import React, { ErrorInfo } from "react";
+import TerriaError, { TerriaErrorOverrides } from "../../Core/TerriaError";
 import ViewState from "../../ReactViewModels/ViewState";
+
+type PropsType = {
+  viewState: ViewState;
+  // Pass in options to customize the title and other presentation aspects of the error
+  terriaErrorOptions?: TerriaErrorOverrides;
+};
 
 /**
  * An error boundary that raises the error to the user.
  */
-export default class RaiseToUserErrorBoundary extends React.Component<{
-  viewState: ViewState;
-}> {
+export default class RaiseToUserErrorBoundary extends React.Component<
+  PropsType
+> {
   state = { hasError: false };
 
   static getDerivedStateFromError(error: any) {
@@ -17,10 +23,9 @@ export default class RaiseToUserErrorBoundary extends React.Component<{
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    const newError = new Error(i18next.t("itemSearchTool.toolLoadError"));
-    newError.name = error.name;
-    newError.stack = error.stack;
-    this.props.viewState.terria.raiseErrorToUser(newError);
+    this.props.viewState.terria.raiseErrorToUser(
+      TerriaError.from(error, this.props.terriaErrorOptions)
+    );
   }
 
   render() {

--- a/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import React, { Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -30,7 +31,12 @@ const LazyItemSearchTool: React.FC<PropsType> = props => {
         </Frame>
       }
     >
-      <RaiseToUserErrorBoundary viewState={viewState}>
+      <RaiseToUserErrorBoundary
+        viewState={viewState}
+        terriaErrorOptions={{
+          title: i18next.t("itemSearchTool.toolLoadError")
+        }}
+      >
         <ItemSearchTool {...props} />
       </RaiseToUserErrorBoundary>
     </Suspense>

--- a/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
@@ -1,10 +1,9 @@
-import i18next from "i18next";
-import React, { ErrorInfo, Suspense } from "react";
+import React, { Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import CatalogMemberMixin from "../../../ModelMixins/CatalogMemberMixin";
-import ViewState from "../../../ReactViewModels/ViewState";
 import AnimatedSpinnerIcon from "../../../Styled/AnimatedSpinnerIcon";
+import RaiseToUserErrorBoundary from "../../Errors/RaiseToUserErrorBoundary";
 import { Frame, Main } from "../ToolModal";
 import { PropsType } from "./ItemSearchTool";
 
@@ -31,9 +30,9 @@ const LazyItemSearchTool: React.FC<PropsType> = props => {
         </Frame>
       }
     >
-      <LazyLoadErrorBoundary viewState={viewState}>
+      <RaiseToUserErrorBoundary viewState={viewState}>
         <ItemSearchTool {...props} />
-      </LazyLoadErrorBoundary>
+      </RaiseToUserErrorBoundary>
     </Suspense>
   );
 };
@@ -42,26 +41,5 @@ const Wrapper = styled(Main)`
   align-items: center;
   justify-content: center;
 `;
-
-class LazyLoadErrorBoundary extends React.Component<{ viewState: ViewState }> {
-  state = { hasError: false };
-
-  static getDerivedStateFromError(error: any) {
-    return {
-      hasError: true
-    };
-  }
-
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    const newError = new Error(i18next.t("itemSearchTool.toolLoadError"));
-    newError.name = error.name;
-    newError.stack = error.stack;
-    this.props.viewState.terria.raiseErrorToUser(newError);
-  }
-
-  render() {
-    return this.state.hasError ? null : this.props.children;
-  }
-}
 
 export default LazyItemSearchTool;

--- a/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
@@ -1,0 +1,67 @@
+import i18next from "i18next";
+import React, { ErrorInfo, Suspense } from "react";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import CatalogMemberMixin from "../../../ModelMixins/CatalogMemberMixin";
+import ViewState from "../../../ReactViewModels/ViewState";
+import AnimatedSpinnerIcon from "../../../Styled/AnimatedSpinnerIcon";
+import { Frame, Main } from "../ToolModal";
+import { PropsType } from "./ItemSearchTool";
+
+const ItemSearchTool = React.lazy(() => import("./ItemSearchTool"));
+
+/**
+ * Lazily loads the item search tool.
+ */
+const LazyItemSearchTool: React.FC<PropsType> = props => {
+  const { viewState, item } = props;
+  const itemName = CatalogMemberMixin.isMixedInto(item) ? item.name : "Item";
+  const [t] = useTranslation();
+
+  return (
+    <Suspense
+      fallback={
+        <Frame
+          viewState={viewState}
+          title={t("itemSearchTool.title", { itemName })}
+        >
+          <Wrapper>
+            <AnimatedSpinnerIcon light styledWidth="25px" styledHeight="25px" />
+          </Wrapper>
+        </Frame>
+      }
+    >
+      <LazyLoadErrorBoundary viewState={viewState}>
+        <ItemSearchTool {...props} />
+      </LazyLoadErrorBoundary>
+    </Suspense>
+  );
+};
+
+const Wrapper = styled(Main)`
+  align-items: center;
+  justify-content: center;
+`;
+
+class LazyLoadErrorBoundary extends React.Component<{ viewState: ViewState }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(error: any) {
+    return {
+      hasError: true
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    const newError = new Error(i18next.t("itemSearchTool.toolLoadError"));
+    newError.name = error.name;
+    newError.stack = error.stack;
+    this.props.viewState.terria.raiseErrorToUser(newError);
+  }
+
+  render() {
+    return this.state.hasError ? null : this.props.children;
+  }
+}
+
+export default LazyItemSearchTool;

--- a/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
@@ -10,7 +10,7 @@ import { PropsType } from "./ItemSearchTool";
 const ItemSearchTool = React.lazy(() => import("./ItemSearchTool"));
 
 /**
- * Lazily loads the item search tool.
+ * Lazily loads the item search tool while showing a the search window and an animated spinner.
  */
 const LazyItemSearchTool: React.FC<PropsType> = props => {
   const { viewState, item } = props;

--- a/lib/ReactViews/Tools/ItemSearchTool/SearchForm.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/SearchForm.tsx
@@ -315,6 +315,8 @@ const Input = styled.input`
   color: ${p => p.theme.dark};
   box-sizing: border-box;
   width: 100%;
+  height: 38px;
+  font-size: 1.1em;
 `;
 
 const Select = styled(ReactSelect).attrs({

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.jsx
@@ -31,6 +31,7 @@ import { exportData } from "../../Preview/ExportData";
 import WorkbenchButton from "../WorkbenchButton";
 import Styles from "./viewing-controls.scss";
 import AnimatedSpinnerIcon from "../../../Styled/AnimatedSpinnerIcon";
+import LazyItemSearchTool from "../../Tools/ItemSearchTool/LazyItemSearchTool";
 import {
   Category,
   DataSourceAction
@@ -247,10 +248,7 @@ const ViewingControls = observer(
       }
       this.props.viewState.openTool({
         toolName: "Search Item",
-        getToolComponent: () =>
-          import("../../Tools/ItemSearchTool/ItemSearchTool").then(
-            m => m.default
-          ),
+        getToolComponent: () => LazyItemSearchTool,
         showCloseButton: false,
         params: {
           item,


### PR DESCRIPTION
### What this PR does

Fixes #5563 

Adds a `LazyItemSearchTool` to show a loading shell while the actual `ItemSearchTool` loads.

This change is required because currently there is no progress indicator between clicking the `Search` button and showing the search form. This could take several seconds depending on the available network speed and the user can get the feeling that the app is broken.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
