### PR TITLE
Update terria-js cesium to `1.81.3`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.14)
 * Reimplement option to zoom on item when adding it to workbench, `zoomOnAddToWorkbench` is added to `MappableTraits`.
+* Update terria-js cesium to `1.81.3` 
 * [The next improvement]
 
 #### 8.1.13

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "style-loader": "^0.23.1",
     "styled-components": "^5.1.0",
     "svg-sprite-loader": "4.1.3",
-    "terriajs-cesium": "1.81.2",
+    "terriajs-cesium": "1.81.3",
     "terriajs-html2canvas": "1.0.0-alpha.12-terriajs-1",
     "terriajs-protomaps": "1.14.0-prerelease",
     "thredds-catalog-crawler": "0.0.5",


### PR DESCRIPTION
### Update terria-js cesium to `1.81.3`

There was an issue in some Worker code. I don't think I ran the `terria-prepare-cesium` gulp task correctly, as Worker didn't reflect changes I had made.

Because of this, some Cesium primitives will kill the renderer

### Example

- Add "test" item to the workbench

http://ci.terria.io/main/#clean&https://gist.githubusercontent.com/nf-s/4a29bdff8cc703f0b4f9562190312b1f/raw/5c60df964e1587c7aa62735c8eaff411f568d9c7/brokengeojson.json

vs

http://ci.terria.io/cesium-1-81-3/#clean&https://gist.githubusercontent.com/nf-s/4a29bdff8cc703f0b4f9562190312b1f/raw/5c60df964e1587c7aa62735c8eaff411f568d9c7/brokengeojson.json

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
