### PR TITLE
Fix global `body` style + add `color:inherit` to `Button`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ Change Log
 * Fix `BottomDock.handleClick` binding
 * Use the theme base font to style story share panel.
 * Fix problem with Story Prompt not showing
+* Fix global body style (font and focus purple)
+* Add `color:inherit` to `Button`
 * [The next improvement]
 
 #### 8.2.4 - 2022-05-23

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
@@ -48,7 +48,7 @@ import WorkflowPanelContainer from "./WorkflowPanelContainer";
 
 const GlobalTerriaStyles = createGlobalStyle`
   body {
-    font-family: ${p => p.theme.fontBase}
+    font-family: ${p => p.theme.fontBase};
 
     *:focus {
       outline: 3px solid #C390F9;

--- a/lib/Styled/Button.tsx
+++ b/lib/Styled/Button.tsx
@@ -158,7 +158,8 @@ export const RawButton = styled.button<IButtonProps>`
   ${props => props.fullHeight && `height: 100%;`}
   ${props => props.styledWidth && `width: ${props.styledWidth};`}
 
-  ${props => (props.textLight ? `color: ${props.theme.textLight}` : ``)}
+  ${props =>
+    props.textLight ? `color: ${props.theme.textLight}` : `color: inherit`}
 `;
 
 type ButtonProps = {


### PR DESCRIPTION
## Fix global `body` style + add `color:inherit` to `Button`

## Test me
  
### Focus color

#### After

<img width="376" alt="image" src="https://user-images.githubusercontent.com/6187649/172298275-f8920f19-39d7-41bb-88aa-d8b4d90f742a.png">

#### Before

<img width="409" alt="image" src="https://user-images.githubusercontent.com/6187649/172298290-5cdd47ba-32ab-4d1e-a22c-abcfe3ff8ea9.png">

### Button color

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/6187649/172298366-8a98a6f9-3133-48f3-ad69-07c4ec18d136.png">

### Fonts

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/6187649/172298402-d6f9a5f5-20a3-4b85-91c9-373deeb367ad.png">

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
