### PR TITLE
Set WMS layers property from CKAN resource url query string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
   * Replace `CompositeBarItemController` `visible` setter with `setVisible` function
 * Use `yarn` in CI scripts (and upgrade node to v14)
 * Fix app crash when previewing a nested reference in the catalog (eg when viewing an indexed search result where the result is a reference).
+* Ported feaure from v7 to set WMS layers property from the value of `LAYERS`, `layers` or `typeName` from query string of CKAN resource URL.
 * [The next improvement]
 
 #### 8.1.4

--- a/lib/Models/Catalog/Ckan/CkanItemReference.ts
+++ b/lib/Models/Catalog/Ckan/CkanItemReference.ts
@@ -467,15 +467,19 @@ export default class CkanItemReference extends UrlMixin(
     }
 
     // Overrides for specific catalog types
-    if (
-      model instanceof WebMapServiceCatalogItem &&
-      this._ckanResource?.wms_layer
-    ) {
-      model.setTrait(
-        CommonStrata.definition,
-        "layers",
-        this._ckanResource.wms_layer
-      );
+    if (model instanceof WebMapServiceCatalogItem) {
+      const params:
+        | Record<string, string | undefined>
+        | undefined = model.uri?.search(true);
+
+      // Mixing ?? and || because for params we don't want to use empty string params if there are non-empty string parameters
+      const layers =
+        this._ckanResource?.wms_layer ??
+        (params?.LAYERS || params?.layers || params?.typeName);
+
+      if (layers) {
+        model.setTrait(CommonStrata.definition, "layers", layers);
+      }
     }
 
     // Tried to make this sequence an updateModelFromJson but wouldn't work?

--- a/wwwroot/test/CKAN/vic-wms-layer-resource.json
+++ b/wwwroot/test/CKAN/vic-wms-layer-resource.json
@@ -1,0 +1,30 @@
+{
+  "help": "https://discover.data.vic.gov.au/api/3/action/help_show?name=resource_show",
+  "success": true,
+  "result": {
+    "cache_last_updated": null,
+    "package_id": "0e1be7ad-e302-4d98-96ca-e133d0ff8a47",
+    "attribution": "Copyright &copy; The State of Victoria, Environment Protection Authority Victoria 2021",
+    "datastore_contains_all_records_of_source_file": false,
+    "datastore_active": false,
+    "id": "7fc14241-b1ff-4fef-a336-c885f9060b57",
+    "size": null,
+    "state": "active",
+    "period_end": "2020-06-30",
+    "hash": "",
+    "description": "",
+    "format": "WMS",
+    "last_modified": null,
+    "url_type": null,
+    "period_start": "1901-01-01",
+    "mimetype": null,
+    "cache_url": null,
+    "name": "EPA Victoria Environmental Audit Reports - Location Points - WMS",
+    "created": "2021-09-30T18:55:58.633227",
+    "url": "http://services.land.vic.gov.au/catalogue/publicproxy/guest/dv_geoserver/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&WIDTH=512&HEIGHT=512&LAYERS=ENVIRONPROTECT_ENVIRO_AUDIT_LOC_POINT&STYLES=&FORMAT=image%2Fpng&SRS=EPSG%3A4283&BBOX=141%2C-39%2C150%2C-34",
+    "mimetype_inner": null,
+    "position": 0,
+    "revision_id": "6fee3812-4bbc-44ff-a359-e8d3cd4574e7",
+    "resource_type": null
+  }
+}


### PR DESCRIPTION
### What this PR does

Fixes TerriaJS/nationalmap#1090.

Test here: http://ci.terria.io/ckan-wms-url-layers/#clean&https://gist.githubusercontent.com/steve9164/bdd8cd04ea0ca32ceb851c3b462089c9/raw/852e90fbf7ed8d9a0bc53817c877f5b51c83313f/test-ckan-resource.json

Note the item doesn't work due to dodgy CORS on the VIC server (for some reason this request https://discover.data.vic.gov.au/api/3/action/resource_show?id=7fc14241-b1ff-4fef-a336-c885f9060b57 doesn't have CORS, but a lot of other APIs at the same URL have CORS).

It'd be a good idea to do similar for MagdaReference.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
