### PR TITLE
Fix `TerriaError.shouldRaiseToUser` bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 #### next release (8.1.5)
 
 * Rename `TerriaError._shouldRaiseToUser` to `overrideRaiseToUser`
-* Fix `overrideRaiseToUser` bug causeing `overrideRaiseToUser` to be set to `true` in `TerriaError.combine`
+* Fix `overrideRaiseToUser` bug causing `overrideRaiseToUser` to be set to `true` in `TerriaError.combine`
 * [The next improvement]
 
 #### 8.1.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 #### next release (8.1.5)
 
 * Rename `TerriaError._shouldRaiseToUser` to `overrideRaiseToUser`
+  * Note: `userProperties.ignoreError = "1"` will take precedence over `overrideRaiseToUser = true`
 * Fix `overrideRaiseToUser` bug causing `overrideRaiseToUser` to be set to `true` in `TerriaError.combine`
 * Add `rollbar.warning` for `TerriaErrorSeverity.Warning`
 * Disable `zFilter` by default

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,8 @@ Change Log
 
 #### next release (8.1.5)
 
-* Rename `TerriaError._shouldRaiseToUser` to `forceRaiseToUser`
-* Fix `forceRaiseToUser` bug
+* Rename `TerriaError._shouldRaiseToUser` to `overrideRaiseToUser`
+* Fix `overrideRaiseToUser` bug causeing `overrideRaiseToUser` to be set to `true` in `TerriaError.combine`
 * [The next improvement]
 
 #### 8.1.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 #### next release (8.1.5)
 
 * Rename `TerriaError._shouldRaiseToUser` to `forceRaiseToUser`
+* Fix `forceRaiseToUser` bug
 * [The next improvement]
 
 #### 8.1.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.5)
 
+* Rename `TerriaError._shouldRaiseToUser` to `forceRaiseToUser`
 * [The next improvement]
 
 #### 8.1.4

