### PR TITLE
Change share conversion version detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Fixed `withControlledVisibility` method to inherit `propTypes` of its wrapped component.
 * Added `MinMaxLevelMixin` and `MinMaxLevelTraits` to handle defining min and max scale denominator for layers.
 * Extracted function `scaleToDenominator` to core - for conversion of scale to zoom level.
+* Share/start data conversion will now only occur if `version` property is `0.x.x`. Previously, it was `version` property is **not** `8.x.x`
 * [The next improvement]
 
 #### 8.1.0


### PR DESCRIPTION
### Change share conversion version detection

Share/start data conversion will now only occur if `version` property is `0.x.x`. Previously, it was `version` property is **not** `8.x.x`

This is compatible with check still in `catalog-converter` - as it is more conservative (it will not convert if version is `8.x.x`)

https://github.com/TerriaJS/catalog-converter/blob/fb4827ad46479974a8c23ab17024f1e2034eb9e6/src/convert.ts#L229-L236

```ts
 // If version 8 return
  if (
    "version" in json &&
    typeof json.version === "string" &&
    json.version.startsWith("8")
  ) {
    return { result: json as Share, converted: false };
  }
```

### Test links

#### v7 startData

http://ci.terria.io/share-data-conversoin/#clean&hideExplorerPanel=1&start=%7B%22version%22%3A%220.0.03%22%2C%22initSources%22%3A%5B%7B%22catalog%22%3A%5B%7B%22type%22%3A%22group%22%2C%22name%22%3A%22User-Added%20Data%22%2C%22description%22%3A%22The%20group%20for%20data%20that%20was%20added%20by%20the%20user%20via%20the%20Add%20Data%20panel.%22%2C%22isUserSupplied%22%3Atrue%2C%22isOpen%22%3Atrue%2C%22items%22%3A%5B%7B%22type%22%3A%22geojson%22%2C%22name%22%3A%22User%20Data%22%2C%22isUserSupplied%22%3Atrue%2C%22isOpen%22%3Atrue%2C%22isEnabled%22%3Atrue%2C%22url%22%3A%22https%3A%2F%2Fpacificdata.org%2Fdata%2Fdataset%2F964dbebf-2f42-414e-bf99-dd7125eedb16%2Fresource%2Fdad3f7b2-a8aa-4584-8bca-a77e16a391fe%2Fdownload%2Fcountry_boundary_eez.geojson%22%7D%5D%7D%5D%2C%22catalogIsUserSupplied%22%3Atrue%2C%22homeCamera%22%3A%7B%22west%22%3A132%2C%22south%22%3A-28%2C%22east%22%3A201%2C%22north%22%3A8%7D%7D%5D%7D

#### v8 startData

**Note** request will fail, but model is correct

http://ci.terria.io/share-data-conversoin/#start=%7B%22initSources%22%3A%5B%7B%22catalog%22%3A%5B%7B%22name%22%3A%22Manningham%20Street%20Trees%20-%20Preview%20this%20Dataset%20(WMS)%22%2C%22type%22%3A%22magda%22%2C%22recordId%22%3A%22dist-dga-125506f6-5954-43e5-9529-67a9c170a72e%22%2C%22url%22%3A%22http%3A%2F%2Flocalhost%3A6108%2F%22%2C%22id%22%3A%22data.gov.au-postMessage-dist-dga-125506f6-5954-43e5-9529-67a9c170a72e%22%7D%5D%2C%22workbench%22%3A%5B%22data.gov.au-postMessage-dist-dga-125506f6-5954-43e5-9529-67a9c170a72e%22%5D%7D%5D%7D

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
