### PR TITLE
Fix default table style legends

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,12 +13,13 @@ Change Log
 - RasterLayerTraits and Cesium3dTilesTraits now share the newly created OpacityTraits
 - `disableOpacityControl` is now a trait and can be set in the catalog.
 - TSXified OpacitySection
+* Upgrade compiler target from es2018 to es2019
+* Fix default table style legends
 * [The next improvement]
 
 #### 8.1.16
 
 * Added region mapping support for Commonwealth Electoral Divisions as at 2 August 2021 (AEC) as com_elb_name_2021.
-* Upgrade compiler target from es2018 to es2019
 
 #### 8.1.15
 

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -18,9 +18,7 @@ import TerriaError from "../Core/TerriaError";
 import ConstantColorMap from "../Map/ConstantColorMap";
 import RegionProviderList from "../Map/RegionProviderList";
 import CommonStrata from "../Models/Definition/CommonStrata";
-import LoadableStratum from "../Models/Definition/LoadableStratum";
-import Model, { BaseModel } from "../Models/Definition/Model";
-import StratumOrder from "../Models/Definition/StratumOrder";
+import Model from "../Models/Definition/Model";
 import updateModelFromJson from "../Models/Definition/updateModelFromJson";
 import SelectableDimensions, {
   SelectableDimension
@@ -28,7 +26,6 @@ import SelectableDimensions, {
 import createLongitudeLatitudeFeaturePerId from "../Table/createLongitudeLatitudeFeaturePerId";
 import createLongitudeLatitudeFeaturePerRow from "../Table/createLongitudeLatitudeFeaturePerRow";
 import createRegionMappedImageryProvider from "../Table/createRegionMappedImageryProvider";
-import { ColorStyleLegend } from "../Table/TableAutomaticStylesStratum";
 import TableColumn from "../Table/TableColumn";
 import TableColumnType from "../Table/TableColumnType";
 import TableStyle from "../Table/TableStyle";
@@ -61,15 +58,7 @@ function TableMixin<T extends Constructor<Model<TableTraits>>>(Base: T) {
     constructor(...args: any[]) {
       super(...args);
 
-      const tableStyle = new TableStyle(this);
-      runInAction(() =>
-        tableStyle.colorTraits.setTrait(
-          CommonStrata.defaults,
-          "legend",
-          new ColorStyleLegend(this, undefined)
-        )
-      );
-      this.defaultTableStyle = tableStyle;
+      this.defaultTableStyle = new TableStyle(this);
     }
 
     get hasTableMixin() {

--- a/lib/Table/TableAutomaticStylesStratum.ts
+++ b/lib/Table/TableAutomaticStylesStratum.ts
@@ -90,6 +90,9 @@ export default class TableAutomaticStylesStratum extends LoadableStratum(
         time: createStratumInstance(TableTimeStyleTraits, {
           timeColumn: timeColumn?.name,
           idColumns: idColumn && [idColumn.name]
+        }),
+        color: createStratumInstance(TableColorStyleTraits, {
+          legend: this._createLegendForColorStyle(-1)
         })
       });
     }
@@ -117,6 +120,9 @@ export default class TableAutomaticStylesStratum extends LoadableStratum(
 
     if (scalarColumns.length >= (hasTime ? 1 : 2)) {
       return createStratumInstance(TableStyleTraits, {
+        color: createStratumInstance(TableColorStyleTraits, {
+          legend: this._createLegendForColorStyle(-1)
+        }),
         chart: createStratumInstance(TableChartStyleTraits, {
           xAxisColumn: hasTime ? timeColumns[0].name : scalarColumns[0].name,
           lines: scalarColumns.slice(hasTime ? 0 : 1).map((column, i) =>
@@ -230,7 +236,7 @@ export class ColorStyleLegend extends LoadableStratum(LegendTraits) {
   /**
    *
    * @param catalogItem
-   * @param index index of column in catalogItem (if undefined, then default style will be used)
+   * @param index index of column in catalogItem (if -1 or undefined, then default style will be used)
    */
   constructor(
     readonly catalogItem: TableCatalogItem,
@@ -249,6 +255,7 @@ export class ColorStyleLegend extends LoadableStratum(LegendTraits) {
   @computed get tableStyle() {
     if (
       isDefined(this.index) &&
+      this.index !== -1 &&
       this.index < this.catalogItem.tableStyles.length
     )
       return this.catalogItem.tableStyles[this.index];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.1.17",
+  "version": "8.1.16",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.1.16",
+  "version": "8.1.17",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {

--- a/test/Core/TerriaErrorSpec.ts
+++ b/test/Core/TerriaErrorSpec.ts
@@ -39,7 +39,6 @@ describe("TerriaError", function() {
     expect(test.message).toBe("some stringy object");
     expect(test.title).toBe("core.terriaError.defaultTitle");
     expect(test.originalError?.[0]).toEqual(new Error("some stringy object"));
-    console.log(test);
   });
 
   it("Can create chain of TerriaErrors and combine them", function() {

--- a/test/Core/uriHelpersSpec.ts
+++ b/test/Core/uriHelpersSpec.ts
@@ -7,7 +7,6 @@ describe("uriHelpers", function() {
       const uriWithPath = new URI(
         "https://a.fully.qualified.domain/and-a-path"
       );
-      console.log("uriWithPath is", uriWithPath);
       expect(getUriWithoutPath(uriWithPath)).toBe(
         "https://a.fully.qualified.domain/"
       );

--- a/test/ModelMixins/Cesium3dTilesMixinSpec.ts
+++ b/test/ModelMixins/Cesium3dTilesMixinSpec.ts
@@ -110,7 +110,7 @@ describe("Cesium3dTilesMixin", function() {
 
   describe("tileset style", function() {
     describe("show expression from filter", function() {
-      fit("casts the property to number", async function() {
+      it("casts the property to number", async function() {
         terria = new Terria({
           baseUrl: "./"
         });

--- a/test/Models/Catalog/CatalogFunctions/YDYRCatalogFunctionJobSpec.ts
+++ b/test/Models/Catalog/CatalogFunctions/YDYRCatalogFunctionJobSpec.ts
@@ -46,7 +46,6 @@ describe("YDYRCatalogFunctionJob", function() {
     ).andCallFunction(req => {
       if (logCounter < 1) {
         req.respondWith({ responseText: `"Some Log ${logCounter}"` });
-        console.log(`"Some Log ${logCounter}"`);
 
         logCounter++;
       } else {

--- a/test/Models/Catalog/CatalogFunctions/YDYRCatalogFunctionSpec.ts
+++ b/test/Models/Catalog/CatalogFunctions/YDYRCatalogFunctionSpec.ts
@@ -52,7 +52,6 @@ describe("YDYRCatalogFunction", function() {
     ).andCallFunction(req => {
       if (logCounter < 1) {
         req.respondWith({ responseText: `"Some Log ${logCounter}"` });
-        console.log(`"Some Log ${logCounter}"`);
 
         logCounter++;
       } else {

--- a/test/Models/Catalog/CatalogGroupSpec.ts
+++ b/test/Models/Catalog/CatalogGroupSpec.ts
@@ -218,8 +218,6 @@ describe("CatalogGroup", function() {
       }
     ]);
 
-    console.log(item);
-
     expect(item.excludeMembers).toEqual(["grandchild1", "parent3"]);
     expect(item.mergedExcludeMembers).toEqual(["grandchild1", "parent3"]);
 

--- a/test/Models/Catalog/CatalogItems/Cesium3DTilesCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/Cesium3DTilesCatalogItemSpec.ts
@@ -105,9 +105,14 @@ describe("Cesium3DTilesCatalogItemSpec", function() {
     });
 
     it("reflects changes to the catalog item's opacity in its style", function() {
-      expect(style.color._expression).not.toContain("${opacity}");
+      item.setTrait("definition", "style", {
+        color: "#ff0000"
+      });
+
       item.setTrait("user", "opacity", 0.5);
-      expect(style.color._expression).toContain("${opacity}");
+      expect((item.cesiumTileStyle as any).color._expression).toBe(
+        "color('#ff0000', ${opacity})"
+      );
     });
 
     describe("when filters are specified", function() {

--- a/test/Models/Catalog/CatalogItems/Cesium3DTilesCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/Cesium3DTilesCatalogItemSpec.ts
@@ -62,7 +62,7 @@ describe("Cesium3DTilesCatalogItemSpec", function() {
       );
       let show: any = item.showExpressionFromFilters;
       expect(show).toBe(
-        "${feature['stratumlev']} >= -1 && ${feature['stratumlev']} <= 10"
+        "Number(${feature['stratumlev']}) >= -1 && Number(${feature['stratumlev']}) <= 10"
       );
     });
 

--- a/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
@@ -536,7 +536,6 @@ describe("GeoJsonCatalogItem - with CZML template", function() {
 
       const entities = (geojson.mapItems[0] as GeoJsonDataSource).entities
         .values;
-      console.log(entities);
       expect(entities.length).toEqual(5);
 
       const entity1 = entities[0];
@@ -856,8 +855,6 @@ describe("geojson can be split", function() {
     );
 
     const loadReferenceResult = await split.loadReference();
-
-    console.log(loadReferenceResult);
 
     expect(loadReferenceResult.error).toBeUndefined();
 

--- a/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
@@ -1,5 +1,6 @@
 import { runInAction } from "mobx";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import createGuid from "terriajs-cesium/Source/Core/createGuid";
 import Iso8601 from "terriajs-cesium/Source/Core/Iso8601";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
@@ -19,6 +20,7 @@ import ProtomapsImageryProvider, {
 } from "../../../../lib/Map/ProtomapsImageryProvider";
 import { getColor } from "../../../../lib/ModelMixins/GeojsonMixin";
 import GeoJsonCatalogItem from "../../../../lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem";
+import SplitItemReference from "../../../../lib/Models/Catalog/CatalogReferences/SplitItemReference";
 import CommonStrata from "../../../../lib/Models/Definition/CommonStrata";
 import updateModelFromJson from "../../../../lib/Models/Definition/updateModelFromJson";
 import Terria from "../../../../lib/Models/Terria";
@@ -826,5 +828,43 @@ describe("Support geojson through apis", () => {
     geojson.setTrait(CommonStrata.user, "responseGeoJsonPath", "nested.data");
     await geojson.loadMapItems();
     expect(geojson.mapItems.length).toEqual(1);
+  });
+});
+
+describe("geojson can be split", function() {
+  let terria: Terria;
+  let geojson: GeoJsonCatalogItem;
+
+  beforeEach(async function() {
+    terria = new Terria({
+      baseUrl: "./"
+    });
+    geojson = new GeoJsonCatalogItem("test-geojson", terria);
+  });
+
+  it("protomaps-mvt", async function() {
+    terria.addModel(geojson);
+    const geojsonString = await loadText("test/GeoJSON/cemeteries.geojson");
+    geojson.setTrait(CommonStrata.user, "geoJsonString", geojsonString);
+    await geojson.loadMapItems();
+
+    const split = new SplitItemReference(createGuid(), terria);
+    split.setTrait(
+      CommonStrata.definition,
+      "splitSourceItemId",
+      geojson.uniqueId
+    );
+
+    const loadReferenceResult = await split.loadReference();
+
+    console.log(loadReferenceResult);
+
+    expect(loadReferenceResult.error).toBeUndefined();
+
+    expect(split.target instanceof GeoJsonCatalogItem).toBeTruthy();
+
+    expect(
+      (await (split.target as GeoJsonCatalogItem).loadMapItems()).error
+    ).toBeUndefined();
   });
 });

--- a/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
+++ b/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
@@ -477,8 +477,6 @@ describe("CkanCatalogGroup", function() {
         ckanCatalogGroup.strata.get(CkanServerStratum.stratumName)
       );
 
-      console.log(ckanCatalogGroup);
-
       let group1 = <CatalogGroup>ckanCatalogGroup.memberModels[1];
 
       expect(group1.memberModels.length).toBe(2);

--- a/test/Models/Catalog/SdmxJson/SdmxJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/SdmxJson/SdmxJsonCatalogItemSpec.ts
@@ -236,8 +236,6 @@ describe("SdmxJsonCatalogItem", function() {
       ?.getRegionProvider("STE_2016")
       ?.loadRegionIDs();
 
-    console.log(sdmxItem);
-
     await sdmxItem.loadMapItems();
 
     expect(sdmxItem.mapItems.length).toBe(1);

--- a/test/Models/GnafApiSpec.js
+++ b/test/Models/GnafApiSpec.js
@@ -162,8 +162,6 @@ describe("GnafApi", function() {
 
     geoCodeCall
       .then(function(results) {
-        console.log(results);
-
         var hit1 = results[0];
         var hit2 = results[1];
 

--- a/test/Models/WorkbenchSpec.ts
+++ b/test/Models/WorkbenchSpec.ts
@@ -224,7 +224,6 @@ describe("Workbench", function() {
 
     const workbenchWithSingleModel = () => {
       expect(model.target).toBeDefined();
-      console.log(workbench.items);
       expect(workbench.items).toEqual([model.target!]); // Note gets deferenced model
       expect(workbench.itemIds).toEqual(["magda-reference"]); // This just gets id of model
       expect(workbench.items[0].type).toBe(WebMapServiceCatalogItem.type);


### PR DESCRIPTION
### Fix default table style legends

Fixes https://github.com/TerriaJS/terriajs/issues/6062 https://github.com/TerriaJS/terriajs/issues/6058

Removes weird setting `legends` trait on `default` stratum to `new ColorStyleLegends(...)`. The default legend is now set in `TableAutomaticStylesStratum.defaultStyle`.
  
### Test me
  
- http://ci.terria.io/fix-table-default-legends/
- Open `GeoJSON Test`
- Click `Compare` in workbench item
- Repeat with http://ci.terria.io/main/ - observe error in console

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