--- a/lib/Core/TerriaError.ts
+++ b/lib/Core/TerriaError.ts
@@ -223,7 +223,7 @@ export default class TerriaError {
 
     // overrideRaiseToUser will be false if:
     // - NO errors includes overrideRaiseToUser = true
-    // - and at least one error includes overrideRaiseToUser = true
+    // - and at least one error includes overrideRaiseToUser = false
     if (
       !isDefined(overrideRaiseToUser) &&
       filteredErrors.map(error => error.overrideRaiseToUser).includes(false)

--- a/lib/Core/TerriaError.ts
+++ b/lib/Core/TerriaError.ts
@@ -53,7 +53,7 @@ export interface TerriaErrorOptions {
   sender?: unknown;
 
   /** True if error message should be shown to user *regardless* of error severity. If this is undefined, then error severity will be used to determine if forceRaiseToUser (severity `Error` are presented to the user. `Warning` will just be printed to console) */
-  forceRaiseToUser?: boolean;
+  forceRaiseToUser?: true;
 
   /** True if the user has seen this error; otherwise, false. */
   raisedToUser?: boolean;
@@ -119,7 +119,7 @@ export default class TerriaError {
   readonly stack: string;
 
   /** Override shouldRaiseToUser (see `get shouldRaiseToUser()`) */
-  forceRaiseToUser: boolean | undefined;
+  forceRaiseToUser: true | undefined;
   @observable showDetails: boolean;
 
   /**
@@ -217,9 +217,9 @@ export default class TerriaError {
         : TerriaErrorSeverity.Warning;
 
     // forceRaiseToUser will be true if at least one error includes forceRaiseToUser = true
-    const forceRaiseToUser = filteredErrors
-      .map(error => error.forceRaiseToUser ?? false)
-      .includes(true);
+    const forceRaiseToUser =
+      filteredErrors.map(error => error.forceRaiseToUser).includes(true) ||
+      undefined;
 
     return new TerriaError({
       // Set default title and message

--- a/lib/Core/TerriaError.ts
+++ b/lib/Core/TerriaError.ts
@@ -217,8 +217,9 @@ export default class TerriaError {
         : TerriaErrorSeverity.Warning;
 
     // overrideRaiseToUser will be true if at least one error includes overrideRaiseToUser = true
+    // Otherwise, it will be undefined
     let overrideRaiseToUser: boolean | undefined =
-      filteredErrors.map(error => error.overrideRaiseToUser).includes(true) ||
+      filteredErrors.some(error => error.overrideRaiseToUser === true) ||
       undefined;
 
     // overrideRaiseToUser will be false if:
@@ -226,7 +227,7 @@ export default class TerriaError {
     // - and at least one error includes overrideRaiseToUser = false
     if (
       !isDefined(overrideRaiseToUser) &&
-      filteredErrors.map(error => error.overrideRaiseToUser).includes(false)
+      filteredErrors.some(error => error.overrideRaiseToUser === false)
     ) {
       overrideRaiseToUser = false;
     }

--- a/lib/Models/Catalog/SdmxJson/SdmxJsonCatalogItem.ts
+++ b/lib/Models/Catalog/SdmxJson/SdmxJsonCatalogItem.ts
@@ -194,7 +194,7 @@ export default class SdmxJsonCatalogItem
             title: i18next.t("models.sdmxCatalogItem.loadDataErrorTitle", this),
             severity: TerriaErrorSeverity.Warning,
             importance: 1,
-            shouldRaiseToUser: true
+            forceRaiseToUser: true
           });
         }
         throw new TerriaError({

--- a/lib/Models/Catalog/SdmxJson/SdmxJsonCatalogItem.ts
+++ b/lib/Models/Catalog/SdmxJson/SdmxJsonCatalogItem.ts
@@ -194,7 +194,7 @@ export default class SdmxJsonCatalogItem
             title: i18next.t("models.sdmxCatalogItem.loadDataErrorTitle", this),
             severity: TerriaErrorSeverity.Warning,
             importance: 1,
-            forceRaiseToUser: true
+            overrideRaiseToUser: true
           });
         }
         throw new TerriaError({

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -577,16 +577,19 @@ export default class Terria {
   ) {
     const terriaError = TerriaError.from(error, overrides);
 
-    // Set shouldRaiseToUser:
-    // - `true` if forceRaiseToUser agrument is true
-    // - `false` if ignoreErrors userProperties is set
+    // Set shouldRaiseToUser true if forceRaiseToUser agrument is true
     if (forceRaiseToUser) terriaError.overrideRaiseToUser = true;
-    else if (this.userProperties.get("ignoreErrors") === "1")
-      terriaError.overrideRaiseToUser = false;
 
     // Log error to error service
     this.errorService.error(terriaError);
-    this.notificationState.addNotificationToQueue(terriaError.toNotification());
+
+    // Only show error to user if `ignoreError` flag hasn't been set to "1"
+    // Note: this will take precedence over forceRaiseToUser/overrideRaiseToUser
+    if (this.userProperties.get("ignoreErrors") !== "1")
+      this.notificationState.addNotificationToQueue(
+        terriaError.toNotification()
+      );
+
     console.log(terriaError.toError());
   }
 

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -580,9 +580,9 @@ export default class Terria {
     // Set shouldRaiseToUser:
     // - `true` if forceRaiseToUser agrument is true
     // - `false` if ignoreErrors userProperties is set
-    if (forceRaiseToUser) terriaError.forceRaiseToUser = true;
+    if (forceRaiseToUser) terriaError.overrideRaiseToUser = true;
     else if (this.userProperties.get("ignoreErrors") === "1")
-      terriaError.forceRaiseToUser = false;
+      terriaError.overrideRaiseToUser = false;
 
     // Log error to error service
     this.errorService.error(terriaError);

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -580,9 +580,9 @@ export default class Terria {
     // Set shouldRaiseToUser:
     // - `true` if forceRaiseToUser agrument is true
     // - `false` if ignoreErrors userProperties is set
-    if (forceRaiseToUser) terriaError.shouldRaiseToUser = true;
+    if (forceRaiseToUser) terriaError.forceRaiseToUser = true;
     else if (this.userProperties.get("ignoreErrors") === "1")
-      terriaError.shouldRaiseToUser = false;
+      terriaError.forceRaiseToUser = false;
 
     // Log error to error service
     this.errorService.error(terriaError);

--- a/test/Core/TerriaErrorSpec.ts
+++ b/test/Core/TerriaErrorSpec.ts
@@ -85,6 +85,63 @@ describe("TerriaError", function() {
     expect(combined?.flatten().length).toBe(7);
   });
 
+  it("Combines correctly with overrideRaiseToUser", function() {
+    const error = new TerriaError({
+      message: "some message",
+      overrideRaiseToUser: true,
+      severity: TerriaErrorSeverity.Error
+    });
+    expect(error.shouldRaiseToUser).toBe(true);
+
+    const error2 = new TerriaError({
+      message: "some message",
+      overrideRaiseToUser: false,
+      severity: TerriaErrorSeverity.Error
+    });
+    expect(error2.shouldRaiseToUser).toBe(false);
+
+    const test3 = TerriaError.from(error2, {
+      title: "A title",
+      severity: TerriaErrorSeverity.Error
+    });
+    expect(error2.shouldRaiseToUser).toBe(false);
+
+    const errors = test3.flatten();
+
+    const combined = TerriaError.combine(errors, "A big error");
+    expect(combined?.message).toBe("A big error");
+    expect(combined?.shouldRaiseToUser).toBeTruthy();
+  });
+
+  it("Combines correctly with overrideRaiseToUser and severity", function() {
+    const error = new TerriaError({
+      message: "some message",
+      overrideRaiseToUser: true,
+      severity: TerriaErrorSeverity.Warning
+    });
+    expect(error.shouldRaiseToUser).toBe(true);
+
+    const error2 = new TerriaError({
+      message: "some message",
+      severity: TerriaErrorSeverity.Warning
+    });
+    expect(error2.shouldRaiseToUser).toBe(false);
+
+    const test3 = TerriaError.from(error2, { title: "A title" });
+    expect(error2.shouldRaiseToUser).toBe(false);
+    expect(error2.severity).toBe(TerriaErrorSeverity.Warning);
+
+    test3.overrideRaiseToUser = false;
+    expect(error2.shouldRaiseToUser).toBe(false);
+
+    const errors = test3.flatten();
+
+    const combined = TerriaError.combine(errors, "A big error");
+    expect(combined?.message).toBe("A big error");
+    expect(combined?.severity).toBe(TerriaErrorSeverity.Warning);
+    expect(combined?.shouldRaiseToUser).toBeTruthy();
+  });
+
   it("Correctly uses importance and highestImportanceError", function() {
     const error = new TerriaError({ message: "some message" });
     const test = TerriaError.from(error);

--- a/test/Core/TerriaErrorSpec.ts
+++ b/test/Core/TerriaErrorSpec.ts
@@ -91,6 +91,7 @@ describe("TerriaError", function() {
       overrideRaiseToUser: true,
       severity: TerriaErrorSeverity.Error
     });
+    expect(error.overrideRaiseToUser).toBe(true);
     expect(error.shouldRaiseToUser).toBe(true);
 
     const error2 = new TerriaError({
@@ -98,6 +99,7 @@ describe("TerriaError", function() {
       overrideRaiseToUser: false,
       severity: TerriaErrorSeverity.Error
     });
+    expect(error2.overrideRaiseToUser).toBe(false);
     expect(error2.shouldRaiseToUser).toBe(false);
 
     const test3 = TerriaError.from(error2, {
@@ -106,7 +108,7 @@ describe("TerriaError", function() {
     });
     expect(error2.shouldRaiseToUser).toBe(false);
 
-    const errors = test3.flatten();
+    const errors = [error, ...test3.flatten()];
 
     const combined = TerriaError.combine(errors, "A big error");
     expect(combined?.message).toBe("A big error");
@@ -134,11 +136,15 @@ describe("TerriaError", function() {
     test3.overrideRaiseToUser = false;
     expect(error2.shouldRaiseToUser).toBe(false);
 
-    const errors = test3.flatten();
+    const errors = [error, ...test3.flatten()];
 
     const combined = TerriaError.combine(errors, "A big error");
     expect(combined?.message).toBe("A big error");
-    expect(combined?.severity).toBe(TerriaErrorSeverity.Warning);
+    expect(
+      typeof combined?.severity === "function"
+        ? combined?.severity()
+        : combined?.severity
+    ).toBe(TerriaErrorSeverity.Warning);
     expect(combined?.shouldRaiseToUser).toBeTruthy();
   });
 

--- a/test/Core/TerriaErrorSpec.ts
+++ b/test/Core/TerriaErrorSpec.ts
@@ -86,13 +86,13 @@ describe("TerriaError", function() {
   });
 
   it("Combines correctly with overrideRaiseToUser", function() {
-    const error = new TerriaError({
+    const errorTrueOverride = new TerriaError({
       message: "some message",
       overrideRaiseToUser: true,
       severity: TerriaErrorSeverity.Error
     });
-    expect(error.overrideRaiseToUser).toBe(true);
-    expect(error.shouldRaiseToUser).toBe(true);
+    expect(errorTrueOverride.overrideRaiseToUser).toBe(true);
+    expect(errorTrueOverride.shouldRaiseToUser).toBe(true);
 
     const error2 = new TerriaError({
       message: "some message",
@@ -108,11 +108,22 @@ describe("TerriaError", function() {
     });
     expect(error2.shouldRaiseToUser).toBe(false);
 
-    const errors = [error, ...test3.flatten()];
+    // This combined error includes errorTrueOverride
+    const combinedTrue = TerriaError.combine(
+      [errorTrueOverride, ...test3.flatten()],
+      "A big error"
+    );
+    expect(combinedTrue?.message).toBe("A big error");
+    expect(combinedTrue?.shouldRaiseToUser).toBeTruthy();
+    expect(combinedTrue?.overrideRaiseToUser).toBeTruthy();
 
-    const combined = TerriaError.combine(errors, "A big error");
-    expect(combined?.message).toBe("A big error");
-    expect(combined?.shouldRaiseToUser).toBeTruthy();
+    const combinedFalse = TerriaError.combine(
+      test3.flatten(),
+      "Another big error"
+    );
+    expect(combinedFalse?.message).toBe("Another big error");
+    expect(combinedFalse?.shouldRaiseToUser).toBe(false);
+    expect(combinedFalse?.overrideRaiseToUser).toBe(false);
   });
 
   it("Combines correctly with overrideRaiseToUser and severity", function() {


### PR DESCRIPTION
### Fix `TerriaError.shouldRaiseToUser` bug

* Rename `TerriaError._shouldRaiseToUser` to `overrideRaiseToUser`
* Fix `overrideRaiseToUser` bug causing `overrideRaiseToUser` to be set to `true` in `TerriaError.combine`

#### Before

https://github.com/TerriaJS/terriajs/blob/62c69365b376eb67f7f38bd10bfc0b4a318ea003/lib/Core/TerriaError.ts#L219-L222

`overrideRaiseToUser` was being incorrectly assigned `false`, which was causing `get shouldRaiseToUser` to return false.

#### After

https://github.com/TerriaJS/terriajs/blob/948bc3d11ac33c3b9936d3940db58ac924cfe1c4/lib/Core/TerriaError.ts#L219-L232

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
