### PR TITLE
Fix crash when showing nested references in catalog.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Remove use of word "outlier" in zFilter dimension and legend item (we now use "Extreme values")
 * Add `cursor:pointer` to `Checkbox`
 * Use `yarn` in CI scripts (and upgrade node to v14)
+* Fix app crash when previewing a nested reference in the catalog (eg when viewing an indexed search result where the result is a reference).
 * [The next improvement]
 
 #### 8.1.4

--- a/lib/ModelMixins/ReferenceMixin.ts
+++ b/lib/ModelMixins/ReferenceMixin.ts
@@ -1,4 +1,4 @@
-import { observable, runInAction, untracked } from "mobx";
+import { observable, runInAction, untracked, computed } from "mobx";
 import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import AsyncLoader from "../Core/AsyncLoader";
 import Constructor from "../Core/Constructor";
@@ -23,7 +23,8 @@ interface ReferenceInterface extends ModelInterface<ReferenceTraits> {
 function ReferenceMixin<T extends Constructor<Model<ReferenceTraits>>>(
   Base: T
 ) {
-  abstract class ReferenceMixin extends Base implements ReferenceInterface {
+  abstract class ReferenceMixinClass extends Base
+    implements ReferenceInterface {
     /** A "weak" reference has a target which doesn't include the `sourceReference` property.
      * This means the reference is treated more like a shortcut to the target. So share links, for example, will use the target instead of sourceReference. */
     protected readonly weakReference: boolean = false;
@@ -76,6 +77,16 @@ function ReferenceMixin<T extends Constructor<Model<ReferenceTraits>>>(
     }
 
     /**
+     * If this a nested reference return the target of the final reference.
+     */
+    @computed
+    get nestedTarget(): BaseModel | undefined {
+      return ReferenceMixin.isMixedInto(this._target)
+        ? this._target.nestedTarget
+        : this._target;
+    }
+
+    /**
      * Asynchronously loads the reference. When the returned promise resolves,
      * {@link ReferenceMixin#target} should return the target of the reference.
      * @param forceReload True to force the load to happen again, even if nothing
@@ -112,7 +123,7 @@ function ReferenceMixin<T extends Constructor<Model<ReferenceTraits>>>(
     }
   }
 
-  return ReferenceMixin;
+  return ReferenceMixinClass;
 }
 
 namespace ReferenceMixin {

--- a/lib/ReactViews/DataCatalog/DataCatalogMember.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogMember.jsx
@@ -31,8 +31,8 @@ export default observer(
     render() {
       const member =
         ReferenceMixin.isMixedInto(this.props.member) &&
-        this.props.member.target !== undefined
-          ? this.props.member.target
+        this.props.member.nestedTarget !== undefined
+          ? this.props.member.nestedTarget
           : this.props.member;
 
       if (ReferenceMixin.isMixedInto(member)) {

--- a/lib/ReactViews/Preview/DataPreview.jsx
+++ b/lib/ReactViews/Preview/DataPreview.jsx
@@ -39,11 +39,12 @@ const DataPreview = observer(
       const { t } = this.props;
       let previewed = this.props.previewed;
       if (previewed !== undefined && ReferenceMixin.isMixedInto(previewed)) {
-        if (previewed.target === undefined) {
+        // We are loading the nested target because we could be dealing with a nested reference here
+        if (previewed.nestedTarget === undefined) {
           // Reference is not available yet.
           return this.renderUnloadedReference();
         }
-        previewed = previewed.target;
+        previewed = previewed.nestedTarget;
       }
 
       let chartData;


### PR DESCRIPTION
### What this PR does

* Fixes crash when previewing a nested reference item.
* Correctly open a nested reference group

This can be seen for example when searching for "Satellite Images" in [nationalmap.gov.au](https://nationalmap.gov.au/) and then clicking on the group to view the result. Here the result is a `CatalogIndexReference -> TerriaReference -> Group`. But because we only resolve up to `TerriaReference` the app crashes as the reference does not have catalog member traits expected by some of the JSX components.

This fix introduces a new method for `ReferenceMixin` called `nestedTarget` to recursively resolve a reference.


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
