### PR TITLE
Fix loading map items of composite catalog item

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Change Log
 * Add `description` trait to `CatalogMemberReferenceTraits`
 * Added `excludeMembers` property to `GroupTraits` (this replaced the `blacklist` property in v7). It is an array of strings of excluded group and item names. A group or item name that appears in this list will not be shown to the user. This is case-insensitive and will also apply to all child/nested groups
 * Fixes an app crash on load in iOS-Safari mobile which was happening when rendering help panel tooltips.
+* Fixed a problem with computeds and AsyncLoader when loading `mapItems` (and hence children's `mapItems`) of a CompositeCatalogItem.
 * [The next improvement]
 
 #### 8.1.0

--- a/lib/Models/Catalog/CatalogItems/CompositeCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/CompositeCatalogItem.ts
@@ -46,6 +46,7 @@ export default class CompositeCatalogItem extends MappableMixin(
   }
 
   protected async forceLoadMetadata(): Promise<void> {
+    await Promise.resolve();
     Result.combine(
       await Promise.all(
         this.memberModels
@@ -57,6 +58,7 @@ export default class CompositeCatalogItem extends MappableMixin(
   }
 
   async forceLoadMapItems(): Promise<void> {
+    await Promise.resolve();
     Result.combine(
       await Promise.all(
         this.memberModels

--- a/lib/Models/Catalog/CatalogItems/CompositeCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/CompositeCatalogItem.ts
@@ -46,25 +46,21 @@ export default class CompositeCatalogItem extends MappableMixin(
   }
 
   protected async forceLoadMetadata(): Promise<void> {
+    const members = this.memberModels.filter(CatalogMemberMixin.isMixedInto);
+    // Avoid calling loadX functions in a computed context
     await Promise.resolve();
     Result.combine(
-      await Promise.all(
-        this.memberModels
-          .filter(CatalogMemberMixin.isMixedInto)
-          .map(async model => await model.loadMetadata())
-      ),
+      await Promise.all(members.map(async model => await model.loadMetadata())),
       "Failed to load composite catalog items metadata"
     ).throwIfError();
   }
 
   async forceLoadMapItems(): Promise<void> {
+    const members = this.memberModels.filter(MappableMixin.isMixedInto);
+    // Avoid calling loadX functions in a computed context
     await Promise.resolve();
     Result.combine(
-      await Promise.all(
-        this.memberModels
-          .filter(MappableMixin.isMixedInto)
-          .map(model => model.loadMapItems())
-      ),
+      await Promise.all(members.map(model => model.loadMapItems())),
       "Failed to load composite catalog items mapItems"
     ).throwIfError();
   }


### PR DESCRIPTION
Run CompositeCatalogItem member loading outside computed


### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
