### PR TITLE
Fix splitter thumb icon position

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Change Log
   * Notes on v7 to v8 Socrata integration:
     * Share links are not preserved
     * Added basic support for dataset resources
+* Fix splitter thumb icon vertical position
 * [The next improvement]
 
 #### 8.0.0-alpha.87

--- a/lib/ReactViews/Map/Splitter.jsx
+++ b/lib/ReactViews/Map/Splitter.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import { withTranslation } from "react-i18next";
-import Icon from "../../Styled/Icon";
+import { GLYPHS, StyledIcon } from "../../Styled/Icon";
 import Styles from "./splitter.scss";
 import { observer } from "mobx-react";
 import { runInAction } from "mobx";
@@ -219,7 +219,7 @@ const Splitter = observer(
             onTouchStart={this.startDrag}
             title={t("splitterTool.title")}
           >
-            <Icon glyph={Icon.GLYPHS.splitter} />
+            <StyledIcon glyph={GLYPHS.splitter} />
           </button>
         </div>
       );


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>
Before:
![image](https://user-images.githubusercontent.com/19208948/126301133-4c7752b8-7a0b-4308-b5e4-431ed973a657.png)
After
![image](https://user-images.githubusercontent.com/19208948/126301171-45b2214b-b50f-4c4c-845d-4864e7aeb478.png)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
