### PR TITLE
Issue/5606 tidy up format string used in `MagdaReference`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * `TableStyles` will only be created for `text` columns if there are no columns of type `scalar`, `enum` or `region`.
 * Fix sharing user added data of type "Auto-detect".
 * [The next improvement]
+* #5605 tidy up format string used in `MagdaReference`
 
 #### 8.0.0-alpha.87
 

--- a/lib/Models/MagdaReference.ts
+++ b/lib/Models/MagdaReference.ts
@@ -97,15 +97,15 @@ export default class MagdaReference extends AccessControlMixin(
     }),
     createStratumInstance(MagdaDistributionFormatTraits, {
       id: "EsriFeatureServer",
-      formatRegex: "ESRI MAPSERVER", // TO DO - tidy up this magda format reference
-      urlRegex: "FeatureServer$|FeatureServer/$",
+      formatRegex: "ESRI (MAPSERVER|FEATURESERVER)", // We still allow `ESRI MAPSERVER` to be considered for compatibility reason
+      urlRegex: "FeatureServer$|FeatureServer/$", // url Regex will exclude MapServer urls
       definition: {
         type: "esri-featureServer-group"
       }
     }),
     createStratumInstance(MagdaDistributionFormatTraits, {
       id: "EsriFeatureServer",
-      formatRegex: "ESRI MAPSERVER", // TO DO - tidy up this magda format reference
+      formatRegex: "ESRI (MAPSERVER|FEATURESERVER)", // We still allow `ESRI MAPSERVER` to be considered for compatibility reason
       urlRegex: "FeatureServer/d",
       definition: {
         type: "esri-featureServer"


### PR DESCRIPTION
### What this PR does

Fixes #5606
Tidy up format string used in `MagdaReference`:
- We previously try to match `ESRI MAPSERVER` format string for the actual ESRI FeatureServer url.
  - We've cleaned up format string generated by Magda format minion in this per: https://github.com/magda-io/magda-minion-format/pull/13
  - We should clean up similarly in `MagdaReference` as well
- Why we match regex `ESRI (MAPSERVER|FEATURESERVER)`?
  - This way it's still backwards compatible and urlregex already excluded potential ESRI MapServer Url  


### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
