### PR TITLE
Fix use of `baseMapContrastColor` in region mapping/protomaps and remove `MAX_SELECTABLE_DIMENSION_OPTIONS`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Fixed bug where `new Terria()` constructror would try to access `document` and throw an error when running in NodeJS.
 * Add WPS support for `Date` (additional to existing `DateTime`) and support for `ComplexData` `Date`/`DateTime` WPS Inputs.
 * TSXified `StandardUserInterface` and some other components. If your TerriaMap imports `StandardUserInterface.jsx` remove the `.jsx` extension so webpack can find the new `.tsx` file.
+* Fix use of `baseMapContrastColor` in region mapping/protomaps and remove `MAX_SELECTABLE_DIMENSION_OPTIONS`
 * [The next improvement]
 
 #### 8.2.4 - 2022-05-23

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -674,7 +674,7 @@ function GeoJsonMixin<T extends Constructor<Model<GeoJsonTraits>>>(Base: T) {
           (isConstantStyleMap(outlineStyleMap)
             ? outlineStyleMap.style.color
             : outlineStyleMap.mapValueToStyle(isJsonNumber(rowId) ? rowId : -1)
-                .color) ?? this.terria.baseMapContrastColor
+                .color) ?? runInAction(() => this.terria.baseMapContrastColor)
         );
       };
 

--- a/lib/Models/Catalog/SdmxJson/SdmxJsonDataflowStratum.ts
+++ b/lib/Models/Catalog/SdmxJson/SdmxJsonDataflowStratum.ts
@@ -2,10 +2,10 @@ import i18next from "i18next";
 import { computed } from "mobx";
 import filterOutUndefined from "../../../Core/filterOutUndefined";
 import isDefined from "../../../Core/isDefined";
-import TerriaError, { networkRequestError } from "../../../Core/TerriaError";
+import { networkRequestError } from "../../../Core/TerriaError";
 import {
-  ShortReportTraits,
-  MetadataUrlTraits
+  MetadataUrlTraits,
+  ShortReportTraits
 } from "../../../Traits/TraitsClasses/CatalogMemberTraits";
 import { DimensionOptionTraits } from "../../../Traits/TraitsClasses/DimensionTraits";
 import { FeatureInfoTemplateTraits } from "../../../Traits/TraitsClasses/FeatureInfoTraits";
@@ -32,11 +32,8 @@ import LoadableStratum from "../../Definition/LoadableStratum";
 import Model, { BaseModel } from "../../Definition/Model";
 import StratumFromTraits from "../../Definition/StratumFromTraits";
 import StratumOrder from "../../Definition/StratumOrder";
+import { filterEnums } from "../../SelectableDimensions/SelectableDimensions";
 import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
