### PR TITLE
Fix `CatalogMemberMixin.hasDescription` null bug + spelling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Fix broken download link for feature info panel charts when no download urls are specified.
 * Fixed parameter names of WPS catalog functions.
 * ArcGisFeatureServerCatalogItem can now load more than the maximum feature limit set by the server by making multiple requests, and uses GeojsonMixin
+* Fix `CatalogMemberMixin.hasDescription` null bug
 * [The next improvement]
 
 #### 8.1.24 - 2022-03-08

--- a/lib/ModelMixins/CatalogMemberMixin.ts
+++ b/lib/ModelMixins/CatalogMemberMixin.ts
@@ -1,7 +1,8 @@
-import { action, computed, runInAction } from "mobx";
+import { action, computed, isObservableArray, runInAction } from "mobx";
 import AsyncLoader from "../Core/AsyncLoader";
 import Constructor from "../Core/Constructor";
 import isDefined from "../Core/isDefined";
+import { isJsonString } from "../Core/Json";
 import Result from "../Core/Result";
 import hasTraits from "../Models/Definition/hasTraits";
 import Model, { BaseModel } from "../Models/Definition/Model";
@@ -119,8 +120,8 @@ function CatalogMemberMixin<T extends Constructor<CatalogMember>>(Base: T) {
     @computed
     get hasDescription(): boolean {
       return (
-        (this.description !== undefined && this.description.length > 0) ||
-        (this.info !== undefined &&
+        (isJsonString(this.description) && this.description.length > 0) ||
+        (isObservableArray(this.info) &&
           this.info.some(info => descriptionRegex.test(info.name || "")))
       );
     }

--- a/lib/Models/Catalog/CatalogItems/OpenDataSoftCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/OpenDataSoftCatalogItem.ts
@@ -244,7 +244,7 @@ export class OpenDataSoftDatasetStratum extends LoadableStratum(
 
     return filterOutUndefined([
       this.catalogItem.timeFieldName,
-      // If aggregating time - avergage color field
+      // If aggregating time - average color field
       this.aggregateTime
         ? `avg(${this.catalogItem.colorFieldName}) as ${this.catalogItem.colorFieldName}`
         : this.catalogItem.colorFieldName,
@@ -272,7 +272,7 @@ export class OpenDataSoftDatasetStratum extends LoadableStratum(
     }
   }
 
-  // Set reigon column type
+  // Set region column type
   @computed get regionColumn() {
     if (this.catalogItem.regionFieldName) {
       return createStratumInstance(TableColumnTraits, {
@@ -401,7 +401,7 @@ export class OpenDataSoftDatasetStratum extends LoadableStratum(
     const row = (title: string, value: string) =>
       `<tr><td style="vertical-align: middle">${title}</td><td>${value}</td></tr>`;
 
-    // Add fields (exepct for geo_* fields)
+    // Add fields (except for geo_* fields)
     template += this.dataset.fields
       ?.filter(
         field => field.type !== "geo_point_2d" && field.type !== "geo_shape"
@@ -503,7 +503,7 @@ export class OpenDataSoftDatasetStratum extends LoadableStratum(
     return lastDate.toString();
   }
 
-  /** Get fields with useful infomation (for visualisation). Eg numbers, text, not IDs, not region... */
+  /** Get fields with useful information (for visualisation). Eg numbers, text, not IDs, not region... */
   @computed get usefulFields() {
     return (
       this.dataset.fields?.filter(
@@ -521,13 +521,13 @@ export class OpenDataSoftDatasetStratum extends LoadableStratum(
     );
   }
 
-  /** Convert usefulFields to a Dimenion (which gets turned into a SelectableDimension in OpenDataSoftCatalogItem).
+  /** Convert usefulFields to a Dimension (which gets turned into a SelectableDimension in OpenDataSoftCatalogItem).
    * This means we can chose which field to "select" when downloading data.
    */
   @computed get availableFields() {
     if (!this.selectAllFields)
       return createStratumInstance(DimensionTraits, {
-        id: "available-fieds",
+        id: "available-fields",
         name: "Fields",
         selectedId: this.catalogItem.colorFieldName,
         options: this.usefulFields.map(f => ({
@@ -596,7 +596,7 @@ export default class OpenDataSoftCatalogItem
     pickResult: any
   ) {
     const feature = new Feature(pickResult?.id);
-    // If feature is time-series, we have to make sure that recordId is set in feature.proprties
+    // If feature is time-series, we have to make sure that recordId is set in feature.properties
     // Otherwise we won't be able to use featureInfoUrlTemplate in FeatureInfoMixin
     const recordId = pickResult?.id?.data?.getValue?.(
       this.terria.timelineClock.currentTime

--- a/lib/Traits/TraitsClasses/CatalogMemberTraits.ts
+++ b/lib/Traits/TraitsClasses/CatalogMemberTraits.ts
@@ -135,7 +135,7 @@ export default class CatalogMemberTraits extends ModelTraits {
   @primitiveArrayTrait({
     type: "string",
     name: "InfoSectionOrder",
-    description: `An array of section titles definining the display order of info sections. If this property is not defined, {@link DataPreviewSections}'s DEFAULT_SECTION_ORDER is used`
+    description: `An array of section titles defining the display order of info sections. If this property is not defined, {@link DataPreviewSections}'s DEFAULT_SECTION_ORDER is used`
   })
   infoSectionOrder?: string[] = [
     i18next.t("preview.disclaimer"),


### PR DESCRIPTION
### Fix `CatalogMemberMixin.hasDescription` null bug
  
### Test me
  
#### Before

- http://ci.terria.io/main/#clean&https://terria-catalogs-public.storage.googleapis.com/common/aus-gov-open-data/nsw/dev.json&share=s-9t9cySg5iLKa9oDCpUFMie0aY5p
- Click "Acid Sulfate Soil" (view in catalog, but don't add to map)
- Crash

#### After

- http://ci.terria.io/hasdescription-bug/#clean&https://terria-catalogs-public.storage.googleapis.com/common/aus-gov-open-data/nsw/dev.json&share=s-9t9cySg5iLKa9oDCpUFMie0aY5p
- Click "Acid Sulfate Soil" (view in catalog, but don't add to map)
- No crash


### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
