### PR TITLE
Add missing default Legend to `TableAutomaticStylesStratum.defaultStyle`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.18)
 
+* Add missing default Legend to `TableAutomaticStylesStratum.defaultStyle`
 * [The next improvement]
 
 #### 8.1.17

--- a/lib/Table/TableAutomaticStylesStratum.ts
+++ b/lib/Table/TableAutomaticStylesStratum.ts
@@ -103,7 +103,12 @@ export default class TableAutomaticStylesStratum extends LoadableStratum(
     }
 
     // Can't do much with this dataset.
-    return createStratumInstance(TableStyleTraits);
+    // Just add default legend
+    return createStratumInstance(TableStyleTraits, {
+      color: createStratumInstance(TableColorStyleTraits, {
+        legend: this._createLegendForColorStyle(-1)
+      })
+    });
   }
 
   @computed

--- a/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
@@ -766,6 +766,36 @@ describe("GeoJsonCatalogItem - with geojson-vt and protomaps", function() {
     expect(geojson.legends.length).toBe(1);
     expect(geojson.legends[0].url).toBe("some-url");
   });
+
+  it("Supports LegendOwnerTraits to override TableMixin.legends - with style disabled", async () => {
+    await geojson.loadMapItems();
+
+    expect(
+      "imageryProvider" in geojson.mapItems[0] &&
+        geojson.mapItems[0].imageryProvider instanceof ProtomapsImageryProvider
+    ).toBeTruthy();
+
+    geojson.setTrait("user", "activeStyle", "");
+
+    expect(geojson.legends.length).toBe(1);
+    expect(geojson.legends[0].items.length).toBe(1);
+    expect(geojson.legends[0].items.map(i => i.color)).toEqual([
+      "rgb(102,194,165)"
+    ]);
+
+    runInAction(() =>
+      updateModelFromJson(geojson, CommonStrata.definition, {
+        legends: [
+          {
+            url: "some-url"
+          }
+        ]
+      })
+    );
+
+    expect(geojson.legends.length).toBe(1);
+    expect(geojson.legends[0].url).toBe("some-url");
+  });
 });
 
 describe("Disables protomaps (mvt) if geoJson simple styling is detected", () => {


### PR DESCRIPTION
### Add missing default Legend to `TableAutomaticStylesStratum.defaultStyle`
  
### Test me

![image](https://user-images.githubusercontent.com/6187649/149448570-0b2e9a1d-4681-4e52-8917-1af708a1d4f9.png)
  
#### Before

http://ci.terria.io/main/#share=s-zEewZf3mMNnLSXEpC9gN0f6DEyJ

#### After

http://ci.terria.io/add-missing-default-legend/#share=s-zEewZf3mMNnLSXEpC9gN0f6DEyJ

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
