### PR TITLE
Fix `MapNavigation` getter/setter `visible` bug.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Remove use of word "outlier" in zFilter dimension and legend item (we now use "Extreme values")
 * Add `cursor:pointer` to `Checkbox`
 * Fix `MapNavigation` getter/setter `visible` bug.
+  * Replace `CompositeBarItemController` `visible` setter with `setVisible` function
 * Use `yarn` in CI scripts (and upgrade node to v14)
 * [The next improvement]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Disable `zFilter` by default
 * Remove use of word "outlier" in zFilter dimension and legend item (we now use "Extreme values")
 * Add `cursor:pointer` to `Checkbox`
+* Fix `MapNavigation` getter/setter `visible` bug.
 * [The next improvement]
 
 #### 8.1.4

--- a/lib/ReactViews/Feedback/FeedbackButtonController.ts
+++ b/lib/ReactViews/Feedback/FeedbackButtonController.ts
@@ -33,8 +33,13 @@ export class FeedbackButtonController extends MapNavigationItemController {
   get visible() {
     return (
       isDefined(this.viewState.terria.configParameters.feedbackUrl) &&
-      !this.viewState.hideMapUi
+      !this.viewState.hideMapUi &&
+      this._visible
     );
+  }
+
+  set visible(value: boolean) {
+    this._visible = value;
   }
 
   @computed

--- a/lib/ReactViews/Feedback/FeedbackButtonController.ts
+++ b/lib/ReactViews/Feedback/FeedbackButtonController.ts
@@ -34,12 +34,8 @@ export class FeedbackButtonController extends MapNavigationItemController {
     return (
       isDefined(this.viewState.terria.configParameters.feedbackUrl) &&
       !this.viewState.hideMapUi &&
-      this._visible
+      super.visible
     );
-  }
-
-  set visible(value: boolean) {
-    this._visible = value;
   }
 
   @computed

--- a/lib/ReactViews/Map/Navigation/Items/AugmentedVirtualityTool.tsx
+++ b/lib/ReactViews/Map/Navigation/Items/AugmentedVirtualityTool.tsx
@@ -119,11 +119,7 @@ export class AugmentedVirtualityRealignController extends MapNavigationItemContr
 
   @computed
   get visible(): boolean {
-    return this.props.augmentedVirtuality.active && this._visible;
-  }
-
-  set visible(value: boolean) {
-    this._visible = value;
+    return this.props.augmentedVirtuality.active && this.visible;
   }
 
   handleClick(): void {
@@ -219,11 +215,7 @@ export class AugmentedVirtualityHoverController extends MapNavigationItemControl
 
   @computed
   get visible(): boolean {
-    return this.props.augmentedVirtuality.active && this._visible;
-  }
-
-  set visible(v: boolean) {
-    this._visible = v;
+    return this.props.augmentedVirtuality.active && this.visible;
   }
 
   handleClick(): void {

--- a/lib/ReactViews/Map/Navigation/Items/AugmentedVirtualityTool.tsx
+++ b/lib/ReactViews/Map/Navigation/Items/AugmentedVirtualityTool.tsx
@@ -119,7 +119,11 @@ export class AugmentedVirtualityRealignController extends MapNavigationItemContr
 
   @computed
   get visible(): boolean {
-    return this.props.augmentedVirtuality.active;
+    return this.props.augmentedVirtuality.active && this._visible;
+  }
+
+  set visible(value: boolean) {
+    this._visible = value;
   }
 
   handleClick(): void {
@@ -215,7 +219,11 @@ export class AugmentedVirtualityHoverController extends MapNavigationItemControl
 
   @computed
   get visible(): boolean {
-    return this.props.augmentedVirtuality.active;
+    return this.props.augmentedVirtuality.active && this._visible;
+  }
+
+  set visible(v: boolean) {
+    this._visible = v;
   }
 
   handleClick(): void {

--- a/lib/ReactViews/Map/Navigation/Items/ToggleSplitterTool.ts
+++ b/lib/ReactViews/Map/Navigation/Items/ToggleSplitterTool.ts
@@ -24,11 +24,7 @@ export class ToggleSplitterController extends MapNavigationItemController {
 
   @computed
   get visible() {
-    return this._visible && this.viewState.terria.currentViewer.canShowSplitter;
-  }
-
-  set visible(v: boolean) {
-    this._visible = v;
+    return super.visible && this.viewState.terria.currentViewer.canShowSplitter;
   }
 
   @computed

--- a/lib/ReactViews/Map/Navigation/Items/ToggleSplitterTool.ts
+++ b/lib/ReactViews/Map/Navigation/Items/ToggleSplitterTool.ts
@@ -24,7 +24,11 @@ export class ToggleSplitterController extends MapNavigationItemController {
 
   @computed
   get visible() {
-    return super.visible || this.viewState.terria.currentViewer.canShowSplitter;
+    return this._visible && this.viewState.terria.currentViewer.canShowSplitter;
+  }
+
+  set visible(v: boolean) {
+    this._visible = v;
   }
 
   @computed

--- a/lib/ReactViews/Map/Navigation/registerMapNavigations.tsx
+++ b/lib/ReactViews/Map/Navigation/registerMapNavigations.tsx
@@ -138,7 +138,7 @@ export const registerMapNavigations = (viewState: ViewState) => {
     render: <CloseToolButton viewState={viewState} />,
     order: 7
   });
-  closeToolButtonController.visible = false;
+  closeToolButtonController.setVisible(false);
 
   const augmentedVirtuality = new AugmentedVirtuality(terria);
   const arController = new AugmentedVirtualityController({

--- a/lib/ViewModels/CompositeBar/CompositeBarItemController.ts
+++ b/lib/ViewModels/CompositeBar/CompositeBarItemController.ts
@@ -107,10 +107,10 @@ export abstract class CompositeBarItemController
 
   /**
    * Whether this item is visible on the screen.
-   * @private
+   * @protected
    */
   @observable
-  private _visible: boolean = true;
+  protected _visible: boolean = true;
 
   /**
    * Gets the {@link this._visible}

--- a/lib/ViewModels/CompositeBar/CompositeBarItemController.ts
+++ b/lib/ViewModels/CompositeBar/CompositeBarItemController.ts
@@ -1,4 +1,4 @@
-import { computed, observable } from "mobx";
+import { computed, observable, action } from "mobx";
 import ViewerMode from "../../Models/ViewerMode";
 import React from "react";
 
@@ -107,10 +107,10 @@ export abstract class CompositeBarItemController
 
   /**
    * Whether this item is visible on the screen.
-   * @protected
+   * @private
    */
   @observable
-  protected _visible: boolean = true;
+  private _visible: boolean = true;
 
   /**
    * Gets the {@link this._visible}
@@ -120,11 +120,9 @@ export abstract class CompositeBarItemController
     return this._visible;
   }
 
-  /**
-   * Sets the {@link this._visible}
-   */
-  set visible(value: boolean) {
-    this._visible = value;
+  @action
+  setVisible(v: boolean) {
+    this._visible = v;
   }
 
   /**

--- a/lib/ViewModels/CompositeBar/CompositeBarModel.ts
+++ b/lib/ViewModels/CompositeBar/CompositeBarModel.ts
@@ -141,7 +141,7 @@ export abstract class CompositeBarModel<
     for (const item of this.items) {
       if (item.id === id) {
         if (item.controller.visible) {
-          item.controller.visible = false;
+          item.controller.setVisible(false);
           return;
         }
         return;
@@ -154,7 +154,7 @@ export abstract class CompositeBarModel<
     for (const item of this.items) {
       if (item.id === id) {
         if (!item.controller.visible) {
-          item.controller.visible = true;
+          item.controller.setVisible(true);
           return;
         }
         return;

--- a/lib/ViewModels/MapNavigation/MapNavigationModel.ts
+++ b/lib/ViewModels/MapNavigation/MapNavigationModel.ts
@@ -34,7 +34,7 @@ export default class MapNavigationModel extends CompositeBarModel<
   addItem(newItem: IMapNavigationItem, requestedIndex?: number) {
     const elementConfig = this.terria.elements.get(newItem.id);
     if (elementConfig && isDefined(elementConfig.visible)) {
-      newItem.controller.visible = elementConfig.visible;
+      newItem.controller.setVisible(elementConfig.visible);
     }
     super.add(newItem, requestedIndex);
   }

--- a/test/Models/MapNavigation/MapNavigationModelSpec.ts
+++ b/test/Models/MapNavigation/MapNavigationModelSpec.ts
@@ -59,7 +59,7 @@ describe("MapNavigationModel", function() {
       screenSize: undefined,
       location: "TOP"
     };
-    item3.controller.visible = false;
+    item3.controller.setVisible(false);
 
     item4 = {
       id: "item4",
@@ -98,7 +98,7 @@ describe("MapNavigationModel", function() {
       screenSize: undefined,
       location: "TOP"
     };
-    item2Duplicate.controller.visible = false;
+    item2Duplicate.controller.setVisible(false);
   });
 
   it("properly constructs model", function() {


### PR DESCRIPTION
### Fix `MapNavigation` getter/setter `visible` bug.

Some classes only implemented `get visible` and not `set visible` - which upset mobx
- I have replaced `CompositeBarItemController` `visible` setter with `setVisible` function

### For example

This init config doesn't work

```json
{
  "elements": {
    "show-workbench": {
      "visible": false
    },
    "map-data-count": {
      "visible": false
    },
    "help": {
      "visible": false
    },
    "menu-bar": {
      "visible": false
    },
    "map-navigation": {
      "visible": true
    },
    "compass": {
      "visible": false
    },
    "zoom": {
      "visible": true
    },
    "my-location": {
      "visible": false
    },
    "split-tool": {
      "visible": false
    },
    "about-link": {
      "visible": false
    },
    "measure-tool": {
      "visible": false
    },
    "feedback": {
      "visible": false
    },
    "related-maps": {
      "visible": false
    }
  },
  "homeCamera": {
    "west": 109,
    "south": -45,
    "east": 158,
    "north": -8
  },
  "services": [],
  "catalog": []
}
```

![image](https://user-images.githubusercontent.com/6187649/138211515-9599148b-bdb2-472a-bca1-1ac4457dea8f.png)

### Before

http://ci.terria.io/main/#https://raw.githubusercontent.com/TerriaJS/saas-catalogs-public/main/pacificmap/mbd.json

### After

http://ci.terria.io/map-nav-get-set-bug/#https://raw.githubusercontent.com/TerriaJS/saas-catalogs-public/main/pacificmap/mbd.json

### Checklist

-   [] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
