### PR TITLE
fix ArcGisMapServer legend whitescreen bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Change Log
 ==========
 
 #### next release (8.1.23)
+
+* Fixed crash caused by ArcGisMapServerCatalogItem layer missing legend.
 * [The next improvement]
 
 #### 8.1.22

--- a/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
@@ -99,7 +99,7 @@ interface Legend {
 }
 
 interface Legends {
-  layers?: { layerId: number; layerName: string; legend: Legend[] }[];
+  layers?: { layerId: number; layerName: string; legend?: Legend[] }[];
 }
 
 class MapServerStratum extends LoadableStratum(

--- a/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
@@ -337,7 +337,7 @@ class MapServerStratum extends LoadableStratum(
         return;
       }
 
-      l.legend.forEach(leg => {
+      l.legend?.forEach(leg => {
         const title = replaceUnderscores(
           leg.label !== "" ? leg.label : l.layerName
         );


### PR DESCRIPTION
### What this PR does

Fixes crash caused by ArcGisMapServerCatalogItem layer missing legend.
  
### Test me
  
http://ci.terria.io/arc-gis-map-server-bug/#clean&https:/gist.githubusercontent.com/KeyboardSounds/7f94500351c9305ac45807e57918b9d1/raw/c7f7a22e3cd7cef51970c2e4b004acc8f046bec5/tree-extent.json

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
