### PR TITLE
Await Internationalisation initialisation in `Terria.start`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.2.8)
 
+* Await Internationalisation initialisation in `Terria.start`
 * [The next improvement]
 
 #### 8.2.7 - 2022-06-30

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 #### next release (8.2.8)
 
 * Await Internationalisation initialisation in `Terria.start`
+* `UserDrawing.messageHeader` can now also be `() => string`
 * [The next improvement]
 
 #### 8.2.7 - 2022-06-30

--- a/lib/Models/Internationalization.ts
+++ b/lib/Models/Internationalization.ts
@@ -62,7 +62,7 @@ class Internationalization {
      */
     i18StartOptions: I18nStartOptions | undefined,
     terriajsResourcesBaseUrl: string
-  ): void {
+  ) {
     const languageConfig = Object.assign(
       defaultLanguageConfiguration,
       languageConfiguration
@@ -77,7 +77,7 @@ class Internationalization {
      * @param {Array} languageConfiguration.changeLanguageOnStartWhen
      */
 
-    i18next
+    return i18next
       .use(HttpApi)
       .use(LanguageDetector)
       .use(initReactI18next)

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -920,7 +920,7 @@ export default class Terria {
       });
     } finally {
       if (!options.i18nOptions?.skipInit) {
-        Internationalization.initLanguage(
+        await Internationalization.initLanguage(
           this.configParameters.languageConfiguration,
           options.i18nOptions,
           this.baseUrl

--- a/lib/Models/UserDrawing.ts
+++ b/lib/Models/UserDrawing.ts
@@ -169,7 +169,7 @@ export default class UserDrawing extends MappableMixin(
       : [this.pointEntities, this.otherEntities];
   }
 
-  @computed get svgPoint() {
+  get svgPoint() {
     /**
      * SVG element for point drawn when user clicks.
      * http://stackoverflow.com/questions/24869733/how-to-draw-custom-dynamic-billboards-in-cesium-js

--- a/lib/Models/UserDrawing.ts
+++ b/lib/Models/UserDrawing.ts
@@ -2,9 +2,9 @@ import i18next from "i18next";
 import {
   computed,
   IReactionDisposer,
+  observable,
   reaction,
-  runInAction,
-  observable
+  runInAction
 } from "mobx";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
@@ -37,7 +37,7 @@ interface OnDrawingCompleteParams {
 
 interface Options {
   terria: Terria;
-  messageHeader?: string;
+  messageHeader?: string | (() => string);
   allowPolygon?: boolean;
   drawRectangle?: boolean;
   onMakeDialogMessage?: () => string;
@@ -52,7 +52,7 @@ interface Options {
 export default class UserDrawing extends MappableMixin(
   CreateModel(MappableTraits)
 ) {
-  private readonly messageHeader: string;
+  private readonly messageHeader: string | (() => string);
   private readonly allowPolygon: boolean;
   private readonly onMakeDialogMessage?: () => string;
   private readonly buttonText?: string;
@@ -555,7 +555,12 @@ export default class UserDrawing extends MappableMixin(
    *     Click to add another point
    */
   getDialogMessage() {
-    let message = "<strong>" + this.messageHeader + "</strong></br>";
+    let message =
+      "<strong>" +
+      (typeof this.messageHeader === "function"
+        ? this.messageHeader()
+        : this.messageHeader) +
+      "</strong></br>";
     let innerMessage = isDefined(this.onMakeDialogMessage)
       ? this.onMakeDialogMessage()
       : "";

--- a/lib/ReactViews/Map/Navigation/Items/MeasureTool.ts
+++ b/lib/ReactViews/Map/Navigation/Items/MeasureTool.ts
@@ -1,6 +1,5 @@
 "use strict";
 import i18next from "i18next";
-import { action } from "mobx";
 import React from "react";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
@@ -41,10 +40,10 @@ export default class MeasureTool extends MapNavigationItemController {
       terria: props.terria,
       messageHeader: () => i18next.t("measure.measureTool"),
       allowPolygon: false,
-      onPointClicked: this.onPointClicked,
-      onPointMoved: this.onPointMoved,
-      onCleanUp: this.onCleanUp,
-      onMakeDialogMessage: this.onMakeDialogMessage
+      onPointClicked: this.onPointClicked.bind(this),
+      onPointMoved: this.onPointMoved.bind(this),
+      onCleanUp: this.onCleanUp.bind(this),
+      onMakeDialogMessage: this.onMakeDialogMessage.bind(this)
     });
     this.onClose = props.onClose;
   }
@@ -84,7 +83,6 @@ export default class MeasureTool extends MapNavigationItemController {
     return numberStr;
   }
 
-  @action
   updateDistance(pointEntities: CustomDataSource) {
     this.totalDistanceMetres = 0;
     if (pointEntities.entities.values.length < 1) {
@@ -118,7 +116,6 @@ export default class MeasureTool extends MapNavigationItemController {
     }
   }
 
-  @action
   updateArea(pointEntities: CustomDataSource) {
     this.totalAreaMetresSquared = 0;
     if (!this.userDrawing.closeLoop) {
@@ -209,20 +206,17 @@ export default class MeasureTool extends MapNavigationItemController {
     return geodesic.surfaceDistance;
   }
 
-  @action.bound
   onCleanUp() {
     this.totalDistanceMetres = 0;
     this.totalAreaMetresSquared = 0;
     super.deactivate();
   }
 
-  @action.bound
   onPointClicked(pointEntities: CustomDataSource) {
     this.updateDistance(pointEntities);
     this.updateArea(pointEntities);
   }
 
-  @action.bound
   onPointMoved(pointEntities: CustomDataSource) {
     // This is no different to clicking a point.
     this.onPointClicked(pointEntities);

--- a/lib/ReactViews/Map/Navigation/Items/MeasureTool.ts
+++ b/lib/ReactViews/Map/Navigation/Items/MeasureTool.ts
@@ -1,11 +1,13 @@
 "use strict";
 import i18next from "i18next";
-import { action, observable } from "mobx";
+import { action } from "mobx";
 import React from "react";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
 import EllipsoidGeodesic from "terriajs-cesium/Source/Core/EllipsoidGeodesic";
+import EllipsoidTangentPlane from "terriajs-cesium/Source/Core/EllipsoidTangentPlane";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
+import PolygonGeometryLibrary from "terriajs-cesium/Source/Core/PolygonGeometryLibrary";
 import PolygonHierarchy from "terriajs-cesium/Source/Core/PolygonHierarchy";
 import VertexFormat from "terriajs-cesium/Source/Core/VertexFormat";
 import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSource";
@@ -15,35 +17,29 @@ import ViewerMode from "../../../../Models/ViewerMode";
 import { GLYPHS } from "../../../../Styled/Icon";
 import MapNavigationItemController from "../../../../ViewModels/MapNavigation/MapNavigationItemController";
 
-const EllipsoidTangentPlane = require("terriajs-cesium/Source/Core/EllipsoidTangentPlane");
-const PolygonGeometryLibrary = require("terriajs-cesium/Source/Core/PolygonGeometryLibrary");
-
-interface PropTypes {
+interface MeasureToolOptions {
   terria: Terria;
-
   onClose(): void;
 }
 
 export default class MeasureTool extends MapNavigationItemController {
   static id = "measure-tool";
   static displayName = "MeasureTool";
-  readonly terria: Terria;
-  @observable
-  totalDistanceMetres: number = 0;
-  @observable
-  totalAreaMetresSquared: number = 0;
-  @observable
-  userDrawing: UserDrawing;
+
+  private readonly terria: Terria;
+  private totalDistanceMetres: number = 0;
+  private totalAreaMetresSquared: number = 0;
+  private userDrawing: UserDrawing;
+
   onClose: () => void;
   itemRef: React.RefObject<HTMLDivElement> = React.createRef();
 
-  constructor(props: PropTypes) {
+  constructor(props: MeasureToolOptions) {
     super();
-    const t = i18next.t.bind(i18next);
     this.terria = props.terria;
     this.userDrawing = new UserDrawing({
       terria: props.terria,
-      messageHeader: i18next.t("measure.measureTool"),
+      messageHeader: () => i18next.t("measure.measureTool"),
       allowPolygon: false,
       onPointClicked: this.onPointClicked,
       onPointMoved: this.onPointMoved,

--- a/lib/ThirdParty/terriajs-cesium-extra/index.d.ts
+++ b/lib/ThirdParty/terriajs-cesium-extra/index.d.ts
@@ -40,6 +40,8 @@ declare module "terriajs-cesium/Source/Widgets/getElement" {
   ): HTMLElement | undefined;
 }
 
+declare module "terriajs-cesium/Source/Core/PolygonGeometryLibrary";
+
 declare interface Axis {
   X: number;
   Y: number;


### PR DESCRIPTION
### Await Internationalisation initialisation in `Terria.start`

Fixes #6336 #6352

![image](https://user-images.githubusercontent.com/6187649/176596827-7828384b-62e6-4a6f-9565-7d77c6042e6f.png)

Also - `UserDrawing.messageHeader` can now also be `() => string`.  
I've done this instead of use `applyTranslationIfExists` as it follows how `onMakeDialogMessage` works
  
### Test me
  
- http://ci.terria.io/main/
- http://ci.terria.io/international-await/
- Measure Tool

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
