### PR TITLE
UserDrawing and BoxDrawing changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ Change Log
   * `/story/:share-id` ➡ loads share JSON from a URL `${configParameters.storyRouteUrlPrefix}:share-id` (`configParameters.storyRouteUrlPrefix` must have a trailing slash)
   * `/catalog/:id` ➡ opens the data catalogue to the specified member
 * Fixed a bug where Cesium3DTilePointFeature info is not shown when being clicked.
+* Added optional `onDrawingComplete` callback to `UserDrawing` to receive drawn points or rectangle when the drawing is complete.
+* Fixed a bug in `BoxDrawing` where the box can be below ground after initialization even when setting `keepBoxAboveGround` to true.
 * [The next improvement]
 
 #### 8.1.25 - 2022-03-16

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -1355,6 +1355,7 @@
       "btnDone": "Done",
       "clickToAddFirstPoint": "Click to add a point",
       "clickToAddAnotherPoint": "Click to add another point",
+      "clickToRedrawRectangle": "Click another point to redraw the rectangle",
       "anotherPoint": "Another Point",
       "userPolygon": "User polygon"
     },

--- a/lib/Models/BoxDrawing.ts
+++ b/lib/Models/BoxDrawing.ts
@@ -238,6 +238,7 @@ export default class BoxDrawing {
 
     this.setTransform(transform);
     this.drawBox();
+    this.setBoxAboveGround();
 
     onBecomeObserved(this, "dataSource", () => this.startInteractions());
     onBecomeUnobserved(this, "dataSource", () => this.stopInteractions());

--- a/lib/Models/UserDrawing.ts
+++ b/lib/Models/UserDrawing.ts
@@ -30,6 +30,11 @@ import CreateModel from "./Definition/CreateModel";
 import MapInteractionMode from "./MapInteractionMode";
 import Terria from "./Terria";
 
+interface OnDrawingCompleteParams {
+  points: Cartesian3[];
+  rectangle?: Rectangle;
+}
+
 interface Options {
   terria: Terria;
   messageHeader?: string;
@@ -39,6 +44,7 @@ interface Options {
   buttonText?: string;
   onPointClicked?: (dataSource: DataSource) => void;
   onPointMoved?: (dataSource: DataSource) => void;
+  onDrawingComplete?: (params: OnDrawingCompleteParams) => void;
   onCleanUp?: () => void;
   invisible?: boolean;
 }
@@ -51,6 +57,10 @@ export default class UserDrawing extends MappableMixin(
   private readonly onMakeDialogMessage?: () => string;
   private readonly buttonText?: string;
   private readonly onPointClicked?: (dataSource: CustomDataSource) => void;
+  private readonly onPointMoved?: (dataSource: CustomDataSource) => void;
+  private readonly onDrawingComplete?: (
+    params: OnDrawingCompleteParams
+  ) => void;
   private readonly onCleanUp?: () => void;
   private readonly invisible?: boolean;
   private readonly dragHelper: DragPoints;
@@ -98,6 +108,19 @@ export default class UserDrawing extends MappableMixin(
     this.onPointClicked = options.onPointClicked;
 
     /**
+     * Callback that occurs when point is moved. Function takes a CustomDataSource which is a list of PointEntities.
+     */
+    this.onPointMoved = options.onPointMoved;
+
+    /**
+     * Callback that occurs when a drawing is complete. This is called when the
+     * user has clicked done button and the shape has at least 1 point.
+     * The callback function will receive the points in the shape and a rectangle
+     * if `drawRectangle` was set to `true`.
+     */
+    this.onDrawingComplete = options.onDrawingComplete;
+
+    /**
      * Callback that occurs on clean up, i.e. when drawing is done or cancelled.
      */
     this.onCleanUp = options.onCleanUp;
@@ -128,6 +151,9 @@ export default class UserDrawing extends MappableMixin(
 
     // helper for dragging points around
     this.dragHelper = new DragPoints(options.terria, customDataSource => {
+      if (typeof this.onPointMoved === "function") {
+        this.onPointMoved(customDataSource);
+      }
       this.prepareToAddNewPoint();
     });
   }
@@ -158,6 +184,10 @@ export default class UserDrawing extends MappableMixin(
 
     // create the cesium entity
     return svgDataDeclare + svgString;
+  }
+
+  @computed get cesiumRectangle(): Rectangle | undefined {
+    return this.getRectangleForShape();
   }
 
   enterDrawMode() {
@@ -298,6 +328,12 @@ export default class UserDrawing extends MappableMixin(
         eyeOffset: new Cartesian3(0.0, 0.0, -50.0)
       }
     });
+    // Remove the existing points if we are in drawRectangle mode and the user
+    // has picked a 3rd point. This lets the user draw new rectangle that
+    // replaces the current one.
+    if (this.drawRectangle && this.pointEntities.entities.values.length === 2) {
+      this.pointEntities.entities.removeAll();
+    }
     this.pointEntities.entities.add(pointEntity);
     this.dragHelper.updateDraggableObjects(this.pointEntities);
     if (isDefined(this.onPointClicked)) {
@@ -323,6 +359,20 @@ export default class UserDrawing extends MappableMixin(
       message: this.getDialogMessage(),
       buttonText: this.getButtonText(),
       onCancel: () => {
+        runInAction(() => {
+          if (this.onDrawingComplete) {
+            const isDrawingComplete =
+              this.pointEntities.entities.values.length >= 2;
+            const points = this.getPointsForShape();
+
+            if (isDrawingComplete && points) {
+              this.onDrawingComplete({
+                points,
+                rectangle: this.getRectangleForShape()
+              });
+            }
+          }
+        });
         this.endDrawing();
       },
       onEnable: (viewState: ViewState) => {
@@ -385,13 +435,7 @@ export default class UserDrawing extends MappableMixin(
             }
             reaction.dispose();
 
-            // If drawing a rectangle -> limit to 2 points
-            if (
-              this.inDrawMode &&
-              (!this.drawRectangle ||
-                (this.drawRectangle &&
-                  this.pointEntities.entities.values.length < 2))
-            ) {
+            if (this.inDrawMode) {
               this.prepareToAddNewPoint();
             }
           }
@@ -520,7 +564,10 @@ export default class UserDrawing extends MappableMixin(
       message += innerMessage + "</br>";
     }
 
-    if (this.pointEntities.entities.values.length > 0) {
+    if (this.drawRectangle && this.pointEntities.entities.values.length >= 2) {
+      message +=
+        "<i>" + i18next.t("models.userDrawing.clickToRedrawRectangle") + "</i>";
+    } else if (this.pointEntities.entities.values.length > 0) {
       message +=
         "<i>" + i18next.t("models.userDrawing.clickToAddAnotherPoint") + "</i>";
     } else {
@@ -560,5 +607,20 @@ export default class UserDrawing extends MappableMixin(
       }
       return pos;
     }
+  }
+
+  getRectangleForShape(): Rectangle | undefined {
+    if (!this.drawRectangle) {
+      return undefined;
+    }
+
+    if (this.pointEntities.entities.values.length < 2) {
+      return undefined;
+    }
+
+    const rectangle = this.otherEntities.entities
+      .getById("rectangle")
+      ?.rectangle?.coordinates?.getValue(this.terria.timelineClock.currentTime);
+    return rectangle;
   }
 }

--- a/test/Models/UserDrawingSpec.ts
+++ b/test/Models/UserDrawingSpec.ts
@@ -617,4 +617,57 @@ describe("UserDrawing", function() {
 
     expect(userDrawing.mapItems.length).toBe(1);
   });
+
+  it("calls onDrawingComplete with the drawn points or rectangle", function() {
+    let completedPoints: Cartesian3[] | undefined;
+    let completedRectangle: Rectangle | undefined;
+    const userDrawing = new UserDrawing({
+      terria,
+      allowPolygon: false,
+      drawRectangle: true,
+      onDrawingComplete: ({ points, rectangle }) => {
+        completedPoints = points;
+        completedRectangle = rectangle;
+      }
+    });
+    userDrawing.enterDrawMode();
+    const pickedFeatures = new PickedFeatures();
+
+    // First point
+    // Points around Parliament house
+    const pt1Position = new Cartographic(
+      CesiumMath.toRadians(149.121),
+      CesiumMath.toRadians(-35.309),
+      CesiumMath.toRadians(0)
+    );
+    const pt1CartesianPosition = Ellipsoid.WGS84.cartographicToCartesian(
+      pt1Position
+    );
+    pickedFeatures.pickPosition = pt1CartesianPosition;
+    runInAction(() => {
+      userDrawing.terria.mapInteractionModeStack[0].pickedFeatures = pickedFeatures;
+    });
+
+    // Second point
+    const pt2Position = new Cartographic(
+      CesiumMath.toRadians(149.124),
+      CesiumMath.toRadians(-35.311),
+      CesiumMath.toRadians(0)
+    );
+    const pt2CartesianPosition = Ellipsoid.WGS84.cartographicToCartesian(
+      pt2Position
+    );
+    pickedFeatures.pickPosition = pt2CartesianPosition;
+    runInAction(() => {
+      userDrawing.terria.mapInteractionModeStack[0].pickedFeatures = pickedFeatures;
+    });
+
+    // Check onDrawingComplete was called when we end the drawing.
+    userDrawing.terria.mapInteractionModeStack[0].onCancel?.();
+    expect(completedPoints).toBeDefined();
+    if (completedPoints) {
+      expect(completedPoints.length).toEqual(2);
+    }
+    expect(completedRectangle).toBeDefined();
+  });
 });


### PR DESCRIPTION
### What this PR does

* Added optional `onDrawingComplete` callback to `UserDrawing` to receive drawn points or rectangle when the drawing is complete. This was required to simplify the implementation of [sample-plugin](github.com/terriajs/sample-plugin).
* Fixed a bug in `BoxDrawing` where the box can be below ground after initialization even when setting `keepBoxAboveGround` to true.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
