### PR TITLE
Natmap fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@ Change Log
 
 #### next release (8.1.27)
 
+* Use CKAN Dataset `name` property for WMS `layers` as last resort.
+* Set CKAN Group will now set CKAN Item `name` in `definition` stratum.
+* Ignore GeoJSON Features with no geometry.
+* Fix feedback link styling.
+* Improve `CatalogIndexReference` error messages.
 * [The next improvement]
 
 #### 8.1.26 - 2022-04-05

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -437,6 +437,11 @@ function GeoJsonMixin<T extends Constructor<Model<GeoJsonTraits>>>(Base: T) {
 
         for (let i = 0; i < features.length; i++) {
           const feature = features[i];
+
+          // Ignore features without geometry or type
+          if (!isJsonObject(feature.geometry, false) || !feature.geometry.type)
+            continue;
+
           if (!feature.properties) {
             feature.properties = {};
           }

--- a/lib/Models/Catalog/CatalogReferences/CatalogIndexReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/CatalogIndexReference.ts
@@ -94,11 +94,15 @@ export default class CatalogIndexReference extends ReferenceMixin(
       return member;
     }
 
+    const parentErrorMessage = new TerriaError({
+      title: `Failed to find dataset "${this.name ?? this.uniqueId}"`,
+      message: {
+        key: "core.terriaError.networkRequestMessage"
+      },
+      importance: 1
+    });
+
     // No member exists - throw error
-    throw TerriaError.combine(
-      errors,
-      `Failed to find member ${this.name ?? this.uniqueId}`
-    ) ??
-      TerriaError.from(`Failed to find member ${this.name ?? this.uniqueId}`);
+    throw TerriaError.combine(errors, parentErrorMessage) ?? parentErrorMessage;
   }
 }

