### PR TITLE
remove font-imports from GlobalTerriaStyles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Fix a bug in CompositeCatalogItem that causes share URLs to become extremely long.
 * Fix `OpacitySection` number precision.
 * Add `sortMembersBy` to `GroupTraits`. This can be set to sort group member models - For example `sortMembersBy = "name"` will alphabetically sort members by name.
+* Remove `theme.fontImports` from `GlobalTerriaStyles` - it is now handled in `TerriaMap/index.js`
 * [The next improvement]
 
 #### 8.1.17

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.jsx
@@ -52,8 +52,6 @@ export const showStoryPrompt = (viewState, terria) => {
     viewState.toggleFeaturePrompt("story", true);
 };
 const GlobalTerriaStyles = createGlobalStyle`
-  ${p => p.theme.fontImports ?? ""}
-
   // Theme-ify sass classes until they are removed
 
   // We override the primary, secondary, map and share buttons here as they


### PR DESCRIPTION
### Remove font-imports from `GlobalTerriaStyles`

Fixes #6094 

**Note this only impacts Google Chrome**

NEII has custom fonts which were injected in `StandardUserInterface`

https://terria-catalogs-public.storage.googleapis.com/neii/map-config/dev.json

<img width="860" alt="image" src="https://user-images.githubusercontent.com/6187649/150332486-9d7b9609-89c4-4d91-8ba8-4d72e074d623.png">

This was a bad idea (sorry it was me) as it caused long Layout/Reflow tasks (see #6094)

I have moved it to `TerriaMap/index.js` - https://github.com/TerriaJS/TerriaMap/pull/571

### Test

- Go to http://ci.terria.io/main/#configUrl=https://terria-catalogs-public.storage.googleapis.com/neii/map-config/dev.json
- Click "explore map data"
- Observe over a second of Layout/Reflow task (**Note this only happens the first time you press it**)
- Repeat with http://ci.terria.io/remove-font-imports/#configUrl=https://terria-catalogs-public.storage.googleapis.com/neii/map-config/dev.json
- Layout/Reflow task is now bearable

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
