### PR TITLE
Set default orientation for GLTFs to zero degrees HPR.

### DIFF
--- a/lib/Models/GltfCatalogItem.ts
+++ b/lib/Models/GltfCatalogItem.ts
@@ -82,13 +82,11 @@ export default class GltfCatalogItem extends MappableMixin(
   @computed
   private get orientation(): Quaternion {
     const { heading, pitch, roll } = this.rotation;
-
-    // If no hpr rotation defined, we default to no rotation
-    if (heading === undefined || pitch === undefined || roll === undefined) {
-      return Quaternion.IDENTITY.clone();
-    }
-
-    const hpr = HeadingPitchRoll.fromDegrees(heading, pitch, roll);
+    const hpr = HeadingPitchRoll.fromDegrees(
+      heading ?? 0,
+      pitch ?? 0,
+      roll ?? 0
+    );
     const orientation = Transforms.headingPitchRollQuaternion(
       this.cesiumPosition,
       hpr

--- a/lib/Traits/TraitsClasses/TransformationTraits.ts
+++ b/lib/Traits/TraitsClasses/TransformationTraits.ts
@@ -17,7 +17,7 @@ export default class TransformationTraits extends ModelTraits {
     type: HeadingPitchRollTraits,
     name: "Rotation",
     description:
-      "The rotation of the model expressed as heading, pitch and roll in the local frame of reference."
+      "The rotation of the model expressed as heading, pitch and roll in the local frame of reference. Defaults to zero rotation."
   })
   rotation?: HeadingPitchRollTraits;
 


### PR DESCRIPTION
### What this PR does

Fixes #5690 

Sets the default orientation for `GltfCatalogItem` to 0 wrt ENU so that it is aligned correctly to the ground at its origin location.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