--- a/lib/Models/Catalog/Ckan/CkanCatalogGroup.ts
+++ b/lib/Models/Catalog/Ckan/CkanCatalogGroup.ts
@@ -32,7 +32,8 @@ import CkanItemReference, {
   CkanResourceWithFormat,
   getSupportedFormats,
   PreparedSupportedFormat,
-  prepareSupportedFormat
+  prepareSupportedFormat,
+  getCkanItemName
 } from "./CkanItemReference";
 
 export function createInheritedCkanSharedTraitsStratum(
@@ -367,6 +368,9 @@ export class CkanServerStratum extends LoadableStratum(CkanCatalogGroupTraits) {
 
         item.setCkanStrata(item);
         item.terria.addModel(item);
+
+        const name = getCkanItemName(item);
+        if (name) item.setTrait(CommonStrata.definition, "name", name);
 
         if (this._catalogGroup.groupBy === "organization") {
           const groupId = ckanDataset.organization

--- a/lib/Models/Catalog/Ckan/CkanItemReference.ts
+++ b/lib/Models/Catalog/Ckan/CkanItemReference.ts
@@ -401,10 +401,13 @@ export default class CkanItemReference extends UrlMixin(
       // Mixing ?? and || because for params we don't want to use empty string params if there are non-empty string parameters
       const layers =
         this._ckanResource?.wms_layer ??
-        (params?.LAYERS || params?.layers || params?.typeName);
+        (params?.LAYERS ||
+          params?.layers ||
+          params?.typeName ||
+          this._ckanResource?.name);
 
       if (layers) {
-        model.setTrait(CommonStrata.definition, "layers", layers);
+        model.setTrait(CommonStrata.definition, "layers", decodeURI(layers));
       }
     }
     return model;

--- a/lib/Models/Catalog/Ckan/CkanItemReference.ts
+++ b/lib/Models/Catalog/Ckan/CkanItemReference.ts
@@ -127,30 +127,7 @@ export class CkanDatasetStratum extends LoadableStratum(
   }
 
   @computed get name() {
-    if (this.ckanResource === undefined) return undefined;
-    if (this.ckanItemReference.useResourceName) return this.ckanResource.name;
-    // via @steve9164
-    /** Switched the order [check `useCombinationNameWhereMultipleResources`
-     * first ] that these are checked so the default is checked last. Otherwise
-     * setting useCombinationNameWhereMultipleResources without setting
-     * useDatasetNameAndFormatWhereMultipleResources to false doesn't do
-     * anything */
-    if (this.ckanDataset) {
-      if (
-        this.ckanItemReference.useCombinationNameWhereMultipleResources &&
-        this.ckanDataset.resources.length > 1
-      ) {
-        return this.ckanDataset.title + " - " + this.ckanResource.name;
-      }
-      if (
-        this.ckanItemReference.useDatasetNameAndFormatWhereMultipleResources &&
-        this.ckanDataset.resources.length > 1
-      ) {
-        return this.ckanDataset.title + " - " + this.ckanResource.format;
-      }
-      return this.ckanDataset.title;
-    }
-    return this.ckanResource.name;
+    return getCkanItemName(this.ckanItemReference);
   }
 
   @computed get rectangle() {
@@ -550,4 +527,32 @@ export function resourceIsSupported(
   }
 
   return match;
+}
+
+export function getCkanItemName(item: CkanItemReference) {
+  if (!item._ckanResource) return;
+
+  if (item.useResourceName) return item._ckanResource.name;
+  // via @steve9164
+  /** Switched the order [check `useCombinationNameWhereMultipleResources`
+   * first ] that these are checked so the default is checked last. Otherwise
+   * setting useCombinationNameWhereMultipleResources without setting
+   * useDatasetNameAndFormatWhereMultipleResources to false doesn't do
+   * anything */
+  if (item._ckanDataset) {
+    if (
+      item.useCombinationNameWhereMultipleResources &&
+      item._ckanDataset.resources.length > 1
+    ) {
+      return item._ckanDataset.title + " - " + item._ckanResource.name;
+    }
+    if (
+      item.useDatasetNameAndFormatWhereMultipleResources &&
+      item._ckanDataset.resources.length > 1
+    ) {
+      return item._ckanDataset.title + " - " + item._ckanResource.format;
+    }
+    return item._ckanDataset.title;
+  }
+  return item._ckanResource.name;
 }

--- a/lib/Models/SearchProviders/CatalogIndex.ts
+++ b/lib/Models/SearchProviders/CatalogIndex.ts
@@ -85,7 +85,7 @@ export default class CatalogIndex {
        *    - "strict" = index whole words
        *  - resolution property = score resolution
        *
-       * Note: beacuse we have set `worker: true`, we must use async calls
+       * Note: because we have set `worker: true`, we must use async calls
        */
       this._searchIndex = new Document({
         worker: true,

--- a/lib/Models/SearchProviders/CatalogSearchProvider.ts
+++ b/lib/Models/SearchProviders/CatalogSearchProvider.ts
@@ -126,12 +126,13 @@ export default class CatalogSearchProvider extends SearchProvider {
     searchText: string,
     searchResults: SearchProviderResults
   ): Promise<void> {
-    this.isSearching = true;
+    runInAction(() => (this.isSearching = true));
+
     searchResults.results.length = 0;
     searchResults.message = undefined;
 
     if (searchText === undefined || /^\s*$/.test(searchText)) {
-      this.isSearching = false;
+      runInAction(() => (this.isSearching = false));
       return Promise.resolve();
     }
 

--- a/lib/ReactViews/Custom/FeedbackLinkCustomComponent.tsx
+++ b/lib/ReactViews/Custom/FeedbackLinkCustomComponent.tsx
@@ -33,7 +33,7 @@ export const FeedbackLink = (props: {
         text-align: left;
       `}
     >
-      <Text bold textLight>
+      <Text bold>
         {parseCustomMarkdownToReact(
           props.feedbackMessage
             ? props.feedbackMessage

--- a/lib/ReactViews/Notification/terriaErrorNotification.tsx
+++ b/lib/ReactViews/Notification/terriaErrorNotification.tsx
@@ -57,6 +57,7 @@ const TerriaErrorBox = (props: {
             margin: 5px 0px;
           }
         `}
+        textLight
       >
         {parseCustomMarkdownToReact(props.error.message, {
           viewState: props.viewState,
@@ -105,7 +106,12 @@ export const terriaErrorNotification = (error: TerriaError) => (
           p {
             margin: 5px 0px;
           }
+          // Fix feedback button color
+          button {
+            color: ${(p: any) => p.theme.textLight};
+          }
         `}
+        textLight
       >
         {parseCustomMarkdownToReact(error.highestImportanceError.message, {
           viewState: viewState,


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/vic-digital-twin/issues/110

* Use CKAN Dataset `name` property for WMS `layers` as last resort.
* Set CKAN Group will now set CKAN Item `name` in `definition` stratum.
* Ignore GeoJSON Features with no geometry.
* Fix feedback link styling.
* Improve `CatalogIndexReference` error messages.
  
### Test me
  
#### Use CKAN Dataset `name` property for WMS `layers` as last resort.

- http://ci.terria.io/main/#configUrl=https://staging.nm.terria.io/config.json&share=s-2wRzj7wqCSrqhLwQSJEDXhn4Cmm
- http://ci.terria.io/natmap-fixes/#configUrl=https://staging.nm.terria.io/config.json&share=s-2wRzj7wqCSrqhLwQSJEDXhn4Cmm

#### Set CKAN Group will now set CKAN Item `name` in `definition` stratum.

Name should be `Road Width and Number of Lanes - Esri REST` not `Road Width and Number of Lanes`

- http://ci.terria.io/main/#configUrl=https://staging.nm.terria.io/config.json&share=s-7cxM5vpAHh5FbJTK5YQkaxyzVsr
- http://ci.terria.io/natmap-fixes/#configUrl=https://staging.nm.terria.io/config.json&share=s-7cxM5vpAHh5FbJTK5YQkaxyzVsr


#### Ignore GeoJSON Features with no geometry + Fix feedback link styling

- http://ci.terria.io/main/#configUrl=https://staging.nm.terria.io/config.json&share=s-aViVejTBZQGpEZDNQFAInecGIh7
- http://ci.terria.io/natmap-fixes/#configUrl=https://staging.nm.terria.io/config.json&share=s-aViVejTBZQGpEZDNQFAInecGIh7

#### Improve `CatalogIndexReference` error messages.

- http://ci.terria.io/main/#configUrl=https://staging.nm.terria.io/config.json
- http://ci.terria.io/natmap-fixes/#configUrl=https://staging.nm.terria.io/config.json
- Search and load "Threatened Ecological Communities"

##### Before vs After

![image](https://user-images.githubusercontent.com/6187649/161919816-40339aa2-24ee-4d17-b8b1-912377edc26d.png)

![image](https://user-images.githubusercontent.com/6187649/161920081-2f17c7d9-bda8-477f-a1df-10ea12e7a56d.png)

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
