### PR TITLE
Remove mobx computed cycle on Ckan item name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Change Log
 * Fix Branding component. It wasn't wrapped in `observer` so it kept getting re-rendered
 * Add `FeedbackLink` and `<feedbacklink>` custom component - this can be used to add a button to open feedback dialog (or show `supportEmail` in feedback is disabled)
 * Fix `ContinuousColorMap` `Legend` issue due to funky JS precision
+* Fix mobx computed cycle in `CkanDatasetStratum` which was making error messages for failed loading of CKAN items worse.
 * [The next improvement]
 
 #### 8.1.2

--- a/lib/Models/Catalog/Ckan/CkanItemReference.ts
+++ b/lib/Models/Catalog/Ckan/CkanItemReference.ts
@@ -124,7 +124,7 @@ export class CkanDatasetStratum extends LoadableStratum(
   }
 
   @computed get name() {
-    if (this.ckanResource === undefined) return this.ckanItemReference.name;
+    if (this.ckanResource === undefined) return undefined;
     if (this.ckanItemReference.useResourceName) return this.ckanResource.name;
     // via @steve9164
     /** Switched the order [check `useCombinationNameWhereMultipleResources`


### PR DESCRIPTION
### What this PR does

When a CkanItemReference doesn't load properly it used to cause a mobx computed cycle. Now it's fixed, so error messages about the item not loading correctly should be improved


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
