### PR TITLE
fix wms get feature info feature count

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,9 @@ Change Log
 * Add `nullColor` to `ConstantColorMap` - used when `colorColumn` is of type `region` to hide regions where rows don't exist.
 * `TableStyles` will only be created for `text` columns if there are no columns of type `scalar`, `enum` or `region`.
 * Fix sharing user added data of type "Auto-detect".
-* [The next improvement]
 * #5605 tidy up format string used in `MagdaReference`
+* Fix wms feature info returning only one feature
+* [The next improvement]
 
 #### 8.0.0-alpha.87
 

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -103,7 +103,7 @@ interface ConfigParameters {
   /**
    * The maximum number of "feature info" boxes that can be displayed when clicking a point.
    */
-  defaultMaximumShownFeatureInfos?: number;
+  defaultMaximumShownFeatureInfos: number;
   /**
    * URL of the JSON file that defines region mapping for CSV files.
    */

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -1186,7 +1186,7 @@ class WebMapServiceCatalogItem
           ...dimensionParameters,
           feature_count:
             1 +
-            (this.maximumShownFeatureInfos ||
+            (this.maximumShownFeatureInfos ??
               this.terria.configParameters.defaultMaximumShownFeatureInfos)!,
           styles: this.styles === undefined ? "" : this.styles
         },

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -1187,7 +1187,7 @@ class WebMapServiceCatalogItem
           feature_count:
             1 +
             (this.maximumShownFeatureInfos ??
-              this.terria.configParameters.defaultMaximumShownFeatureInfos)!,
+              this.terria.configParameters.defaultMaximumShownFeatureInfos),
           styles: this.styles === undefined ? "" : this.styles
         },
         tileWidth: this.tileWidth,

--- a/lib/Models/WebMapServiceCatalogItem.ts
+++ b/lib/Models/WebMapServiceCatalogItem.ts
@@ -1158,10 +1158,7 @@ class WebMapServiceCatalogItem
         "width",
         "height",
         "bbox",
-        "layers",
-        // This is here as a temporary fix until Cesium implements this fix
-        // https://github.com/CesiumGS/cesium/issues/9021
-        "version"
+        "layers"
       ];
 
       const baseUrl = queryParametersToRemove.reduce(
@@ -1187,6 +1184,10 @@ class WebMapServiceCatalogItem
         parameters: parameters,
         getFeatureInfoParameters: {
           ...dimensionParameters,
+          feature_count:
+            1 +
+            (this.maximumShownFeatureInfos ||
+              this.terria.configParameters.defaultMaximumShownFeatureInfos)!,
           styles: this.styles === undefined ? "" : this.styles
         },
         tileWidth: this.tileWidth,

--- a/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.jsx
@@ -42,7 +42,9 @@ const FeatureInfoCatalogItem = observer(
         // Display no more than defined number of feature infos
         totalFeaturesCount = features.length;
         if (defined(catalogItem)) {
-          maximumShownFeatureInfos = catalogItem.maximumShownFeatureInfos;
+          if (catalogItem.maximumShownFeatureInfos) {
+            maximumShownFeatureInfos = catalogItem.maximumShownFeatureInfos;
+          }
           featureInfoTemplate = catalogItem.featureInfoTemplate;
         }
         hiddenNumber = totalFeaturesCount - maximumShownFeatureInfos; // A positive hiddenNumber => some are hidden; negative means none are.

--- a/lib/Traits/WebMapServiceCatalogItemTraits.ts
+++ b/lib/Traits/WebMapServiceCatalogItemTraits.ts
@@ -343,4 +343,12 @@ export default class WebMapServiceCatalogItemTraits extends mixTraits(
       "The maximum of the color scale range. Because COLORSCALERANGE is a non-standard property supported by ncWMS servers, this property is ignored unless WebMapServiceCatalogItem's supportsColorScaleRange is true. WebMapServiceCatalogItem's colorScaleMinimum must be set as well."
   })
   colorScaleMaximum: number = 50;
+
+  @primitiveTrait({
+    type: "number",
+    name: "Maximum shown feature infos",
+    description:
+      'The maximum number of "feature infos" that can be displayed in feature info panel.'
+  })
+  maximumShownFeatureInfos?: number;
 }


### PR DESCRIPTION
### What this PR does

Fixes #4925 

Added `feature_count` to `getFeatureInfo` parameters as it was done in v7 (#1050).

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
