### PR TITLE
feat: implement cesium and leaflet credits as react components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ Change Log
 * Fixed default 3d-tiles styling to add a workaround for a Cesium bug which resulted in wrong translucency value for point clouds.
 * Remove Pell dependency, now replaced with TinyMCE (WYSIWYG editor library).
 * Fix `includes` path for `url-loader` rule so that it doesn't incorrectly match package names with `terriajs` as prefix.
+* Implement Leaflet credits as a react component, so it is easier to maintain them. Leaflet view now show terria extra credits.
+* Implement Cesium credits as a react component, so it is easier to maintain them.
+* Fixed translation of Leaflet and Cesium credits.
 * [The next improvement]
 
 #### 8.2.5 - 2022-06-07

--- a/lib/Map/Cesium/CesiumSelectionIndicator.ts
+++ b/lib/Map/Cesium/CesiumSelectionIndicator.ts
@@ -17,6 +17,7 @@ import isDefined from "../../Core/isDefined";
 declare module "terriajs-cesium/Source/Scene/Scene" {
   export default interface Scene {
     tweens: TweenCollection;
+    frameState: any;
   }
 }
 

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -53,6 +53,7 @@ import Feature from "./Feature";
 import GlobeOrMap from "./GlobeOrMap";
 import MapInteractionMode from "./MapInteractionMode";
 import Terria from "./Terria";
+import { LeafletAttribution } from "./LeafletAttribution";
 
 // We want TS to look at the type declared in lib/ThirdParty/terriajs-cesium-extra/index.d.ts
 // and import doesn't allows us to do that, so instead we use require + type casting to ensure
