### PR TITLE
Various fixes for SOS.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.17)
 
+* Re-enable procedure and observable selectors for SOS items.
 * [The next improvement]
 
 #### 8.1.16

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 #### next release (8.1.17)
 
 * Re-enable procedure and observable selectors for SOS items.
+* Fix broken "Ideal zoom" for TableMixin items.
 * [The next improvement]
 
 #### 8.1.16

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -255,7 +255,9 @@ function TableMixin<T extends Constructor<Model<TableTraits>>>(Base: T) {
     get disableZoomTo() {
       // Disable zoom if only showing imagery parts  (eg region mapping) and no rectangle is defined
       if (
-        !this.mapItems.find(m => m instanceof DataSource) &&
+        !this.mapItems.find(
+          m => m instanceof DataSource || m instanceof CustomDataSource
+        ) &&
         !isDefined(this.cesiumRectangle)
       ) {
         return true;
@@ -472,7 +474,6 @@ function TableMixin<T extends Constructor<Model<TableTraits>>>(Base: T) {
       if (this.mapItems.length === 0 && !this.enableManualRegionMapping) {
         return;
       }
-
       return {
         id: "activeStyle",
         name: "Display Variable",

--- a/lib/Models/Catalog/Ows/SensorObservationServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/SensorObservationServiceCatalogItem.ts
@@ -105,6 +105,9 @@ class SosAutomaticStylesStratum extends TableAutomaticStylesStratum {
         pointSize: createStratumInstance(TablePointSizeStyleTraits, {
           pointSizeColumn: p.identifier
         }),
+        // table style is hidden by default when the table uses only 1 color (https://github.com/TerriaJS/terriajs/blob/bbe8a11ae9bf6c0eb78c52d7b5c9b260d5ddc8cf/lib/Table/TableStyle.ts#L82)
+        // force hidden to false so that the frequency and procedure selector will always be shown
+        // Ideally we should rewrite frequency & procedure selector using selectable dimensions and stop using styles to display them.
         hidden: false
       });
     });

--- a/lib/Models/Catalog/Ows/SensorObservationServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/SensorObservationServiceCatalogItem.ts
@@ -104,7 +104,8 @@ class SosAutomaticStylesStratum extends TableAutomaticStylesStratum {
         }),
         pointSize: createStratumInstance(TablePointSizeStyleTraits, {
           pointSizeColumn: p.identifier
-        })
+        }),
+        hidden: false
       });
     });
   }
@@ -316,6 +317,12 @@ export default class SensorObservationServiceCatalogItem extends TableMixin(
     this.strata.set(
       TableAutomaticStylesStratum.stratumName,
       new SosAutomaticStylesStratum(this)
+    );
+    // Temporary workaround for https://github.com/TerriaJS/terriajs/issues/6058
+    this.defaultTableStyle.colorTraits.setTrait(
+      CommonStrata.defaults,
+      "legend",
+      undefined
     );
   }
 

--- a/lib/ReactViews/Custom/Chart/BottomDockChart.jsx
+++ b/lib/ReactViews/Custom/Chart/BottomDockChart.jsx
@@ -515,7 +515,7 @@ function calculateDomain(chartItems) {
   const ymax = Math.max(...chartItems.map(c => c.domain.y[1]));
   return {
     x: [xmin, xmax],
-    y: [Math.min(0, ymin), ymax]
+    y: [ymin, ymax]
   };
 }
 

--- a/lib/Table/createLongitudeLatitudeFeaturePerRow.ts
+++ b/lib/Table/createLongitudeLatitudeFeaturePerRow.ts
@@ -79,7 +79,7 @@ export function getRowValues(
   const result: JsonObject = {};
 
   tableColumns.forEach(column => {
-    result[column.title] = column.valueFunctionForType(index);
+    result[column.name] = column.valueFunctionForType(index);
   });
 
   return result;

--- a/test/ModelMixins/TableMixinSpec.ts
+++ b/test/ModelMixins/TableMixinSpec.ts
@@ -150,7 +150,7 @@ describe("TableMixin", function() {
         const duplicateValue = 7;
         let occurrences = 0;
         for (let entity of mapItem.entities.values) {
-          const val = entity.properties?.Value.getValue();
+          const val = entity.properties?.value.getValue();
           if (val === duplicateValue) {
             occurrences++;
           }
@@ -167,7 +167,7 @@ describe("TableMixin", function() {
       const dataSource = item.mapItems[0] as CustomDataSource;
       const propertyNames =
         dataSource.entities.values[0].properties?.propertyNames;
-      expect(propertyNames).toEqual(["lat", "lon", "val"]);
+      expect(propertyNames).toEqual(["lat", "lon", "value"]);
     });
   });
 

--- a/test/ModelMixins/TableMixinSpec.ts
+++ b/test/ModelMixins/TableMixinSpec.ts
@@ -1,5 +1,7 @@
 import { runInAction } from "mobx";
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSource";
+import PropertyBag from "terriajs-cesium/Source/DataSources/PropertyBag";
 import { ImageryParts } from "../../lib/ModelMixins/MappableMixin";
 import CsvCatalogItem from "../../lib/Models/Catalog/CatalogItems/CsvCatalogItem";
 import CommonStrata from "../../lib/Models/Definition/CommonStrata";
@@ -155,6 +157,17 @@ describe("TableMixin", function() {
         }
         expect(occurrences).toBe(1);
       }
+    });
+
+    it("has the correct property names", async function() {
+      runInAction(() =>
+        item.setTrait(CommonStrata.user, "csvString", LatLonValCsv)
+      );
+      await item.loadMapItems();
+      const dataSource = item.mapItems[0] as CustomDataSource;
+      const propertyNames =
+        dataSource.entities.values[0].properties?.propertyNames;
+      expect(propertyNames).toEqual(["lat", "lon", "val"]);
     });
   });
 

--- a/test/Models/Catalog/CatalogItems/SensorObservationServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/SensorObservationServiceCatalogItemSpec.ts
@@ -212,6 +212,17 @@ describe("SensorObservationServiceCatalogItem", function() {
           "Observation Type"
         ]);
       });
+
+      it("shows all options for the procedure selector", async function() {
+        await item.loadMapItems();
+        const procedureSelector = item.selectableDimensions.find(
+          s => s.name === "Frequency"
+        );
+        expect(procedureSelector).toBeDefined();
+        if (procedureSelector) {
+          expect(procedureSelector.options?.length).toEqual(4);
+        }
+      });
     });
   });
 


### PR DESCRIPTION
### What this PR does

- Re-enables procedure and observable selectors - Fixes https://github.com/TerriaJS/neii-viewer/issues/191
- Fixes feature info template rendering that was broken because of using `title` instead of `name` as property names.
  Previously:
    
![image](https://user-images.githubusercontent.com/1430/147300428-afd08d46-fcc1-4a0f-9db1-855646ce951b.png)

- Temporary workaround for an app crash when rendering feature info chart. The actual cause is explained here https://github.com/TerriaJS/terriajs/issues/6058
- Fixes "ideal zoom" for table mixin items.
- Removes clamping of min y-axis value to 0 in bottom panel chart. This resulted in the feature info panel chart looking very different from the bottom panel chart for scales >> 0. Not sure of the original reasoning but I think it is a harmless change.

Test link:
http://ci.terria.io/fix-sos/#clean&https://raw.githubusercontent.com/TerriaJS/saas-catalogs-public/main/neii/water/prod.json


### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
