### PR TITLE
Fix `sortMembersBy` for child `Groups` and `References`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * TSify `BottomDock` and `measureElement` components.
 * Fixed a bug in `GltfMixin` which resulted in some traits missing from `GltfCatalogItem` and broke tools like the scene editor.
 * Re-add missing `helpPanel.mapUserGuide` translation string
+* Fix `sortMembersBy` for child `Groups` and `References`
 * [The next improvement]
 
 #### 8.2.3 - 2022-04-22

--- a/lib/ModelMixins/GroupMixin.ts
+++ b/lib/ModelMixins/GroupMixin.ts
@@ -15,6 +15,7 @@ import ModelReference from "../Traits/ModelReference";
 import GroupTraits from "../Traits/TraitsClasses/GroupTraits";
 import { ItemPropertiesTraits } from "../Traits/TraitsClasses/ItemPropertiesTraits";
 import CatalogMemberMixin, { getName } from "./CatalogMemberMixin";
+import ReferenceMixin from "./ReferenceMixin";
 
 const naturalSort = require("javascript-natural-sort");
 naturalSort.insensitive = true;
@@ -95,16 +96,8 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
       // If not, then the model will be placed at the end of the array
       if (isDefined(this.sortMembersBy)) {
         return models.sort((a, b) => {
-          const aValue =
-            CatalogMemberMixin.isMixedInto(a) &&
-            hasTraits(a, a.TraitsClass, this.sortMembersBy as any)
-              ? a[this.sortMembersBy!]
-              : Infinity;
-          const bValue =
-            CatalogMemberMixin.isMixedInto(b) &&
-            hasTraits(b, b.TraitsClass, this.sortMembersBy as any)
-              ? b[this.sortMembersBy!]
-              : Infinity;
+          const aValue = getSortProperty(a, this.sortMembersBy!);
+          const bValue = getSortProperty(b, this.sortMembersBy!);
           return naturalSort(
             isJsonString(aValue) || isJsonNumber(aValue) ? aValue : Infinity,
             isJsonString(bValue) || isJsonNumber(bValue) ? bValue : Infinity
@@ -359,6 +352,17 @@ namespace GroupMixin {
 }
 
 export default GroupMixin;
+
+function getSortProperty(model: BaseModel, prop: string) {
+  return (CatalogMemberMixin.isMixedInto(model) &&
+    hasTraits(model, model.TraitsClass, prop as any)) ||
+    (GroupMixin.isMixedInto(model) &&
+      hasTraits(model, model.TraitsClass, prop as any)) ||
+    (ReferenceMixin.isMixedInto(model) &&
+      hasTraits(model, model.TraitsClass, prop as any))
+    ? model[prop!]
+    : undefined;
+}
 
 function setItemPropertyTraits(
   model: BaseModel,

--- a/test/Models/Catalog/CatalogGroupSpec.ts
+++ b/test/Models/Catalog/CatalogGroupSpec.ts
@@ -278,30 +278,43 @@ describe("CatalogGroup", function() {
         type: "group",
         name: "ab",
         description: "b"
-      }
+      },
+      { type: "terria-reference", name: "A reference" }
     ]);
 
-    expect(
-      item.memberModels.map(member =>
-        CatalogMemberMixin.isMixedInto(member) ? member.name : ""
-      )
-    ).toEqual(["1", "aCC", "10", "2", "AC", "ab"]);
+    expect(item.memberModels.map(member => (member as any).name)).toEqual([
+      "1",
+      "aCC",
+      "10",
+      "2",
+      "AC",
+      "ab",
+      "A reference"
+    ]);
 
     item.setTrait(CommonStrata.user, "sortMembersBy", "name");
 
-    expect(
-      item.memberModels.map(member =>
-        CatalogMemberMixin.isMixedInto(member) ? member.name : ""
-      )
-    ).toEqual(["1", "2", "10", "ab", "AC", "aCC"]);
+    expect(item.memberModels.map(member => (member as any).name)).toEqual([
+      "1",
+      "2",
+      "10",
+      "A reference",
+      "ab",
+      "AC",
+      "aCC"
+    ]);
 
     item.setTrait(CommonStrata.user, "sortMembersBy", "description");
 
-    expect(
-      item.memberModels.map(member =>
-        CatalogMemberMixin.isMixedInto(member) ? member.name : ""
-      )
-    ).toEqual(["AC", "ab", "2", "10", "1", "aCC"]);
+    expect(item.memberModels.map(member => (member as any).name)).toEqual([
+      "AC",
+      "ab",
+      "2",
+      "10",
+      "1",
+      "aCC",
+      "A reference"
+    ]);
   });
 
   it("supports itemProperties, itemPropertiesByType and itemPropertiesByIds", async function() {


### PR DESCRIPTION
### Fix `sortMembersBy` for child `Groups` and `References`

Before `sortMembersBy` was only sorting models which have `CatalogMemberMixin` (so not `GroupMixin` or `ReferenceMixin`)

### Before vs After

Notice `Climate` group is above `Boundaries` group

![image](https://user-images.githubusercontent.com/6187649/168951312-1b7b61fc-7f74-47e6-b55d-7d7cec4659ef.png)
 
### Test me
  
- **Before** http://ci.terria.io/main/#clean&https://gist.githubusercontent.com/nf-s/2838c00b6b24e88df1559972191992dc/raw/4950e4d28e2bc187555e84ca09cd1bdbf3c4e57e/sort-members-by-fix.json

- **After** http://ci.terria.io/fix-sortmembersby/#clean&https://gist.githubusercontent.com/nf-s/2838c00b6b24e88df1559972191992dc/raw/4950e4d28e2bc187555e84ca09cd1bdbf3c4e57e/sort-members-by-fix.json

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
