### PR TITLE
Bump minimum node version to 12

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ Change Log
 
 #### next release (8.1.17)
 
+- **Breaking changes**:
+  * Minimum node version is now 12 after upgrading node-sass dependency
+
 * Automatically cast property value to number in style expressions generated for 3d tiles filter.
 * Re-enable procedure and observable selectors for SOS items.
 * Fix broken "Ideal zoom" for TableMixin items.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -29,7 +29,7 @@ If you run into trouble or want more explanation, read on.
 TerriaJS can be built and run on almost any macOS, Linux, or Windows system.  The following are required to build TerriaJS:
 
 * The Bash command shell. On macOS or Linux you almost certainly already have this. On Windows, you can easily get it by installing [Git for Windows](https://gitforwindows.org/). In the instructions below, we assume you're using a Bash command prompt.
-* [Node.js](https://nodejs.org) v10.0 or later.  You can check your node version by running `node --version` on the command-line.
+* [Node.js](https://nodejs.org) v12.0 or later.  You can check your node version by running `node --version` on the command-line.
 * [npm](https://www.npmjs.com/) v6.0 or later.  npm is usually installed automatically alongside the above.  You can check your npm version by running `npm --version`.
 * [yarn](https://yarnpkg.com/) v1.19.0 or later. This can be installed using `npm install -g yarn@^1.19.0`
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 12.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### What this PR does

Bumps minimum node version to 12, since the new node-sass version we're using only supports 12+.
  
### Test me
  
N/A

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
