### PR TITLE
Rename all mixin instance types to MixinX.Instance.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ Change Log
     * Share links are not preserved
     * Added basic support for dataset resources
 * Fix splitter thumb icon vertical position
+* Renamed all mixin instance type definitions to `XMixin.Instance`.
 * [The next improvement]
 
 #### 8.0.0-alpha.87

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Change Log
 
 - **Breaking changes**:
   - `colorPalette` no longer supports a list of CSS colors (eg `rgb(0,0,255)-rgb(0,255,0)-rgb(255,0,0)`). Instead please use `binColors`.
+  - Organise `Traits` folder into `Traits/Decorators` and `Traits/TraitsClasses`
+  - Renamed all mixin instance type definitions to `XMixin.Instance`.
 
 * Fixed a bug with numeric item search where it sometimes fails to return all matching values.
 * Respect order of objects from lower strata in `objectArrayTrait`.

--- a/architecture/0004-next-catalog-functions.md
+++ b/architecture/0004-next-catalog-functions.md
@@ -139,7 +139,7 @@ This handles downloading job results, it can be triggered three ways:
 
 ```ts
     abstract async downloadResults(): Promise<
-      CatalogMemberMixin.CatalogMemberMixin[] | void
+      CatalogMemberMixin.Instance[] | void
     >;
 ```
 
@@ -149,7 +149,7 @@ returns catalog members which are added to the workbench
 #### `results`
 
 ```ts
-results: CatalogMemberMixin.CatalogMemberMixin[]
+results: CatalogMemberMixin.Instance[]
 ```
 
 Job result `CatalogMembers` - set from calling `CatalogFunctionJobMixin#downloadResults` (in `CatalogFunctionJobMixin#onJobFinish`)

--- a/lib/Core/getDereferencedIfExists.ts
+++ b/lib/Core/getDereferencedIfExists.ts
@@ -3,8 +3,8 @@ import GroupMixin from "../ModelMixins/GroupMixin";
 import ReferenceMixin from "../ModelMixins/ReferenceMixin";
 
 export default function getDereferencedIfExists(
-  item: BaseModel | GroupMixin.GroupMixin
-): BaseModel | GroupMixin.GroupMixin {
+  item: BaseModel | GroupMixin.Instance
+): BaseModel | GroupMixin.Instance {
   if (ReferenceMixin.is(item) && item.target) {
     return item.target;
   }

--- a/lib/ModelMixins/AccessControlMixin.ts
+++ b/lib/ModelMixins/AccessControlMixin.ts
@@ -64,10 +64,10 @@ function AccessControlMixin<T extends Constructor<AccessControlModel>>(
 }
 
 namespace AccessControlMixin {
-  export interface AccessControlMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof AccessControlMixin>> {}
 
-  export function isMixedInto(model: any): model is AccessControlMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && model.hasAccessControlMixin;
   }
 }

