### PR TITLE
Fix handling GeoJSON if features have null geometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 #### next release (8.2.7)
 
+* Improve TerriaReference error logging
+* Fix handling GeoJSON if features have null geometry
 * [The next improvement]
 
 #### 8.2.6 - 2022-06-17

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -435,9 +435,9 @@ function GeoJsonMixin<T extends Constructor<Model<GeoJsonTraits>>>(Base: T) {
         let numFeaturesWithSimpleStyle = 0;
         const featureCounts = { point: 0, line: 0, polygon: 0 };
 
+        // We will re-add features depending if filterByProperties - or geometry is invalid
         const features = geoJsonWgs84.features;
-        // If filtering features - Clear all features and re add them if props match filterByProperties
-        if (filterByProperties) geoJsonWgs84.features = [];
+        geoJsonWgs84.features = [];
 
         for (let i = 0; i < features.length; i++) {
           const feature = features[i];
@@ -451,15 +451,16 @@ function GeoJsonMixin<T extends Constructor<Model<GeoJsonTraits>>>(Base: T) {
           }
 
           // Filter features by `featureFilterByProps` trait if defined
-          if (filterByProperties) {
-            if (
-              Object.entries(filterByProperties).every(
-                ([key, value]) => feature.properties![key] === value
-              )
+          if (
+            filterByProperties &&
+            !Object.entries(filterByProperties).every(
+              ([key, value]) => feature.properties![key] === value
             )
-              geoJsonWgs84.features.push(feature);
-            else continue;
+          ) {
+            continue;
           }
+
+          geoJsonWgs84.features.push(feature);
 
           const properties = feature.properties!;
           properties[FEATURE_ID_PROP] = i;

--- a/lib/Models/Catalog/CatalogReferences/TerriaReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/TerriaReference.ts
@@ -108,7 +108,7 @@ export default class TerriaReference extends UrlMixin(
           targetJson
         ).catchError(error => {
           target.setTrait(CommonStrata.underride, "isExperiencingIssues", true);
-          console.log(error.toError());
+          error.log();
         });
         return target;
       }

--- a/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
@@ -40,6 +40,45 @@ describe("GeoJsonCatalogItemSpec", () => {
     });
 
     describe("GeoJsonCatalogItem", function() {
+      it("handles features with null geom", async () => {
+        geojson.setTrait(CommonStrata.user, "geoJsonData", {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              properties: {
+                LGA_CODE19: "19499",
+                LGA_NAME19: "No usual address (NSW)",
+                STE_CODE16: "1",
+                STE_NAME16: "New South Wales",
+                AREASQKM19: 0.0
+              },
+              geometry: null
+            },
+            {
+              type: "Feature",
+              properties: {},
+              geometry: {
+                type: "Polygon",
+                coordinates: [
+                  [
+                    [144.80667114257812, -32.96258644191746],
+                    [145.008544921875, -33.19273094190691],
+                    [145.557861328125, -32.659031913817685],
+                    [145.04287719726562, -32.375322284319346],
+                    [144.7998046875, -32.96719522935591],
+                    [144.80667114257812, -32.96258644191746]
+                  ]
+                ]
+              }
+            }
+          ]
+        });
+
+        await geojson.loadMapItems();
+        expect(geojson.readyData?.features.length).toBe(1);
+      });
+
       it("reloads when the URL is changed", async function() {
         geojson.setTrait(
           CommonStrata.user,


### PR DESCRIPTION
### Fix handling GeoJSON if features have null geometry
  
### Test me

- Explore Map Data
- Add "geojson with null geom" to workbench

[Before](http://ci.terria.io/main/#clean&https://gist.githubusercontent.com/nf-s/05b2bea3fdc72b0beef040aaf6e92491/raw/e5294d05bc255f64af5fe06288066d0aa66c04fb/geojson-null-geom.json)
  
[After](http://ci.terria.io/geojson-feature-null/#clean&https://gist.githubusercontent.com/nf-s/05b2bea3fdc72b0beef040aaf6e92491/raw/e5294d05bc255f64af5fe06288066d0aa66c04fb/geojson-null-geom.json)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
