### PR TITLE
`TableStyle` now calculates `rectangle` for point based styles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,9 +14,9 @@ Change Log
 * WMS `styles`, `tileWidth`, `tileHeight` and `crs`/`srs` will use value in `url` if it is defined (similar to existing behavior with `layers`)
 * WMS will now show warning if invalid `layers` (eg if the specified `layers` don't exist in `GetCapabilities`)
 * ArcGisFeatureServerCatalogItem can now load more than the maximum feature limit set by the server by making multiple requests, and uses GeojsonMixin
-* Modify "Ideal zoom" for cesium `DataSource` - if `boundingSphere.radius` is 0 - use 100m instead.
 * Avoid creating duplication in categories in ArcGisPortalCatalogGroup.
 * Fix `CatalogMemberMixin.hasDescription` null bug
+* `TableStyle` now calculates `rectangle` for point based styles
 * [The next improvement]
 
 #### 8.1.24 - 2022-03-08

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Fix broken download link for feature info panel charts when no download urls are specified.
 * Fixed parameter names of WPS catalog functions.
 * ArcGisFeatureServerCatalogItem can now load more than the maximum feature limit set by the server by making multiple requests, and uses GeojsonMixin
+* Modify "Ideal zoom" for cesium `DataSource` - if `boundingSphere.radius` is 0 - use 100m instead.
 * [The next improvement]
 
 #### 8.1.24 - 2022-03-08

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -1555,12 +1555,7 @@ function zoomToDataSource(
               // cesium calculate an appropriate zoom distance. For the rest
               // use the radius as the zoom distance because the offset
               // distance cesium calculates for large models is often too far away.
-              // But, if radius is 0, set to 100m so we aren't underground
-              boundingSphere.radius < 100
-                ? boundingSphere.radius === 0
-                  ? 100
-                  : undefined
-                : boundingSphere.radius
+              boundingSphere.radius < 100 ? undefined : boundingSphere.radius
             )
           }
         );

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -1555,7 +1555,12 @@ function zoomToDataSource(
               // cesium calculate an appropriate zoom distance. For the rest
               // use the radius as the zoom distance because the offset
               // distance cesium calculates for large models is often too far away.
-              boundingSphere.radius < 100 ? undefined : boundingSphere.radius
+              // But, if radius is 0, set to 100m so we aren't underground
+              boundingSphere.radius < 100
+                ? boundingSphere.radius === 0
+                  ? 100
+                  : undefined
+                : boundingSphere.radius
             )
           }
         );

--- a/lib/Table/TableAutomaticStylesStratum.ts
+++ b/lib/Table/TableAutomaticStylesStratum.ts
@@ -47,6 +47,11 @@ export default class TableAutomaticStylesStratum extends LoadableStratum(
   }
 
   @computed
+  get rectangle() {
+    return this.catalogItem.activeTableStyle.rectangle;
+  }
+
+  @computed
   get disableOpacityControl() {
     // disable opacity control for point tables - or if no mapItems
     return (
@@ -328,16 +333,16 @@ export class ColorStyleLegend extends LoadableStratum(LegendTraits) {
         return;
 
       // We want to show fraction digits depending on how small difference is between min and max.
-      // This also takes into consideration the defualt number of legend items - 7
+      // This also takes into consideration the default number of legend items - 7
       // So we add an extra digit
       // For example:
-      // - if difference is 10 - we wnat to show one fraction digit
+      // - if difference is 10 - we want to show one fraction digit
       // - if difference is 1 - we want to show two fraction digits
       // - if difference is 0.1 - we want to show three fraction digits
 
       // log_10(20/x) achieves this (where x is difference between min and max)
       // https://www.wolframalpha.com/input/?i=log_10%2820%2Fx%29
-      // We use 20 here instead of 10 to give us a more convervative value (that is, we may show an extra fraction digit even if it is not needed)
+      // We use 20 here instead of 10 to give us a more conservative value (that is, we may show an extra fraction digit even if it is not needed)
       // So when x >= 20 - we will not show any fraction digits
 
       // Clamp values between 0 and 5

--- a/test/ModelMixins/TableMixinSpec.ts
+++ b/test/ModelMixins/TableMixinSpec.ts
@@ -81,6 +81,13 @@ describe("TableMixin", function() {
       }
     });
 
+    it("calculates rectangle", async function() {
+      expect(item.rectangle.north).toEqual(-20);
+      expect(item.rectangle.south).toEqual(-37);
+      expect(item.rectangle.east).toEqual(155);
+      expect(item.rectangle.west).toEqual(115);
+    });
+
     describe("the entities", function() {
       it("has availability defined over the correct span", function() {
         expect(


### PR DESCRIPTION
### `TableStyle` now calculates `rectangle` for point based styles

Fixes https://github.com/terriajs/vic-digital-twin/issues/288

### Test me

#### Before
  
- http://ci.terria.io/main/#clean&https://terria-catalogs-public.storage.googleapis.com/common/aus-gov-open-data/vic/prod.json&share=s-4D90C5rfB8iQUBmo9aAWfzgDE0L
- Press "Ideal zoom"
- You are now under the surface

#### After

- http://ci.terria.io/data-source-zoom/#clean&https://terria-catalogs-public.storage.googleapis.com/common/aus-gov-open-data/vic/prod.json&share=s-4D90C5rfB8iQUBmo9aAWfzgDE0L
- Press "Ideal zoom"
- You are not under the surface

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
