### PR TITLE
Fix CI & publish to npm - unencrypted git protocol support dropped by GitHub

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 Change Log
 ==========
 
-#### next release (8.1.25)
+#### next release (8.1.26)
+
+* [The next improvement]
+
+#### 8.1.25 - 2022-03-16
 
 * Fix broken download link for feature info panel charts when no download urls are specified.
 * Fixed parameter names of WPS catalog functions.
@@ -17,7 +21,7 @@ Change Log
 * Avoid creating duplication in categories in ArcGisPortalCatalogGroup.
 * Fix `CatalogMemberMixin.hasDescription` null bug
 * `TableStyle` now calculates `rectangle` for point based styles
-* [The next improvement]
+* Fixed error installing dependencies by changing dependency "pell" to use github protocol rather than unencrypted Git protocol, which is no longer supported by GitHub as of 2022-03-15.
 
 #### 8.1.24 - 2022-03-08
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "mutationobserver-shim": "^0.3.1",
     "papaparse": "^5.2.0",
     "pbf": "^3.0.1",
-    "pell": "git://github.com/TerriaJS/pell#master",
+    "pell": "github:TerriaJS/pell#master",
     "point-in-polygon": "^1.0.1",
     "proj4": "^2.4.4",
     "prop-types": "^15.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.1.24",
+  "version": "8.1.25",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10825,9 +10825,9 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-"pell@git://github.com/TerriaJS/pell#master":
+"pell@github:TerriaJS/pell#master":
   version "1.0.6"
-  resolved "git://github.com/TerriaJS/pell#7cd23a55cdfd130fedf3679433991bb7d958fc42"
+  resolved "https://codeload.github.com/TerriaJS/pell/tar.gz/7cd23a55cdfd130fedf3679433991bb7d958fc42"
 
 pend@~1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Installing dependencies in terriajs or any project using terriajs will be broken. We should push an update to TerriaMap ASAP once this is merged and published.

Caused by https://github.blog/2021-09-01-improving-git-protocol-security-github/ and our one package "pell" that we depend on as a git url.

### What does this PR do?

Change dependency to work after unencrypted git protocol support dropped.