--- a/lib/ModelMixins/CatalogFunctionJobMixin.ts
+++ b/lib/ModelMixins/CatalogFunctionJobMixin.ts
@@ -17,15 +17,13 @@ import CatalogMemberMixin from "./CatalogMemberMixin";
 import GroupMixin from "./GroupMixin";
 
 class FunctionJobStratum extends LoadableStratum(CatalogFunctionJobTraits) {
-  constructor(
-    readonly catalogFunctionJob: CatalogFunctionJobMixin.CatalogFunctionJobMixin
-  ) {
+  constructor(readonly catalogFunctionJob: CatalogFunctionJobMixin.Instance) {
     super();
   }
 
   duplicateLoadableStratum(model: BaseModel): this {
     return new FunctionJobStratum(
-      model as CatalogFunctionJobMixin.CatalogFunctionJobMixin
+      model as CatalogFunctionJobMixin.Instance
     ) as this;
   }
 
@@ -235,14 +233,14 @@ function CatalogFunctionJobMixin<
      * Job result CatalogMembers - set from calling {@link CatalogFunctionJobMixin#downloadResults}
      */
     @observable
-    public results: CatalogMemberMixin.CatalogMemberMixin[] = [];
+    public results: CatalogMemberMixin.Instance[] = [];
 
     /**
      * Called in {@link CatalogFunctionJobMixin#onJobFinish}
      * @returns catalog members to add to workbench
      */
     abstract async downloadResults(): Promise<
-      CatalogMemberMixin.CatalogMemberMixin[] | void
+      CatalogMemberMixin.Instance[] | void
     >;
 
     @action
@@ -308,9 +306,9 @@ function CatalogFunctionJobMixin<
 
 namespace CatalogFunctionJobMixin {
   StratumOrder.addLoadStratum(FunctionJobStratum.name);
-  export interface CatalogFunctionJobMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof CatalogFunctionJobMixin>> {}
-  export function isMixedInto(model: any): model is CatalogFunctionJobMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && model.hasCatalogFunctionJobMixin;
   }
 }

--- a/lib/ModelMixins/CatalogFunctionMixin.ts
+++ b/lib/ModelMixins/CatalogFunctionMixin.ts
@@ -101,9 +101,9 @@ function CatalogFunctionMixin<T extends Constructor<CatalogFunctionMixin>>(
 }
 
 namespace CatalogFunctionMixin {
-  export interface CatalogFunctionMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof CatalogFunctionMixin>> {}
-  export function isMixedInto(model: any): model is CatalogFunctionMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && model.hasCatalogFunctionMixin;
   }
 }

--- a/lib/ModelMixins/CatalogMemberMixin.ts
+++ b/lib/ModelMixins/CatalogMemberMixin.ts
@@ -181,9 +181,9 @@ function CatalogMemberMixin<T extends Constructor<CatalogMember>>(Base: T) {
 const descriptionRegex = /description/i;
 
 namespace CatalogMemberMixin {
-  export interface CatalogMemberMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof CatalogMemberMixin>> {}
-  export function isMixedInto(model: any): model is CatalogMemberMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && model.hasCatalogMemberMixin;
   }
 }

--- a/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
+++ b/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
@@ -374,10 +374,10 @@ function DiscretelyTimeVaryingMixin<
 }
 
 namespace DiscretelyTimeVaryingMixin {
-  export interface DiscretelyTimeVaryingMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof DiscretelyTimeVaryingMixin>> {}
 
-  export function isMixedInto(model: any): model is DiscretelyTimeVaryingMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && model.hasDiscreteTimes;
   }
 }

--- a/lib/ModelMixins/ExportableMixin.ts
+++ b/lib/ModelMixins/ExportableMixin.ts
@@ -34,9 +34,9 @@ function ExportableMixin<T extends Constructor<Model<ExportableTraits>>>(
 }
 
 namespace ExportableMixin {
-  export interface ExportableMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof ExportableMixin>> {}
-  export function isMixedInto(model: any): model is ExportableMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && "exportData" in model && "canExportData" in model;
   }
 }

--- a/lib/ModelMixins/GroupMixin.ts
+++ b/lib/ModelMixins/GroupMixin.ts
@@ -248,9 +248,9 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
 }
 
 namespace GroupMixin {
-  export interface GroupMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof GroupMixin>> {}
-  export function isMixedInto(model: any): model is GroupMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && "isGroup" in model && model.isGroup;
   }
 }

--- a/lib/ModelMixins/MappableMixin.ts
+++ b/lib/ModelMixins/MappableMixin.ts
@@ -161,9 +161,9 @@ function MappableMixin<T extends Constructor<Model<MappableTraits>>>(Base: T) {
 }
 
 namespace MappableMixin {
-  export interface MappableMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof MappableMixin>> {}
-  export function isMixedInto(model: any): model is MappableMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && model.isMappable;
   }
 }

