### PR TITLE
Filter table column values by Z Score

### DIFF
--- a/lib/Map/ContinuousColorMap.ts
+++ b/lib/Map/ContinuousColorMap.ts
@@ -3,6 +3,7 @@ import ColorMap from "./ColorMap";
 
 export interface ContinuousColorMapOptions {
   readonly nullColor: Readonly<Color>;
+  readonly outlierColor: Readonly<Color>;
   readonly minValue: number;
   readonly maxValue: number;
   readonly colorScale: (t: number) => string;
@@ -11,6 +12,7 @@ export interface ContinuousColorMapOptions {
 export default class ContinuousColorMap extends ColorMap {
   readonly colorScale: (t: number) => string;
   readonly nullColor: Readonly<Color>;
+  readonly outlierColor: Readonly<Color>;
   readonly minValue: number;
   readonly maxValue: number;
 
@@ -27,6 +29,7 @@ export default class ContinuousColorMap extends ColorMap {
 
     this.colorScale = options.colorScale;
     this.nullColor = options.nullColor;
+    this.outlierColor = options.outlierColor;
     this.minValue = options.minValue;
     this.maxValue = options.maxValue;
   }
@@ -35,6 +38,9 @@ export default class ContinuousColorMap extends ColorMap {
     if (typeof value !== "number") {
       return this.nullColor;
     }
+
+    if (value > this.maxValue || value < this.minValue)
+      return this.outlierColor;
 
     return Color.fromCssColorString(
       this.colorScale((value - this.minValue) / (this.maxValue - this.minValue))

--- a/lib/Table/TableColorMap.ts
+++ b/lib/Table/TableColorMap.ts
@@ -52,21 +52,38 @@ export default class TableColorMap {
   }
 
   @computed
+  get filteredValues() {
+    const values =
+      this.regionValues ?? this.colorColumn?.valuesAsNumbers.values ?? [];
+    const numValues = values.filter(val => val !== null) as number[];
+    if (numValues.length === 0) return [];
+
+    // Filter by z-score if applicable
+    // This will filter out values which are outside of `zScoreFilter` standard deviations from the mean
+    if (this.colorTraits.zScoreFilter) {
+      const std = getStandardDeviation(numValues);
+      const mean = getMean(numValues);
+
+      return numValues.filter(
+        val => Math.abs((val - mean) / std) <= this.colorTraits.zScoreFilter!
+      );
+    }
+
+    return numValues;
+  }
+
+  @computed
   get minimumValue() {
     if (isDefined(this.colorTraits.minimumValue))
       return this.colorTraits.minimumValue;
-    return this.regionValues
-      ? Math.min(...this.regionValues)
-      : this.colorColumn?.valuesAsNumbers.minimum;
+    return Math.min(...this.filteredValues);
   }
 
   @computed
   get maximumValue() {
     if (isDefined(this.colorTraits.maximumValue))
       return this.colorTraits.maximumValue;
-    return this.regionValues
-      ? Math.max(...this.regionValues)
-      : this.colorColumn?.valuesAsNumbers.maximum;
+    return Math.max(...this.filteredValues);
   }
 
   /**
@@ -86,6 +103,10 @@ export default class TableColorMap {
     const nullColor = colorTraits.nullColor
       ? Color.fromCssColorString(colorTraits.nullColor) ?? Color.TRANSPARENT
       : Color.TRANSPARENT;
+
+    const outlierColor = colorTraits.outlierColor
+      ? Color.fromCssColorString(colorTraits.outlierColor) ?? Color.BLACK
+      : Color.BLACK;
 
     // If column type is `scalar` - use DiscreteColorMap or ContinuousColorMap
     if (colorColumn && colorColumn.type === TableColumnType.scalar) {
@@ -118,7 +139,8 @@ export default class TableColorMap {
           colorScale,
           minValue: this.minimumValue,
           maxValue: this.maximumValue,
-          nullColor
+          nullColor,
+          outlierColor
         });
       }
     }
@@ -447,4 +469,17 @@ export default class TableColorMap {
       );
     }
   }
+}
+
+function getMean(array: number[]) {
+  return array.reduce((a, b) => a + b) / array.length;
+}
+
+// https://stackoverflow.com/a/53577159
+function getStandardDeviation(array: number[]) {
+  const n = array.length;
+  const mean = getMean(array);
+  return Math.sqrt(
+    array.map(x => Math.pow(x - mean, 2)).reduce((a, b) => a + b) / n
+  );
 }

--- a/lib/Traits/TraitsClasses/TableColorStyleTraits.ts
+++ b/lib/Traits/TraitsClasses/TableColorStyleTraits.ts
@@ -54,6 +54,14 @@ export default class TableColorStyleTraits extends ModelTraits {
   nullColor?: string;
 
   @primitiveTrait({
+    name: "Outlier Color",
+    description:
+      'The color to use when the value is considered an "outlier" (and therefore not shown on color scale), specified as a CSS color string. This will only apply if `zScoreFilter` is defined',
+    type: "string"
+  })
+  outlierColor?: string;
+
+  @primitiveTrait({
     name: "Region Color",
     description:
       "The color to use when the styling the region, specified as a CSS color string.",
@@ -173,4 +181,12 @@ export default class TableColorStyleTraits extends ModelTraits {
     type: LegendTraits
   })
   legend?: LegendTraits;
+
+  @primitiveTrait({
+    name: "Z-score filter",
+    description:
+      "Treat values outside of specifed z-score as outliers, and therefore do not include in color scale. This value is magnitude of z-score - it will apply to positive and negative z-scores. For example a value of `2` will treat all values that are 2 or more standard deviations from the mean as outliers.",
+    type: "number"
+  })
+  zScoreFilter?: number;
 }


### PR DESCRIPTION
### Filter table column values by Z Score

For https://github.com/PacificCommunity/Terria-PacificMap/issues/70

Experiment to see if filtering column values by z score improves continuous color map for region mapping.

https://towardsdatascience.com/a-brief-overview-of-outlier-detection-techniques-1e0b2c19e561

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [ ] I've updated CHANGES.md with what I changed.
