### PR TITLE
Add all knownContainerIds to sharelink models 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ Change Log
 * Add `FeedbackLink` and `<feedbacklink>` custom component - this can be used to add a button to open feedback dialog (or show `supportEmail` in feedback is disabled)
 * Fix `ContinuousColorMap` `Legend` issue due to funky JS precision
 * Fix mobx computed cycle in `CkanDatasetStratum` which was making error messages for failed loading of CKAN items worse.
-* Change flexsearch to use web workers
+* Make flex-search usage (for `CatalogIndex`) web-worker based
 * Add `completeKnownContainerUniqueIds` to `Model` class - This will recursively travese tree of knownContainerUniqueIds models to return full list of dependencies
 * Add all `completeKnownContainerUniqueIds` to shareData.models
 * Add all models from `completeKnownContainerUniqueIds` to shareData.models (even if they are empty)
@@ -38,7 +38,6 @@ Change Log
 * Wrap clean initSources with action.
 * Modified `TerriaReference` to retain its name when expanded. Previously, when the reference is expanded, it will assume the name of the group or item of the target.
 * Proxy `catalogIndex.url`
-* Make flex-search usage (for `CatalogIndex`) web-worker based
 
 #### 8.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,6 @@ Change Log
 * Fix mobx computed cycle in `CkanDatasetStratum` which was making error messages for failed loading of CKAN items worse.
 * Make flex-search usage (for `CatalogIndex`) web-worker based
 * Add `completeKnownContainerUniqueIds` to `Model` class - This will recursively travese tree of knownContainerUniqueIds models to return full list of dependencies
-* Add all `completeKnownContainerUniqueIds` to shareData.models
 * Add all models from `completeKnownContainerUniqueIds` to shareData.models (even if they are empty)
 * [The next improvement]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Wrap clean initSources with action.
 * Modified `TerriaReference` to retain its name when expanded. Previously, when the reference is expanded, it will assume the name of the group or item of the target.
 * Proxy `catalogIndex.url`
+* Make flex-search usage (for `CatalogIndex`) web-worker based
 
 #### 8.1.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@ Change Log
 * Add `FeedbackLink` and `<feedbacklink>` custom component - this can be used to add a button to open feedback dialog (or show `supportEmail` in feedback is disabled)
 * Fix `ContinuousColorMap` `Legend` issue due to funky JS precision
 * Fix mobx computed cycle in `CkanDatasetStratum` which was making error messages for failed loading of CKAN items worse.
+* Change flexsearch to use web workers
+* Add `completeKnownContainerUniqueIds` to `Model` class - This will recursively travese tree of knownContainerUniqueIds models to return full list of dependencies
+* Add all `completeKnownContainerUniqueIds` to shareData.models
+* Add all models from `completeKnownContainerUniqueIds` to shareData.models (even if they are empty)
 * [The next improvement]
 
 #### 8.1.2