-import {
-  MAX_SELECTABLE_DIMENSION_OPTIONS,
-  filterEnums
-} from "../../SelectableDimensions/SelectableDimensions";
 import SdmxJsonCatalogItem from "./SdmxJsonCatalogItem";
 import { loadSdmxJsonStructure, parseSdmxUrn } from "./SdmxJsonServerStratum";
 import {
@@ -292,41 +289,34 @@ export class SdmxJsonDataflowStratum extends LoadableStratum(
 
           let options: StratumFromTraits<DimensionOptionTraits>[] = [];
 
-          // Only create options if less then MAX_SELECTABLE_DIMENSION_OPTIONS (1000) values
-          if (allowedOptionIds.size < MAX_SELECTABLE_DIMENSION_OPTIONS) {
-            // Get codes by merging allowedOptionIds with codelist
-            let filteredCodesList =
-              (allowedOptionIds.size > 0
-                ? codelist?.codes?.filter(code =>
-                    allowedOptionIds.has(code.id!)
-                  )
-                : // If no allowedOptions were found -> return all codes
-                  codelist?.codes) ?? [];
+          // Get codes by merging allowedOptionIds with codelist
+          let filteredCodesList =
+            (allowedOptionIds.size > 0
+              ? codelist?.codes?.filter(code => allowedOptionIds.has(code.id!))
+              : // If no allowedOptions were found -> return all codes
+                codelist?.codes) ?? [];
 
-            // Create options object
-            // If modelOverride `options` has been defined -> use it
-            // Other wise use filteredCodesList
-            const overrideOptions = modelOverride?.options;
-            options =
-              isDefined(overrideOptions) && overrideOptions.length > 0
-                ? overrideOptions.map(option => {
-                    return {
-                      id: option.id,
-                      name: option.name,
-                      value: undefined
-                    };
-                  })
-                : filteredCodesList.map(code => {
-                    return { id: code.id!, name: code.name, value: undefined };
-                  });
-          }
+          // Create options object
+          // If modelOverride `options` has been defined -> use it
+          // Other wise use filteredCodesList
+          const overrideOptions = modelOverride?.options;
+          options =
+            isDefined(overrideOptions) && overrideOptions.length > 0
+              ? overrideOptions.map(option => {
+                  return {
+                    id: option.id,
+                    name: option.name,
+                    value: undefined
+                  };
+                })
+              : filteredCodesList.map(code => {
+                  return { id: code.id!, name: code.name, value: undefined };
+                });
 
           // Use first option as default if no other default is provided
-          let selectedId: string | undefined =
-            modelOverride?.allowUndefined ||
-            allowedOptionIds.size >= MAX_SELECTABLE_DIMENSION_OPTIONS
-              ? undefined
-              : options[0]?.id;
+          let selectedId: string | undefined = modelOverride?.allowUndefined
+            ? undefined
+            : options[0]?.id;
 
           // Override selectedId if it a valid option
           const selectedIdOverride = modelOverride?.selectedId;

--- a/lib/Models/SelectableDimensions/SelectableDimensions.ts
+++ b/lib/Models/SelectableDimensions/SelectableDimensions.ts
@@ -85,9 +85,6 @@ export interface SelectableDimensionEnum
   optionRenderer?: OptionRenderer;
 }
 
-/** Maximum number of options for a `SelectableDimension` */
-export const MAX_SELECTABLE_DIMENSION_OPTIONS = 1000;
-
 export interface SelectableDimensionCheckbox
   extends SelectableDimensionBase<"true" | "false">,
     EnumDimension<"true" | "false"> {
@@ -215,11 +212,7 @@ const isEnabled = (dim: SelectableDimension) => !dim.disable;
 /** Filter out dimensions with only 1 option (unless they have 1 option and allow undefined - which is 2 total options) */
 const enumHasValidOptions = (dim: EnumDimension) => {
   const minLength = dim.allowUndefined ? 1 : 2;
-  return (
-    isDefined(dim.options) &&
-    dim.options.length >= minLength &&
-    dim.options.length < MAX_SELECTABLE_DIMENSION_OPTIONS
-  );
+  return isDefined(dim.options) && dim.options.length >= minLength;
 };
 
 /** Filter with SelectableDimension should be shown for a given placement.

--- a/lib/ReactViews/SelectableDimensions/Select.tsx
+++ b/lib/ReactViews/SelectableDimensions/Select.tsx
@@ -1,5 +1,6 @@
 import i18next from "i18next";
 import { runInAction } from "mobx";
+import { observer } from "mobx-react";
 import React from "react";
 import ReactSelect from "react-select";
 import ReactSelectCreatable from "react-select/creatable";
@@ -10,7 +11,7 @@ import { SelectableDimensionEnum as SelectableDimensionEnumModel } from "../../M
 export const SelectableDimensionEnum: React.FC<{
   id: string;
   dim: SelectableDimensionEnumModel;
-}> = ({ id, dim }) => {
+}> = observer(({ id, dim }) => {
   const theme = useTheme();
 
   const undefinedOption = {
@@ -86,4 +87,4 @@ export const SelectableDimensionEnum: React.FC<{
       })}
     />
   );
-};
+});

--- a/lib/Table/createRegionMappedImageryProvider.ts
+++ b/lib/Table/createRegionMappedImageryProvider.ts
@@ -1,5 +1,5 @@
 import { VectorTileFeature } from "@mapbox/vector-tile";
-import { action } from "mobx";
+import { action, runInAction } from "mobx";
 import Color from "terriajs-cesium/Source/Core/Color";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
@@ -73,7 +73,8 @@ export default function createRegionMappedImageryProvider(
         : outlineStyleMap.mapValueToStyle(rowNumber ?? -1);
 
       const outlineColorValue = Color.fromCssColorString(
-        outlineStyle.color ?? style.tableModel.terria.baseMapContrastColor
+        outlineStyle.color ??
+          runInAction(() => style.tableModel.terria.baseMapContrastColor)
       );
 
       return {


### PR DESCRIPTION
Fix use of `baseMapContrastColor` in region mapping/protomaps and remove `MAX_SELECTABLE_DIMENSION_OPTIONS`

We were getting lots of "computed value being read outside reactive context"
  
### Test me
  
- Before http://ci.terria.io/main/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-iqncdPtpesebOUf0s0MPgiKhKtn
- After http://ci.terria.io/fix-basemapconstrastcol/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-iqncdPtpesebOUf0s0MPgiKhKtn

#### SA1 performance

- http://ci.terria.io/main/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-fbOAzdb2rrDHfMyUgIga2BCACwO
- http://ci.terria.io/fix-basemapconstrastcol/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-fbOAzdb2rrDHfMyUgIga2BCACwO

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
