### PR TITLE
Fix docs generation

### DIFF
--- a/buildprocess/generateDocs.js
+++ b/buildprocess/generateDocs.js
@@ -5,10 +5,10 @@ import fs from "fs";
 import YAML from "yaml";
 import CatalogMemberFactory from "../lib/Models/CatalogMemberFactory";
 import registerCatalogMembers from "../lib/Models/registerCatalogMembers";
-import { ObjectArrayTrait } from "../lib/Traits/objectArrayTrait";
-import { ObjectTrait } from "../lib/Traits/objectTrait";
-import { PrimitiveArrayTrait } from "../lib/Traits/primitiveArrayTrait";
-import { PrimitiveTrait } from "../lib/Traits/primitiveTrait";
+import { ObjectArrayTrait } from "../lib/Traits/Decorators/objectArrayTrait";
+import { ObjectTrait } from "../lib/Traits/Decorators/objectTrait";
+import { PrimitiveArrayTrait } from "../lib/Traits/Decorators/primitiveArrayTrait";
+import { PrimitiveTrait } from "../lib/Traits/Decorators/primitiveTrait";
 import Terria from "../lib/Models/Terria";
 
 // Run with cwd = /build


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

When moving Traits classes to a new folder I skipped to update `generateDocs.js` which result in the failure of docs script. This just fixes the import location

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
