### PR TITLE
Fix model update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Change Log
 * Added `catalog-converter` support for v7 `#start` data.
 * add french Help button translation
 * Enable FeatureInfoSectionSpec tests
+* Fixed unnecessary model reloads or recomputing of `mapItems` when switching between story scenes.
+* Fixed story reset button.
 * [The next improvement]
 
 #### 8.0.0

--- a/lib/Core/AsyncLoader.ts
+++ b/lib/Core/AsyncLoader.ts
@@ -100,6 +100,7 @@ export default class AsyncLoader {
     return this._result;
   }
 
+  @action
   async load(forceReload: boolean = false): Promise<Result<void>> {
     if (forceReload) {
       runInAction(() => ++this._forceReloadCount);

--- a/lib/ModelMixins/CatalogMemberMixin.ts
+++ b/lib/ModelMixins/CatalogMemberMixin.ts
@@ -1,4 +1,4 @@
-import { computed, runInAction } from "mobx";
+import { action, computed, runInAction } from "mobx";
 import AsyncLoader from "../Core/AsyncLoader";
 import Constructor from "../Core/Constructor";
 import isDefined from "../Core/isDefined";
@@ -203,10 +203,10 @@ namespace CatalogMemberMixin {
 export default CatalogMemberMixin;
 
 /** Convenience function to get user readable name of a BaseModel */
-export function getName(model: BaseModel | undefined) {
+export const getName = action((model: BaseModel | undefined) => {
   return (
     (CatalogMemberMixin.isMixedInto(model) ? model.name : undefined) ??
     model?.uniqueId ??
     "Unknown model"
   );
-}
+});

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -29,11 +29,12 @@ import isDefined from "../Core/isDefined";
 import { isJsonObject, JsonObject } from "../Core/Json";
 import makeRealPromise from "../Core/makeRealPromise";
 import runLater from "../Core/runLater";
+import TerriaError from "../Core/TerriaError";
+import proxyCatalogItemUrl from "../Models/Catalog/proxyCatalogItemUrl";
 import CommonStrata from "../Models/Definition/CommonStrata";
 import createStratumInstance from "../Models/Definition/createStratumInstance";
-import Feature from "../Models/Feature";
 import Model from "../Models/Definition/Model";
-import proxyCatalogItemUrl from "../Models/Catalog/proxyCatalogItemUrl";
+import Feature from "../Models/Feature";
 import { SelectableDimension } from "../Models/SelectableDimensions";
 import Cesium3DTilesCatalogItemTraits from "../Traits/TraitsClasses/Cesium3DTilesCatalogItemTraits";
 import Cesium3dTilesTraits, {
@@ -42,7 +43,6 @@ import Cesium3dTilesTraits, {
 import CatalogMemberMixin, { getName } from "./CatalogMemberMixin";
 import MappableMixin from "./MappableMixin";
 import ShadowMixin from "./ShadowMixin";
-import TerriaError from "../Core/TerriaError";
 
 const DEFAULT_HIGHLIGHT_COLOR = "#ff3f00";
 

--- a/lib/ModelMixins/MappableMixin.ts
+++ b/lib/ModelMixins/MappableMixin.ts
@@ -1,5 +1,5 @@
 import i18next from "i18next";
-import { computed } from "mobx";
+import { computed, runInAction } from "mobx";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import TerrainProvider from "terriajs-cesium/Source/Core/TerrainProvider";
 import DataSource from "terriajs-cesium/Source/DataSources/DataSource";
@@ -119,11 +119,13 @@ function MappableMixin<T extends Constructor<Model<MappableTraits>>>(Base: T) {
      */
     async loadMapItems(force?: boolean): Promise<Result<void>> {
       try {
-        if (this.shouldShowInitialMessage) {
-          // Don't await the initialMessage because this causes cyclic dependency between loading
-          //  and user interaction (see https://github.com/TerriaJS/terriajs/issues/5528)
-          this.showInitialMessage();
-        }
+        runInAction(() => {
+          if (this.shouldShowInitialMessage) {
+            // Don't await the initialMessage because this causes cyclic dependency between loading
+            //  and user interaction (see https://github.com/TerriaJS/terriajs/issues/5528)
+            this.showInitialMessage();
+          }
+        });
         if (CatalogMemberMixin.isMixedInto(this))
           (await this.loadMetadata()).throwIfError();
 

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -951,9 +951,14 @@ export default class Cesium extends GlobeOrMap {
   @computed
   get _extraCredits() {
     const credits: { cesium?: Credit; terria?: Credit } = {};
-    if (this._terrainWithCredits.credit) {
-      credits.cesium = this._terrainWithCredits.credit;
-    }
+    // Disabling this for now as it doesn't seem to be used anywhere but
+    // results in mapItems being computed twice for all workbench items when
+    // cesium map is loaded. This happens because the reference to
+    // _extraCredits is from within the constructor for Cesium which itself is
+    // called inside an untracked() call in TerriaViewer.
+    // if (this._terrainWithCredits.credit) {
+    //   credits.cesium =  this._terrainWithCredits.credit;
+    //}
     if (!this.terria.configParameters.hideTerriaLogo) {
       const logo = require("../../wwwroot/images/terria-watermark.svg");
       credits.terria = new Credit(

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1045,10 +1045,12 @@ export default class Terria {
       })
     );
 
-    if (!this.mainViewer.baseMap) {
-      // Note: there is no "await" here - as basemaps can take a while to load and there is no need to wait for them to load before rendering Terria
-      this.loadPersistedOrInitBaseMap();
-    }
+    runInAction(() => {
+      if (!this.mainViewer.baseMap) {
+        // Note: there is no "await" here - as basemaps can take a while to load and there is no need to wait for them to load before rendering Terria
+        this.loadPersistedOrInitBaseMap();
+      }
+    });
 
     if (errors.length > 0) {
       // Note - this will get wrapped up in a Result object because it is called in AsyncLoader

--- a/lib/ReactViews/Story/StoryPanel.jsx
+++ b/lib/ReactViews/Story/StoryPanel.jsx
@@ -37,7 +37,7 @@ export async function activateStory(scene, terria) {
         try {
           await terria.applyInitData({
             initData: initSource,
-            replaceStratum: false,
+            replaceStratum: true,
             canUnsetFeaturePickingState: true
           });
         } catch (e) {

--- a/lib/ReactViews/Story/StoryPanel.jsx
+++ b/lib/ReactViews/Story/StoryPanel.jsx
@@ -159,14 +159,7 @@ const StoryPanel = observer(
     },
 
     onCenterScene(story) {
-      if (story.shareData) {
-        this.props.terria
-          .updateFromStartData(
-            story.shareData,
-            `Story data: \`${story.title ?? story.id}\``
-          )
-          .raiseError(this.props.terria);
-      }
+      activateStory(story, this.props.terria);
     },
 
     goToPrevStory() {

--- a/lib/Traits/Decorators/anyTrait.ts
+++ b/lib/Traits/Decorators/anyTrait.ts
@@ -1,3 +1,4 @@
+import { computed } from "mobx";
 import Result from "../../Core/Result";
 import { BaseModel } from "../../Models/Definition/Model";
 import Trait, { TraitOptions } from "../Trait";
@@ -19,6 +20,8 @@ export default function anyTrait(options: TraitOptions) {
 }
 
 export class AnyTrait extends Trait {
+  readonly decoratorForFlattened = computed.struct;
+
   constructor(id: string, options: AnyTraitOptions, parent: any) {
     super(id, options, parent);
   }


### PR DESCRIPTION
### What this PR does

Fixes #4119 and also will improve performance when switching between story scenes.

Changes:
- Wraps `AsyncLoader.load()` in action so that mobx correctly caches load item promise and `mapItems`.
-  Fully resets a model state when switching story scenes

### Testing - model state reset
- Open this `main` branch [story](http://ci.terria.io/main/#share=s-uHFdujNkQUq9wukMQVnZdQd40cf)
- Switch story scenes from `A -> B -> A`
- Observe that the style is not reset back to True color when switching back to scene `A` from `B`.
- Now repeat the same for this [branch](http://ci.terria.io/fix-model-update/#share=s-uHFdujNkQUq9wukMQVnZdQd40cf).
- Observe that the style is reset back to True color.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
