### PR TITLE
TerriaReference should retain its name when expanded.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.2)
 
+* Modified `TerriaReference` to retain its name when expanded. Previously, when the reference is expanded, it will assume the name of the group or item of the target.
 * [The next improvement]
 
 #### 8.1.1

--- a/lib/Models/Catalog/CatalogReferences/TerriaReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/TerriaReference.ts
@@ -81,6 +81,11 @@ export default class TerriaReference extends UrlMixin(
           })
         });
       } else {
+        if (targetJson.name !== undefined) {
+          // Override the target's name with the name of this reference.
+          // This avoids the name of the catalog suddenly changing after the reference is loaded.
+          targetJson.name = this.name;
+        }
         updateModelFromJson(
           target,
           CommonStrata.definition,

--- a/test/Models/Catalog/CatalogReferences/TerriaReferenceSpec.ts
+++ b/test/Models/Catalog/CatalogReferences/TerriaReferenceSpec.ts
@@ -2,7 +2,9 @@ import GroupMixin from "../../../../lib/ModelMixins/GroupMixin";
 import TerriaReference from "../../../../lib/Models/Catalog/CatalogReferences/TerriaReference";
 import WebMapServiceCatalogItem from "../../../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
 import CommonStrata from "../../../../lib/Models/Definition/CommonStrata";
+import hasTraits from "../../../../lib/Models/Definition/hasTraits";
 import Terria from "../../../../lib/Models/Terria";
+import CatalogMemberTraits from "../../../../lib/Traits/TraitsClasses/CatalogMemberTraits";
 
 describe("TerriaReference", function() {
   it("can load a full terria catalog", async function() {
@@ -41,5 +43,19 @@ describe("TerriaReference", function() {
     const target = ref.target;
     expect(target).toBeDefined();
     expect(target instanceof WebMapServiceCatalogItem).toBe(true);
+  });
+
+  it("the target item should use the name of the terria reference item", async function() {
+    const ref = new TerriaReference("test", new Terria());
+    ref.setTrait(CommonStrata.user, "url", "test/init/wms-v8.json");
+    ref.setTrait(CommonStrata.user, "isGroup", true);
+    ref.setTrait(CommonStrata.user, "path", ["MLzS8W"]);
+    ref.setTrait(CommonStrata.user, "name", "Foo");
+    await ref.loadReference();
+    const target = ref.target;
+    expect(hasTraits(target, CatalogMemberTraits, "name")).toBe(true);
+    if (hasTraits(target, CatalogMemberTraits, "name")) {
+      expect(target.name).toBe("Foo");
+    }
   });
 });


### PR DESCRIPTION
### What this PR does

Modified `TerriaReference` to retain its name when expanded. Previously, when the reference is expanded, it will assume the name of the group or item of the target.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
