### PR TITLE
Add `feature` to FeatureInfo getTemplateData

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,7 +53,7 @@ Change Log
   * Replaced with `disableZoomTo` in `MappableTraits`
 * Clean up `showsInfo`
   * Replaced with `disableAboutData` in `CatalogMemberTraits`
-* Add `feature` object to `FeatureInfoSection.getTemplateData 
+* Add `feature` object to `FeatureInfoSection.getTemplateData`
 * [The next improvement]
 
 #### 8.0.0-alpha.87

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@ Change Log
   * Replaced with `disableZoomTo` in `MappableTraits`
 * Clean up `showsInfo`
   * Replaced with `disableAboutData` in `CatalogMemberTraits`
+* Add `feature` object to `FeatureInfoSection.getTemplateData 
 * [The next improvement]
 
 #### 8.0.0-alpha.87

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -109,6 +109,10 @@ export const FeatureInfoSection = observer(
           value
         })
       );
+
+      // Add entire feature object
+      propertyData.feature = this.props.feature;
+
       propertyData.terria = {
         formatNumber: mustacheFormatNumberFunction,
         formatDateTime: mustacheFormatDateTime,


### PR DESCRIPTION
### What this PR does

http://ci.terria.io/feature-template-data/#clean&https://gist.githubusercontent.com/nf-s/d1a6b434cb2799832eb8f69ef4e3120a/raw/fe5bc0de8f1c7fcbace867ca8d4513060c23cc0a/feature-info-test.json

This means we can use feature properties inside Mustache templates - eg:

`"template": "{{feature.data.layerName}}\n{{Pixel Value}} people in given radius."` 

in

```json
{
      "type": "esri-mapServer",
      "name": "Residential Population Density",
      "featureInfoTemplate": {
        "template": "{{feature.data.layerName}}\n{{Pixel Value}} people in given radius."
      },
      "id": "Root Group/National Data Sets/Social and Economic/Population Estimates",
      "info": [
        {
          "name": "Licence",
          "content": "[Creative Commons Attribution 4.0 International (CC BY 4.0)](http://creativecommons.org/licenses/by/4.0/)"
        }
      ],
      "url": "http://services.ga.gov.au/gis/rest/services/NEXIS_Residential_Dwelling_Density/MapServer",
      "dataCustodian": "[Geoscience Australia](http://www.ga.gov.au/)",
      "shareKeys": [
        "Root Group/National Datasets/Social and Economic/Population Estimates/Residential Population Density"
      ]
    }
```

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
