### PR TITLE
Add back props `localDataTypes` and `remoteDataTypes` to AddData & MyData components.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Ignores duplicate model ids in members array in `updateModelFromJson`
 * Add support for `crs` property in GeoJSON `Feature`
 * Add feature highlighting for Protomaps vector tiles
+* Add back props `localDataTypes` and `remoteDataTypes` to the component `MyData` for customizing list of types shown in file upload modal.
 * [The next improvement]
 
 #### 8.1.23

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -31,13 +31,20 @@ const AddData = createReactClass({
     viewState: PropTypes.object,
     resetTab: PropTypes.func,
     activeTab: PropTypes.string,
+    // localDataTypes & remoteDataTypes specifies the file types to show in dropdowns for local and remote data uploads.
+    // These default to the lists defined in getDataType.ts
+    // Some external components use these props to customize the types shown.
+    localDataTypes: PropTypes.arrayOf(PropTypes.object),
+    remoteDataTypes: PropTypes.arrayOf(PropTypes.object),
     onFileAddFinished: PropTypes.func.isRequired,
     t: PropTypes.func.isRequired
   },
 
   getInitialState() {
-    const remoteDataTypes = getDataType().remoteDataType;
-    const localDataTypes = getDataType().localDataType;
+    const remoteDataTypes =
+      this.props.remoteDataTypes ?? getDataType().remoteDataType;
+    const localDataTypes =
+      this.props.localDataTypes ?? getDataType().localDataType;
 
     return {
       remoteDataTypes,

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -23,6 +23,8 @@ const MyDataTab = observer(
       terria: PropTypes.object,
       viewState: PropTypes.object,
       onFileAddFinished: PropTypes.func.isRequired,
+      localDataTypes: PropTypes.arrayOf(PropTypes.object),
+      remoteDataTypes: PropTypes.arrayOf(PropTypes.object),
       t: PropTypes.func.isRequired
     },
 
@@ -156,6 +158,8 @@ const MyDataTab = observer(
                 activeTab={this.state.activeTab}
                 resetTab={this.resetTab}
                 onFileAddFinished={this.props.onFileAddFinished}
+                localDataTypes={this.props.localDataTypes}
+                remoteDataTypes={this.props.remoteDataTypes}
               />
             </If>
             <If condition={showTwoColumn}>


### PR DESCRIPTION
### What this PR does

This PR adds back the props removed in #6146.

These props are used by scene editor to customize the list of types presented to the user during model upload.

### Before/After
Before: props `localDataTypes` and `remoteDataTypes` are ignored by the upload modal and all types are shown.

![image](https://user-images.githubusercontent.com/1430/156964236-27b57730-81de-4dd5-a8ac-78a8d01f0b8b.png)

After: File modal only shows types passed in props `localDataTypes` and `remoteDataTypes`.
![image](https://user-images.githubusercontent.com/1430/156964167-502170c5-1667-4f84-9dfe-a41f0de989ef.png)

### Test

This shouldn't break the current behavior in CI. Only affects scene editor modal popup.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
