### PR TITLE
Progress bar visibility #6144

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.2.4)
 
+* ProgressBar colour now depends on baseMapContrastColor - improves visibility on light map backgrounds
 * [The next improvement]
 
 #### 8.2.3 - 2022-04-22

--- a/lib/ReactViews/Map/ProgressBar.jsx
+++ b/lib/ReactViews/Map/ProgressBar.jsx
@@ -5,67 +5,76 @@ import PropTypes from "prop-types";
 import createReactClass from "create-react-class";
 import EventHelper from "terriajs-cesium/Source/Core/EventHelper";
 import classNames from "classnames";
+import { observer } from "mobx-react";
 
 import Styles from "./progress-bar.scss";
 
 // The map navigation region
-const ProgressBar = createReactClass({
-  propTypes: {
-    terria: PropTypes.object.isRequired
-  },
+const ProgressBar = observer(
+  createReactClass({
+    displayName: "ProgressBar",
+    propTypes: {
+      terria: PropTypes.object.isRequired
+    },
 
-  getInitialState() {
-    return {
-      visible: "hidden"
-    };
-  },
+    getInitialState() {
+      return {
+        visible: "hidden"
+      };
+    },
 
-  /* eslint-disable-next-line camelcase */
-  UNSAFE_componentWillMount() {
-    this.eventHelper = new EventHelper();
+    /* eslint-disable-next-line camelcase */
+    UNSAFE_componentWillMount() {
+      this.eventHelper = new EventHelper();
 
-    this.eventHelper.add(
-      this.props.terria.tileLoadProgressEvent,
-      this.setProgress
-    );
+      this.eventHelper.add(
+        this.props.terria.tileLoadProgressEvent,
+        this.setProgress
+      );
 
-    // TODO - is this actually needed now? load events always get called when
-    // changing viewer. if still reuqired,
-    // clear progress when new viewer observed, rather than mounting to a 'current viewer'
+      // TODO - is this actually needed now? load events always get called when
+      // changing viewer. if still reuqired,
+      // clear progress when new viewer observed, rather than mounting to a 'current viewer'
 
-    // // Clear progress when the viewer changes so we're not left with an invalid progress bar hanging on the screen.
-    // this.eventHelper.add(
-    //   this.props.terria.currentViewer.beforeViewerChanged,
-    //   this.setProgress.bind(this, 0, 0)
-    // );
-  },
+      // // Clear progress when the viewer changes so we're not left with an invalid progress bar hanging on the screen.
+      // this.eventHelper.add(
+      //   this.props.terria.currentViewer.beforeViewerChanged,
+      //   this.setProgress.bind(this, 0, 0)
+      // );
+    },
 
-  setProgress(remaining, max) {
-    const rawPercentage = (1 - remaining / max) * 100;
-    const sanitisedPercentage = Math.floor(remaining > 0 ? rawPercentage : 100);
+    setProgress(remaining, max) {
+      const rawPercentage = (1 - remaining / max) * 100;
+      const sanitisedPercentage = Math.floor(
+        remaining > 0 ? rawPercentage : 100
+      );
 
-    this.setState({
-      percentage: sanitisedPercentage
-    });
-  },
+      this.setState({
+        percentage: sanitisedPercentage
+      });
+    },
 
-  componentWillUnmount() {
-    this.eventHelper.removeAll();
-  },
+    componentWillUnmount() {
+      this.eventHelper.removeAll();
+    },
 
-  render() {
-    const width = this.state.percentage + "%";
-    const visibility = this.state.percentage < 100 ? "visible" : "hidden";
-    const complete = this.state.percentage === 100;
+    render() {
+      const width = this.state.percentage + "%";
+      const visibility = this.state.percentage < 100 ? "visible" : "hidden";
+      const complete = this.state.percentage === 100;
+      // use the baseMapContrastColor to ensure progress bar is visible on light backgrounds
+      const backgroundColor =
+        this.props.terria.baseMapContrastColor ?? "#ffffff";
 
-    return (
-      <div
-        className={classNames(Styles.progressBar, {
-          [Styles.complete]: complete
-        })}
-        style={{ visibility, width }}
-      />
-    );
-  }
-});
+      return (
+        <div
+          className={classNames(Styles.progressBar, {
+            [Styles.complete]: complete
+          })}
+          style={{ visibility, width, backgroundColor }}
+        />
+      );
+    }
+  })
+);
 module.exports = ProgressBar;


### PR DESCRIPTION
### What this PR does

Fixes #6144 

When rendering `ProgressBar` get the current `baseMapContrastColor` and use that for the ProgressBar `background-color`.

As this is a computed value solution required wrapping the return value of `createReactClass()` in `observer()`

![Screen Shot 2022-04-28 at 11 37 44 am (2)](https://user-images.githubusercontent.com/7980991/165671702-51d361f0-f8f9-477c-9d31-31b60d630907.png)


  
### Test me
  
Manually toggle the basemap to different settings in Map Settings dialog. If necessary enable throttling on Network tab of dev tools to slow down loading and observe the changes.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
