### PR TITLE
Add `rollbar.warning` and change CI to use `yarn`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '10'
-
-      - run: npm install
+      - run: npm install -g yarn@^1.19.0 && yarn install
 
       - name: Check formatting with prettier
         run: npm run prettier-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
-          node-version: '10'
+          node-version: '14.x'
       - run: npm install -g yarn@^1.19.0 && yarn install
 
       - name: Check formatting with prettier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
       - run: npm install -g yarn@^1.19.0 && yarn install
 
       - name: Check formatting with prettier
-        run: npm run prettier-check
+        run: yarn prettier-check
 
       - name: Build TerriaJS tests
-        run: npm run gulp lint release -- --continue
+        run: yarn gulp lint release -- --continue
         env:
           NODE_OPTIONS: --max_old_space_size=4096
 
       - name: Run tests using xvfb
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: npm run gulp test-firefox
+          run: yarn gulp test-firefox

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '10.x'
+          node-version: '14.x'
       - uses: google-github-actions/setup-gcloud@v0.2.1
         with:
           service_account_key: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,9 +37,13 @@ jobs:
         with:
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install yarn
+        if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
+        run: npm install -g yarn@^1.19.0
+
       - name: Install dependencies
         if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
-        run: npm install
+        run: yarn install
 
       - name: Lint and build terriajs
         if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.5)
 
+* Add `rollbar.warning` for `TerriaErrorSeverity.Warning`
 * [The next improvement]
 
 #### 8.1.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Disable `zFilter` by default
 * Remove use of word "outlier" in zFilter dimension and legend item (we now use "Extreme values")
 * Add `cursor:pointer` to `Checkbox`
+* Use `yarn` in CI scripts (and upgrade node to v14)
 * [The next improvement]
 
 #### 8.1.4

--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -17,6 +17,7 @@ gh api /repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA} -f state=pending -f co
 # Install some tools we need from npm
 npm install -g https://github.com/terriajs/sync-dependencies
 npm install request@^2.83.0
+npm install -g yarn@^1.19.0
 
 # Clone and build TerriaMap, using this version of TerriaJS
 TERRIAJS_COMMIT_HASH=$(git rev-parse HEAD)
@@ -29,9 +30,9 @@ git config --global user.email "info@terria.io"
 git config --global user.name "GitHub Actions"
 git commit -a -m 'temporary commit' # so the version doesn't indicate local modifications
 git tag -a "TerriaMap-$TERRIAMAP_COMMIT_HASH--TerriaJS-$TERRIAJS_COMMIT_HASH" -m 'temporary tag'
-rm package-lock.json # because TerriaMap's package-lock.json won't reflect terriajs dependencies
-npm install
-npm install moment@2.24.0
+rm yarn.lock # because TerriaMap's package-lock.json won't reflect terriajs dependencies
+yarn install
+yarn install moment@2.24.0
 npm run gulp build
 
 npm run "--terriajs-map:docker_name=terriajs-ci" docker-build-ci -- --tag "asia.gcr.io/terriajs-automated-deployment/terria-ci:$SAFE_BRANCH_NAME"

--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -30,7 +30,7 @@ git config --global user.email "info@terria.io"
 git config --global user.name "GitHub Actions"
 git commit -a -m 'temporary commit' # so the version doesn't indicate local modifications
 git tag -a "TerriaMap-$TERRIAMAP_COMMIT_HASH--TerriaJS-$TERRIAJS_COMMIT_HASH" -m 'temporary tag'
-rm yarn.lock # because TerriaMap's package-lock.json won't reflect terriajs dependencies
+rm yarn.lock # because TerriaMap's yarn.lock won't reflect terriajs dependencies
 yarn install
 yarn add -W moment@2.24.0
 npm run gulp build

--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -33,9 +33,9 @@ git tag -a "TerriaMap-$TERRIAMAP_COMMIT_HASH--TerriaJS-$TERRIAJS_COMMIT_HASH" -m
 rm yarn.lock # because TerriaMap's yarn.lock won't reflect terriajs dependencies
 yarn install
 yarn add -W moment@2.24.0
