### PR TITLE
Wc sourcemaps

### DIFF
--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -104,7 +104,7 @@ function configureWebpack(terriaJSBasePath, config, devMode, hot, MiniCssExtract
                 loader: 'babel-loader',
                 options: {
                     cacheDirectory: true,
-                    sourceMaps: !!devMode,
+                    sourceMaps: true,
                     presets: [
                       [
                         '@babel/preset-env',

--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -104,6 +104,7 @@ function configureWebpack(terriaJSBasePath, config, devMode, hot, MiniCssExtract
                 loader: 'babel-loader',
                 options: {
                     cacheDirectory: true,
+                    sourceMaps: true,
                     presets: [
                       [
                         '@babel/preset-env',

--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -104,7 +104,7 @@ function configureWebpack(terriaJSBasePath, config, devMode, hot, MiniCssExtract
                 loader: 'babel-loader',
                 options: {
                     cacheDirectory: true,
-                    sourceMaps: true,
+                    sourceMaps: !!devMode,
                     presets: [
                       [
                         '@babel/preset-env',

--- a/buildprocess/webpack.config.make.js
+++ b/buildprocess/webpack.config.make.js
@@ -22,9 +22,9 @@ module.exports = function(hot, dev) {
             filename: 'TerriaJS-specs.js',
             publicPath: 'build/'
         },
-        devtool: 'source-map',
+        // devtool: 'source-map',
         // Use eval cheap module source map for quicker incremental tests
-        // devtool: dev ? 'eval-cheap-module-source-map' : 'source-map',
+        devtool: dev ? 'eval-cheap-module-source-map' : 'source-map',
         module: {
             rules: [
                 {
@@ -62,5 +62,5 @@ module.exports = function(hot, dev) {
     };
 
     config.plugins = [new MiniCssExtractPlugin({filename: "nationalmap.css", disable: false, ignoreOrder: true})];
-    return configureWebpack(terriaJSBasePath, config, hot, hot, MiniCssExtractPlugin, true);
+    return configureWebpack(terriaJSBasePath, config, dev, hot, MiniCssExtractPlugin, true);
 };

--- a/buildprocess/webpack.config.make.js
+++ b/buildprocess/webpack.config.make.js
@@ -22,9 +22,9 @@ module.exports = function(hot, dev) {
             filename: 'TerriaJS-specs.js',
             publicPath: 'build/'
         },
-        // devtool: 'source-map',
+        devtool: 'source-map',
         // Use eval cheap module source map for quicker incremental tests
-        devtool: dev ? 'eval-cheap-module-source-map' : 'source-map',
+        // devtool: dev ? 'eval-cheap-module-source-map' : 'source-map',
         module: {
             rules: [
                 {

--- a/buildprocess/webpack.config.make.js
+++ b/buildprocess/webpack.config.make.js
@@ -34,14 +34,14 @@ module.exports = function(hot, dev) {
                     loader: 'imports-loader?require=>false'
                 },
 
-                {
-                  test: /\.(ts|js)x?$/,
-                  include: [path.resolve(terriaJSBasePath, "lib")],
-                  use: {
-                    loader: "istanbul-instrumenter-loader"
-                  },
-                  enforce: "post"
-                }
+                // {
+                //   test: /\.(ts|js)x?$/,
+                //   include: [path.resolve(terriaJSBasePath, "lib")],
+                //   use: {
+                //     loader: "istanbul-instrumenter-loader"
+                //   },
+                //   enforce: "post"
+                // }
             ]
         },
         devServer: {

--- a/buildprocess/webpack.config.make.js
+++ b/buildprocess/webpack.config.make.js
@@ -62,5 +62,5 @@ module.exports = function(hot, dev) {
     };
 
     config.plugins = [new MiniCssExtractPlugin({filename: "nationalmap.css", disable: false, ignoreOrder: true})];
-    return configureWebpack(terriaJSBasePath, config, dev, hot, MiniCssExtractPlugin, true);
+    return configureWebpack(terriaJSBasePath, config, (dev || hot), hot, MiniCssExtractPlugin, true);
 };

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -534,6 +534,7 @@ export default class Terria {
   errorService: ErrorServiceProvider = new StubErrorServiceProvider();
 
   constructor(options: TerriaOptions = {}) {
+    debugger;
     if (options.baseUrl) {
       if (options.baseUrl.lastIndexOf("/") !== options.baseUrl.length - 1) {
         this.baseUrl = options.baseUrl + "/";

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -534,7 +534,6 @@ export default class Terria {
   errorService: ErrorServiceProvider = new StubErrorServiceProvider();
 
   constructor(options: TerriaOptions = {}) {
-    debugger;
     if (options.baseUrl) {
       if (options.baseUrl.lastIndexOf("/") !== options.baseUrl.length - 1) {
         this.baseUrl = options.baseUrl + "/";


### PR DESCRIPTION
### What this PR does
This enables sourcemaps when devmode is true (ie yarn dev). I have also disabled istandbul coverage reporter as that was interferring with source map generation

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [ ] I've updated CHANGES.md with what I changed.
