### PR TITLE
Extend recognised file types to include ifc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Wrap the following components in `observer` - `ChartItem`, `LineChart`, (chart) `Legends`, `ChartPanelDownloadButton`
 * Improve TerriaReference error logging
 * Fix handling GeoJSON if features have null geometry
+* Allow IFC files to be added to a map from local or web data (Requires non-open source plugin) 
 * [The next improvement]
 
 #### 8.2.6 - 2022-06-17

--- a/lib/Core/getDataType.ts
+++ b/lib/Core/getDataType.ts
@@ -148,6 +148,12 @@ export default function() {
         value: "shp",
         name: i18next.t("core.dataType.shp"),
         extensions: ["zip"]
+      },
+      {
+        // NOTE: will only work if non open-source terriajs-ifc plugin is added to the map
+        value: "ifc",
+        name: i18next.t("core.dataType.ifc"),
+        extensions: ["ifc"]
       }
     ]
   };

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -713,9 +713,10 @@
       "gpx": "GPX",
       "json": "JSON",
       "carto": "Carto",
-      "gltf": "GLTF",
+      "gltf": "glTF",
       "shp": "Shapefile (zip)",
-      "socrata-group": "Socrata Server"
+      "socrata-group": "Socrata Server",
+      "ifc": "IFC"
     },
     "printWindow": {
       "errorTitle": "Error printing",


### PR DESCRIPTION
**Note that terriajs DOES NOT support IFC without a closed source plugin that isn't publicly available at this time.**

### What this PR does

When the terriajs-ifc plugin is present, users will be able to add data to a map from local storage and web sources.
  
### Test me
  
1. Try uploading any terria-compatible file to the map. It should work.
2. Try upload an IFC file. It should fail gracefully.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [X] ~I've updated relevant documentation in `doc/`.~
-   [X] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
