### PR TITLE
Fix Story Prompt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Replace Pell WYSIWYG editor library with TinyMCE, allows richer editing of Stories in the Story Builder
 * Added support for using Compare / Split Screen mode with Cesium 3D Tiles.
 * Fix `BottomDock.handleClick` binding
+* Fix problem with Story Prompt not showing
 * [The next improvement]
 
 #### 8.2.4 - 2022-05-23

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -533,7 +533,7 @@ export default class Terria {
   @observable depthTestAgainstTerrainEnabled = false;
 
   @observable stories: StoryData[] = [];
-  @observable storyPromptShown: number = 0;
+  @observable storyPromptShown: number = 0; // Story Prompt modal will be rendered when this property changes. See StandardUserInterface, section regarding sui.notifications. Ideally move this to ViewState.
 
   /**
    * Gets or sets the ID of the catalog member that is currently being

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -533,6 +533,7 @@ export default class Terria {
   @observable depthTestAgainstTerrainEnabled = false;
 
   @observable stories: StoryData[] = [];
+  @observable storiesInitialized: boolean = false;
 
   /**
    * Gets or sets the ID of the catalog member that is currently being
@@ -1513,6 +1514,7 @@ export default class Terria {
     // Add stories
     if (Array.isArray(initData.stories)) {
       this.stories = initData.stories;
+      this.storiesInitialized = true;
     }
 
     // Add map settings

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -533,7 +533,7 @@ export default class Terria {
   @observable depthTestAgainstTerrainEnabled = false;
 
   @observable stories: StoryData[] = [];
-  @observable storiesInitialized: boolean = false;
+  @observable storyPromptShown: number = 0;
 
   /**
    * Gets or sets the ID of the catalog member that is currently being
@@ -1514,7 +1514,7 @@ export default class Terria {
     // Add stories
     if (Array.isArray(initData.stories)) {
       this.stories = initData.stories;
-      this.storiesInitialized = true;
+      this.storyPromptShown++;
     }
 
     // Add map settings

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
@@ -161,6 +161,9 @@ const StandardUserInterface = observer<React.FC<StandardUserInterfaceProps>>(
     useEffect(() => {
       window.addEventListener("resize", resizeListener, false);
       resizeListener();
+      return () => {
+        window.removeEventListener("resize", resizeListener, false);
+      };
     }, []);
 
     useEffect(() => {
@@ -185,10 +188,6 @@ const StandardUserInterface = observer<React.FC<StandardUserInterfaceProps>>(
           width: 300
         });
       }
-
-      return () => {
-        window.removeEventListener("resize", resizeListener, false);
-      };
     }, [props.terria.storyPromptShown]);
 
     // Merge theme in order of highest priority: themeOverrides props -> theme config parameter -> default terriaTheme

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
@@ -158,6 +158,7 @@ const StandardUserInterface = observer<React.FC<StandardUserInterfaceProps>>(
       props.viewState.useSmallScreenInterface = shouldUseMobileInterface;
     });
 
+    //TODO: Changes here
     useEffect(() => {
       window.addEventListener("resize", resizeListener, false);
       resizeListener();
@@ -187,7 +188,7 @@ const StandardUserInterface = observer<React.FC<StandardUserInterfaceProps>>(
       return () => {
         window.removeEventListener("resize", resizeListener, false);
       };
-    }, []);
+    }, [props.terria.storiesInitialized]);
 
     // Merge theme in order of highest priority: themeOverrides props -> theme config parameter -> default terriaTheme
     const mergedTheme = combine(

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
@@ -158,11 +158,12 @@ const StandardUserInterface = observer<React.FC<StandardUserInterfaceProps>>(
       props.viewState.useSmallScreenInterface = shouldUseMobileInterface;
     });
 
-    //TODO: Changes here
     useEffect(() => {
       window.addEventListener("resize", resizeListener, false);
       resizeListener();
+    }, []);
 
+    useEffect(() => {
       if (
         props.terria.configParameters.storyEnabled &&
         props.terria.stories &&
@@ -188,7 +189,7 @@ const StandardUserInterface = observer<React.FC<StandardUserInterfaceProps>>(
       return () => {
         window.removeEventListener("resize", resizeListener, false);
       };
-    }, [props.terria.storiesInitialized]);
+    }, [props.terria.storyPromptShown]);
 
     // Merge theme in order of highest priority: themeOverrides props -> theme config parameter -> default terriaTheme
     const mergedTheme = combine(


### PR DESCRIPTION
### What this PR does

Fixes #6325

When sharing a map with stories included, a 'stroy prompt' should show:
![image](https://user-images.githubusercontent.com/7980991/172280449-9b7b316c-a97e-44bc-a2b7-fa5b3595cea5.png)

  
### Test me
  
Create a story in a map, and share it.
Open the share link.
The story prompt should show.

### Checklist

-   [y] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [y] I've updated relevant documentation in `doc/`.
-   [y] I've updated CHANGES.md with what I changed.
-   [y] I've provided instructions in the PR description on how to test this PR.