-npm run gulp build
+yarn gulp build
 
-npm run "--terriajs-map:docker_name=terriajs-ci" docker-build-ci -- --tag "asia.gcr.io/terriajs-automated-deployment/terria-ci:$SAFE_BRANCH_NAME"
+yarn "--terriajs-map:docker_name=terriajs-ci" docker-build-ci -- --tag "asia.gcr.io/terriajs-automated-deployment/terria-ci:$SAFE_BRANCH_NAME"
 gcloud auth configure-docker asia.gcr.io --quiet
 docker push "asia.gcr.io/terriajs-automated-deployment/terria-ci:$SAFE_BRANCH_NAME"
 helm upgrade --install --recreate-pods -f ../buildprocess/ci-values.yml --set global.exposeNodePorts=true --set "terriamap.image.full=asia.gcr.io/terriajs-automated-deployment/terria-ci:$SAFE_BRANCH_NAME" --set "terriamap.serverConfig.shareUrlPrefixes.s.accessKeyId=$SHARE_S3_ACCESS_KEY_ID" --set "terriamap.serverConfig.shareUrlPrefixes.s.secretAccessKey=$SHARE_S3_SECRET_ACCESS_KEY" --set "terriamap.serverConfig.feedback.accessToken=$FEEDBACK_GITHUB_TOKEN" "terriajs-$SAFE_BRANCH_NAME" deploy/helm/terria

--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -32,7 +32,7 @@ git commit -a -m 'temporary commit' # so the version doesn't indicate local modi
 git tag -a "TerriaMap-$TERRIAMAP_COMMIT_HASH--TerriaJS-$TERRIAJS_COMMIT_HASH" -m 'temporary tag'
 rm yarn.lock # because TerriaMap's package-lock.json won't reflect terriajs dependencies
 yarn install
-yarn install moment@2.24.0
+yarn add moment@2.24.0
 npm run gulp build
 
 npm run "--terriajs-map:docker_name=terriajs-ci" docker-build-ci -- --tag "asia.gcr.io/terriajs-automated-deployment/terria-ci:$SAFE_BRANCH_NAME"

--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -32,7 +32,7 @@ git commit -a -m 'temporary commit' # so the version doesn't indicate local modi
 git tag -a "TerriaMap-$TERRIAMAP_COMMIT_HASH--TerriaJS-$TERRIAJS_COMMIT_HASH" -m 'temporary tag'
 rm yarn.lock # because TerriaMap's package-lock.json won't reflect terriajs dependencies
 yarn install
