### PR TITLE
Fix feature highliting for `Line`, `MultiLine` and `MultiPoint`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,15 @@
 Change Log
 ==========
 
-#### next release (8.2.7)
+#### next release (8.2.8)
+
+* Table styling is disabled if `MultiPoint` are in GeoJSON
+* Add `GeoJsonTraits.useOutlineColorForLineFeatures` - If enabled, `TableOutlineStyleTraits` will be used to color Line Features, otherwise `TableColorStyleTraits` will be used.
+* Fix feature highliting for `Line`, `MultiLine` and `MultiPoint`
+* [The next improvement]
+
+
+#### 8.2.7 - 2022-06-30
 
 * Fix `WorkbenchItem` title height
 * Add region map info and move "No Data" message to `InfoSections` in `TableAutomaticStylesStratum`
@@ -21,12 +29,10 @@ Change Log
 * Fix handling GeoJSON if features have null geometry
 * Fix bug where map tools names appear as translation strings
 * Allow IFC files to be added to a map from local or web data (Requires non-open source plugin) 
+* Rename `useTranslationIfExists` to `applyTranslationIfExists` so it doesn't look like a React hook.
+* Added a required parameter i18n to `applyTranslationIfExists` to avoid having stale translated strings when the language changes.
 * Fix `StoryBuilder` remove all text color
 * Fix `FeatureInfoPanel` `Loader` color
-* Add limited support for GeoJSON `MultiPoint` features - only the first point is added
-* Add `GeoJsonTraits.useOutlineColorForLineFeatures` - If enabled, `TableOutlineStyleTraits` will be used to color Line Features, otherwise `TableColorStyleTraits` will be used.
-* Fix feature highliting for `Line`, `MultiLine` and `MultiPoint`
-* [The next improvement]
 
 #### 8.2.6 - 2022-06-17
 
@@ -40,7 +46,6 @@ Change Log
 * Made `order` optional for `ICompositeBarItem`.
 * Fix `includes` path for `url-loader` rule so that it doesn't incorrectly match package names with `terriajs` as prefix.
 * Add help button for bookmarking sharelinks to SharePanel (if that help item exists in config)
-* [The next improvement]
 
 #### 8.2.5 - 2022-06-07
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,6 @@ Change Log
 * Fix feature highliting for `Line`, `MultiLine` and `MultiPoint`
 * [The next improvement]
 
-
-* [The next improvement]
-
 #### 8.2.7 - 2022-06-30
 
 * Fix `WorkbenchItem` title height

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,9 @@ Change Log
 * Allow IFC files to be added to a map from local or web data (Requires non-open source plugin) 
 * Fix `StoryBuilder` remove all text color
 * Fix `FeatureInfoPanel` `Loader` color
+* Add limited support for GeoJSON `MultiPoint` features - only the first point is added
+* Add `GeoJsonTraits.useOutlineColorForLineFeatures` - If enabled, `TableOutlineStyleTraits` will be used to color Line Features, otherwise `TableColorStyleTraits` will be used.
+* Fix feature highliting for `Line`, `MultiLine` and `MultiPoint`
 * [The next improvement]
 
 #### 8.2.6 - 2022-06-17

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -598,11 +598,10 @@ function GeoJsonMixin<T extends Constructor<Model<GeoJsonTraits>>>(Base: T) {
         else if (isMultiPoint(feature)) {
           latitudes.push(feature.geometry.coordinates[0][1]);
           longitudes.push(feature.geometry.coordinates[0][0]);
+        } else {
+          latitudes.push(null);
+          longitudes.push(null);
         }
-
-        latitudes.push(null);
-        longitudes.push(null);
-        continue;
       }
 
       const dataSource = new CustomDataSource(this.name || "Table");