--- a/lib/ModelMixins/ShadowMixin.ts
+++ b/lib/ModelMixins/ShadowMixin.ts
@@ -50,9 +50,9 @@ function ShadowMixin<T extends Constructor<Model<ShadowTraits>>>(Base: T) {
 }
 
 namespace ShadowMixin {
-  export interface ShadowsMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof ShadowMixin>> {}
-  export function isMixedInto(model: any): model is ShadowsMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && model.hasShadows;
   }
 }

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -925,10 +925,10 @@ function TableMixin<T extends Constructor<Model<TableTraits>>>(Base: T) {
 }
 
 namespace TableMixin {
-  export interface TableMixin
+  export interface Instance
     extends InstanceType<ReturnType<typeof TableMixin>> {}
 
-  export function isMixedInto(model: any): model is TableMixin {
+  export function isMixedInto(model: any): model is Instance {
     return model && model.hasTableMixin;
   }
 }

--- a/lib/ModelMixins/TileErrorHandlerMixin.ts
+++ b/lib/ModelMixins/TileErrorHandlerMixin.ts
@@ -22,7 +22,7 @@ import MappableMixin from "./MappableMixin";
 type ModelType = Model<
   MappableTraits & RasterLayerTraits & CatalogMemberTraits
 > &
-  MappableMixin.MappableMixin;
+  MappableMixin.Instance;
 
 /**
  * A mixin for handling tile errors in raster layers

--- a/lib/ModelMixins/TimeFilterMixin.ts
+++ b/lib/ModelMixins/TimeFilterMixin.ts
@@ -208,7 +208,7 @@ namespace TimeFilterMixin {
  * Return the feature at position containing the time filter property.
  */
 const resolveFeature = action(async function(
-  model: MappableMixin.MappableMixin & TimeVarying,
+  model: MappableMixin.Instance & TimeVarying,
   propertyName: string,
   position: LatLonHeight,
   tileCoords: ProviderCoords

--- a/lib/ModelMixins/UrlMixin.ts
+++ b/lib/ModelMixins/UrlMixin.ts
@@ -25,8 +25,8 @@ function UrlMixin<T extends Constructor<UrlModel>>(Base: T) {
 }
 
 namespace UrlMixin {
-  export interface UrlMixin extends InstanceType<ReturnType<typeof UrlMixin>> {}
-  export function isMixedInto(model: any): model is UrlMixin {
+  export interface Instance extends InstanceType<ReturnType<typeof UrlMixin>> {}
+  export function isMixedInto(model: any): model is Instance {
     return model && model.hasUrlMixin;
   }
 }

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -101,7 +101,7 @@ export default class Cesium extends GlobeOrMap {
     | CameraView
     | Rectangle
     | DataSource
-    | MappableMixin.MappableMixin
+    | MappableMixin.Instance
     | /*TODO Cesium.Cesium3DTileset*/ any;
 
   // When true, feature picking is paused. This is useful for temporarily
@@ -1358,7 +1358,7 @@ export default class Cesium extends GlobeOrMap {
     return result;
   }
 
-  getImageryLayersForItem(item: MappableMixin.MappableMixin): ImageryLayer[] {
+  getImageryLayersForItem(item: MappableMixin.Instance): ImageryLayer[] {
     return filterOutUndefined(
       item.mapItems.map(m => {
         if (ImageryParts.is(m)) {
@@ -1370,7 +1370,7 @@ export default class Cesium extends GlobeOrMap {
 
   private _makeImageryLayerFromParts(
     parts: ImageryParts,
-    item: MappableMixin.MappableMixin
+    item: MappableMixin.Instance
   ): ImageryLayer {
     const layer = this._createImageryLayer(
       parts.imageryProvider,

--- a/lib/Models/GlobeOrMap.ts
+++ b/lib/Models/GlobeOrMap.ts
@@ -56,7 +56,7 @@ export default abstract class GlobeOrMap {
   abstract destroy(): void;
 
   abstract doZoomTo(
-    target: CameraView | Rectangle | MappableMixin.MappableMixin,
+    target: CameraView | Rectangle | MappableMixin.Instance,
     flightDurationSeconds: number
   ): Promise<void>;
 
@@ -69,7 +69,7 @@ export default abstract class GlobeOrMap {
    */
   @action
   zoomTo(
-    target: CameraView | Rectangle | MappableMixin.MappableMixin,
+    target: CameraView | Rectangle | MappableMixin.Instance,
     flightDurationSeconds: number
   ): Promise<void> {
     this.isMapZooming = true;

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -112,7 +112,7 @@ export default class Leaflet extends GlobeOrMap {
 
   private _makeImageryLayerFromParts(
     parts: ImageryParts,
-    item: MappableMixin.MappableMixin
+    item: MappableMixin.Instance
   ) {
     if (TileErrorHandlerMixin.isMixedInto(item)) {
       // because this code path can run multiple times, make sure we remove the
@@ -353,7 +353,7 @@ export default class Leaflet extends GlobeOrMap {
       ];
       // Flatmap
       const allImageryMapItems = ([] as {
-        item: MappableMixin.MappableMixin;
+        item: MappableMixin.Instance;
         parts: ImageryParts;
       }[]).concat(
         ...catalogItems
@@ -438,12 +438,7 @@ export default class Leaflet extends GlobeOrMap {
   }
 
   doZoomTo(
-    target:
-      | CameraView
-      | Rectangle
-      | DataSource
-      | MappableMixin.MappableMixin
-      | any,
+    target: CameraView | Rectangle | DataSource | MappableMixin.Instance | any,
     flightDurationSeconds: number
   ): Promise<void> {
     if (!isDefined(target)) {
@@ -848,7 +843,7 @@ export default class Leaflet extends GlobeOrMap {
   }
 
   getImageryLayersForItem(
-    item: MappableMixin.MappableMixin
+    item: MappableMixin.Instance
   ): (CesiumTileLayer | MapboxVectorCanvasTileLayer)[] {
     return filterOutUndefined(
       item.mapItems.map(m => {

--- a/lib/Models/NoViewer.ts
+++ b/lib/Models/NoViewer.ts
@@ -24,7 +24,7 @@ class NoViewer extends GlobeOrMap {
   destroy() {}
 
   doZoomTo(
-    v: CameraView | Rectangle | MappableMixin.MappableMixin,
+    v: CameraView | Rectangle | MappableMixin.Instance,
     t: any
   ): Promise<void> {
     if (v instanceof CameraView) {

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1509,7 +1509,7 @@ export default class Terria {
           hasTraits(item, MappableTraits, "show") &&
           item.show &&
           MappableMixin.isMixedInto(item)
-      ) as MappableMixin.MappableMixin[];
+      ) as MappableMixin.Instance[];
 
       relevantItems.forEach(item => {
         const entities: Entity[] = item.mapItems

--- a/lib/Models/WebProcessingServiceCatalogFunctionJob.ts
+++ b/lib/Models/WebProcessingServiceCatalogFunctionJob.ts
@@ -304,7 +304,7 @@ export default class WebProcessingServiceCatalogFunctionJob extends XmlRequestMi
 
     const outputs = runInAction(() => this.outputs);
 
-    const results: CatalogMemberMixin.CatalogMemberMixin[] = [];
+    const results: CatalogMemberMixin.Instance[] = [];
 
     await Promise.all(
       outputs.map(async (output, i) => {

--- a/lib/Models/YDYRCatalogFunction.ts
+++ b/lib/Models/YDYRCatalogFunction.ts
@@ -201,7 +201,7 @@ export default class YDYRCatalogFunction extends CatalogFunctionMixin(
   }
 
   @computed
-  get selectedTableCatalogMember(): TableMixin.TableMixin | undefined {
+  get selectedTableCatalogMember(): TableMixin.Instance | undefined {
     if (!isDefined(this.inputLayers?.value)) {
       return;
     }

--- a/lib/ReactViews/Preview/ExportData.tsx
+++ b/lib/ReactViews/Preview/ExportData.tsx
@@ -11,10 +11,10 @@ import ExportableMixin from "../../ModelMixins/ExportableMixin";
 const FileSaver = require("file-saver");
 
 interface PropsType extends WithTranslation {
-  item: ExportableMixin.ExportableMixin;
+  item: ExportableMixin.Instance;
 }
 
-export async function exportData(item: ExportableMixin.ExportableMixin) {
+export async function exportData(item: ExportableMixin.Instance) {
   const data = await item.exportData();
   if (!isDefined(data)) {
     return;
@@ -31,7 +31,7 @@ export async function exportData(item: ExportableMixin.ExportableMixin) {
  */
 @observer
 class ExportData extends React.Component<PropsType> {
-  exportDataClicked(item: ExportableMixin.ExportableMixin) {
+  exportDataClicked(item: ExportableMixin.Instance) {
     exportData(item).catch(e => {
       if (e instanceof TerriaError) {
         this.props.item.terria.raiseErrorToUser(e);

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -19,7 +19,7 @@ import {
 /**
  * @typedef {object} Props
  * @prop {Terria} terria
- * @prop {MappableMixin.MappableMixin} previewed
+ * @prop {MappableMixin.Instance} previewed
  * @prop {ViewState} viewState
  *
  */

--- a/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
@@ -14,7 +14,7 @@ const minimapNavIcon = require("../../../../wwwroot/images/minimap-nav.svg");
 
 type MiniMapProps = {
   terria: Terria;
-  baseMap: MappableMixin.MappableMixin;
+  baseMap: MappableMixin.Instance;
   view: MiniMapView;
 };
 

--- a/lib/ReactViews/Workbench/Controls/Legend.tsx
+++ b/lib/ReactViews/Workbench/Controls/Legend.tsx
@@ -37,7 +37,7 @@ function checkMimeType(legend: Model<LegendTraits>) {
 
 @observer
 export default class Legend extends React.Component<{
-  item: CatalogMemberMixin.CatalogMemberMixin;
+  item: CatalogMemberMixin.Instance;
   forPrint?: boolean;
 }> {
   static defaultProps = {

--- a/lib/ReactViews/Workbench/Controls/ShortReport.tsx
+++ b/lib/ReactViews/Workbench/Controls/ShortReport.tsx
@@ -14,7 +14,7 @@ import parseCustomMarkdownToReact from "../../Custom/parseCustomMarkdownToReact"
 
 @observer
 export default class ShortReport extends React.Component<{
-  item: CatalogMemberMixin.CatalogMemberMixin;
+  item: CatalogMemberMixin.Instance;
 }> {
   clickShortReport(reportName: string | undefined, isOpen: boolean) {
     const shortReportSections = this.props.item.shortReportSections;

--- a/lib/ViewModels/BaseMapViewModel.ts
+++ b/lib/ViewModels/BaseMapViewModel.ts
@@ -2,10 +2,10 @@ import { observable } from "mobx";
 import MappableMixin from "../ModelMixins/MappableMixin";
 
 export class BaseMapViewModel {
-  @observable mappable: MappableMixin.MappableMixin;
+  @observable mappable: MappableMixin.Instance;
   @observable image: string | undefined;
 
-  constructor(mappable: MappableMixin.MappableMixin, image?: string) {
+  constructor(mappable: MappableMixin.Instance, image?: string) {
     this.mappable = mappable;
     this.image = image;
   }

--- a/lib/ViewModels/TerriaViewer.ts
+++ b/lib/ViewModels/TerriaViewer.ts
@@ -36,13 +36,13 @@ export default class TerriaViewer {
   readonly terria: Terria;
 
   @observable
-  private _baseMap: MappableMixin.MappableMixin | undefined;
+  private _baseMap: MappableMixin.Instance | undefined;
 
   get baseMap() {
     return this._baseMap;
   }
 
-  async setBaseMap(baseMap?: MappableMixin.MappableMixin) {
+  async setBaseMap(baseMap?: MappableMixin.Instance) {
     if (!baseMap) return;
 
     try {
@@ -70,8 +70,8 @@ export default class TerriaViewer {
 
   // This is a "view" of a workbench/other
   readonly items:
-    | IComputedValue<MappableMixin.MappableMixin[]>
-    | IObservableValue<MappableMixin.MappableMixin[]>;
+    | IComputedValue<MappableMixin.Instance[]>
+    | IObservableValue<MappableMixin.Instance[]>;
 
   @observable
   viewerMode: ViewerMode | undefined = ViewerMode.Cesium;
@@ -94,10 +94,7 @@ export default class TerriaViewer {
   readonly beforeViewerChanged = new CesiumEvent();
   readonly afterViewerChanged = new CesiumEvent();
 
-  constructor(
-    terria: Terria,
-    items: IComputedValue<MappableMixin.MappableMixin[]>
-  ) {
+  constructor(terria: Terria, items: IComputedValue<MappableMixin.Instance[]>) {
     this.terria = terria;
     this.items = items;
   }

--- a/test/Models/CswCatalogGroupSpec.ts
+++ b/test/Models/CswCatalogGroupSpec.ts
@@ -70,12 +70,12 @@ describe("CswCatalogGroup", function() {
     await group.loadMembers();
 
     expect(group.memberModels.length).toBe(3);
-    expect(
-      (group.memberModels[0] as CatalogMemberMixin.CatalogMemberMixin).name
-    ).toBe("Multiple Use");
-    expect(
-      (group.memberModels[2] as CatalogMemberMixin.CatalogMemberMixin).name
-    ).toBe("Wave Energy Resource");
+    expect((group.memberModels[0] as CatalogMemberMixin.Instance).name).toBe(
+      "Multiple Use"
+    );
+    expect((group.memberModels[2] as CatalogMemberMixin.Instance).name).toBe(
+      "Wave Energy Resource"
+    );
 
     const tidalEnergyGroup = group.memberModels[1] as CatalogGroup;
     expect(tidalEnergyGroup.name).toBe("Tidal Energy");
@@ -101,14 +101,14 @@ describe("CswCatalogGroup", function() {
 
     expect(group2.memberModels.length).toBe(230);
 
-    expect(
-      (group2.memberModels[0] as CatalogMemberMixin.CatalogMemberMixin).name
-    ).toBe("Percent Occurrence Tidal Currant Exceeds 1.0 m/s");
+    expect((group2.memberModels[0] as CatalogMemberMixin.Instance).name).toBe(
+      "Percent Occurrence Tidal Currant Exceeds 1.0 m/s"
+    );
     expect(group2.memberModels[0].type).toBe(WebMapServiceCatalogItem.type);
 
-    expect(
-      (group2.memberModels[1] as CatalogMemberMixin.CatalogMemberMixin).name
-    ).toBe("Percent Occurrence Tidal Currant Exceeds 1.5 m/s");
+    expect((group2.memberModels[1] as CatalogMemberMixin.Instance).name).toBe(
+      "Percent Occurrence Tidal Currant Exceeds 1.5 m/s"
+    );
     expect(group2.memberModels[1].type).toBe(WebMapServiceCatalogItem.type);
   });
 
@@ -118,14 +118,14 @@ describe("CswCatalogGroup", function() {
 
     expect(group.memberModels.length).toBe(230);
 
-    expect(
-      (group.memberModels[0] as CatalogMemberMixin.CatalogMemberMixin).name
-    ).toBe("Percent Occurrence Tidal Currant Exceeds 1.0 m/s");
+    expect((group.memberModels[0] as CatalogMemberMixin.Instance).name).toBe(
+      "Percent Occurrence Tidal Currant Exceeds 1.0 m/s"
+    );
     expect(group.memberModels[0].type).toBe(WebMapServiceCatalogItem.type);
 
-    expect(
-      (group.memberModels[1] as CatalogMemberMixin.CatalogMemberMixin).name
-    ).toBe("Percent Occurrence Tidal Currant Exceeds 1.5 m/s");
+    expect((group.memberModels[1] as CatalogMemberMixin.Instance).name).toBe(
+      "Percent Occurrence Tidal Currant Exceeds 1.5 m/s"
+    );
     expect(group.memberModels[1].type).toBe(WebMapServiceCatalogItem.type);
   });
 


### PR DESCRIPTION
### What this PR does

Fixes #5374 

Renames all mixin instance type names from `XMixin.Mixin` to `XMixin.Instance`.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
