### PR TITLE
Add sortMembersBy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Add missing default Legend to `TableAutomaticStylesStratum.defaultStyle`
 * Fix a bug in CompositeCatalogItem that causes share URLs to become extremely long.
 * Fix `OpacitySection` number precision.
+* Add `sortMembersBy` to `GroupTraits`. This can be set to sort group member models - For example `sortMembersBy = "name"` will alphabetically sort members by name.
 * [The next improvement]
 
 #### 8.1.17

--- a/lib/Traits/TraitsClasses/GroupTraits.ts
+++ b/lib/Traits/TraitsClasses/GroupTraits.ts
@@ -1,9 +1,9 @@
 import CatalogMemberFactory from "../../Models/Catalog/CatalogMemberFactory";
-import ModelReference from "../ModelReference";
 import modelReferenceArrayTrait from "../Decorators/modelReferenceArrayTrait";
-import ModelTraits from "../ModelTraits";
-import primitiveTrait from "../Decorators/primitiveTrait";
 import primitiveArrayTrait from "../Decorators/primitiveArrayTrait";
+import primitiveTrait from "../Decorators/primitiveTrait";
+import ModelReference from "../ModelReference";
+import ModelTraits from "../ModelTraits";
 
 export default class GroupTraits extends ModelTraits {
   @primitiveArrayTrait({
@@ -20,6 +20,14 @@ export default class GroupTraits extends ModelTraits {
     type: "boolean"
   })
   isOpen: boolean = false;
+
+  @primitiveTrait({
+    name: "Sort members by",
+    description:
+      "Sort members by this property/trait. For example `name`, will sort all members by alphabetically",
+    type: "string"
+  })
+  sortMembersBy: string | undefined;
 
   @modelReferenceArrayTrait({
     name: "Members",

--- a/lib/Traits/TraitsClasses/GroupTraits.ts
+++ b/lib/Traits/TraitsClasses/GroupTraits.ts
@@ -24,7 +24,7 @@ export default class GroupTraits extends ModelTraits {
   @primitiveTrait({
     name: "Sort members by",
     description:
-      "Sort members by this property/trait. For example `name`, will sort all members by alphabetically",
+      "Sort members by the given property/trait. For example `name`, will sort all members by alphabetically",
     type: "string"
   })
   sortMembersBy: string | undefined;

--- a/test/Models/Catalog/CatalogGroupSpec.ts
+++ b/test/Models/Catalog/CatalogGroupSpec.ts
@@ -1,12 +1,12 @@
+import CatalogMemberMixin from "../../../lib/ModelMixins/CatalogMemberMixin";
 import CatalogGroup from "../../../lib/Models/Catalog/CatalogGroup";
 import GeoJsonCatalogItem from "../../../lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem";
-import BaseModel from "../../../lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem";
-import Terria from "../../../lib/Models/Terria";
-import upsertModelFromJson from "../../../lib/Models/Definition/upsertModelFromJson";
-import CatalogMemberFactory from "../../../lib/Models/Catalog/CatalogMemberFactory";
-import CommonStrata from "../../../lib/Models/Definition/CommonStrata";
 import StubCatalogItem from "../../../lib/Models/Catalog/CatalogItems/StubCatalogItem";
+import CatalogMemberFactory from "../../../lib/Models/Catalog/CatalogMemberFactory";
 import { getUniqueStubName } from "../../../lib/Models/Catalog/createStubCatalogItem";
+import CommonStrata from "../../../lib/Models/Definition/CommonStrata";
+import upsertModelFromJson from "../../../lib/Models/Definition/upsertModelFromJson";
+import Terria from "../../../lib/Models/Terria";
 
 describe("CatalogGroup", function() {
   let terria: Terria, json: any, catalogGroup: CatalogGroup;
@@ -242,5 +242,64 @@ describe("CatalogGroup", function() {
       "grandchild1",
       "parent3"
     ]);
+  });
+
+  it("sortMembersBy", function() {
+    const item = new CatalogGroup("what", terria);
+
+    item.addMembersFromJson(CommonStrata.definition, [
+      {
+        type: "group",
+        name: "1",
+        description: "f"
+      },
+      {
+        type: "group",
+        name: "aCC"
+      },
+      {
+        type: "group",
+        name: "10",
+        description: "d"
+      },
+      {
+        type: "group",
+        name: "2",
+        description: "c"
+      },
+      {
+        type: "group",
+        name: "AC",
+        description: "a"
+      },
+
+      {
+        type: "group",
+        name: "ab",
+        description: "b"
+      }
+    ]);
+
+    expect(
+      item.memberModels.map(member =>
+        CatalogMemberMixin.isMixedInto(member) ? member.name : ""
+      )
+    ).toEqual(["1", "aCC", "10", "2", "AC", "ab"]);
+
+    item.setTrait(CommonStrata.user, "sortMembersBy", "name");
+
+    expect(
+      item.memberModels.map(member =>
+        CatalogMemberMixin.isMixedInto(member) ? member.name : ""
+      )
+    ).toEqual(["1", "2", "10", "ab", "AC", "aCC"]);
+
+    item.setTrait(CommonStrata.user, "sortMembersBy", "description");
+
+    expect(
+      item.memberModels.map(member =>
+        CatalogMemberMixin.isMixedInto(member) ? member.name : ""
+      )
+    ).toEqual(["AC", "ab", "2", "10", "1", "aCC"]);
   });
 });


### PR DESCRIPTION
### Add `sortMembersBy` to `GroupTraits`

Fixes https://github.com/TerriaJS/terriajs/issues/5081

Replaced https://github.com/TerriaJS/terriajs/pull/4809

Related to https://github.com/TerriaJS/terriajs/issues/3123

Add `sortMembersBy` to `GroupTraits`. This can be set to sort group member models - For example `sortMembersBy = "name"` will alphabetically sort members by name.

### Example

http://ci.terria.io/sort-members-by/#clean&https://gist.githubusercontent.com/nf-s/f55f14d31f80829a968b4c323a462cf1/raw/9acc82eb82c12214336d47b764c16e5b3fbb48f7/sort-members-by.json

```json
{
  "catalog": [
    {
      "type": "wms-group",
      "name": "No sort",
      "url": "proxy/_0d/http://ereeftds.bom.gov.au/ereefs/tds/wms/ereefs/mwq_gridAgg_P1M"
    },
    {
      "type": "wms-group",
      "name": "Sort by name",
      "url": "proxy/_0d/http://ereeftds.bom.gov.au/ereefs/tds/wms/ereefs/mwq_gridAgg_P1M",
      "sortMembersBy": "name"
    },
    {
      "type": "wms-group",
      "name": "Sort by WMS layers",
      "url": "proxy/_0d/http://ereeftds.bom.gov.au/ereefs/tds/wms/ereefs/mwq_gridAgg_P1M",
      "sortMembersBy": "layers"
    }
  ]
}

```

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
