### PR TITLE
Avoid creating duplicated category groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Fix broken download link for feature info panel charts when no download urls are specified.
 * Fixed parameter names of WPS catalog functions.
 * ArcGisFeatureServerCatalogItem can now load more than the maximum feature limit set by the server by making multiple requests, and uses GeojsonMixin
+* Avoid creating duplication in categories in ArcGisPortalCatalogGroup.
 * [The next improvement]
 
 #### 8.1.24 - 2022-03-08

--- a/lib/Models/Catalog/Esri/ArcGisPortalCatalogGroup.ts
+++ b/lib/Models/Catalog/Esri/ArcGisPortalCatalogGroup.ts
@@ -175,7 +175,8 @@ export class ArcGisPortalStratum extends LoadableStratum(
         const categories = new Map();
 
         portalItemsServerResponse.results.forEach(function(item) {
-          item.categories.forEach(function(category: string, index: number) {
+          item.categories.forEach(function(rawCategory: string, index: number) {
+            const category = rawCategory.trim();
             if (index === 0) {
               item.groupId = category;
             }


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/nsw-digital-twin/issues/532#issuecomment-1062595350
  
### Test me
See 
https://dev.nsw.digitaltwin.terria.io/#share=s-4ntB3QlcPydd4P2lMP0R2afaIdJ

There is only one `Features of Interest` group in the catalog.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
