### PR TITLE
Show selectable dimension checkbox group even when its child dimensions are empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.2.1)
 
+* Fixed selectable-dimension checkbox group rendering bug where the group is hidden when it has empty children.
 * [The next improvement]
 
 #### 8.2.0 - 2022-04-12

--- a/lib/ReactViews/SelectableDimensions/Group.tsx
+++ b/lib/ReactViews/SelectableDimensions/Group.tsx
@@ -3,7 +3,8 @@ import CommonStrata from "../../Models/Definition/CommonStrata";
 import {
   filterSelectableDimensions,
   SelectableDimensionCheckboxGroup as SelectableDimensionCheckboxGroupModel,
-  SelectableDimensionGroup as SelectableDimensionGroupModel
+  SelectableDimensionGroup as SelectableDimensionGroupModel,
+  isGroup
 } from "../../Models/SelectableDimensions/SelectableDimensions";
 import Box from "../../Styled/Box";
 import Collapsible from "../Custom/Collapsible/Collapsible";
@@ -19,7 +20,9 @@ export const SelectableDimensionGroup: React.FC<{
   const childDims = filterSelectableDimensions(dim.placement)(
     dim.selectableDimensions
   );
-  if (childDims.length === 0) return null;
+  // Hide static groups with empty children.
+  // We still show checkbox groups with empty children as they are stateful.
+  if (isGroup(dim) && childDims.length === 0) return null;
   return (
     <Collapsible
       title={


### PR DESCRIPTION

### What this PR does

Fixes selectable dimension checkbox group rendering so that it is shown even when its child dimensions are empty. This is required because the checkbox dimension group itself has state.

### Test me
 
- Open any 3d tiles catalog item from the workbench
- Before: The clipping box options are not shown in the workbench
- After: The clipping box options will be shown.


### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
