### PR TITLE
Allow translation of some components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@ Change Log
 * Moved d3-scale-chromatic code into `tableColorMap.colorScaleCategorical()` and `tableColorMap.colorScaleContinuous()`
 * Disabled welcome popup for shared stories
 * Add WMS support for default value of time dimension.
+* Allow translation of some components.
 * [The next improvement]
 
 #### 8.0.0-alpha.87

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -262,6 +262,7 @@
     "qualityLabel": "Quality",
     "performanceLabel": "Performance",
     "timeline": {
+      "title": "Timeline",
       "alwaysShowLabel": "Press to start only showing the timeline when there are time-varying datasets on the workbench",
       "hideLabel": "Press to start always showing the timeline, even when no time-varying datasets are on the workbench",
       "alwaysShow": "Always show"

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -452,7 +452,9 @@
     "searchCatalogue": "Search the catalogue"
   },
   "mobile": {
-    "toggleNavigation": "toggle navigation"
+    "toggleNavigation": "toggle navigation",
+    "addDataBtnText": "Data",
+    "doneBtnText": "Done"
   },
   "preview": {
     "doesNotContainGeospatialData": "This file does not contain geospatial data.",

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -293,6 +293,7 @@
     "minLength": "Minimum length of feedback comment is {{minLength}}"
   },
   "helpPanel": {
+    "btnText": "Help",
     "menuPaneTitle": "We're here to help",
     "menuPaneBody": "Find useful tips on how to use TerriaJS by either checking the guides below or by contacting the team at [info@terria.io](mailto:info@terria.io)",
     "promptMessage": "Find the Tour, how-to videos & other help content here",

--- a/lib/ReactViews/Map/MapNavigation.jsx
+++ b/lib/ReactViews/Map/MapNavigation.jsx
@@ -28,7 +28,7 @@ import FeedbackButton from "../Feedback/FeedbackButton";
 import CloseToolButton from "./Navigation/CloseToolButton";
 import Prompt from "../Generic/Prompt";
 import { runInAction } from "mobx";
-import { withTranslation } from "react-i18next";
+import { withTranslation, useTranslation } from "react-i18next";
 import Cesium from "../../Models/Cesium";
 
 /**
@@ -50,6 +50,7 @@ const StyledMapNavigation = styled.div`
 `;
 
 const HelpIcon = withControlledVisibility(props => {
+  const { t } = useTranslation();
   return (
     <MapIconButton
       expandInPlace
@@ -57,7 +58,7 @@ const HelpIcon = withControlledVisibility(props => {
       onClick={() => props.viewState.showHelpPanel()}
       neverCollapse={props.viewState.featurePrompts.indexOf("help") >= 0}
     >
-      Help
+      {t("helpPanel.btnText")}
     </MapIconButton>
   );
 });

--- a/lib/ReactViews/Map/Panels/SettingPanel.jsx
+++ b/lib/ReactViews/Map/Panels/SettingPanel.jsx
@@ -346,7 +346,9 @@ class SettingPanel extends React.Component {
           </ul>
         </div>
         <div className={DropdownStyles.section}>
-          <label className={DropdownStyles.heading}>Timeline</label>
+          <label className={DropdownStyles.heading}>
+            {t("settingPanel.timeline.title")}
+          </label>
           <section
             className={Styles.nativeResolutionWrapper}
             title={qualityLabels[this.props.terria.quality]}

--- a/lib/ReactViews/Mobile/MobileHeader.jsx
+++ b/lib/ReactViews/Mobile/MobileHeader.jsx
@@ -208,7 +208,7 @@ const MobileHeader = observer(
                     className={Styles.btnAdd}
                     onClick={this.onMobileDataCatalogClicked}
                   >
-                    Data
+                    {t("mobile.addDataBtnText")}
                     <Icon glyph={Icon.GLYPHS.increase} />
                   </button>
                   <If condition={nowViewingLength > 0}>

--- a/lib/ReactViews/Mobile/MobileModalWindow.jsx
+++ b/lib/ReactViews/Mobile/MobileModalWindow.jsx
@@ -12,6 +12,7 @@ import Icon from "../../Styled/Icon";
 
 import Styles from "./mobile-modal-window.scss";
 import { runInAction } from "mobx";
+import { withTranslation } from "react-i18next";
 
 const MobileModalWindow = observer(
   createReactClass({
@@ -19,7 +20,8 @@ const MobileModalWindow = observer(
 
     propTypes: {
       terria: PropTypes.object,
-      viewState: PropTypes.object.isRequired
+      viewState: PropTypes.object.isRequired,
+      t: PropTypes.func.isRequired
     },
 
     renderModalContent() {
@@ -108,6 +110,7 @@ const MobileModalWindow = observer(
           this.props.viewState.mobileView
       });
       const mobileView = this.props.viewState.mobileView;
+      const { t } = this.props;
 
       return (
         <div className={modalClass}>
@@ -123,7 +126,7 @@ const MobileModalWindow = observer(
                   className={Styles.doneButton}
                   onClick={this.onClearMobileUI}
                 >
-                  Done
+                  {t("mobile.doneBtnText")}
                 </button>
               </If>
               <button
@@ -149,4 +152,4 @@ const MobileModalWindow = observer(
     }
   })
 );
-module.exports = MobileModalWindow;
+module.exports = withTranslation()(MobileModalWindow);


### PR DESCRIPTION
### What this PR does

This patch ports some hardcoded strings into the i18n message registry.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
    - Unit tests aren't applicable because the changes are only about translation. I manually tested the affected components renders as before (in English :-) ).
-   [x] I've updated CHANGES.md with what I changed.
