### PR TITLE
Fixed Polyline position not being updated correctly in Leaflet mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Added experimental routing system - there may be breaking changes to this system in subsequent patch releases for a short time. The routes currently include:
   * `/story/:share-id` ➡ loads share JSON from a URL `${configParameters.storyRouteUrlPrefix}:share-id` (`configParameters.storyRouteUrlPrefix` must have a trailing slash)
   * `/catalog/:id` ➡ opens the data catalogue to the specified member
+* Fixed a polyline position update bug in `LeafletVisualizer`. Polylines with time varying position will now correctly animate in leaflet mode.
 * [The next improvement]
 
 #### 8.1.25 - 2022-03-16

--- a/lib/Map/LeafletVisualizer.ts
+++ b/lib/Map/LeafletVisualizer.ts
@@ -1008,7 +1008,7 @@ class LeafletGeomVisualizer {
       let bPosChange = latlngs.length !== curLatLngs.length;
       for (let i = 0; i < curLatLngs.length && !bPosChange; i++) {
         const latlng = curLatLngs[i];
-        if (latlng instanceof L.LatLng && latlng.equals(latlngs[i])) {
+        if (latlng instanceof L.LatLng && !latlng.equals(latlngs[i])) {
           bPosChange = true;
         }
       }


### PR DESCRIPTION
### Fixed Polyline position not being updated correctly in Leaflet mode

Fixes #6189

**LeafletVisualizer.ts**
Added a Not-operator to the condition that checks for position equality during update of polylines. This was probably missed during port to TypeScript.
  
### Test me
 
Add this CZML through MyData/Add Local Data
 [CzmlSpeedVectorTest.czml](https://gist.github.com/himby/0e6f3f68d8116f8a48ebfa449f0aabc0)

Before PR speed vectors are just drawn but not moving.
After PR the speed vector lines shall move together with point (billboard without image in this case)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
    - Cannot find any unit tests for LeafletVisualizer at all.
-   [ ] I've updated relevant documentation in `doc/`.
-   [ ] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
