### PR TITLE
`WebMapServiceCatalogGroup` will now create layer auto-IDs using `Name` field to avoid ID clashes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,9 @@ Change Log
 * Add `nullColor` to `ConstantColorMap` - used when `colorColumn` is of type `region` to hide regions where rows don't exist.
 * `TableStyles` will only be created for `text` columns if there are no columns of type `scalar`, `enum` or `region`.
 * Fix sharing user added data of type "Auto-detect".
-* [The next improvement]
 * #5605 tidy up format string used in `MagdaReference`
+* `WebMapServiceCatalogGroup` will now create layer auto-IDs using `Name` field to avoid ID clashes.
+* [The next improvement]
 
 #### 8.0.0-alpha.87
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Fix sharing user added data of type "Auto-detect".
 * #5605 tidy up format string used in `MagdaReference`
 * `WebMapServiceCatalogGroup` will now create layer auto-IDs using `Name` field to avoid ID clashes.
+* Added `GroupMixin` `shareKey` generation for members - if the group has `shareKeys`.
 * [The next improvement]
 
 #### 8.0.0-alpha.87

--- a/architecture/0006-dynamic-groups-and-shareKeys.md
+++ b/architecture/0006-dynamic-groups-and-shareKeys.md
@@ -105,7 +105,10 @@ To do this, we need a reverse map of `id` -> `shareKeys`.
 
 ### Revert v8 WMS-group member ids to match v7
 
-This means we don't need to add manual `shareKeys` to WMS-groups.
+~~This means we don't need to add manual `shareKeys` to WMS-groups.~~
+
+WMS-group IDs will now use `Layer.Name` if is defined - otherwise `Layer.Title`.
+Sharekeys will be added so both cases are covered.
 
 ## Consequences
 

--- a/lib/ModelMixins/GroupMixin.ts
+++ b/lib/ModelMixins/GroupMixin.ts
@@ -108,17 +108,29 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
        * - member.uniqueId = 'some-group-id/some-member-id'
        * - group.shareKeys = 'old-group-id'
        * - So we want to create member.shareKeys = ["old-group-id/some-member-id"]
+       *
+       * We also repeat this process for each shareKey for each member
        */
 
       this.memberModels.forEach((model: BaseModel) => {
         // Only add shareKey if model.uniqueId is an autoID (i.e. contains groupId)
         if (isDefined(model.uniqueId) && model.uniqueId.includes(groupId)) {
-          shareKeys.forEach(groupShareKey =>
+          shareKeys.forEach(groupShareKey => {
+            // Get shareKeys for current model
+            const modelShareKeys = this.terria.modelIdShareKeysMap.get(
+              model.uniqueId!
+            );
+            modelShareKeys?.forEach(modelShareKey => {
+              this.terria.addShareKey(
+                model.uniqueId!,
+                modelShareKey.replace(groupId, groupShareKey)
+              );
+            });
             this.terria.addShareKey(
               model.uniqueId!,
               model.uniqueId!.replace(groupId, groupShareKey)
-            )
-          );
+            );
+          });
         }
       });
     }

--- a/lib/ModelMixins/GroupMixin.ts
+++ b/lib/ModelMixins/GroupMixin.ts
@@ -14,7 +14,7 @@ import ModelReference from "../Traits/ModelReference";
 import CatalogMemberMixin from "./CatalogMemberMixin";
 
 function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
-  abstract class GroupMixin extends Base implements Group {
+  abstract class Klass extends Base implements Group {
     private _memberLoader = new AsyncLoader(this.forceLoadMembers.bind(this));
 
     /**
@@ -91,7 +91,7 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
     }
 
     @action
-    addShareKeysToMembers(): void {
+    addShareKeysToMembers(members = this.memberModels): void {
       const groupId = this.uniqueId;
       if (!groupId) return;
 
@@ -112,7 +112,7 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
        * We also repeat this process for each shareKey for each member
        */
 
-      this.memberModels.forEach((model: BaseModel) => {
+      members.forEach((model: BaseModel) => {
         // Only add shareKey if model.uniqueId is an autoID (i.e. contains groupId)
         if (isDefined(model.uniqueId) && model.uniqueId.includes(groupId)) {
           shareKeys.forEach(groupShareKey => {
@@ -131,6 +131,10 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
               model.uniqueId!.replace(groupId, groupShareKey)
             );
           });
+          // If member is a Group -> apply shareKeys to the next level of members
+          if (GroupMixin.isMixedInto(model)) {
+            this.addShareKeysToMembers(model.memberModels);
+          }
         }
       });
     }
@@ -240,7 +244,7 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
     }
   }
 
