### PR TITLE
Cast property to number in show expression generated from filters for 3d tiles.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.17)
 
+* Automatically cast property value to number in style expressions generated for 3d tiles filter.
 * [The next improvement]
 
 #### 8.1.16

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -313,6 +313,7 @@ export default function Cesium3dTilesMixin<
           return "";
         }
 
+        // Escape single quotes, cast property value to number
         const property =
           "Number(${feature['" + filter.property.replace(/'/g, "\\'") + "']})";
         const min =

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -314,7 +314,7 @@ export default function Cesium3dTilesMixin<
         }
 
         const property =
-          "${feature['" + filter.property.replace(/'/g, "\\'") + "']}";
+          "Number(${feature['" + filter.property.replace(/'/g, "\\'") + "']})";
         const min =
           isDefined(filter.minimumValue) &&
           isDefined(filter.minimumShown) &&
@@ -327,6 +327,7 @@ export default function Cesium3dTilesMixin<
           filter.maximumShown < filter.maximumValue
             ? property + " <= " + filter.maximumShown
             : "";
+
         return [min, max].filter(x => x.length > 0).join(" && ");
       });
 

--- a/test/ModelMixins/Cesium3dTilesMixinSpec.ts
+++ b/test/ModelMixins/Cesium3dTilesMixinSpec.ts
@@ -6,12 +6,14 @@ import ClippingPlane from "terriajs-cesium/Source/Scene/ClippingPlane";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Color from "terriajs-cesium/Source/Core/Color";
 import Matrix4 from "terriajs-cesium/Source/Core/Matrix4";
+import Cesium3DTileset from "terriajs-cesium/Source/Scene/Cesium3DTileset";
+import CommonStrata from "../../lib/Models/Definition/CommonStrata";
 
 describe("Cesium3dTilesMixin", function() {
-  describe(" - loadClippingPlanes", function() {
-    let terria: Terria;
-    let cesium3dTiles: Cesium3DTilesCatalogItem;
+  let terria: Terria;
+  let cesium3dTiles: Cesium3DTilesCatalogItem;
 
+  describe(" - loadClippingPlanes", function() {
     beforeEach(async function() {
       terria = new Terria({
         baseUrl: "./"
@@ -103,6 +105,47 @@ describe("Cesium3dTilesMixin", function() {
     it(" - ClippingPlaneCollection must content Identity Matrix as modelMatrix", function() {
       const cpc = cesium3dTiles.cesiumTileClippingPlaneCollection;
       expect(cpc?.modelMatrix.equals(Matrix4.IDENTITY)).toBe(true);
+    });
+  });
+
+  describe("tileset style", function() {
+    describe("show expression from filter", function() {
+      fit("casts the property to number", async function() {
+        terria = new Terria({
+          baseUrl: "./"
+        });
+        cesium3dTiles = new Cesium3DTilesCatalogItem("test", terria);
+        cesium3dTiles.setTrait(
+          CommonStrata.user,
+          "url",
+          "test/Cesium3DTiles/tileset.json"
+        );
+        const filter = cesium3dTiles.addObject(
+          CommonStrata.user,
+          "filters",
+          "level-filter"
+        );
+        filter?.setTrait(CommonStrata.user, "name", "Level filter");
+        filter?.setTrait(CommonStrata.user, "property", "level");
+        filter?.setTrait(CommonStrata.user, "minimumValue", 0);
+        filter?.setTrait(CommonStrata.user, "maximumValue", 42);
+        filter?.setTrait(CommonStrata.user, "minimumShown", 10);
+        filter?.setTrait(CommonStrata.user, "maximumShown", 20);
+        await cesium3dTiles.loadMapItems();
+        const tileset = cesium3dTiles.mapItems[0] as Cesium3DTileset;
+        const show = tileset.style?.show;
+        const expr = (show as any)?.expression as string;
+        expect(expr).toBeDefined();
+        if (expr) {
+          const [cond1, cond2] = expr.split("&&");
+          expect(cond1.trim().startsWith("Number(${feature['level']})")).toBe(
+            true
+          );
+          expect(cond2.trim().startsWith("Number(${feature['level']})")).toBe(
+            true
+          );
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
### What this PR does

Cesium throws an error when the property used with a `filter` is a string instead of a number which is the case for some datasets. This PR adds an explicit cast from string to number to fix the problems.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