--- a/lib/Models/Catalog/CatalogReferences/CatalogIndexReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/CatalogIndexReference.ts
@@ -43,22 +43,19 @@ export default class CatalogIndexReference extends ReferenceMixin(
 
     // No member exists, so try to load containers
     // Get full list of containers by recursively searching for parent models
-    const findContainers = (model: CatalogIndexReference): string[] => {
-      const knownContainerUniqueIds: string[] = [
-        ...model.memberKnownContainerUniqueIds,
-        ...flatten(
-          filterOutUndefined(
-            model.memberKnownContainerUniqueIds.map(parentId => {
-              const parent = this.terria.catalogIndex?.models?.get(parentId);
-              if (parent) {
-                return findContainers(parent);
-              }
-            })
-          )
+    const findContainers = (model: CatalogIndexReference): string[] => [
+      ...model.memberKnownContainerUniqueIds,
+      ...flatten(
+        filterOutUndefined(
+          model.memberKnownContainerUniqueIds.map(parentId => {
+            const parent = this.terria.catalogIndex?.models?.get(parentId);
+            if (parent) {
+              return findContainers(parent);
+            }
+          })
         )
-      ];
-      return knownContainerUniqueIds;
-    };
+      )
+    ];
 
     const containers = findContainers(this).reverse();
 

--- a/lib/Models/SearchProviders/CatalogIndex.ts
+++ b/lib/Models/SearchProviders/CatalogIndex.ts
@@ -1,5 +1,5 @@
 import { Document } from "flexsearch";
-import { action, observable, ObservableMap } from "mobx";
+import { action, runInAction } from "mobx";
 import loadJson from "../../Core/loadJson";
 import CatalogIndexReferenceTraits from "../../Traits/TraitsClasses/CatalogIndexReferenceTraits";
 import CatalogIndexReference from "../Catalog/CatalogReferences/CatalogIndexReference";
@@ -129,10 +129,13 @@ export default class CatalogIndex {
         if (indexReference && !matchedIds.has(id)) {
           matchedIds.add(id);
           results.push(
-            new SearchResult({
-              name: indexReference.name ?? indexReference.uniqueId,
-              catalogItem: indexReference
-            })
+            runInAction(
+              () =>
+                new SearchResult({
+                  name: indexReference.name ?? indexReference.uniqueId,
+                  catalogItem: indexReference
+                })
+            )
           );
         }
       });

--- a/lib/Models/SearchProviders/CatalogIndex.ts
+++ b/lib/Models/SearchProviders/CatalogIndex.ts
@@ -23,7 +23,9 @@ export default class CatalogIndex {
   get models() {
     return this._models;
   }
-  private _searchIndex: any; // Flex-search document index
+  private _searchIndex:
+    | Document<{ id: string; name: string; description: string }>
+    | undefined; // Flex-search document index
 
   get searchIndex() {
     return this._searchIndex;
@@ -53,8 +55,11 @@ export default class CatalogIndex {
        *    - "full" = index every possible combination
        *    - "strict" = index whole words
        *  - resolution property = score resolution
+       *
+       * Note: beacuse we have set `worker: true`, we must use async calls
        */
       this._searchIndex = new Document({
+        worker: true,
         document: {
           id: "id",
           index: [
@@ -83,7 +88,7 @@ export default class CatalogIndex {
         this._models!.set(id, reference);
 
         // Add document to search index
-        this._searchIndex.add({
+        this._searchIndex.addAsync(id, {
           id,
           name: model.name ?? "",
           description: model.description ?? ""
@@ -94,7 +99,7 @@ export default class CatalogIndex {
     }
   }
 
-  public search(q: string) {
+  public async search(q: string) {
     const results: SearchResult[] = [];
     /** Example matches object
     ```json
@@ -114,7 +119,9 @@ export default class CatalogIndex {
     ]
     ```
 */
-    const matches = this.searchIndex.search(q);
+    if (!this.searchIndex) return [];
+
+    const matches = await this.searchIndex.searchAsync(q);
     const matchedIds = new Set<string>();
     matches.forEach((fieldResult: any) => {
       fieldResult.result.forEach((id: string) => {

--- a/lib/Models/SearchProviders/CatalogSearchProvider.ts
+++ b/lib/Models/SearchProviders/CatalogSearchProvider.ts
@@ -139,7 +139,7 @@ export default class CatalogSearchProvider extends SearchProvider {
 
     try {
       if (this.terria.catalogIndex) {
-        const results = this.terria.catalogIndex?.search(searchText);
+        const results = await this.terria.catalogIndex?.search(searchText);
         searchResults.results = results;
       } else {
         await loadAndSearchCatalogRecursively(

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -573,7 +573,7 @@ export default class Terria {
   raiseErrorToUser(
     error: unknown,
     overrides?: TerriaErrorOverrides,
-    forceRaiseToUser = true
+    forceRaiseToUser = false
   ) {
     const terriaError = TerriaError.from(error, overrides);
 
@@ -1106,8 +1106,7 @@ export default class Terria {
     modelId: string,
     stratumId: string,
     allModelStratumData: JsonObject,
-    replaceStratum: boolean,
-    errorSeverity?: TerriaErrorSeverity
+    replaceStratum: boolean
   ): Promise<Result<BaseModel | undefined>> {
     const thisModelStratumData = allModelStratumData[modelId] || {};
     if (!isJsonObject(thisModelStratumData)) {
@@ -1137,8 +1136,7 @@ export default class Terria {
               containerId,
               stratumId,
               allModelStratumData,
-              replaceStratum,
-              errorSeverity
+              replaceStratum
             )
           ).pushErrorTo(errors, `Failed to load container ${containerId}`);
 
@@ -1168,8 +1166,7 @@ export default class Terria {
           splitSourceId,
           stratumId,
           allModelStratumData,
-          replaceStratum,
-          errorSeverity
+          replaceStratum
         )
       ).pushErrorTo(
         errors,
@@ -1257,14 +1254,12 @@ export default class Terria {
       loadedModel,
       TerriaError.combine(errors, {
         // This will set TerriaErrorSeverity to Error if the model which FAILED to load is in the workbench.
-        severity:
-          errorSeverity ??
-          (() =>
-            this.workbench.items.find(
-              workbenchItem => workbenchItem.uniqueId === modelId
-            )
-              ? TerriaErrorSeverity.Error
-              : TerriaErrorSeverity.Warning),
+        severity: () =>
+          this.workbench.items.find(
+            workbenchItem => workbenchItem.uniqueId === modelId
+          )
+            ? TerriaErrorSeverity.Error
+            : TerriaErrorSeverity.Warning,
         message: {
           key: "models.terria.loadModelErrorMessage",
           parameters: { model: modelId }
@@ -1401,11 +1396,7 @@ export default class Terria {
               modelId,
               stratumId,
               models,
-              replaceStratum,
-              // Set error severity to Error if model is in workbench array
-              workbench.includes(modelId)
-                ? TerriaErrorSeverity.Error
-                : undefined
+              replaceStratum
             )
           ).pushErrorTo(errors);
         })

--- a/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
+++ b/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
@@ -11,6 +11,7 @@ import hashEntity from "../../../../Core/hashEntity";
 import CommonStrata from "../../../../Models/Definition/CommonStrata";
 import saveStratumToJson from "../../../../Models/Definition/saveStratumToJson";
 import { BaseModel } from "../../../../Models/Definition/Model";
+import { runInAction } from "mobx";
 
 const CatalogMember = {}; // TODO
 
@@ -56,33 +57,35 @@ export function getShareData(
   viewState,
   options = { includeStories: true }
 ) {
-  const { includeStories } = options;
-  const initSource = {};
-  const initSources = [initSource]; // includeStories ? terria.initSources.slice() : [];
+  return runInAction(() => {
+    const { includeStories } = options;
+    const initSource = {};
+    const initSources = [initSource]; // includeStories ? terria.initSources.slice() : [];
 
-  addStratum(terria, CommonStrata.user, initSource);
-  addWorkbench(terria, initSource);
-  addTimelineItems(terria, initSource);
-  addViewSettings(terria, viewState, initSource);
-  addFeaturePicking(terria, initSource);
-  addBaseMaps(terria, CommonStrata.definition, initSource);
-  if (includeStories) {
-    // info that are not needed in scene share data
-    addStories(terria, initSource);
-  }
+    addStratum(terria, CommonStrata.user, initSource);
+    addWorkbench(terria, initSource);
+    addTimelineItems(terria, initSource);
+    addViewSettings(terria, viewState, initSource);
+    addFeaturePicking(terria, initSource);
+    addBaseMaps(terria, CommonStrata.definition, initSource);
+    if (includeStories) {
+      // info that are not needed in scene share data
+      addStories(terria, initSource);
+    }
 
-  const oldShare = false;
-  if (oldShare === true) {
-    addUserAddedCatalog(terria, initSources);
-    addSharedMembers(terria, initSources);
-    addLocationMarker(terria, initSources);
-    addTimeline(terria, initSources);
-  }
+    const oldShare = false;
+    if (oldShare === true) {
+      addUserAddedCatalog(terria, initSources);
+      addSharedMembers(terria, initSources);
+      addLocationMarker(terria, initSources);
+      addTimeline(terria, initSources);
+    }
 
-  return {
-    version: SHARE_VERSION,
-    initSources: initSources
-  };
+    return {
+      version: SHARE_VERSION,
+      initSources: initSources
+    };
+  });
 }
 
 function addStratum(terria, stratumId, initSource) {
@@ -142,7 +145,9 @@ function addModelStratum(terria, model, stratumId, force, initSource) {
     model.knownContainerUniqueIds &&
     model.knownContainerUniqueIds.length > 0
   ) {
-    models[id].knownContainerUniqueIds = model.knownContainerUniqueIds.slice();
+    models[
+      id
+    ].knownContainerUniqueIds = model.completeKnownContainerUniqueIds.slice();
   }
 
   if (models[id].members) {

--- a/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
+++ b/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
@@ -98,9 +98,10 @@ function addStratum(terria, stratumId, initSource) {
   });
 
   // Go through knownContainerUniqueIds and make sure they exist in models
-  Object.values(initSource.models).forEach(model => {
-    if (model.knownContainerUniqueIds) {
-      model.knownContainerUniqueIds.forEach(containerId => {
+  Object.keys(initSource.models).forEach(modelId => {
+    const model = terria.getModelById(BaseModel, modelId);
+    if (model)
+      model.completeKnownContainerUniqueIds.forEach(containerId => {
         if (!initSource.models[containerId]) {
           const containerModel = terria.getModelById(BaseModel, containerId);
           if (containerModel)
@@ -113,7 +114,6 @@ function addStratum(terria, stratumId, initSource) {
             );
         }
       });
-    }
   });
 }
 
@@ -164,9 +164,7 @@ function addModelStratum(terria, model, stratumId, force, initSource) {
     model.knownContainerUniqueIds &&
     model.knownContainerUniqueIds.length > 0
   ) {
-    models[
-      id
-    ].knownContainerUniqueIds = model.completeKnownContainerUniqueIds.slice();
+    models[id].knownContainerUniqueIds = model.knownContainerUniqueIds.slice();
   }
 
   if (models[id].members) {

--- a/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
+++ b/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.js
@@ -96,6 +96,25 @@ function addStratum(terria, stratumId, initSource) {
     const force = terria.workbench.contains(model);
     addModelStratum(terria, model, stratumId, force, initSource);
   });
+
+  // Go through knownContainerUniqueIds and make sure they exist in models
+  Object.values(initSource.models).forEach(model => {
+    if (model.knownContainerUniqueIds) {
+      model.knownContainerUniqueIds.forEach(containerId => {
+        if (!initSource.models[containerId]) {
+          const containerModel = terria.getModelById(BaseModel, containerId);
+          if (containerModel)
+            addModelStratum(
+              terria,
+              containerModel,
+              stratumId,
+              true,
+              initSource
+            );
+        }
+      });
+    }
+  });
 }
 
 function addBaseMaps(terria, initSource) {}

--- a/test/Models/ItemSearchProviders/CatalogIndexSpec.ts
+++ b/test/Models/ItemSearchProviders/CatalogIndexSpec.ts
@@ -74,7 +74,7 @@ describe("CatalogIndex", function() {
   });
 
   it("search for items", async function() {
-    const results = catalogIndex.search("group");
+    const results = await catalogIndex.search("group");
 
     console.log(results);
 
@@ -90,7 +90,7 @@ describe("CatalogIndex", function() {
   });
 
   it("search for group", async function() {
-    const results = catalogIndex.search("cool");
+    const results = await catalogIndex.search("cool");
 
     expect((results[0].catalogItem as CatalogIndexReference).name).toBe(
       "Test item"
@@ -98,7 +98,7 @@ describe("CatalogIndex", function() {
   });
 
   it("load group reference", async function() {
-    const results = catalogIndex.search("some random words");
+    const results = await catalogIndex.search("some random words");
 
     const group = results[0].catalogItem as CatalogIndexReference;
 
@@ -108,7 +108,7 @@ describe("CatalogIndex", function() {
   });
 
   it("load nested reference", async function() {
-    const results = catalogIndex.search("nested");
+    const results = await catalogIndex.search("nested");
 
     const item = results[0].catalogItem as CatalogIndexReference;
 


### PR DESCRIPTION
### Add all knownContainerIds to sharelink models 

* Make flex-search usage (for `CatalogIndex`) web-worker based
* Add `completeKnownContainerUniqueIds` to `Model` class - This will recursively travese tree of knownContainerUniqueIds models to return full list of dependencies
* Add all models from `completeKnownContainerUniqueIds` to shareData.models (even if they are empty)

### Changes to share JSON

![image](https://user-images.githubusercontent.com/6187649/137271657-b07e7d81-ae08-4089-9a0a-4d3f345a222d.png)

### Before

http://ci.terria.io/main/#configUrl=https://nationalmap.gov.au/config.json&share=s-ycMoOeupODIhbZ5IH0pWuidNw9N

### After

http://ci.terria.io/sharelink-modelids/#configUrl=https://nationalmap.gov.au/config.json&share=s-89q4Fvaz6O3Y1iz5l3dLhxgi1m3

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
