### PR TITLE
Fix clean hash parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.2)
 
+* Wrap clean initSources with action.
 * [The next improvement]
 
 #### 8.1.1

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1747,7 +1747,9 @@ async function interpretHash(
   baseUri: uri.URI
 ) {
   if (isDefined(hashProperties.clean)) {
-    terria.initSources.splice(0, terria.initSources.length);
+    runInAction(() => {
+      terria.initSources.splice(0, terria.initSources.length);
+    });
   }
 
   runInAction(() => {


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Adding `#clean` to URL fails with 
```
[mobx] Since strict-mode is enabled, changing observed observable values outside actions is not allowed. Please wrap the code in an `action` if this change is intended. Tried to modify: Terria@128.initSources
```
### Checklist

-   [x] ~~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~~
-   [x] ~~I've updated relevant documentation in `doc/`.~~
-   [x] I've updated CHANGES.md with what I changed.
