### PR TITLE
Add wms-group to ckan and ignore duplicate wms layers in groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ Change Log
 
 #### next release (8.2.2)
 
+* **Breaking changes:**
+  * `CkanItemReference` no longer copies `default` stratum to target - please use `itemProperties` instead.
+
 * **Revert** Use CKAN Dataset `name` property for WMS `layers` as last resort.
 * Add support for `WebMapServiceCatalogGroup` to `CkanItemReference` - this will be used instead of `WebMapServiceCatalogItem` if WMS `layers` can't be identified from CKAN resource metadata.
 * Ignore WMS `Layers` with duplicate `Name` properties

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.2.2)
 
+* **Revert** Use CKAN Dataset `name` property for WMS `layers` as last resort.
 * Add support for `WebMapServiceCatalogGroup` to `CkanItemReference` - this will be used instead of `WebMapServiceCatalogItem` if WMS `layers` can't be identified from CKAN resource metadata.
 * Ignore WMS `Layers` with duplicate `Name` properties
 * [The next improvement]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 #### next release (8.2.2)
 
+* Add support for `WebMapServiceCatalogGroup` to `CkanItemReference` - this will be used instead of `WebMapServiceCatalogItem` if WMS `layers` can't be identified from CKAN resource metadata.
+* Ignore WMS `Layers` with duplicate `Name` properties
 * [The next improvement]
 
 #### 8.2.1 - 2022-04-13

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 
 * **Revert** Use CKAN Dataset `name` property for WMS `layers` as last resort.
 * Add support for `WebMapServiceCatalogGroup` to `CkanItemReference` - this will be used instead of `WebMapServiceCatalogItem` if WMS `layers` can't be identified from CKAN resource metadata.
+  * Add `allowEntireWmsServers` to `CkanCatalogGroupTraits` - defaults to `true`
 * Ignore WMS `Layers` with duplicate `Name` properties
 * Fix selectable dimensions passing reactive objects and arrays to updateModelFromJson (which could cause problems with array detection).
 * [The next improvement]

--- a/lib/Models/Catalog/Ckan/CkanCatalogGroup.ts
+++ b/lib/Models/Catalog/Ckan/CkanCatalogGroup.ts
@@ -21,6 +21,7 @@ import StratumFromTraits from "../../Definition/StratumFromTraits";
 import StratumOrder from "../../Definition/StratumOrder";
 import Terria from "../../Terria";
 import CatalogGroup from "../CatalogGroup";
