### PR TITLE
Correct a comment in proxyCatalogItemUrl

### DIFF
--- a/lib/Models/Catalog/proxyCatalogItemUrl.ts
+++ b/lib/Models/Catalog/proxyCatalogItemUrl.ts
@@ -10,7 +10,7 @@ import UrlReference from "./CatalogReferences/UrlReference";
  * The terriajs-server is the default server that proxies a URL associated with a catalog item, if necessary.
  * @param {CatalogItem} [catalogItem] The catalog item.
  * @param {string} url The URL to be proxied.
- * @param {string} [cacheDuration] The cache duration to override catalogItem.cacheDuration.
+ * @param {string} [cacheDuration] The cache duration to use if catalogItem.cacheDuration is undefined.
  * @returns {string} The URL, now cached if necessary.
  */
 export default function proxyCatalogItemUrl(


### PR DESCRIPTION
The comment about the purpose of `cacheDuration` parameter was changed mistakenly. This restores the old correct comment.