### PR TITLE
Small zFilter improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ Change Log
 
 #### next release (8.1.5)
 
+* Disable `zFilter` by default
+* Remove use of word "outlier" in zFilter dimension and legend item (we now use "Extreme values")
+* Add `cursor:pointer` to `Checkbox`
 * [The next improvement]
 
 #### 8.1.4

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -1294,7 +1294,11 @@
       "bulkGeocoderInfoMessage": "The CSV contains addresses, but {{number}} can't be located on the map: ",
       "bulkGeocoderInfo2Message": "{{nullAddresses}} addresses are missing from the CSV.",
       "bulkGeocoderErrorTitle": "Bulk Geocoder Error",
-      "bulkGeocoderErrorMessage": "Unable to map addresses to lat-long coordinates, as an error occurred while retrieving address coordinates. Please check your internet connection or try again later."
+      "bulkGeocoderErrorMessage": "Unable to map addresses to lat-long coordinates, as an error occurred while retrieving address coordinates. Please check your internet connection or try again later.",
+      "legendZFilterLabel": "Extreme values",
+      "legendNullLabel": "(No value)",
+      "zFilterEnabled": "Extreme values hidden (click to show)",
+      "zFilterDisabled": "Extreme values detected (click to hide)"
     },
     "terrainCatalog": {
       "notSupportedErrorTitle": "Not supported in 2D",

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -560,8 +560,8 @@ function TableMixin<T extends Constructor<Model<TableTraits>>>(Base: T) {
       return {
         id: "outlierFilter",
         options: [
-          { id: "true", name: "Outliers filtered (click to disable)" },
-          { id: "false", name: "Outliers detected (click to filter out)" }
+          { id: "true", name: i18next.t("models.tableData.zFilterEnabled") },
+          { id: "false", name: i18next.t("models.tableData.zFilterDisabled") }
         ],
         selectedId: this.activeTableStyle.colorTraits.zScoreFilterEnabled
           ? "true"

--- a/lib/Styled/Checkbox/Checkbox.tsx
+++ b/lib/Styled/Checkbox/Checkbox.tsx
@@ -62,6 +62,7 @@ const Checkbox = memo(
           }
           ${!isDisabled &&
             `
+            cursor: pointer;
             &:hover svg {
               opacity: 0.6;
             }

--- a/lib/Table/TableAutomaticStylesStratum.ts
+++ b/lib/Table/TableAutomaticStylesStratum.ts
@@ -1,3 +1,4 @@
+import i18next from "i18next";
 import { computed } from "mobx";
 import { createTransformer } from "mobx-utils";
 import isDefined from "../Core/isDefined";
@@ -301,7 +302,9 @@ export class ColorStyleLegend extends LoadableStratum(LegendTraits) {
             createStratumInstance(LegendItemTraits, {
               color: activeStyle.colorTraits.nullColor || "rgba(0, 0, 0, 0)",
               addSpacingAbove: true,
-              title: activeStyle.colorTraits.nullLabel || "(No value)"
+              title:
+                activeStyle.colorTraits.nullLabel ||
+                i18next.t("models.tableData.legendNullLabel")
             })
           ]
         : [];
@@ -313,7 +316,9 @@ export class ColorStyleLegend extends LoadableStratum(LegendTraits) {
             createStratumInstance(LegendItemTraits, {
               color: activeStyle.tableColorMap.outlierColor.toCssColorString(),
               addSpacingAbove: true,
-              title: activeStyle.colorTraits.outlierLabel || "Outliers"
+              title:
+                activeStyle.colorTraits.outlierLabel ||
+                i18next.t("models.tableData.legendZFilterLabel")
             })
           ]
         : [];

--- a/lib/Traits/TraitsClasses/TableColorStyleTraits.ts
+++ b/lib/Traits/TraitsClasses/TableColorStyleTraits.ts
@@ -81,7 +81,7 @@ export default class TableColorStyleTraits extends ModelTraits {
     description: "The label to use in the legend for outlier values.",
     type: "string"
   })
-  outlierLabel?: string = "Outliers";
+  outlierLabel?: string;
 
   // @primitiveTrait({
   //   name: "Bin Method",
@@ -202,7 +202,7 @@ export default class TableColorStyleTraits extends ModelTraits {
     description: "True, if z-score filter is enabled.",
     type: "boolean"
   })
-  zScoreFilterEnabled: boolean = true;
+  zScoreFilterEnabled: boolean = false;
 
   @primitiveTrait({
     name: "Range filter",

--- a/test/Table/TableStyleSpec.ts
+++ b/test/Table/TableStyleSpec.ts
@@ -370,7 +370,13 @@ describe("TableStyle", function() {
       updateModelFromJson(csvItem, CommonStrata.definition, {
         csvString: SedCsv,
         activeStyle: "Value",
-        defaultStyle: { color: { zScoreFilter: 2, rangeFilter: 0.1 } }
+        defaultStyle: {
+          color: {
+            zScoreFilter: 2,
+            rangeFilter: 0.1,
+            zScoreFilterEnabled: true
+          }
+        }
       });
 
       await csvItem.loadMapItems();
@@ -396,7 +402,13 @@ describe("TableStyle", function() {
 
       // Change zScoreFilter and rangeFilter - should also expect not to be applied
       updateModelFromJson(csvItem, CommonStrata.definition, {
-        defaultStyle: { color: { zScoreFilter: 1, rangeFilter: 0.25 } }
+        defaultStyle: {
+          color: {
+            zScoreFilter: 1,
+            rangeFilter: 0.25,
+            zScoreFilterEnabled: true
+          }
+        }
       });
 
       expect(activeStyle.tableColorMap.zScoreFilterValues).toBeUndefined();
@@ -410,7 +422,13 @@ describe("TableStyle", function() {
       expect(csvItem.legends[0].items.length).toBe(7);
 
       updateModelFromJson(csvItem, CommonStrata.definition, {
-        defaultStyle: { color: { zScoreFilter: 1, rangeFilter: 0.1 } }
+        defaultStyle: {
+          color: {
+            zScoreFilter: 1,
+            rangeFilter: 0.1,
+            zScoreFilterEnabled: true
+          }
+        }
       });
 
       // Change zScoreFilter and rangeFilter again - should be applied this time
@@ -426,7 +444,9 @@ describe("TableStyle", function() {
       // Check legend for outlier item
       expect(csvItem.legends.length).toBe(1);
       expect(csvItem.legends[0].items.length).toBe(8);
-      expect(csvItem.legends[0].items[7].title).toBe("Outliers");
+      expect(csvItem.legends[0].items[7].title).toBe(
+        "models.tableData.legendZFilterLabel"
+      );
       expect(csvItem.legends[0].items[7].addSpacingAbove).toBeTruthy();
       expect(csvItem.legends[0].items[7].color).toBe(
         activeStyle.tableColorMap.outlierColor.toCssColorString()


### PR DESCRIPTION
Small zFilter improvements

* Disable `zFilter` by default
* Remove use of word "outlier" in zFilter dimension and legend item (we now use "Extreme values")
* Add `cursor:pointer` to `Checkbox`

### After vs Before

![image](https://user-images.githubusercontent.com/6187649/138023964-0be3efb2-7bfe-49e7-b17e-f96224b2714c.png)

![image](https://user-images.githubusercontent.com/6187649/138023980-a0026b96-0308-464d-bb96-970a08dca95f.png)

### Test links

http://ci.terria.io/z-filter-updates/#configUrl=https://raw.githubusercontent.com/TerriaJS/saas-catalogs-public/main/pacificmap/map-config/test.json&share=s-goZJRpooIjVBkwnade8iNvA4YKR

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
