### PR TITLE
Fix error when adding a reference catalog item while the story is playing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,7 @@ Change Log
 * New model-generated documentation in `generateDocs.ts`
 * Refactored some `Traits` classes so they use `mixTraits` instead of extending other `Traits` classes.
 * Allow translation of some components.
+* Fixed a bug which prevented adding any reference catalog item while the story is playing.
 * [The next improvement]
 
 #### 8.0.0-alpha.87

--- a/lib/ReactViews/DataCatalog/DataCatalogReference.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogReference.jsx
@@ -1,5 +1,6 @@
 import createReactClass from "create-react-class";
 import { observer } from "mobx-react";
+import { runInAction } from "mobx";
 import PropTypes from "prop-types";
 import React from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
@@ -38,7 +39,9 @@ const DataCatalogReference = observer(
       }
 
       if (defined(this.props.viewState.storyShown)) {
-        this.props.viewState.storyShown = false;
+        runInAction(() => {
+          this.props.viewState.storyShown = false;
+        });
       }
 
       if (


### PR DESCRIPTION
### What this PR does

Fixes a bug which causes an error to be thrown in the console and the UI doing nothing when trying to add a reference catalog item while the story is playing. The reference catalog item is any item with a `ReferenceMixin`.

Fixes issue reported here - https://github.com/TerriaJS/vic-digital-twin/issues/99

### Reproducing the error
- Visit this `next` branch [link](http://ci.terria.io/next/#share=s-qCDxjPHftfPTfkVSFHR7pPeSzdk&https://gist.githubusercontent.com/na9da/f7f289425fa78a76d8d251c10d399c52/raw/f5ea72ebcdd889ff920828115c2129ded6883b62/ref.json)
- Play the story
- Now open the catalog editor and add the item "I am a reference"
- The item should have been added to the workbench, but nothing happens
- Open the console to see a mobx error

### Testing the fix
- Repeat the same steps for this branch here - [link](http://ci.terria.io/fix-ref-add-with-story/#share=s-qCDxjPHftfPTfkVSFHR7pPeSzdk&https://gist.githubusercontent.com/na9da/f7f289425fa78a76d8d251c10d399c52/raw/f5ea72ebcdd889ff920828115c2129ded6883b62/ref.json)

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated CHANGES.md with what I changed.
