### PR TITLE
Re-add missing `helpPanel.mapUserGuide` translation string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Fix bug that broke the `DiffTool` preventing it from opening. 
 * TSify `BottomDock` and `measureElement` components.
 * Fixed a bug in `GltfMixin` which resulted in some traits missing from `GltfCatalogItem` and broke tools like the scene editor.
+* Re-add missing `helpPanel.mapUserGuide` translation string
 * [The next improvement]
 
 #### 8.2.3 - 2022-04-22

--- a/lib/Language/en/translation.json
+++ b/lib/Language/en/translation.json
@@ -298,7 +298,8 @@
     "menuPaneBody": "Find useful tips on how to use TerriaJS by either checking the guides below or by contacting the team at [{{supportEmail}}]({{supportEmail}})",
     "promptMessage": "Find the Tour, how-to videos & other help content here",
     "dismissText": "Got it, thanks!",
-    "takeTour": "Take the tour"
+    "takeTour": "Take the tour",
+    "mapUserGuide": "Map user guide"
   },
   "helpMenu": {
     "btnText": "Help",


### PR DESCRIPTION
### Re-add missing `helpPanel.mapUserGuide` translation string
  
Fixes https://github.com/terriajs/nationalmap/issues/1145

![image](https://user-images.githubusercontent.com/6187649/168743918-d4487c28-b1cd-4747-a4cd-1d8e9d47d760.png)

This string is used by heaps of maps

EG

https://github.com/TerriaJS/saas-catalogs-public/blob/ee25532a331ca8a81bf4e1dc2092afb5eb5c5b87/de-australia/map-config/dev.json#L183-L188

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