-yarn add moment@2.24.0
+yarn add -W moment@2.24.0
 npm run gulp build
 
 npm run "--terriajs-map:docker_name=terriajs-ci" docker-build-ci -- --tag "asia.gcr.io/terriajs-automated-deployment/terria-ci:$SAFE_BRANCH_NAME"

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -4,7 +4,7 @@ First, read [Getting Started](../getting-started.md).
 
 What if you need to make changes to [TerriaJS](https://github.com/TerriaJS/terriajs) while working on a site that depends on it?
 
-In the process described in [Getting Started](../getting-started.md), the [TerriaJS package](https://www.npmjs.com/package/terriajs) is installed to the `node_modules` directory by `npm install`.  Please do not edit TerriaJS directly in the `node_modules` directory, because changes will be clobbered the next time you run `npm install`.
+In the process described in [Getting Started](../getting-started.md), the [TerriaJS package](https://www.npmjs.com/package/terriajs) is installed to the `node_modules` directory by `yarn install`.  Please do not edit TerriaJS directly in the `node_modules` directory, because changes will be clobbered the next time you run `yarn install`.
 
 Instead, we want to clone TerriaJS from its [GitHub repo](https://github.com/TerriaJS/terriajs) and use that in our TerriaMap build.  Traditionally, `npm link` is the way to do this.  However, we do not recommend use of `npm link` because it frequently leads to multiple copies of some libraries being installed, which in turn leads to all sorts of frustrating build problems.  Instead, we recommend [yarn](https://yarnpkg.com) and its [workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) feature.  `yarn` workspaces let us safely clone a git repo into the `packages` directory and wire it into any other packages that use it.
 

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -107,7 +107,7 @@ The `package.json` in the `master` branch of TerriaMap should point to official 
 Documentation is automatically generated from the source via JSDoc (reference) and MkDocs (user guide) by running:
 
 ```
-npm run gulp docs
+yarn gulp docs
 ```
 
 It will be placed in the `wwwroot/doc` folder.
@@ -123,20 +123,20 @@ pip install -r doc/requirements.txt
 We use [Jasmine](https://jasmine.github.io/) for the TerriaJS tests, called specs in Jasmine parlance.  To run the specs, you first need to build them by running this in the TerriaJS  (not TerriaMap!) directory:
 
 ```
-npm run gulp
+yarn gulp
 ```
 
 And start the development web server by running (also from the TerriaJS and not TerriaMap! directory):
 
 ```
-npm start
+yarn start
 ```
 
 The test suite is run by opening a web browser on [http://localhost:3002/SpecRunner.html](http://localhost:3002/SpecRunner.html).  The source code for the specs is found in the `test/` directory.
 
 ## TerriaJS Gulp Tasks
 
-Run any of these tasks with `npm run gulp <task name>` from within the TerriaJS directory:
+Run any of these tasks with `yarn gulp <task name>` from within the TerriaJS directory:
 
 * default - Invoked by running gulp without any arguments, this task invokes the `build` and `lint` tasks.
 * `build` - Builds a non-minified version of the TerriaJS tests.  This task may take 10 seconds or more, which is the main reason for the next task.
@@ -154,7 +154,7 @@ See `gulpfile.js` for more gulp tasks.
 
 ## TerriaMap Gulp Tasks
 
-Run any of these tasks with `npm run gulp <task name>` from within the TerriaMap directory:
+Run any of these tasks with `yarn gulp <task name>` from within the TerriaMap directory:
 
 * default - Invoked by running gulp without any arguments, this task invokes the `build` and `lint` tasks.
 * `build` - Builds a non-minified version of TerriaMap, TerriaJS, Cesium, and all other dependencies, together in one JS file (called `wwwroot/build/TerriaMap.js`). Only the parts of TerriaJS and Cesium that we use (directly or indirectly) are pulled in.  Web Workers, CSS, and other resources are also built by this task.  This task may take 10 seconds or more, which is the main reason for the next task.
@@ -165,7 +165,7 @@ Run any of these tasks with `npm run gulp <task name>` from within the TerriaMap
 
 | Argument | Description |
 |----------|-------------|
-| `--packageName <name>` | The name of the package.  If not specified, the name is `<npm_package_name>-<git_describe>`, where `<npm_package_name>` is the value of the `npm_package_name` environment variable and `<git_describe>` is the output of running `git describe`.  If you invoke this task using `npm run gulp make-package` instead of simply `gulp make-package`, the `npm_package_name` environment variable will be automatically set to the name of the project in `package.json`. |
+| `--packageName <name>` | The name of the package.  If not specified, the name is `<npm_package_name>-<git_describe>`, where `<npm_package_name>` is the value of the `npm_package_name` environment variable and `<git_describe>` is the output of running `git describe`.  If you invoke this task using `yarn gulp make-package` instead of simply `gulp make-package`, the `npm_package_name` environment variable will be automatically set to the name of the project in `package.json`. |
 | `--serverConfigOverride <file>` | The path to a file with overrides of the `devserverconfig.json` file.  If not specified, `devserverconfig.json` is used unmodified. |
 | `--clientConfigOverride <file>` | The path to a file with overrides of the `wwwroot/config.json` file.  If not specified, `wwwroot/config.json` is used unmodified. |
 

--- a/doc/contributing/setting-up-saucelabs.md
+++ b/doc/contributing/setting-up-saucelabs.md
@@ -3,7 +3,7 @@
 - Go to "My Account" in saucelabs (bottom left menu) and copy your access key (middle of the page roughly).
 - Set env variables for SAUCE_USERNAME and SAUCE_ACCESS_KEY using your OS's method for doing that (`export` in bash) with your sauce username and the access key you just copied.
 - Run `npm install -g karma-cli` Without this karma will sort-of work but give you confusing errors.
-- Run `npm start` in your `terriajs` dir in another terminal.
+- Run `yarn start` in your `terriajs` dir in another terminal.
 - Run `gulp test-saucelabs` if you have a `karma-saucelabs.conf.js` file, or run `karma start` from the TerriaJS directory if you have a `karma.config.js` file.
 
 If you want to narrow down the browsers being run (i.e. only run IE9), you can remove them from `karma[-saucelabs].config.js` under `browsers`.

--- a/doc/customizing/client-side-config.md
+++ b/doc/customizing/client-side-config.md
@@ -189,7 +189,7 @@ The https://github.com/nextapps-de/flexsearch library is used to index and searc
 
 To generate the catalog index:
 
-- `npm run build-tools`
+- `yarn build-tools`
 - `node .\build\generateCatalogIndex.js config-url base-url` where
   - `config-url` is URL to client-side-config file
   - `base-url` is URL to terriajs-server (this is used to load `server-config` and to proxy requests)

--- a/doc/deploying/deploying-terriamap.md
+++ b/doc/deploying/deploying-terriamap.md
@@ -3,10 +3,10 @@ TerriaMap can be deployed in almost any environment.
 First, you may want to build a minified version of TerriaMap by running:
 
 ```
-npm run gulp release
+yarn gulp release
 ```
 
-The normal build (`npm run gulp`) can be deployed as well, but the release version is smaller and faster.
+The normal build (`yarn gulp`) can be deployed as well, but the release version is smaller and faster.
 
 Then, you can host your TerriaMap using either the included Node.js-based web server, or by using any web server of your choosing.
 

--- a/doc/deploying/deploying-to-aws.md
+++ b/doc/deploying/deploying-to-aws.md
@@ -59,7 +59,7 @@ git push origin 2016-05-17
 Deployment is initiated via `npm` scripts.  A full production deployment may be initiated with:
 
 ```
-npm run deploy
+yarn deploy
 ```
 
 Once the stack starts up, it will be available at `terriajs-map-2016-05-17.terria.io`, where `terriajs-map` is the name of the project in `package.json` and `2016-05-17` is the output of `git describe` (that's why you should tag before starting a deployment).

--- a/doc/deploying/deploying-with-kubernetes.md
+++ b/doc/deploying/deploying-with-kubernetes.md
@@ -36,7 +36,7 @@ terriamap:
 ```
 
 # Building Your Own Image
-You can build your own TerriaMap image by changing the `config.docker.name` key in `package.json`, then running `npm run docker-build-prod`.
+You can build your own TerriaMap image by changing the `config.docker.name` key in `package.json`, then running `yarn docker-build-prod`.
 
 # Working Locally
 If you want to run a local version of TerriaMap then you can use [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).
@@ -51,9 +51,9 @@ helm repo update
 helm install --name docker-registry -f deploy/helm/docker-registry.yml stable/docker-registry
 helm install --name kube-registry-proxy -f deploy/helm/kube-registry-proxy.yml incubator/kube-registry-proxy
 
-npm run docker-build-local
+yarn docker-build-local
 
 helm upgrade --install -f deploy/helm/example-prod.yml terria deploy/helm/terria
 ```
 
-This will set you up with helm on your local minikube instance, install a local docker registry that will be pushed to with `npm run docker-build-local` and then installs a chart for terria that will use that docker image. You can keep running `npm run docker-build-local` and deleting the terria-server pod to update it. Keep in mind that you have to run `npm run gulp` to rebuild each time you redeploy. You can modify or copy `example-prod.yml` to change the config.
+This will set you up with helm on your local minikube instance, install a local docker registry that will be pushed to with `yarn docker-build-local` and then installs a chart for terria that will use that docker image. You can keep running `yarn docker-build-local` and deleting the terria-server pod to update it. Keep in mind that you have to run `yarn gulp` to rebuild each time you redeploy. You can modify or copy `example-prod.yml` to change the config.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -17,7 +17,7 @@ export NODE_OPTIONS=--max_old_space_size=4096
 
 npm install -g yarn
 
-yarn install && npm run gulp && npm start
+yarn install && yarn gulp && yarn start
 
 # Open at http://localhost:3001
 ```
@@ -72,22 +72,22 @@ The dependencies are installed in the `node_modules` subdirectory.  No global ch
 Do a standard build of TerriaMap with:
 
 ```bash
-npm run gulp
+yarn gulp
 ```
 
 Or, you can create a minified release build with:
 
 ```bash
-npm run gulp release
+yarn gulp release
 ```
 
 To watch for changes and automatically do an incremental build when any are detected, use:
 
 ```bash
-npm run gulp watch
+yarn gulp watch
 ```
 
-`npm run gulp` simply runs `gulp`, so you can use that directly if you prefer (run `npm install -g gulp-cli` to install it globally).
+`yarn gulp` simply runs `gulp`, so you can use that directly if you prefer (run `npm install -g gulp-cli` to install it globally).
 
 _If any of the above fail with an error that includes `Allocation failed - JavaScript heap out of memory` (see e.g. [the stack trace in this issue](https://github.com/TerriaJS/TerriaMap/issues/374)) run the task again after setting a higher Node.js allocation limit:_
 ```bash
@@ -101,7 +101,7 @@ The full set of `gulp` tasks can be found on the [Development Environment](contr
 TerriaMap includes a simple Node.js-based web server, called [terriajs-server](https://github.com/TerriaJS/terriajs-server).  To start it, run:
 
 ```bash
-npm start
+yarn start
 ```
 
 Then, open a web browser on `http://localhost:3001` to use TerriaMap.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -15,7 +15,9 @@ cd TerriaMap
 
 export NODE_OPTIONS=--max_old_space_size=4096
 
-npm install && npm run gulp && npm start
+npm install -g yarn
+
+yarn install && npm run gulp && npm start
 
 # Open at http://localhost:3001
 ```
@@ -29,6 +31,7 @@ TerriaJS can be built and run on almost any macOS, Linux, or Windows system.  Th
 * The Bash command shell. On macOS or Linux you almost certainly already have this. On Windows, you can easily get it by installing [Git for Windows](https://gitforwindows.org/). In the instructions below, we assume you're using a Bash command prompt.
 * [Node.js](https://nodejs.org) v10.0 or later.  You can check your node version by running `node --version` on the command-line.
 * [npm](https://www.npmjs.com/) v6.0 or later.  npm is usually installed automatically alongside the above.  You can check your npm version by running `npm --version`.
+* [yarn](https://yarnpkg.com/) v1.19.0 or later. This can be installed using `npm install -g yarn@^1.19.0`
 
 The following components are optional:
 
@@ -56,10 +59,10 @@ export NODE_OPTIONS=--max_old_space_size=4096
 
 ### Installing Dependencies
 
-All of the dependencies required to build and run TerriaMap, other than the prerequisites listed above, are installed using `npm`:
+All of the dependencies required to build and run TerriaMap, other than the prerequisites listed above, are installed using `yarn`:
 
 ```bash
-npm install
+yarn install
 ```
 
 The dependencies are installed in the `node_modules` subdirectory.  No global changes are made to your system.
@@ -107,11 +110,11 @@ Then, open a web browser on `http://localhost:3001` to use TerriaMap.
 
 If you're building an application by using TerriaMap as a starting point, you will want to keep in sync as TerriaMap is improved and updated to use new versions of TerriaJS.  Forking the TerriaMap repo and using git to keep it in sync is outside the scope of this document, but GitHub has a [nice explanation](https://help.github.com/articles/fork-a-repo/).
 
-After pulling new changes, you will need to run `npm install` again to pick up any changed dependencies and then build TerriaMap.  If you have problems building or running, it is sometimes helpful to remove and reinstall the dependencies from npm:
+After pulling new changes, you will need to run `yarn install` again to pick up any changed dependencies and then build TerriaMap.  If you have problems building or running, it is sometimes helpful to remove and reinstall the dependencies from npm:
 
 ```bash
 rm -rf node_modules
-npm install
+yarn install
 ```
 
 ### Having trouble? 

--- a/lib/Models/ErrorServiceProviders/RollbarErrorServiceProvider.ts
+++ b/lib/Models/ErrorServiceProviders/RollbarErrorServiceProvider.ts
@@ -1,5 +1,5 @@
 import Rollbar from "rollbar";
-import TerriaError from "../../Core/TerriaError";
+import TerriaError, { TerriaErrorSeverity } from "../../Core/TerriaError";
 import { ErrorServiceProvider } from "./ErrorService";
 
 export default class RollbarErrorServiceProvider
@@ -21,6 +21,12 @@ export default class RollbarErrorServiceProvider
   }
 
   error(error: string | Error | TerriaError) {
-    this.rollbar.error(error instanceof TerriaError ? error.toError() : error);
+    if (error instanceof TerriaError) {
+      error.severity === TerriaErrorSeverity.Error
+        ? this.rollbar.error(error.toError())
+        : this.rollbar.warning(error.toError());
+    } else {
+      this.rollbar.error(error);
+    }
   }
 }

--- a/lib/Models/ErrorServiceProviders/RollbarErrorServiceProvider.ts
+++ b/lib/Models/ErrorServiceProviders/RollbarErrorServiceProvider.ts
@@ -22,9 +22,15 @@ export default class RollbarErrorServiceProvider
 
   error(error: string | Error | TerriaError) {
     if (error instanceof TerriaError) {
-      error.severity === TerriaErrorSeverity.Error
-        ? this.rollbar.error(error.toError())
-        : this.rollbar.warning(error.toError());
+      if (
+        (typeof error.severity === "function"
+          ? error.severity()
+          : error.severity) === TerriaErrorSeverity.Error
+      ) {
+        this.rollbar.error(error.toError());
+      } else {
+        this.rollbar.warning(error.toError());
+      }
     } else {
       this.rollbar.error(error);
     }

--- a/package.json
+++ b/package.json
@@ -225,13 +225,13 @@
     "hot": "webpack-dev-server --inline --config buildprocess/webpack.config.hot.js --hot --host 0.0.0.0",
     "build-tools": "webpack --config buildprocess/webpack-tools.config.js",
     "watch-tools": "webpack --watch --config buildprocess/webpack-tools.config.js",
-    "build-docs": "npm run build-tools && node build/generateDocs.js",
+    "build-docs": "yarn build-tools && node build/generateDocs.js",
     "publish-doc": "bash -c \"rm -rf wwwroot/doc && mkdir wwwroot/doc && cp doc/index-built.html wwwroot/doc/index.html && cp doc/CNAME wwwroot/doc/CNAME && gulp docs && cd wwwroot/doc && git init && git remote add origin $npm_package_config_docRepo && git add . && git commit -m 'Generate Documentation' && git push -f origin HEAD:gh-pages\"",
     "prettier": "prettier --write \"**/*\"",
     "pretty-quick": "pretty-quick",
     "prettier-check": "prettier --check \"**/*\"",
     "build-for-node": "tsc -b tsconfig-node.json",
-    "prepare": "npm run build-for-node"
+    "prepare": "yarn build-for-node"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
- Add `rollbar.warning` for `TerriaErrorSeverity.Warning`
* Use `yarn` in CI scripts (and upgrade node to v14)
* change `npm run` usage to `yarn` 

TerriaMap PR to change `npm run` usage to `yarn` - https://github.com/TerriaJS/TerriaMap/pull/560

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
