### PR TITLE
Fix GltfMixin to correctly extend the Base class parameter.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Fix `CatalogIndex` types
 * Fix bug that broke the `DiffTool` preventing it from opening. 
 * TSify `BottomDock` and `measureElement` components.
+* Fixed a bug in `GltfMixin` which resulted in some traits missing from `GltfCatalogItem` and broke tools like the scene editor.
 * [The next improvement]
 
 #### 8.2.3 - 2022-04-22

--- a/lib/ModelMixins/GltfMixin.ts
+++ b/lib/ModelMixins/GltfMixin.ts
@@ -11,7 +11,6 @@ import ModelGraphics from "terriajs-cesium/Source/DataSources/ModelGraphics";
 import HeightReference from "terriajs-cesium/Source/Scene/HeightReference";
 import Constructor from "../Core/Constructor";
 import CommonStrata from "../Models/Definition/CommonStrata";
-import CreateModel from "../Models/Definition/CreateModel";
 import Model from "../Models/Definition/Model";
 import HasLocalData from "../Models/HasLocalData";
 import GltfTraits from "../Traits/TraitsClasses/GltfTraits";
@@ -29,9 +28,7 @@ type GltfModel = Model<GltfTraits>;
 
 function GltfMixin<T extends Constructor<GltfModel>>(Base: T) {
   class GltfMixin
-    extends ShadowMixin(
-      UrlMixin(CatalogMemberMixin(MappableMixin(CreateModel(GltfTraits))))
-    )
+    extends ShadowMixin(UrlMixin(CatalogMemberMixin(MappableMixin(Base))))
     implements HasLocalData {
     @observable hasLocalData = false;
 


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs-place-editor/issues/11

Fixes `GltfMixin` to correctly extend from the `Base` parameter. This resulted in `GltfCatalogItem` missing some of the additional traits it passes in.
  

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
