### PR TITLE
Skip error service initialization when no config provided.

### DIFF
--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -683,8 +683,8 @@ export default class Terria {
   /**
    * Initialize errorService from config parameters.
    */
-  setupErrorServiceProvider() {
-    initializeErrorServiceProvider(this.configParameters.errorService)
+  setupErrorServiceProvider(errorService: any) {
+    initializeErrorServiceProvider(errorService)
       .then(errorService => {
         this.errorService = errorService;
       })
@@ -783,7 +783,9 @@ export default class Terria {
         if (isJsonObject(config) && isJsonObject(config.parameters)) {
           this.updateParameters(config.parameters);
         }
-        this.setupErrorServiceProvider();
+        if (this.configParameters.errorService) {
+          this.setupErrorServiceProvider(this.configParameters.errorService);
+        }
         this.setupInitializationUrls(baseUri, config);
       });
     } catch (error) {


### PR DESCRIPTION
### What this PR does

Currently we try to initialize error service even when no error service configuration is provided. This, although harmless, pollutes the console by unnecessarily logging an error. This change fixes that by attempting to initialize the error service only if a configuration is provided.

### Testing
- Visit `next` branch CI - [link](http://ci.terria.io/next/)
- Open the console to see the error `Failed to initialize error service Error: Unknown error service provider: undefined`
- Now visit the CI for this branch - [link](http://ci.terria.io/no-config-no-init/)
- Open the console, you shouldn't see the error.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