+import WebMapServiceCatalogItem from "../Ows/WebMapServiceCatalogItem";
 import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
 import CkanDefaultFormatsStratum from "./CkanDefaultFormatsStratum";
 import {
@@ -30,10 +31,10 @@ import {
 } from "./CkanDefinitions";
 import CkanItemReference, {
   CkanResourceWithFormat,
+  getCkanItemName,
   getSupportedFormats,
   PreparedSupportedFormat,
-  prepareSupportedFormat,
-  getCkanItemName
+  prepareSupportedFormat
 } from "./CkanItemReference";
 
 export function createInheritedCkanSharedTraitsStratum(
@@ -367,6 +368,16 @@ export class CkanServerStratum extends LoadableStratum(CkanCatalogGroupTraits) {
         item.setSupportedFormat(format);
 
         item.setCkanStrata(item);
+
+        // If Item is WMS-group and allowEntireWmsServers === false, then stop here
+        if (
+          format.definition?.type === WebMapServiceCatalogItem.type &&
+          !item.wmsLayers &&
+          !this._catalogGroup.allowEntireWmsServers
+        ) {
+          return;
+        }
+
         item.terria.addModel(item);
 
         const name = getCkanItemName(item);

--- a/lib/Models/Catalog/Ckan/CkanItemReference.ts
+++ b/lib/Models/Catalog/Ckan/CkanItemReference.ts
@@ -3,6 +3,7 @@ import { action, computed, runInAction } from "mobx";
 import { createTransformer } from "mobx-utils";
 import URI from "urijs";
 import isDefined from "../../../Core/isDefined";
+import { isJsonString } from "../../../Core/Json";
 import loadJson from "../../../Core/loadJson";
 import ReferenceMixin from "../../../ModelMixins/ReferenceMixin";
 import UrlMixin from "../../../ModelMixins/UrlMixin";
@@ -396,8 +397,20 @@ export default class CkanItemReference extends UrlMixin(
       getCkanItemResourceUrl(this)
     )?.search(true);
 
+    const layersFromItemProperties =
+      this.itemPropertiesByIds?.find(
+        itemProps => this.uniqueId && itemProps.ids.includes(this.uniqueId)
+      )?.itemProperties?.layers ??
+      this.itemPropertiesByType?.find(
+        itemProps => itemProps.type === WebMapServiceCatalogItem.type
+      )?.itemProperties?.layers ??
+      this.itemProperties?.layers;
+
     // Mixing ?? and || because for params we don't want to use empty string params if there are non-empty string parameters
     return (
+      (isJsonString(layersFromItemProperties)
+        ? layersFromItemProperties
+        : undefined) ??
       this._ckanResource?.wms_layer ??
       (params?.LAYERS || params?.layers || params?.typeName)
     );

--- a/lib/Models/Catalog/Ows/WebMapServiceCatalogGroup.ts
+++ b/lib/Models/Catalog/Ows/WebMapServiceCatalogGroup.ts
@@ -195,7 +195,17 @@ class GetCapabilitiesStratum extends LoadableStratum(
       let model: CatalogGroup;
       if (existingModel === undefined) {
         model = new CatalogGroup(layerId, this.catalogGroup.terria);
-        this.catalogGroup.terria.addModel(model, this.getLayerShareKeys(layer));
+        try {
+          // Sometimes WMS Layers have duplicate names
+          // At the moment we ignore duplicate layers
+          this.catalogGroup.terria.addModel(
+            model,
+            this.getLayerShareKeys(layer)
+          );
+        } catch (e) {
+          TerriaError.from(e, "Failed to add CatalogGroup").log();
+          return;
+        }
       } else {
         model = existingModel;
       }
@@ -237,7 +247,14 @@ class GetCapabilitiesStratum extends LoadableStratum(
     if (existingModel === undefined) {
       model = new WebMapServiceCatalogItem(layerId, this.catalogGroup.terria);
 
-      this.catalogGroup.terria.addModel(model, this.getLayerShareKeys(layer));
+      try {
+        // Sometimes WMS Layers have duplicate names
+        // At the moment we ignore duplicate layers
+        this.catalogGroup.terria.addModel(model, this.getLayerShareKeys(layer));
+      } catch (e) {
+        TerriaError.from(e, "Failed to add WebMapServiceCatalogItem").log();
+        return;
+      }
     } else {
       model = existingModel;
     }

--- a/lib/Traits/TraitsClasses/CkanCatalogGroupTraits.ts
+++ b/lib/Traits/TraitsClasses/CkanCatalogGroupTraits.ts
@@ -54,4 +54,11 @@ export default class CkanCatalogGroupTraits extends mixTraits(
       If the value is a blank string or undefined, these items will be left at the top level, not grouped.`
   })
   ungroupedTitle: string = "No group";
+
+  @primitiveTrait({
+    type: "boolean",
+    name: "Allow entire WMS Servers",
+    description: `True to allow entire WMS servers (that is, WMS resources without a clearly-defined layer) to be added to the catalog; otherwise, false.`
+  })
+  allowEntireWmsServers: boolean = true;
 }

--- a/wwwroot/test/CKAN/search-result.json
+++ b/wwwroot/test/CKAN/search-result.json
@@ -600,8 +600,7 @@
             "size": null,
             "state": "active",
             "url": "https://data.gov.au/geoserver/groundwater-sdl-resource-units/wms?request=GetCapabilities",
-            "url_type": null,
-            "wms_layer": "ckan_66e3efa7_fb5c_4bd7_9478_74adb6277955"
+            "url_type": null
           },
           {
             "cache_last_updated": null,

--- a/wwwroot/test/CKAN/wms-no-layer-resource.json
+++ b/wwwroot/test/CKAN/wms-no-layer-resource.json
@@ -1,0 +1,28 @@
+{
+  "help": "https://data.gov.au/api/3/action/help_show?name=resource_show",
+  "success": true,
+  "result": {
+    "cache_last_updated": null,
+    "package_id": "95d9e550-8b36-4273-8df7-2b76c140e73a",
+    "webstore_last_updated": null,
+    "datastore_active": false,
+    "id": "205ef0d1-521b-4e3c-a26c-4e49e00f1a05",
+    "size": null,
+    "state": "active",
+    "hash": "",
+    "description": "View the data in this dataset online via an online map",
+    "format": "wms",
+    "last_modified": "2015-08-25T08:04:40.677513",
+    "url_type": null,
+    "mimetype": null,
+    "cache_url": null,
+    "name": "Taxation statistics 2011-12 - Preview this Dataset (WMS)",
+    "created": "2014-07-15T07:55:50.273031",
+    "url": "http://data.gov.au/geoserver/taxation-statistics-2011-12/wms?request=GetCapabilities",
+    "webstore_url": null,
+    "mimetype_inner": null,
+    "position": 98,
+    "revision_id": "95382692-1cc9-423e-8f2b-678d807ca059",
+    "resource_type": null
+  }
+}


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs/issues/5745 https://github.com/TerriaJS/terriajs/issues/5893

Reverts parts of https://github.com/TerriaJS/terriajs/pull/6240

* **Breaking changes:**
  * `CkanItemReference` no longer copies `default` stratum to target - please use `itemProperties` instead.
* **Revert** Use CKAN Dataset `name` property for WMS `layers` as last resort.
* Add support for `WebMapServiceCatalogGroup` to `CkanItemReference` - this will be used instead of `WebMapServiceCatalogItem` if WMS `layers` can't be identified from CKAN resource metadata.
  * Add `allowEntireWmsServers` to `CkanCatalogGroupTraits` - defaults to `true`
* Ignore WMS `Layers` with duplicate `Name` properties
  
## Test me
  
### Previously broken layers

#### NationalMap BOM layers

- http://ci.terria.io/main/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-6lVY0nbynTMbxNrcDNxAhpnoEMD
- http://ci.terria.io/wms-group-ckan/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-6lVY0nbynTMbxNrcDNxAhpnoEMD

#### Pacificmap "GEBCO"

- http://ci.terria.io/main/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fpacificmap%2Fmap-config%2Fdev.json&share=s-e6pCuveWY2VQSontFWdHIB3bwFd
- http://ci.terria.io/wms-group-ckan/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fpacificmap%2Fmap-config%2Fdev.json&share=s-e6pCuveWY2VQSontFWdHIB3bwFd

#### Pacificmap "Global Distribution of Coral Reefs"

- http://ci.terria.io/main/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fpacificmap%2Fmap-config%2Fdev.json&share=s-yXBz4vDt6z7oFfDPBoEzsSMuJrk
- http://ci.terria.io/wms-group-ckan/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fpacificmap%2Fmap-config%2Fdev.json&share=s-yXBz4vDt6z7oFfDPBoEzsSMuJrk

#### Pacificmap "SEDAC data products and services"

- http://ci.terria.io/main/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fpacificmap%2Fmap-config%2Fdev.json&share=s-4DIE4HSWa5G7mqWbP6beENTTqJh
- http://ci.terria.io/wms-group-ckan/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fpacificmap%2Fmap-config%2Fdev.json&share=s-4DIE4HSWa5G7mqWbP6beENTTqJh

### Layers which are now worse off - they are now groups

This is due to "**Revert** Use CKAN Dataset `name` property for WMS `layers` as last resort"

- http://ci.terria.io/main/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-nxnnxNRNJKbbAPYNX2jzTID5k7M
- http://ci.terria.io/wms-group-ckan/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-nxnnxNRNJKbbAPYNX2jzTID5k7M

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
