### PR TITLE
Bump version to 8.1.8.

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -57,6 +57,7 @@ jobs:
         if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
         run: npm publish --tag ${NPM_TAG}
         env:
+          NODE_OPTIONS: '--max_old_space_size=8192'
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # These slack success and failure message actions can be combined but it means there'll be no notification on a failed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
 Change Log
 ==========
 
-#### next release (8.1.8)
+#### next release (8.1.9)
 * [The next improvement]
 
-#### 8.1.7
+#### 8.1.8
 * Tsified `SettingPanel`
 * Moved `setViewerMode` function from `Terria` class to `ViewerMode`
 * Refactored checkbox to use children elements for label instead of label

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.1.7",
+  "version": "8.1.8",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### What this PR does

* Version bump to v8.1.8
* Increase `max_old_space_size` to `8192` for `npm publish` in github action.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