-  return GroupMixin;
+  return Klass;
 }
 
 namespace GroupMixin {

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -595,7 +595,9 @@ export default class Terria {
     }
 
     if (this.models.has(model.uniqueId)) {
-      throw new RuntimeError("A model with the specified ID already exists.");
+      throw new RuntimeError(
+        `A model with the specified ID already exists: \`${model.uniqueId}\``
+      );
     }
 
     this.models.set(model.uniqueId, model);

--- a/lib/Models/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/WebMapServiceCatalogGroup.ts
@@ -296,7 +296,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
    * Previously we used layer.Title, so we now add it as a shareKey
    */
   getLayerShareKeys(layer: CapabilitiesLayer) {
-    if (isDefined(layer.Name))
+    if (isDefined(layer.Name) && layer.Title !== layer.Name)
       return [`${this.catalogGroup.uniqueId}/${layer.Title}`];
 
     return [];

--- a/lib/Models/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/WebMapServiceCatalogGroup.ts
@@ -194,7 +194,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
       let model: CatalogGroup;
       if (existingModel === undefined) {
         model = new CatalogGroup(layerId, this.catalogGroup.terria);
-        this.catalogGroup.terria.addModel(model);
+        this.catalogGroup.terria.addModel(model, this.getLayerShareKeys(layer));
       } else {
         model = existingModel;
       }
@@ -233,7 +233,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
     if (existingModel === undefined) {
       model = new WebMapServiceCatalogItem(layerId, this.catalogGroup.terria);
 
-      this.catalogGroup.terria.addModel(model);
+      this.catalogGroup.terria.addModel(model, this.getLayerShareKeys(layer));
     } else {
       model = existingModel;
     }
@@ -288,7 +288,18 @@ class GetCapabilitiesStratum extends LoadableStratum(
     if (!isDefined(this.catalogGroup.uniqueId)) {
       return;
     }
-    return `${this.catalogGroup.uniqueId}/${layer.Title}`;
+    return `${this.catalogGroup.uniqueId}/${layer.Name ?? layer.Title}`;
+  }
+
+  /** For backward-compatibility.
+   * If layer.Name is defined, we will use it to create layer autoID (see `this.getLayerId`).
+   * Previously we used layer.Title, so we now add it as a shareKey
+   */
+  getLayerShareKeys(layer: CapabilitiesLayer) {
+    if (isDefined(layer.Name))
+      return [`${this.catalogGroup.uniqueId}/${layer.Title}`];
+
+    return [];
   }
 }
 

--- a/test/Models/WebMapServiceCatalogGroupSpec.ts
+++ b/test/Models/WebMapServiceCatalogGroupSpec.ts
@@ -111,10 +111,12 @@ describe("WebMapServiceCatalogGroup", function() {
       const wmsItem = wms.memberModels[0] as WebMapServiceCatalogItem;
       expect(wmsItem.uniqueId).toBeDefined();
       expect(terria.modelIdShareKeysMap.has(wmsItem.uniqueId!)).toBeTruthy();
-      expect(terria.modelIdShareKeysMap.get(wmsItem.uniqueId!)![0]).toEqual(
-        `some-share-key/${wmsItem.name}`
-      );
-      console.log(wmsItem);
+
+      expect(terria.modelIdShareKeysMap.get(wmsItem.uniqueId!)).toEqual([
+        "test/average_data",
+        "some-share-key/average_data",
+        "some-share-key/single_period"
+      ]);
     });
   });
 

--- a/test/Models/upsertModelFromJsonSpec.ts
+++ b/test/Models/upsertModelFromJsonSpec.ts
@@ -45,7 +45,8 @@ describe("upsertModelFromJson", function() {
       members: [
         {
           type: "wms",
-          localId: "Funded Base Stations with Ineligible Areas",
+          localId:
+            "mobile-black-spot-programme:funded-base-stations-round4-group",
           name: "Override"
         }
       ]
@@ -68,7 +69,7 @@ describe("upsertModelFromJson", function() {
     const group = <WebMapServiceCatalogGroup>model;
     const item = terria.getModelById(
       WebMapServiceCatalogItem,
-      "/Test/Funded Base Stations with Ineligible Areas"
+      "/Test/mobile-black-spot-programme:funded-base-stations-round4-group"
     );
     expect(item).toBeDefined();
     if (!item) {


### PR DESCRIPTION
### `WebMapServiceCatalogGroup` will now create layer auto-IDs using `Name` field to avoid ID clashes.

Fixes https://github.com/terriajs/de-australia-map/issues/102

Unfortunately, because of this change I had to add more shareKeys :(

See https://github.com/TerriaJS/terriajs/pull/5613#discussion_r663903084

### Test links

Using https://ows.dea.ga.gov.au/?service=WMS&version=1.3.0&request=GetCapabilities - which has duplicate layer `Title`s (which is valid WMS - but we don't handle properly)

<img src="https://user-images.githubusercontent.com/6187649/124474689-2ea85d80-dde4-11eb-8f27-e88c597bfe07.png" width="400px">

- After http://ci.terria.io/wms-group-id-fix/#share=s-bgXPnmHxWdu59rfRXjtC3pYwBRG

- Before http://ci.terria.io/next/#share=s-bgXPnmHxWdu59rfRXjtC3pYwBRG

![image](https://user-images.githubusercontent.com/6187649/124474915-74652600-dde4-11eb-9a5a-58d691d22877.png)

### Checklist

- [x] Test with live share link buckets
-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
