### PR TITLE
Add maincode aliases for all SA regions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Change Log
 ==========
 
 #### next release (8.1.10)
+* Added `MAINCODE` aliases for all ABS Statistical Area regions that were missing them.
 * [The next improvement]
 
 #### 8.1.9

--- a/wwwroot/data/regionMapping.json
+++ b/wwwroot/data/regionMapping.json
@@ -70,8 +70,8 @@
             "aliases": [
                 "sa1",
                 "sa1_code",
-                "sa1_maincode_2016",
-                "sa1_code_2016"
+                "sa1_code_2016",
+                "sa1_maincode_2016"
             ],
             "nameProp": "SA1_7DIG16",
             "description": "Statistical Area Level 1 2016 (ABS)",
@@ -107,7 +107,8 @@
             "analyticsWmsServer": "http://geoserver.nationalmap.nicta.com.au/region_map/ows",
             "regionProp": "SA4_CODE11",
             "aliases": [
-                "sa4_code_2011"
+                "sa4_code_2011",
+                "sa4_maincode_2011"
             ],
             "digits": 3,
             "description": "Statistical Area Level 4",
@@ -167,6 +168,7 @@
             "aliases": [
                 "sa4",
                 "sa4_code",
+                "sa4_maincode_2016",
                 "sa4_code_2016"
             ],
             "nameProp": "SA4_NAME16",
@@ -203,7 +205,8 @@
             "analyticsWmsServer": "http://geoserver.nationalmap.nicta.com.au/region_map/ows",
             "regionProp": "SA3_CODE11",
             "aliases": [
-                "sa3_code_2011"
+                "sa3_code_2011",
+                "sa3_maincode_2011"
             ],
             "digits": 5,
             "description": "Statistical Area Level 3",
@@ -264,7 +267,8 @@
             "aliases": [
                 "sa3",
                 "sa3_code",
-                "sa3_code_2016"
+                "sa3_code_2016",
+                "sa3_maincode_2016"
             ],
             "nameProp": "SA3_NAME16",
             "description": "Statistical Area Level 3 2016 (ABS)",
@@ -300,7 +304,8 @@
             "analyticsWmsServer": "http://geoserver.nationalmap.nicta.com.au/region_map/ows",
             "regionProp": "SA2_MAIN11",
             "aliases": [
-                "sa2_code_2011"
+                "sa2_code_2011",
+                "sa2_maincode_2011"
             ],
             "digits": 9,
             "description": "Statistical Area Level 2",
@@ -385,7 +390,8 @@
             "aliases": [
                 "sa2",
                 "sa2_code",
-                "sa2_code_2016"
+                "sa2_code_2016",
+                "sa2_maincode_2016"
             ],
             "nameProp": "SA2_NAME16",
             "description": "Statistical Area Level 2 2016 (ABS)",


### PR DESCRIPTION
### What this PR does

Fixes terriajs#5974

I've added `maincode` aliases for all SA regions that were missing them to ensure we support the default ABS column naming.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist) - no idea
-   [ ] I've updated relevant documentation in `doc/`. - none required
-   [x] I've updated CHANGES.md with what I changed.
