### PR TITLE
Change NaturalEarth II basemap to use `url-template-imagery`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,7 @@ Change Log
   * This uses new `TableStyle.isCustom` property
 * Move workbench item controls from `WorkbenchItem.jsx` `WorkbenchItemControls.tsx`
 * Add `UrlTempalteImageryCatalogItem`, rename `RasterLayerTraits` to `ImageryProviderTraits` and add some properties.
+* Change NaturalEarth II basemap to use `url-template-imagery`
 * [The next improvement]
 
 #### 8.1.25 - 2022-03-16

--- a/lib/Models/BaseMaps/defaultBaseMaps.ts
+++ b/lib/Models/BaseMaps/defaultBaseMaps.ts
@@ -82,10 +82,10 @@ export function defaultBaseMaps(terria: Terria): any[] {
     item: {
       id: "basemap-natural-earth-II",
       name: "Natural Earth II",
-      type: "wms",
+      type: "url-template-imagery",
       url:
-        "http://geoserver.nationalmap.nicta.com.au/imagery/natural-earth-ii/wms",
-      layers: "NE2_HR_LC_SR_W_DR",
+        "https://storage.googleapis.com/terria-datasets-public/basemaps/natural-earth-tiles/{z}/{x}/{reverseY}.png",
+      maximumLevel: 7,
       opacity: 1.0
     },
     image: "build/TerriaJS/images/natural-earth.png",


### PR DESCRIPTION
### Change NaturalEarth II basemap to use `url-template-imagery`
  
### Test me
  
- http://ci.terria.io/natearth-basemap-urltemp/
- Select Natural Earth II basemap
- Inspect network requests to see pattern `https://storage.googleapis.com/terria-datasets-public/basemaps/natural-earth-tiles/z/x/y.png`

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
