### PR TITLE
Fix wms no style crash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.21)
 
+* Fixed bug where WMS layer would crash terria if it had no styles, introduced in 8.1.14
 * [The next improvement]
 
 #### 8.1.20

--- a/lib/Models/Catalog/Ows/WebMapServiceCapabilitiesStratum.ts
+++ b/lib/Models/Catalog/Ows/WebMapServiceCapabilitiesStratum.ts
@@ -400,7 +400,7 @@ export default class WebMapServiceCapabilitiesStratum extends LoadableStratum(
     if (!this.catalogItem.supportsGetLegendGraphic) {
       return this.catalogItem.availableStyles
         .map(layer => {
-          if (layer.layerName) {
+          if (layer.layerName && layer.styles.length > 0) {
             return layer.styles[0].name ?? "";
           }
           return "";


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/nationalmap/issues/1116

Fixes bug where WMS layer would crash terria if it had no styles, introduced in 8.1.14

### Test me
 
Broken when you open any of the layers in the group here: https://nationalmap.gov.au/#share=s-8m0g8YqkjsPSG0Z5X9KBSEqTen7

Fixed here: http://ci.terria.io/fix-wms-no-style-crash/#clean&https://gist.githubusercontent.com/KeyboardSounds/17f7a0129031b040e0d0f6aae8f9eef8/raw/3bf7fda6e8b50aa9a7e5556e2b91c356c50068e2/pumped-hydro.json

### Checklist

-   [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [X] I've updated relevant documentation in `doc/`.
-   [X] I've updated CHANGES.md with what I changed.
-   [X] I've provided instructions in the PR description on how to test this PR.
