### PR TITLE
GeoJSON - add filterByProperties and polygon support for czmlTemplate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
   * `/catalog/:id` ➡ opens the data catalogue to the specified member
 * Add `GeoJsonTraits.filterByProperties` - this can be used to filter GeoJSON features by properties
 * Add GeoJSON `czmlTemplate` support for `Polygon/MultiPolygon`
+* Add custom `heightOffset` property to `czmlTemplate`
 * [The next improvement]
 
 #### 8.1.25 - 2022-03-16

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ Change Log
 * Added experimental routing system - there may be breaking changes to this system in subsequent patch releases for a short time. The routes currently include:
   * `/story/:share-id` ➡ loads share JSON from a URL `${configParameters.storyRouteUrlPrefix}:share-id` (`configParameters.storyRouteUrlPrefix` must have a trailing slash)
   * `/catalog/:id` ➡ opens the data catalogue to the specified member
+* Add `GeoJsonTraits.filterByProperties` - this can be used to filter GeoJSON features by properties
+* Add GeoJSON `czmlTemplate` support for `Polygon/MultiPolygon`
 * [The next improvement]
 
 #### 8.1.25 - 2022-03-16

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -57,7 +57,7 @@ import filterOutUndefined from "../Core/filterOutUndefined";
 import formatPropertyValue from "../Core/formatPropertyValue";
 import hashFromString from "../Core/hashFromString";
 import isDefined from "../Core/isDefined";
-import { isJsonObject, JsonObject } from "../Core/Json";
+import { isJsonObject, JsonObject, isJsonNumber } from "../Core/Json";
 import { isJson } from "../Core/loadBlob";
 import makeRealPromise from "../Core/makeRealPromise";
 import StandardCssColors from "../Core/StandardCssColors";
@@ -719,6 +719,10 @@ function GeoJsonMixin<T extends Constructor<Model<GeoJsonTraits>>>(Base: T) {
             coords[2] = 0;
           }
 
+          if (isJsonNumber(this.czmlTemplate?.heightOffset)) {
+            coords[2] += this.czmlTemplate!.heightOffset;
+          }
+
           czml.position = {
             cartographicDegrees: point.coordinates
           };
@@ -747,14 +751,24 @@ function GeoJsonMixin<T extends Constructor<Model<GeoJsonTraits>>>(Base: T) {
             const holes: number[][] = [];
 
             geom[0].forEach(coords => {
-              positions.push(coords[0], coords[1], coords[2] ?? 0);
+              if (isJsonNumber(this.czmlTemplate?.heightOffset)) {
+                coords[2] = (coords[2] ?? 0) + this.czmlTemplate!.heightOffset;
+              }
+              positions.push(coords[0], coords[1], coords[2]);
             });
 
             geom.forEach((ring, idx) => {
               if (idx === 0) return;
 
               holes.push(
-                ...ring.map(coords => [coords[0], coords[1], coords[2] ?? 0])
+                ...ring.map(coords => {
+                  if (isJsonNumber(this.czmlTemplate?.heightOffset)) {
+                    coords[2] =
+                      (coords[2] ?? 0) + this.czmlTemplate!.heightOffset;
+                  }
+
+                  return [coords[0], coords[1], coords[2]];
+                })
               );
             });
 

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -761,14 +761,16 @@ function GeoJsonMixin<T extends Constructor<Model<GeoJsonTraits>>>(Base: T) {
               if (idx === 0) return;
 
               holes.push(
-                ...ring.map(coords => {
+                ring.reduce<number[]>((acc, current) => {
                   if (isJsonNumber(this.czmlTemplate?.heightOffset)) {
-                    coords[2] =
-                      (coords[2] ?? 0) + this.czmlTemplate!.heightOffset;
+                    current[2] =
+                      (current[2] ?? 0) + this.czmlTemplate!.heightOffset;
                   }
 
-                  return [coords[0], coords[1], coords[2]];
-                })
+                  acc.push(current[0], current[1], current[2]);
+
+                  return acc;
+                }, [])
               );
             });
 

--- a/lib/Traits/TraitsClasses/GeoJsonTraits.ts
+++ b/lib/Traits/TraitsClasses/GeoJsonTraits.ts
@@ -83,6 +83,13 @@ export class GeoJsonTraits extends mixTraits(
   })
   forceCesiumPrimitives?: boolean;
 
