### PR TITLE
Upgrade compiler target to es2019

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 #### 8.1.16
 
 * Added region mapping support for Commonwealth Electoral Divisions as at 2 August 2021 (AEC) as com_elb_name_2021.
+* Upgrade compiler target from es2018 to es2019
 
 #### 8.1.15
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es2018",
+        "target": "es2019",
         "experimentalDecorators": true,
         "module": "esNext",
         "moduleResolution": "node",


### PR DESCRIPTION
###  upgrade compiler target to es2019 to support flat() in ApiTableCatlogItem.ts
Evergreen browsers have good support for this:
![Screen Shot 2021-12-24 at 3 12 41 pm](https://user-images.githubusercontent.com/4196561/147315325-6cff3302-d086-4691-bb89-4916903ee755.png)


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
