### PR TITLE
Fix legends in TableMixin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Anonymize user IP when using google analytics.
 * Fix crash when TableMixin-based catalog item had invalid date values
 * Fix `WebMapServiceCatalogItem.styles` if `supportsGetLegendGraphics = false`. This means that if a WMS server doesn't support `GetLegendGraphics` requests, the first style will be set as the default style.
+* Fixes an issue where custom legends defined in the catalog were always ignored by TableMixin.
 
 #### 8.1.13
 


### PR DESCRIPTION
### What this PR does

Fixes an issue where custom legends defined in the catalog were always ignored by TableMixin.

This bug resulted from the `legends` trait being overridden in TableMixin in such a way that it ignored any other legend definitions that might exist in higher strata.

### Checklist

-   [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [X] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