--- a/lib/Models/GlobeOrMap.ts
+++ b/lib/Models/GlobeOrMap.ts
@@ -396,6 +396,12 @@ export default abstract class GlobeOrMap {
 
             catalogItem.setTrait(
               CommonStrata.user,
+              "useOutlineColorForLineFeatures",
+              true
+            );
+
+            catalogItem.setTrait(
+              CommonStrata.user,
               "defaultStyle",
               createStratumInstance(TableStyleTraits, {
                 outline: createStratumInstance(TableOutlineStyleTraits, {

--- a/lib/Traits/TraitsClasses/GeoJsonTraits.ts
+++ b/lib/Traits/TraitsClasses/GeoJsonTraits.ts
@@ -51,6 +51,14 @@ export class GeoJsonTraits extends mixTraits(
   })
   enableManualRegionMapping: false = false;
 
+  @primitiveTrait({
+    name: "Use outline color for line features",
+    description:
+      "If enabled, TableOutlineStyleTraits will be used to color Line Features, otherwise TableColorStyleTraits will be used.",
+    type: "boolean"
+  })
+  useOutlineColorForLineFeatures?: boolean;
+
   @objectTrait({
     type: StyleTraits,
     name: "Style",

--- a/lib/Traits/TraitsClasses/GeoJsonTraits.ts
+++ b/lib/Traits/TraitsClasses/GeoJsonTraits.ts
@@ -79,7 +79,7 @@ export class GeoJsonTraits extends mixTraits(
     type: "boolean",
     name: "Force cesium primitives",
     description:
-      "Force rendering GeoJSON features as Cesium primitives. This will be true if you are using `style`, `perPropertyStyles`, `timeProperty`, `heightProperty` or `czmlTemplate`. If undefined, geojson-vt/protomaps will be used"
+      "Force rendering GeoJSON features as Cesium primitives. This will be true if you are using `style`, `perPropertyStyles`, `timeProperty`, `heightProperty` or `czmlTemplate`. If undefined, geojson-vt/protomaps will be used. This will be set to true if simplestyle-spec properties are detected in over 50% of GeoJSON features, or if any MultiPoint features are found "
   })
   forceCesiumPrimitives?: boolean;
 


### PR DESCRIPTION
### Fix feature highliting for `Line`, `MultiLine` and `MultiPoint`

* Table styling is disabled if `MultiPoint` are in GeoJSON
* Add `GeoJsonTraits.useOutlineColorForLineFeatures` - If enabled, `TableOutlineStyleTraits` will be used to color Line Features, otherwise `TableColorStyleTraits` will be used.
* Fix feature highliting for `Line`, `MultiLine` and `MultiPoint`

Issue to add Table styling `MultiPoint` support https://github.com/TerriaJS/terriajs/issues/6374
  
### Test me
  
- [Before link](http://ci.terria.io/main/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fde-australia%2Fmap-config%2Fprod.json&start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22CqkxcG%22%3A%7B%22isOpen%22%3Afalse%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22ahjVXr%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22dn823X%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22D7zEZL%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22dkjsia%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22D7zEZL%22%5D%2C%22type%22%3A%22group%22%7D%2C%22dea_coastlines%22%3A%7B%22isOpenInWorkbench%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22dkjsia%22%5D%2C%22type%22%3A%22wms%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%22___%24FeatureHighlight%26__%22%2C%22dea_coastlines%22%5D%2C%22timeline%22%3A%5B%22dea_coastlines%22%5D%2C%22initialCamera%22%3A%7B%22west%22%3A142.05322265625003%2C%22south%22%3A-42.98857645832183%2C%22east%22%3A152.27050781250003%2C%22north%22%3A-31.86822781618069%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%222d%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.4999%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Atrue%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-positron%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)
- [After link](http://ci.terria.io/fix-feature-hightlighting/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fde-australia%2Fmap-config%2Fprod.json&start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22CqkxcG%22%3A%7B%22isOpen%22%3Afalse%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22ahjVXr%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22dn823X%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22D7zEZL%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22dkjsia%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22D7zEZL%22%5D%2C%22type%22%3A%22group%22%7D%2C%22dea_coastlines%22%3A%7B%22isOpenInWorkbench%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22dkjsia%22%5D%2C%22type%22%3A%22wms%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%22___%24FeatureHighlight%26__%22%2C%22dea_coastlines%22%5D%2C%22timeline%22%3A%5B%22dea_coastlines%22%5D%2C%22initialCamera%22%3A%7B%22west%22%3A142.05322265625003%2C%22south%22%3A-42.98857645832183%2C%22east%22%3A152.27050781250003%2C%22north%22%3A-31.86822781618069%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%222d%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.4999%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Atrue%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-positron%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)
- Click on point feature
- Zoom in - click on line feature

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
