### PR TITLE
Fix `GeoJsonCatalogItem.legends`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Fix picked feature highlighting for ArcGis REST API features (and TSify `featureDataToGeoJson`)
 * Re-enable GeoJSON simple styling - now if more than 50% of features have [simple-style-spec properties](https://github.com/mapbox/simplestyle-spec) - automatic styling will be disabled (this behaviour can be disabled by setting `forceCesiumPrimitives = false`)
 * Don't show `TableMixin` `legends` or `mapItems` if no data
+* Fix `GeoJsonCatalogItem.legends`
 * [The next improvement]
 
 #### 8.1.14

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -76,6 +76,7 @@ import Model, { BaseModel } from "../Models/Definition/Model";
 import StratumOrder from "../Models/Definition/StratumOrder";
 import TableAutomaticStylesStratum from "../Table/TableAutomaticStylesStratum";
 import { GeoJsonTraits } from "../Traits/TraitsClasses/GeoJsonTraits";
+import LegendTraits from "../Traits/TraitsClasses/LegendTraits";
 import { RectangleTraits } from "../Traits/TraitsClasses/MappableTraits";
 import { DiscreteTimeAsJS } from "./DiscretelyTimeVaryingMixin";
 import { ExportData } from "./ExportableMixin";
@@ -299,6 +300,22 @@ function GeoJsonMixin<T extends Constructor<Model<GeoJsonTraits>>>(Base: T) {
     @computed
     get disableSplitter() {
       return !this._imageryProvider;
+    }
+
+    /** Special case for legends.
+     * Because TableMixin does not have LegendTraits, but GeoJsonMixin does, we need to check to see if traits have been defined.
+     * If so, they will override TableMixin legends
+     */
+    @computed
+    get legends(): Model<LegendTraits>[] {
+      const legendTraits = this.traits.legends.getValue(this) as
+        | Model<LegendTraits>
+        | undefined;
+      if (Array.isArray(legendTraits) && legendTraits.length > 0) {
+        return legendTraits;
+      }
+
+      return super.legends;
     }
 
     @computed get mapItems() {

--- a/lib/Traits/TraitsClasses/GeoJsonTraits.ts
+++ b/lib/Traits/TraitsClasses/GeoJsonTraits.ts
@@ -9,6 +9,7 @@ import FeatureInfoTraits from "./FeatureInfoTraits";
 import StyleTraits from "./StyleTraits";
 import TableTraits from "./TableTraits";
 import UrlTraits from "./UrlTraits";
+import LegendOwnerTraits from "./LegendOwnerTraits";
 
 export class PerPropertyGeoJsonStyleTraits extends ModelTraits {
   @anyTrait({
@@ -36,6 +37,7 @@ export class PerPropertyGeoJsonStyleTraits extends ModelTraits {
 }
 
 export class GeoJsonTraits extends mixTraits(
+  LegendOwnerTraits,
   TableTraits,
   FeatureInfoTraits,
   UrlTraits

--- a/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
@@ -732,6 +732,39 @@ describe("GeoJsonCatalogItem - with geojson-vt and protomaps", function() {
       ).toBe(col);
     });
   });
+
+  it("Supports LegendOwnerTraits to override TableMixin.legends", async () => {
+    await geojson.loadMapItems();
+
+    expect(
+      "imageryProvider" in geojson.mapItems[0] &&
+        geojson.mapItems[0].imageryProvider instanceof ProtomapsImageryProvider
+    ).toBeTruthy();
+
+    expect(geojson.legends.length).toBe(1);
+    expect(geojson.legends[0].items.map(i => i.color)).toEqual([
+      "rgb(103,0,13)",
+      "rgb(176,18,24)",
+      "rgb(226,48,40)",
+      "rgb(249,105,76)",
+      "rgb(252,160,130)",
+      "rgb(253,211,193)",
+      "rgb(255,245,240)"
+    ]);
+
+    runInAction(() =>
+      updateModelFromJson(geojson, CommonStrata.definition, {
+        legends: [
+          {
+            url: "some-url"
+          }
+        ]
+      })
+    );
+
+    expect(geojson.legends.length).toBe(1);
+    expect(geojson.legends[0].url).toBe("some-url");
+  });
 });
 
 describe("Disables protomaps (mvt) if geoJson simple styling is detected", () => {


### PR DESCRIPTION
### Fix `GeoJsonCatalogItem.legends`

https://github.com/TerriaJS/terriajs/pull/6046 removed `LegendTraits` from `GeoJsonMixin`, but we need them

### Test catalog

https://gist.githubusercontent.com/nf-s/7babad578ac9b9d7412aaa6dc2f9602b/raw/56f95f04be02e84f59efefc7c7aa0a7207c116f6/geojson-legend-fix.json

```json
{
  "catalog": [
    {
      "type": "geojson",
      "name": "Distribution powerlines",
      "id": "649c5937",
      "url": "https://uts-nom.herokuapp.com/capacity/published/combined-distribution-powerlines.geojson",
      "legends": [
        {
          "url": "https://network-opportunity-maps.s3-ap-southeast-2.amazonaws.com/capacity/legends/nom_legend_lines.png"
        }
      ],
      "forceCesiumPrimitives": true
    }
  ],
  "workbench": ["649c5937"]
}
```

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
