### PR TITLE
Fix the story share panel font.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Replace Pell WYSIWYG editor library with TinyMCE, allows richer editing of Stories in the Story Builder
 * Added support for using Compare / Split Screen mode with Cesium 3D Tiles.
 * Fix `BottomDock.handleClick` binding
+* Use the theme base font to style story share panel.
 * [The next improvement]
 
 #### 8.2.4 - 2022-05-23

--- a/lib/ReactViews/Map/Panels/SharePanel/StorySharePanel.jsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/StorySharePanel.jsx
@@ -80,6 +80,7 @@ const StorySharePanel = createReactClass({
           <div
             css={`
               margin-top: 35px;
+              font-family: ${p => p.theme.fontBase};
             `}
           >
             <InnerPanel


### PR DESCRIPTION
### What this PR does

Fixes #6320 

Fixes the story share panel font by forcing it to use the theme `font-family`.  

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