@@ -155,38 +156,11 @@ export default class Leaflet extends GlobeOrMap {
 
     this.scene = new LeafletScene(this.map);
 
-    const attributionProps: L.Control.AttributionOptions = {
-      position: "bottomleft"
-    };
-
-    if (isDefined(this.terria.configParameters.leafletAttributionPrefix)) {
-      attributionProps.prefix = this.terria.configParameters.leafletAttributionPrefix;
-    }
-
-    this._attributionControl = L.control.attribution(attributionProps);
+    this._attributionControl = new LeafletAttribution(this.terria);
     this.map.addControl(this._attributionControl);
-
-    // this.map.screenSpaceEventHandler = {
-    //     setInputAction : function() {},
-    //     remoteInputAction : function() {}
-    // };
 
     this._leafletVisualizer = new LeafletVisualizer();
     this._selectionIndicator = new LeafletSelectionIndicator(this);
-
-    // const terriaLogo = this.terriaViewer.defaultTerriaCredit ? this.terriaViewer.defaultTerriaCredit.html : '';
-
-    // const creditParts = [
-    //     this._getDisclaimer(),
-    //     this._developerAttribution && createCredit(this._developerAttribution.text, this._developerAttribution.link),
-    //     new Credit('<a target="_blank" href="http://leafletjs.com/">Leaflet</a>')
-    // ];
-
-    // this.attributionControl.setPrefix(terriaLogo + creditParts.filter(part => defined(part)).map(credit => credit.html).join(' | '));
-
-    // map.on("boxzoomend", function(e) {
-    //     console.log(e.boxZoomBounds);
-    // });
 
     this.dataSourceDisplay = new LeafletDataSourceDisplay({
       scene: this.scene,

--- a/lib/Models/LeafletAttribution.ts
+++ b/lib/Models/LeafletAttribution.ts
@@ -1,0 +1,73 @@
+import Terria from "./Terria";
+import { LeafletCredits } from "../ReactViews/Credits";
+import L from "leaflet";
+import React from "react";
+import ReactDOM from "react-dom";
+
+export class LeafletAttribution extends L.Control.Attribution {
+  private readonly terria: Terria;
+  private map?: L.Map;
+  private _container!: HTMLElement;
+  private currentAttibution?: HTMLElement;
+
+  constructor(terria: Terria) {
+    const options: L.Control.AttributionOptions = {
+      position: "bottomleft"
+    };
+    if (terria.configParameters.leafletAttributionPrefix) {
+      options.prefix = terria.configParameters.leafletAttributionPrefix;
+    }
+    super(options);
+
+    this.terria = terria;
+  }
+
+  onAdd(map: L.Map) {
+    map.attributionControl = this;
+    this.map = map;
+
+    this._container = L.DomUtil.create("div", "leaflet-control-attribution");
+    L.DomEvent.disableClickPropagation(this._container);
+
+    map.eachLayer(layer => {
+      if (layer.getAttribution) {
+        const att = layer.getAttribution();
+        if (att) this.addAttribution(att);
+      }
+    });
+
+    return this._container;
+  }
+
+  _update() {
+    if (!this.map) {
+      return;
+    }
+    if (this.currentAttibution) {
+      this._container.removeChild(this.currentAttibution);
+    }
+
+    const attribs: string[] = [];
+    //@ts-ignore
+    const attributions = this._attributions;
+    for (const i in attributions) {
+      if (attributions[i]) {
+        attribs.push(i);
+      }
+    }
+
+    const domElement = document.createElement("div");
+    const element = React.createElement(LeafletCredits, {
+      hideTerriaLogo: !!this.terria.configParameters.hideTerriaLogo,
+      prefix: `${this.options.prefix}`,
+      credits: this.terria.configParameters.extraCreditLinks?.slice(),
+      dataAttributions: attribs
+    });
+    ReactDOM.render(element, domElement);
+    const child = domElement.firstElementChild as HTMLElement;
+    if (child) {
+      this.currentAttibution = child;
+      this._container?.appendChild(child);
+    }
+  }
+}

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -55,6 +55,7 @@ import TimeVarying from "../ModelMixins/TimeVarying";
 import { HelpContentItem } from "../ReactViewModels/defaultHelpContent";
 import { defaultTerms, Term } from "../ReactViewModels/defaultTerms";
 import NotificationState from "../ReactViewModels/NotificationState";
+import { ICredit } from "../ReactViews/Credits/Credit.type";
 import { SHARE_VERSION } from "../ReactViews/Map/Panels/SharePanel/BuildShareLink";
 import { shareConvertNotification } from "../ReactViews/Notification/shareConvertNotification";
 import MappableTraits from "../Traits/TraitsClasses/MappableTraits";
@@ -283,7 +284,7 @@ interface ConfigParameters {
   /**
    * Extra links to show in the credit line at the bottom of the map (currently only the Cesium map).
    */
-  extraCreditLinks?: { url: string; text: string }[];
+  extraCreditLinks?: ICredit[];
 
   /**
    * Configurable discalimer that shows up in print view

--- a/lib/ReactViews/Credits/Cesium/CesiumCredits.props.ts
+++ b/lib/ReactViews/Credits/Cesium/CesiumCredits.props.ts
@@ -1,0 +1,8 @@
+import { ICredit } from "../Credit.type";
+
+export interface ICesiumCreditsProps {
+  hideTerriaLogo: boolean;
+  credits?: ICredit[];
+  expandDataCredits?: () => void;
+  cesiumLogoElement?: HTMLElement;
+}

--- a/lib/ReactViews/Credits/Cesium/CesiumCredits.tsx
+++ b/lib/ReactViews/Credits/Cesium/CesiumCredits.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from "react";
+import { useTranslation } from "react-i18next";
+import Box from "../../../Styled/Box";
+import { Credits, Spacer } from "../Credits";
+import { TerriaLogo } from "../TerriaLogo";
+import { VanillaChildren } from "../VanillaChildren";
+import { ICesiumCreditsProps } from "./CesiumCredits.props";
+
+export const CesiumCredits: FC<ICesiumCreditsProps> = ({
+  hideTerriaLogo,
+  credits,
+  expandDataCredits,
+  cesiumLogoElement
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Box verticalCenter gap>
+      {!hideTerriaLogo ? <TerriaLogo /> : null}
+      {cesiumLogoElement ? (
+        <VanillaChildren children={cesiumLogoElement} />
+      ) : null}
+      <Credits credits={credits}></Credits>
+      <Spacer />
+      <a onClick={expandDataCredits}>{t("map.extraCreditLinks.basemap")}</a>
+    </Box>
+  );
+};

--- a/lib/ReactViews/Credits/Credit.tsx
+++ b/lib/ReactViews/Credits/Credit.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { ExternalLinkIcon } from "../Custom/parseCustomHtmlToReact";
+import { ICredit } from "./Credit.type";
+import { Spacer } from "./Credits";
+
+export const Credit: FC<{
+  credit: ICredit;
+  lastElement: boolean;
+}> = ({ credit, lastElement }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <a
+        key={credit.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        href={credit.url}
+      >
+        {t(credit.text)} <ExternalLinkIcon />
+      </a>
+      {!lastElement ? <Spacer /> : null}
+    </>
+  );
+};

--- a/lib/ReactViews/Credits/Credit.type.ts
+++ b/lib/ReactViews/Credits/Credit.type.ts
@@ -1,0 +1,4 @@
+export interface ICredit {
+  url: string;
+  text: string;
+}

--- a/lib/ReactViews/Credits/Credits.props.ts
+++ b/lib/ReactViews/Credits/Credits.props.ts
@@ -1,0 +1,5 @@
+import { ICredit } from "./Credit.type";
+
+export interface ICreditsProps {
+  credits?: ICredit[];
+}

--- a/lib/ReactViews/Credits/Credits.tsx
+++ b/lib/ReactViews/Credits/Credits.tsx
@@ -1,0 +1,24 @@
+import React, { FC } from "react";
+import { Credit } from "./Credit";
+import { ICreditsProps } from "./Credits.props";
+
+export const Spacer = () => {
+  return <span aria-hidden="true">|</span>;
+};
+
+export const Credits: FC<ICreditsProps> = ({ credits }) => {
+  if (!credits || credits.length === 0) {
+    return null;
+  }
+  return (
+    <>
+      {credits.map((credit, index) => (
+        <Credit
+          key={index}
+          credit={credit}
+          lastElement={index === credits.length - 1}
+        />
+      ))}
+    </>
+  );
+};

--- a/lib/ReactViews/Credits/Leaflet/LeafletCredits.props.ts
+++ b/lib/ReactViews/Credits/Leaflet/LeafletCredits.props.ts
@@ -1,0 +1,8 @@
+import { ICredit } from "../Credit.type";
+
+export interface ILeafletCreditsProps {
+  hideTerriaLogo: boolean;
+  prefix?: string;
+  credits?: ICredit[];
+  dataAttributions: string[];
+}

--- a/lib/ReactViews/Credits/Leaflet/LeafletCredits.tsx
+++ b/lib/ReactViews/Credits/Leaflet/LeafletCredits.tsx
@@ -1,0 +1,24 @@
+import React, { FC } from "react";
+import Box from "../../../Styled/Box";
+import parseCustomHtmlToReact from "../../Custom/parseCustomHtmlToReact";
+import { Credits, Spacer } from "../Credits";
+import { TerriaLogo } from "../TerriaLogo";
+import { ILeafletCreditsProps } from "./LeafletCredits.props";
+
+export const LeafletCredits: FC<ILeafletCreditsProps> = ({
+  hideTerriaLogo,
+  prefix,
+  credits,
+  dataAttributions
+}) => {
+  return (
+    <Box verticalCenter gap>
+      {!hideTerriaLogo ? <TerriaLogo /> : null}
+      {prefix ? parseCustomHtmlToReact(prefix) : null}
+      <Spacer />
+      <Credits credits={credits}></Credits>
+      <Spacer />
+      {parseCustomHtmlToReact(dataAttributions.join(","))}
+    </Box>
+  );
+};

--- a/lib/ReactViews/Credits/TerriaLogo.tsx
+++ b/lib/ReactViews/Credits/TerriaLogo.tsx
@@ -1,0 +1,17 @@
+import React, { FC } from "react";
+import Box from "../../Styled/Box";
+
+const logo = require("../../../wwwroot/images/terria-watermark.svg");
+
+export const TerriaLogo: FC = () => {
+  return (
+    <Box
+      as={"a"}
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://terria.io/"
+    >
+      <img css={{ height: "24px" }} src={logo} title="Built with Terria" />
+    </Box>
+  );
+};

--- a/lib/ReactViews/Credits/VanillaChildren.tsx
+++ b/lib/ReactViews/Credits/VanillaChildren.tsx
@@ -1,0 +1,11 @@
+import React, { useRef, useEffect } from "react";
+
+export const VanillaChildren = ({ children }: { children: HTMLElement }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    ref.current?.appendChild(children);
+  });
+
+  return <div ref={ref} />;
+};

--- a/lib/ReactViews/Credits/index.ts
+++ b/lib/ReactViews/Credits/index.ts
@@ -1,0 +1,2 @@
+export { CesiumCredits } from "./Cesium/CesiumCredits";
+export { LeafletCredits } from "./Leaflet/LeafletCredits";

--- a/lib/ReactViews/Custom/parseCustomHtmlToReact.ts
+++ b/lib/ReactViews/Custom/parseCustomHtmlToReact.ts
@@ -31,7 +31,7 @@ const shouldProcessEveryNodeExceptWhiteSpace = function(node: DomElement) {
 
 let keyIndex = 0;
 
-const ExternalLinkIcon = styled(StyledIcon).attrs({
+export const ExternalLinkIcon = styled(StyledIcon).attrs({
   glyph: Icon.GLYPHS.externalLink,
   styledWidth: "10px",
   styledHeight: "10px",

--- a/lib/ReactViews/Map/terria-viewer-wrapper.scss
+++ b/lib/ReactViews/Map/terria-viewer-wrapper.scss
@@ -35,13 +35,17 @@
       background: linear-gradient(180deg, #000000 0%, #000000 100%);
       height: 30px;
       width: 100%;
-      // @extend %sm-show;
-      display: table-row;
+      max-height: 30px;
+      display: flex;
+      align-items: center;
+      gap: $padding-small;
 
       div {
         // For some reasons the div and a elements have style attribute display:inline
         // attached by default...
-        display: table-cell !important;
+        display: flex !important;
+        align-items: center;
+        gap: $padding-small;
 
         img {
           height: 24px;
@@ -50,20 +54,16 @@
       }
 
       a {
-        // text-decoration: none;
-        // color: $color-primary;
-
         // I refuse to make this text-light without underlining it
         text-decoration: underline;
         color: $text-light;
-        display: table-cell !important;
-        vertical-align: middle;
-        padding: $padding-mini $padding-small;
-      }
+        display: flex !important;
+        align-items: center;
 
-      .cesium-credit-logoContainer::after {
-        content: "";
-        display: table-cell;
+        cursor: pointer;
+        &.cesium-credit-expand-link {
+          display: none !important;
+        }
       }
     }
 
@@ -88,7 +88,10 @@
       }
 
       .leaflet-control-attribution {
+        display: flex;
+        gap: $padding-small;
         line-height: 30px;
+        max-height: 30px;
         background: none;
         color: rgba(#fff, 0.8);
         #terriaLogoWrapper {

--- a/lib/ReactViews/SelectableDimensions/Color.tsx
+++ b/lib/ReactViews/SelectableDimensions/Color.tsx
@@ -90,7 +90,7 @@ export const SelectableDimensionColor: React.FC<{
         <div
           css={{
             position: "absolute",
-            zIndex: "2"
+            zIndex: 2
           }}
         >
           <div


### PR DESCRIPTION
### What this PR does

Implement Cesium and Leafet credits as react components so they can properly utilise translation and it is easier to maintain them. This fixes part of #6336, the credits are not being updated on language change.

- [x] Show Terria logo in the 2d viewer
- [x] Show extra credits links in the 2d viewer
- [ ] Implement a modal as react component to show data attribution in both cesium and leaflet viewers so they are consistent. ~Is it better to leave this as a `Good first issue`?~ - better not, turns out this was a little ... to implement reactively. Done in #6340

### Test me

Try changing language in leaflet or cesium viewer, and observe that credits are being translated  

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated relevant documentation in `doc/`. - not relevant
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
