### PR TITLE
Fix a couple of bugs that caused the app to show scrollbar in certain instances.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@ Change Log
 ==========
 
 #### next release (8.1.2)
-* Fixed a bug where the app shows a scrollbar in some instances.
 
+* Fixed a bug where the app shows a scrollbar in some instances.
 * Wrap clean initSources with action.
 * Modified `TerriaReference` to retain its name when expanded. Previously, when the reference is expanded, it will assume the name of the group or item of the target.
 * [The next improvement]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Change Log
 ==========
 
 #### next release (8.1.2)
-
+* Fixed a bug where the app shows a scrollbar in some instances.
 * [The next improvement]
 
 #### 8.1.1

--- a/lib/ReactViews/DragDropFile.tsx
+++ b/lib/ReactViews/DragDropFile.tsx
@@ -119,7 +119,7 @@ class DragDropFile extends React.Component<PropsType> {
           [Styles.isActive]: this.props.viewState.isDraggingDroppingFile
         })}
       >
-        {isDefined(this.props.viewState.isDraggingDroppingFile) ? (
+        {this.props.viewState.isDraggingDroppingFile ? (
           <div className={Styles.inner}>
             <Trans i18nKey="dragDrop.text">
               <h3 className={Styles.heading}>Drag & Drop</h3>

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -248,7 +248,7 @@ const StandardUserInterface = observer(
         !this.shouldUseMobileInterface();
       const showStoryPanel =
         this.props.terria.configParameters.storyEnabled &&
-        this.props.terria.stories.length &&
+        this.props.terria.stories.length > 0 &&
         this.props.viewState.storyShown &&
         !this.props.viewState.explorerPanelIsVisible &&
         !this.props.viewState.storyBuilderShown;


### PR DESCRIPTION
### What this PR does

Fix a couple of bugs that caused the app to show scrollbar in certain instances.

### Testing

Since the scrollbar is currently triggered only in the natmap repo, the changes need to be tested against that repo.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
