### PR TITLE
Remove help menu icon and tooltip from map navigation menu.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@ Change Log
 ==========
 
 #### next release (8.1.2)
-* Removed duplicate Help icon and tooltip from the map navigation menu at the bottom as it is now shown in the top menu.
 
+* Removed duplicate Help icon and tooltip from the map navigation menu at the bottom as it is now shown in the top menu.
 * Fixed a bug where the app shows a scrollbar in some instances.
 * Wrap clean initSources with action.
 * Modified `TerriaReference` to retain its name when expanded. Previously, when the reference is expanded, it will assume the name of the group or item of the target.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Change Log
 ==========
 
 #### next release (8.1.2)
-
+* Removed duplicate Help icon and tooltip from the map navigation menu at the bottom as it is now shown in the top menu.
 * [The next improvement]
 
 #### 8.1.1

--- a/lib/ReactViews/Map/Navigation/MapNavigation.tsx
+++ b/lib/ReactViews/Map/Navigation/MapNavigation.tsx
@@ -16,13 +16,10 @@ import isDefined from "../../../Core/isDefined";
 import ViewState from "../../../ReactViewModels/ViewState";
 import Box from "../../../Styled/Box";
 import Icon, { GLYPHS } from "../../../Styled/Icon";
-import Text from "../../../Styled/Text";
 import MapNavigationModel, {
   IMapNavigationItem,
   OVERFLOW_ITEM_ID
 } from "../../../ViewModels/MapNavigation/MapNavigationModel";
-import Prompt from "../../Generic/Prompt";
-import { Medium } from "../../Generic/Responsive";
 import withControlledVisibility from "../../HOCs/withControlledVisibility";
 import MapIconButton from "../../MapIconButton/MapIconButton";
 import { Control, MapNavigationItem } from "./Items/MapNavigationItem";
@@ -323,31 +320,6 @@ class MapNavigation extends React.Component<PropTypes> {
             {bottomItems?.map(item => (
               <MapNavigationItem key={item.id} item={item} terria={terria} />
             ))}
-            <Medium>
-              <Prompt
-                content={
-                  <div>
-                    <Text bold extraLarge textLight>
-                      {t("helpPanel.promptMessage")}
-                    </Text>
-                  </div>
-                }
-                displayDelay={500}
-                dismissText={t("helpPanel.dismissText")}
-                dismissAction={() => {
-                  runInAction(() =>
-                    viewState.toggleFeaturePrompt("help", false, true)
-                  );
-                }}
-                caretTopOffset={75}
-                caretLeftOffset={265}
-                caretSize={15}
-                promptWidth={273}
-                promptTopOffset={20}
-                promptLeftOffset={-330}
-                isVisible={viewState.featurePrompts.indexOf("help") >= 0}
-              />
-            </Medium>
           </ControlWrapper>
         </Box>
       </StyledMapNavigation>

--- a/lib/ReactViews/Map/Navigation/registerMapNavigations.tsx
+++ b/lib/ReactViews/Map/Navigation/registerMapNavigations.tsx
@@ -13,7 +13,6 @@ import PedestrianMode, {
   PEDESTRIAN_MODE_ID
 } from "../../Tools/PedestrianMode/PedestrianMode";
 import { ToolButtonController } from "../../Tools/Tool";
-import { HELP_PANEL_ID } from "../Panels/HelpPanel/HelpPanel";
 import {
   AR_TOOL_ID,
   AugmentedVirtualityController,
@@ -201,19 +200,5 @@ export const registerMapNavigations = (viewState: ViewState) => {
     screenSize: "medium",
     controller: feedbackController,
     order: 8
-  });
-
-  const helpController = new GenericMapNavigationItemController({
-    icon: GLYPHS.helpThick,
-    handleClick: () => viewState.showHelpPanel()
-  });
-  mapNavigationModel.addItem({
-    id: HELP_PANEL_ID,
-    name: "translate#helpMenu.btnText",
-    title: "translate#helpMenu.btnTitle",
-    location: "BOTTOM",
-    screenSize: "medium",
-    controller: helpController,
-    order: 9
   });
 };


### PR DESCRIPTION
### What this PR does

Removes duplicate Help icon and tooltip from the map navigation menu at the bottom as it is now shown in the top menu.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
