### PR TITLE
Fix `OpacitySection` number precision.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 #### next release (8.1.18)
 
 * Fix a bug in CompositeCatalogItem that causes share URLs to become extremely long.
+* Fix `OpacitySection` number precision.
 * [The next improvement]
 
 #### 8.1.17

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.tsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.tsx
@@ -40,7 +40,7 @@ class OpacitySection extends React.Component<OpacitySectionProps> {
       <div className={Styles.opacity}>
         <label htmlFor="opacity">
           {t("workbench.opacity", {
-            opacity: item.opacity * 100
+            opacity: Math.round(item.opacity * 100)
           })}
         </label>
         <Slider


### PR DESCRIPTION
### Fix `OpacitySection` number precision.

Fixes #6091 
  
### Test me
  
- http://ci.terria/io/fix-opacity-precision/
- Open `GeoJson Test`
- Drag slider

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] ~I've provided instructions in the PR description on how to test this PR.~
