### PR TITLE
add --ignore-engines flag to yarn install to by pass node engine error during yarn install

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
-        run: yarn install
+        run: yarn install --ignore-engines
 
       - name: Lint and build terriajs
         if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version


### PR DESCRIPTION
### What this PR does

We used to use npm to install deps in CI pipeline and some deps produce an error:
```
npm WARN notsup Unsupported engine for jsdom@17.0.0: wanted: {"node":">=12"} (current: {"node":"10.24.1","npm":"6.14.12"})
```
And npm will just get along with it without breaking the process.

See previous publish log here:

https://github.com/TerriaJS/terriajs/runs/3892529562?check_suite_focus=true

We recently switch to use `yarn` and now `yarn install` will throw an error for the same reason and stop the publishing process:

https://github.com/TerriaJS/terriajs/runs/4042329139?check_suite_focus=true

`--ignore-engines` will make yarn ignore the error and act in a way similar to previous npm behaviours. 

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [ ] I've updated CHANGES.md with what I changed.