+  @anyTrait({
+    name: "Feature filter (by properties)",
+    description:
+      "Filter GeoJSON features by properties. If the properties of a feature match `filterByProperties`, then show that feature. All other features are hidden"
+  })
+  filterByProperties?: JsonObject;
+
   @objectArrayTrait({
     name: "Per property styles",
     type: PerPropertyGeoJsonStyleTraits,
@@ -110,7 +117,13 @@ export class GeoJsonTraits extends mixTraits(
 
   @anyTrait({
     name: "CZML template",
-    description: `CZML template to be used to replace each GeoJSON **Point** feature. Feature coordinates and properties will automatically be applied to CZML packet, so they can be used as references. If this is defined, \`clampToGround\`, \`style\`, \`perPropertyStyles\`, \`timeProperty\` and \`heightProperty\` will be ignored.
+    description: `CZML template to be used to replace each GeoJSON **Point** and **Polygon/MultiPolygon** feature. Feature coordinates and properties will automatically be applied to CZML packet, so they can be used as references.
+
+    Polygon/MultiPolygon features only support the \`polygon\` CZML packet.
+
+    Point features support all packets except ones which require a \`PositionsList\` (eg \`polygon\`, \`polyline\`, ...)
+
+    If this is defined, \`clampToGround\`, \`style\`, \`perPropertyStyles\`, \`timeProperty\` and \`heightProperty\` will be ignored.
 
     For example - this will render a cylinder for every point (and use the length and radius feature properties)
       \`\`\`json
@@ -134,7 +147,9 @@ export class GeoJsonTraits extends mixTraits(
           }
         }
       }
-      \`\`\``
+      \`\`\`
+
+      For more info see Cesium's CZML docs https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/CZML-Guide`
   })
   czmlTemplate?: JsonObject;
 }

--- a/lib/Traits/TraitsClasses/GeoJsonTraits.ts
+++ b/lib/Traits/TraitsClasses/GeoJsonTraits.ts
@@ -149,7 +149,10 @@ export class GeoJsonTraits extends mixTraits(
       }
       \`\`\`
 
-      For more info see Cesium's CZML docs https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/CZML-Guide`
+    For more info see Cesium's CZML docs https://github.com/AnalyticalGraphicsInc/czml-writer/wiki/CZML-Guide
+
+    The following custom properties are supported:
+    - \`heightOffset: number\` to offset height values (in m)`
   })
   czmlTemplate?: JsonObject;
 }


### PR DESCRIPTION
### GeoJSON - add filterByProperties and polygon support for czmlTemplate

For https://github.com/terriajs/vic-digital-twin/issues/269

* Add `GeoJsonTraits.filterByProperties` - this can be used to filter GeoJSON features by properties
* Add GeoJSON `czmlTemplate` support for `Polygon/MultiPolygon`
* Add custom `heightOffset` property to `czmlTemplate`
  
### Test me
  
http://ci.terria.io/geojson-czml-plus/#clean&https://gist.githubusercontent.com/nf-s/fd4ef5e0b16a013bd853e049c77fc798/raw/a5069895682445d419d84e2962e19204d2decb30/czmlPolygon.json&share=s-sE1hqgJuL4ELV9EfOzSUp6i9o2Q&playStory=1

#### Two items

##### First is polygon with `heightOffset`

```json
{
      "id": "test",
      "name": "Route Risk",
      "geoJsonData": ...
      "type": "geojson",
      "czmlTemplate": {
        "heightOffset": 5000,
        "polygon": {
          "heightReference": "RELATIVE_TO_GROUND",
          "extrudedHeight": 10000,
          "perPositionHeight": true,
          "material": {
            "solidColor": {
              "color": {
                "rgba": [
                  255,
                  0,
                  0,
                  255
                ]
              }
            }
          }
        }
      }
    }
```

##### Second is polygon with `filterByProperties`

```json
{
      "name": "SIP test",
      "filterByProperties": {
        "project_area": "Kingston Estate, Stage 10D2"
      },
      "geoJsonData": {...
      "type": "geojson",
      "czmlTemplate": {
        "polygon": {
          "heightReference": "RELATIVE_TO_GROUND",
          "extrudedHeight": 1000,
          "material": {
            "solidColor": {
              "color": {
                "rgba": [
                  255,
                  120,
                  0,
                  255
                ]
              }
            }
          }
        }
      }
    },
```

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
