### PR TITLE
Fix WPS function parameter names.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.1.25)
 
+* Fixed parameter names of WPS catalog functions.
 * [The next improvement]
 
 

--- a/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunction.ts
+++ b/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunction.ts
@@ -57,7 +57,7 @@ type BoundingBoxData = {
 
 type Input = {
   Identifier?: string;
-  Name?: string;
+  Title?: string;
   Abstract?: string;
   LiteralData?: LiteralData;
   ComplexData?: ComplexData;
@@ -295,7 +295,7 @@ export default class WebProcessingServiceCatalogFunction extends XmlRequestMixin
       const converter = parameterConverters[i];
       const parameter = converter.inputToParameter(catalogFunction, input, {
         id: input.Identifier,
-        name: input.Name,
+        name: input.Title,
         description: input.Abstract,
         isRequired
       });

--- a/test/Models/Catalog/Ows/WebProcessingServiceCatalogFunctionSpec.ts
+++ b/test/Models/Catalog/Ows/WebProcessingServiceCatalogFunctionSpec.ts
@@ -330,7 +330,7 @@ describe("WebProcessingServiceCatalogFunction", function() {
     it("works for a simple input", function() {
       const parameter = wps.convertInputToParameter(wps, {
         Identifier: "geometry_id",
-        Name: "Geometry ID",
+        Title: "Geometry ID",
         Abstract: "ID of the input",
         LiteralData: { AnyValue: {} },
         minOccurs: 1


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/RaPPMap/issues/122

When generating input form for WPS, we were incorrectly setting input names from a non-existent `Name` field. This PR fixes it by setting the name from `Title` field to match the [behavior in v7](https://github.com/TerriaJS/terriajs/blob/a6a2e6464cec91578b924728cdb3e3689b8c2794/lib/Models/WebProcessingServiceCatalogFunction.js#L144). 
 
Before:
![image](https://user-images.githubusercontent.com/1430/157157638-c8e20022-43e8-48af-898d-9fa2e07fea0c.png)

After:

![image](https://user-images.githubusercontent.com/1430/157157524-8042bca7-85e9-4260-8f21-e5d549f3348e.png)


### Test me

- Open this [CI link](http://ci.terria.io/fix-wps-param-name/#share=s-pHbnAvxlZSGdfXGhb5Pl90OzJrF&clean&https://terria-catalogs-public.storage.googleapis.com/geo-rapp/dev.json)
- From catalog, open `Analysis Tools > Proportion of region within a Total Vegetation Cover range (Monthly)`
- The WPS form inputs should have descriptive names instead of IDs (like geometry_id).


### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
