### PR TITLE
Wc print2

### DIFF
--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintView.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintView.tsx
@@ -133,7 +133,7 @@ const getScale = (maybeElement: Element | undefined) =>
 
 const PrintView = (props: Props) => {
   const rootNode = useRef(document.createElement("main"));
-  
+
   const [screenshot, setScreenshot] = useState<Promise<string> | null>(null);
   const [shareLink, setShareLink] = useState("");
 

--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintView.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import Terria from "../../../../../Models/Terria";
 import ViewState from "../../../../../ReactViewModels/ViewState";
@@ -132,14 +132,15 @@ const getScale = (maybeElement: Element | undefined) =>
     : 1;
 
 const PrintView = (props: Props) => {
-  const [rootNode] = useState(document.createElement("main"));
+  const rootNode = useRef(document.createElement("main"));
+  
   const [screenshot, setScreenshot] = useState<Promise<string> | null>(null);
   const [shareLink, setShareLink] = useState("");
 
   useEffect(() => {
     props.window.document.title = "Print view";
     props.window.document.head.appendChild(mkStyle(styles));
-    props.window.document.body.appendChild(rootNode);
+    props.window.document.body.appendChild(rootNode.current);
     props.window.addEventListener("beforeunload", props.closeCallback);
   }, [props.window]);
 
@@ -160,7 +161,7 @@ const PrintView = (props: Props) => {
   }, [props.terria, props.viewState]);
 
   return ReactDOM.createPortal(
-    <StyleSheetManager target={rootNode}>
+    <StyleSheetManager target={props.window.document.head}>
       <ThemeProvider theme={terriaTheme}>
         <PrintViewButtons window={props.window} screenshot={screenshot} />
         <section className="mapSection">
@@ -190,7 +191,7 @@ const PrintView = (props: Props) => {
         </section>
       </ThemeProvider>
     </StyleSheetManager>,
-    rootNode
+    rootNode.current
   );
 };
 


### PR DESCRIPTION
### What this PR does

Fixes #6123 

Important bit is the change to the target in <StyleSheetManager />. Previously, production builds targetted at the rootNode would cause the app to error out but works fine in dev builds. This change makes it work in both.

### Test me
From the latest main branch and a terriamap, change the mode in webpack.config.js within TerriaMap to 'production'.
Start the server.
Observe that accessing print preview causes the app to white screen error out.

From this branch with a webpack production build Terriamap.
Start the server again
Observe that accessing print preview works normally.
 

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
