### PR TITLE
Fix `ContinuousColorMap` `Legend` issue due to funky JS precision

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 #### next release (8.1.3)
 
 * Reimplement map viewer url param
+* Fix `ContinuousColorMap` `Legend` issue due to funky JS precision
 * [The next improvement]
 
 #### 8.1.2

--- a/lib/Table/TableAutomaticStylesStratum.ts
+++ b/lib/Table/TableAutomaticStylesStratum.ts
@@ -321,8 +321,12 @@ export class ColorStyleLegend extends LoadableStratum(LegendTraits) {
     return new Array(7)
       .fill(0)
       .map((_, i) => {
+        // Use maxValue if i === 6 so we don't get funky JS precision
         const value =
-          colorMap.minValue + (colorMap.maxValue - colorMap.minValue) * (i / 6);
+          i === 6
+            ? colorMap.maxValue
+            : colorMap.minValue +
+              (colorMap.maxValue - colorMap.minValue) * (i / 6);
         return createStratumInstance(LegendItemTraits, {
           color: colorMap.mapValueToColor(value).toCssColorString(),
           title: this._formatValue(value, this.numberFormatOptions)


### PR DESCRIPTION
### What this PR does

![image](https://user-images.githubusercontent.com/6187649/136964313-fa4e849e-4822-43ab-9997-722003c1560a.png)

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
