### PR TITLE
Fix timeseries chart download link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.25)
 
+* Fix broken download link for feature info panel charts when no download urls are specified.
 * [The next improvement]
 
 

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.tsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.tsx
@@ -197,6 +197,7 @@ const ExpandAndDownloadButtons = function(props: {
       </button>
       {props.downloadUrl && (
         <a
+          download
           className={classNames(Styles.btnSmall, Styles.aDownload)}
           href={props.downloadUrl}
         >

--- a/lib/ReactViews/Custom/ChartCustomComponent.ts
+++ b/lib/ReactViews/Custom/ChartCustomComponent.ts
@@ -203,6 +203,18 @@ export default abstract class ChartCustomComponent<
     sourceReference: BaseModel | undefined
   ) => Promise<CatalogItemType | undefined> = undefined;
 
+  /**
+   * Construct a download URL from the chart body text.
+   * This URL will be used to present a download link when other download
+   * options are not specified for the chart.
+   *
+   * See {@CsvChartCustomComponent} for an example implementation.
+   *
+   * @param body The body string.
+   * @return URL to be passed as `href` for the download link.
+   */
+  protected constructDownloadUrlFromBody?: (body: string) => string;
+
   private processChart(
     context: ProcessNodeContext,
     node: DomElement,
@@ -228,6 +240,15 @@ export default abstract class ChartCustomComponent<
       typeof child === "string" ? child : undefined;
     const chartElements = [];
     this.chartItemId = this.chartItemId ?? createGuid();
+
+    // If downloads not specified but we have a body string, convert it to a downloadable data URI.
+    if (
+      attrs.downloads === undefined &&
+      body &&
+      this.constructDownloadUrlFromBody !== undefined
+    ) {
+      attrs.downloads = [this.constructDownloadUrlFromBody?.(body)];
+    }
 
     if (!attrs.hideButtons) {
       // Build expand/download buttons

--- a/lib/ReactViews/Custom/CsvChartCustomComponent.ts
+++ b/lib/ReactViews/Custom/CsvChartCustomComponent.ts
@@ -196,6 +196,11 @@ export default class CsvChartCustomComponent extends ChartCustomComponent<
     parsed.chartGlyphStyle = nodeAttrs["chart-glyph-style"];
     return parsed;
   }
+
+  constructDownloadUrlFromBody = (body: string) => {
+    const blob = new Blob([body], { type: "text/csv;charset=utf-8" });
+    return URL.createObjectURL(blob);
+  };
 }
 
 function parseIntOrUndefined(s: string | undefined): number | undefined {

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -825,12 +825,12 @@ function getTimeSeriesChartContext(catalogItem, feature, getChartDetails) {
     CustomComponent.isRegistered("chart")
   ) {
     const chartDetails = getChartDetails();
-    const { title, csvData } = chartDetails;
     const distinguishingId = catalogItem.dataViewId;
     const featureId = defined(distinguishingId)
       ? distinguishingId + "--" + feature.id
       : feature.id;
     if (chartDetails) {
+      const { title, csvData } = chartDetails;
       const result = {
         ...chartDetails,
         id: featureId?.replace(/\"/g, ""),

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.jsx
@@ -643,7 +643,7 @@ function mustacheFormatNumberFunction() {
  *     ...
  *   }
  * }
- * 
+ *
  * E.g. {{#terria.partialByName}}{{value}}{{/terria.partialByName}}
      "featureInfoTemplate": {
         "template": "{{Pixel Value}} dwellings in {{#terria.partialByName}}{{feature.data.layerId}}{{/terria.partialByName}} radius.",
@@ -837,9 +837,8 @@ function getTimeSeriesChartContext(catalogItem, feature, getChartDetails) {
         data: csvData?.replace(/\\n/g, "\\n")
       };
       const idAttr = 'id="' + result.id + '" ';
-      const sourceAttr = 'sources="1"';
       const titleAttr = title ? `title="${title}"` : "";
-      result.chart = `<chart ${idAttr} ${sourceAttr} ${titleAttr}>${result.data}</chart>`;
+      result.chart = `<chart ${idAttr} ${titleAttr}>${result.data}</chart>`;
       return result;
     }
   }

--- a/lib/Table/getChartDetailsFn.ts
+++ b/lib/Table/getChartDetailsFn.ts
@@ -2,7 +2,8 @@ import TableStyle from "./TableStyle";
 
 export default function getChartDetailsFn(style: TableStyle, rowIds: number[]) {
   return () => {
-    if (!style.timeColumn || !style.colorColumn || rowIds.length < 2) return {};
+    if (!style.timeColumn || !style.colorColumn || rowIds.length < 2)
+      return undefined;
     const chartColumns = [style.timeColumn, style.colorColumn];
     const csvData = [
       chartColumns.map(col => col!.title).join(","),

--- a/test/ReactViews/Custom/Chart/ChartCustomComponentSpec.tsx
+++ b/test/ReactViews/Custom/Chart/ChartCustomComponentSpec.tsx
@@ -1,9 +1,10 @@
 import { ReactChild } from "react";
+import { isComponentOfType } from "react-shallow-testutils";
 import ChartableMixin from "../../../../lib/ModelMixins/ChartableMixin";
-import CreateModel from "../../../../lib/Models/Definition/CreateModel";
-import Feature from "../../../../lib/Models/Feature";
-import { BaseModel } from "../../../../lib/Models/Definition/Model";
 import StubCatalogItem from "../../../../lib/Models/Catalog/CatalogItems/StubCatalogItem";
+import CreateModel from "../../../../lib/Models/Definition/CreateModel";
+import { BaseModel } from "../../../../lib/Models/Definition/Model";
+import Feature from "../../../../lib/Models/Feature";
 import Terria from "../../../../lib/Models/Terria";
 import ChartExpandAndDownloadButtons from "../../../../lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons";
 import Chart from "../../../../lib/ReactViews/Custom/Chart/FeatureInfoPanelChart";
@@ -14,12 +15,9 @@ import {
   DomElement,
   ProcessNodeContext
 } from "../../../../lib/ReactViews/Custom/CustomComponent";
-import UrlTraits from "../../../../lib/Traits/TraitsClasses/UrlTraits";
 import mixTraits from "../../../../lib/Traits/mixTraits";
 import MappableTraits from "../../../../lib/Traits/TraitsClasses/MappableTraits";
-
-const isComponentOfType: any = require("react-shallow-testutils")
-  .isComponentOfType;
+import UrlTraits from "../../../../lib/Traits/TraitsClasses/UrlTraits";
 
 describe("ChartCustomComponent", function() {
   let terria: Terria;

--- a/test/ReactViews/Custom/Chart/CsvChartCustomComponentSpec.tsx
+++ b/test/ReactViews/Custom/Chart/CsvChartCustomComponentSpec.tsx
@@ -72,5 +72,10 @@ describe("CsvChartCustomComponent", function() {
         expect(csvCatalogItem.columns[2].title).toBe("Temperature");
       }
     });
+
+    it("can create a download url from csv text passed as chart body", function() {
+      const url = component.constructDownloadUrlFromBody("a,b\n1,2\n3,4");
+      expect(url.startsWith("blob:")).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
### What this PR does

Fixes #6112 

This PR fixes the download link for the feature info panel chart for CSV items without a template strings.
  
### Test me

 - Open this [CI link](http://ci.terria.io/fix-timeseries-chart-download-link/#share=s-yZM68Po9YIfeybZhKmZwsS152bs&clean&https://gist.githubusercontent.com/na9da/4bfe951663bca8141a3ddd90c9f7ddf3/raw/6b95b4af35d90e9c04625d9e9fe6e3975adbe1c2/air-quality-liverpool.json).
 - Click any station point to open the feature info panel with a chart
 - Click the download button for the chart. It should trigger a CSV download.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
