### PR TITLE
Remove SOS defaults legend workaround

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 - TSXified OpacitySection
 * Upgrade compiler target from es2018 to es2019
 * Fix default table style legends
+* Remove SOS defaults legend workaround
 * [The next improvement]
 
 #### 8.1.16

--- a/lib/Models/Catalog/Ows/SensorObservationServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/SensorObservationServiceCatalogItem.ts
@@ -321,12 +321,6 @@ export default class SensorObservationServiceCatalogItem extends TableMixin(
       TableAutomaticStylesStratum.stratumName,
       new SosAutomaticStylesStratum(this)
     );
-    // Temporary workaround for https://github.com/TerriaJS/terriajs/issues/6058
-    this.defaultTableStyle.colorTraits.setTrait(
-      CommonStrata.defaults,
-      "legend",
-      undefined
-    );
   }
 
   get type() {


### PR DESCRIPTION
### Remove SOS defaults legend workaround

Because https://github.com/TerriaJS/terriajs/pull/6083 has been merged

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
