### PR TITLE
Fix `itemProperties` split bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 #### next release (8.2.8)
 
+* Improve Split/compare error handling
+* Fix `itemProperties` split bug
 * [The next improvement]
 
 #### 8.2.7 - 2022-06-30

--- a/lib/ModelMixins/GroupMixin.ts
+++ b/lib/ModelMixins/GroupMixin.ts
@@ -381,7 +381,8 @@ function setItemPropertyTraits(
 export function applyItemProperties(
   model: HasTrait<ItemPropertiesTraits, "itemProperties"> &
     HasTrait<ItemPropertiesTraits, "itemPropertiesByType"> &
-    HasTrait<ItemPropertiesTraits, "itemPropertiesByIds">,
+    HasTrait<ItemPropertiesTraits, "itemPropertiesByIds"> &
+    BaseModel,
   target: BaseModel
 ) {
   runInAction(() => {
@@ -412,21 +413,21 @@ export function applyItemProperties(
       target.setTrait(
         CommonStrata.underride,
         "itemProperties",
-        model.itemProperties
+        model.traits.itemProperties.toJson(model.itemProperties)
       );
 
     if (hasTraits(target, ItemPropertiesTraits, "itemPropertiesByType"))
       target.setTrait(
         CommonStrata.underride,
         "itemPropertiesByType",
-        model.itemPropertiesByType
+        model.traits.itemPropertiesByType.toJson(model.itemPropertiesByType)
       );
 
     if (hasTraits(target, ItemPropertiesTraits, "itemPropertiesByIds"))
       target.setTrait(
         CommonStrata.underride,
         "itemPropertiesByIds",
-        model.itemPropertiesByIds
+        model.traits.itemPropertiesByIds.toJson(model.itemPropertiesByIds)
       );
   });
 }

--- a/lib/Models/Catalog/CatalogReferences/SplitItemReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/SplitItemReference.ts
@@ -1,4 +1,3 @@
-import i18next from "i18next";
 import getDereferencedIfExists from "../../../Core/getDereferencedIfExists";
 import TerriaError from "../../../Core/TerriaError";
 import { getName } from "../../../ModelMixins/CatalogMemberMixin";

--- a/lib/Models/Catalog/CatalogReferences/SplitItemReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/SplitItemReference.ts
@@ -29,7 +29,7 @@ export default class SplitItemReference extends ReferenceMixin(
   ): Promise<BaseModel | undefined> {
     if (this.splitSourceItemId === undefined || this.uniqueId === undefined) {
       throw new TerriaError({
-        title: i18next.t("splitterTool.errorTitle"),
+        title: { key: "splitterTool.errorTitle" },
         message: "`splitSourceItemId` and `uniqueId` must be defined"
       });
     }
@@ -40,10 +40,13 @@ export default class SplitItemReference extends ReferenceMixin(
     );
     if (sourceItem === undefined) {
       throw new TerriaError({
-        title: i18next.t("splitterTool.errorTitle"),
-        message: i18next.t("splitterTool.modelNotFoundErrorMessage", {
-          id: this.splitSourceItemId
-        }),
+        title: { key: "splitterTool.errorTitle" },
+        message: {
+          key: "splitterTool.modelNotFoundErrorMessage",
+          parameters: {
+            id: this.splitSourceItemId
+          }
+        },
         importance: 1
       });
     }
@@ -54,12 +57,13 @@ export default class SplitItemReference extends ReferenceMixin(
       return sourceItem.duplicateModel(this.uniqueId, this);
     } catch (e) {
       throw TerriaError.from(e, {
-        title: i18next.t("splitterTool.errorTitle", {
-          name: getName(sourceItem)
-        }),
-        message: i18next.t("splitterTool.duplicateModelErrorMessage", {
-          name: getName(sourceItem)
-        }),
+        title: { key: "splitterTool.errorTitle" },
+        message: {
+          key: "splitterTool.duplicateModelErrorMessage",
+          parameters: {
+            name: getName(sourceItem)
+          }
+        },
         importance: 1
       });
     }

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -66,6 +66,9 @@
     "centreMap": "Centre map at your current location"
   },
   "splitterTool": {
+    "errorTitle": "Failed to compare catalog item.",
+    "duplicateModelErrorMessage": "An error occurred while splitting the catalog item `\"{{name}}\"`. This catalog item may not support \"compare\" functionality",
+    "modelNotFoundErrorMessage": "Model ID `\"{{id}}\"` could not be found",
     "toggleSplitterToolTitle": "Compare",
     "toggleSplitterTool": "Enable side-by-side comparison between two different sets of data",
     "toggleSplitterToolDisabled": "Please disable other side-by-side comparison features in order to enable standard compare",


### PR DESCRIPTION
### Fix `itemProperties` split bug

Fixes #6376 

Previously, `itemProperties` was incorrectly setting traits in `underride` stratum with `BaseModel` values.  
This was upsetting `duplicateModel` in `CreateModel.ts` - as it was calling the mobx `toJS()` function on `BaseModel` which is not entirely observable.

Now we convert `itemProperties` to JSON before setting `traits`.

I also improved error handling when splitting/comparing items.
  
### Test me
  
- [before link](http://ci.terria.io/main/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22__User-Added_Data__%22%3A%7B%22isOpen%22%3Atrue%2C%22members%22%3A%5B%222a41d726-a3c4-470a-b7e0-239d1527a131%22%2C%22d2f96ff5-39f7-4530-85cf-d64d223d68c8%22%2C%22a1f38f74-5db6-434d-96b2-849dce5bf0f8%22%5D%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22cZ1FnXgI%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22KfTLZijL%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22nQy48tMJ%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22LtQxrhEf%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22ANfTXBNT%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22KrauUHsH%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22AZJZTz%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22df11d3d1-0e32-4fb5-982f-bdb725406e44%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Afalse%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%226ATFM7CB%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22ZntTIvdp%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22vBwsllcv%22%3A%7B%22isOpen%22%3Afalse%2C%22knownContainerUniqueIds%22%3A%5B%22KrauUHsH%22%5D%2C%22type%22%3A%22wms-group%22%7D%2C%22gHzKBd%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22AZJZTz%22%5D%2C%22type%22%3A%22group%22%7D%2C%22acc95f32-b8cb-448d-94f7-21f94d18087e%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22df11d3d1-0e32-4fb5-982f-bdb725406e44%22%5D%2C%22type%22%3A%22esri-mapServer-group%22%7D%2C%22DPYjz1cT%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22ZntTIvdp%22%5D%2C%22type%22%3A%22sdmx-group%22%7D%2C%22RqYSQCYx%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22ZntTIvdp%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%3A%7B%22splitDirection%22%3A1%2C%22defaultStyle%22%3A%7B%22color%22%3A%7B%22zScoreFilterEnabled%22%3Atrue%7D%7D%2C%22dimensions%22%3A%5B%7B%22id%22%3A%22SEXP%22%2C%22selectedId%22%3A%222%22%7D%5D%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-LGA_GCP_C21%22%5D%2C%22type%22%3A%22sdmx-json%22%7D%2C%22DPYjz1cT%2Fcategory-LGA_GCP_C21%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-GCP_C21%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2Fcategory-ASGS_GCP_C21%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-GCP_C21%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2Fcategory-GCP_C21%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2FcategoryScheme-CENSUS_2021%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2FcategoryScheme-CENSUS_2021%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%22%5D%2C%22type%22%3A%22group%22%7D%2C%222a41d726-a3c4-470a-b7e0-239d1527a131%22%3A%7B%22splitSourceItemId%22%3A%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%2C%22dereferenced%22%3A%7B%22splitDirection%22%3A1%7D%2C%22knownContainerUniqueIds%22%3A%5B%22__User-Added_Data__%22%5D%2C%22type%22%3A%22split-reference%22%7D%2C%22d2f96ff5-39f7-4530-85cf-d64d223d68c8%22%3A%7B%22splitSourceItemId%22%3A%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%2C%22dereferenced%22%3A%7B%22splitDirection%22%3A1%7D%2C%22knownContainerUniqueIds%22%3A%5B%22__User-Added_Data__%22%5D%2C%22type%22%3A%22split-reference%22%7D%2C%22a1f38f74-5db6-434d-96b2-849dce5bf0f8%22%3A%7B%22splitSourceItemId%22%3A%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%2C%22dereferenced%22%3A%7B%22name%22%3A%22Census+2021%2C+G04+Age+by+sex%2C+Local+Government+Area+2021+%28LGA+2021+boundaries%29+%28copy%29%22%2C%22isOpen%22%3Atrue%2C%22splitDirection%22%3A-1%2C%22defaultStyle%22%3A%7B%22color%22%3A%7B%22zScoreFilterEnabled%22%3Atrue%7D%7D%2C%22dimensions%22%3A%5B%7B%22id%22%3A%22SEXP%22%2C%22selectedId%22%3A%221%22%7D%5D%7D%2C%22knownContainerUniqueIds%22%3A%5B%22__User-Added_Data__%22%5D%2C%22type%22%3A%22split-reference%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%2C%22Root+Group%2FNational+Data+Sets%22%3A%7B%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%22a1f38f74-5db6-434d-96b2-849dce5bf0f8%22%2C%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%5D%2C%22timeline%22%3A%5B%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%5D%2C%22initialCamera%22%3A%7B%22west%22%3A144.51961433980216%2C%22south%22%3A-38.324197066004885%2C%22east%22%3A145.63858743481035%2C%22north%22%3A-37.057762224035415%2C%22position%22%3A%7B%22x%22%3A-4222402.550242312%2C%22y%22%3A2947879.089305629%2C%22z%22%3A-3953025.5975554003%7D%2C%22direction%22%3A%7B%22x%22%3A0.6482319699130125%2C%22y%22%3A-0.45256449293691875%2C%22z%22%3A0.6123566713243558%7D%2C%22up%22%3A%7B%22x%22%3A-0.5020976435293788%2C%22y%22%3A0.35054051018062277%2C%22z%22%3A0.7905816258202271%7D%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%223dSmooth%22%2C%22showSplitter%22%3Atrue%2C%22splitPosition%22%3A0.36784193548387095%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Afalse%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-positron%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)

- [after link](http://ci.terria.io/item-props-split-bug/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22__User-Added_Data__%22%3A%7B%22isOpen%22%3Atrue%2C%22members%22%3A%5B%222a41d726-a3c4-470a-b7e0-239d1527a131%22%2C%22d2f96ff5-39f7-4530-85cf-d64d223d68c8%22%2C%22a1f38f74-5db6-434d-96b2-849dce5bf0f8%22%5D%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22cZ1FnXgI%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22KfTLZijL%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22nQy48tMJ%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22LtQxrhEf%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22ANfTXBNT%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22KrauUHsH%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22AZJZTz%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22df11d3d1-0e32-4fb5-982f-bdb725406e44%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Afalse%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%226ATFM7CB%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22ZntTIvdp%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22vBwsllcv%22%3A%7B%22isOpen%22%3Afalse%2C%22knownContainerUniqueIds%22%3A%5B%22KrauUHsH%22%5D%2C%22type%22%3A%22wms-group%22%7D%2C%22gHzKBd%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22AZJZTz%22%5D%2C%22type%22%3A%22group%22%7D%2C%22acc95f32-b8cb-448d-94f7-21f94d18087e%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22df11d3d1-0e32-4fb5-982f-bdb725406e44%22%5D%2C%22type%22%3A%22esri-mapServer-group%22%7D%2C%22DPYjz1cT%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22ZntTIvdp%22%5D%2C%22type%22%3A%22sdmx-group%22%7D%2C%22RqYSQCYx%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22ZntTIvdp%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%3A%7B%22splitDirection%22%3A1%2C%22defaultStyle%22%3A%7B%22color%22%3A%7B%22zScoreFilterEnabled%22%3Atrue%7D%7D%2C%22dimensions%22%3A%5B%7B%22id%22%3A%22SEXP%22%2C%22selectedId%22%3A%222%22%7D%5D%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-LGA_GCP_C21%22%5D%2C%22type%22%3A%22sdmx-json%22%7D%2C%22DPYjz1cT%2Fcategory-LGA_GCP_C21%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-GCP_C21%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2Fcategory-ASGS_GCP_C21%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-GCP_C21%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2Fcategory-GCP_C21%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2FcategoryScheme-CENSUS_2021%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2FcategoryScheme-CENSUS_2021%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%22%5D%2C%22type%22%3A%22group%22%7D%2C%222a41d726-a3c4-470a-b7e0-239d1527a131%22%3A%7B%22splitSourceItemId%22%3A%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%2C%22dereferenced%22%3A%7B%22splitDirection%22%3A1%7D%2C%22knownContainerUniqueIds%22%3A%5B%22__User-Added_Data__%22%5D%2C%22type%22%3A%22split-reference%22%7D%2C%22d2f96ff5-39f7-4530-85cf-d64d223d68c8%22%3A%7B%22splitSourceItemId%22%3A%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%2C%22dereferenced%22%3A%7B%22splitDirection%22%3A1%7D%2C%22knownContainerUniqueIds%22%3A%5B%22__User-Added_Data__%22%5D%2C%22type%22%3A%22split-reference%22%7D%2C%22a1f38f74-5db6-434d-96b2-849dce5bf0f8%22%3A%7B%22splitSourceItemId%22%3A%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%2C%22dereferenced%22%3A%7B%22name%22%3A%22Census+2021%2C+G04+Age+by+sex%2C+Local+Government+Area+2021+%28LGA+2021+boundaries%29+%28copy%29%22%2C%22isOpen%22%3Atrue%2C%22splitDirection%22%3A-1%2C%22defaultStyle%22%3A%7B%22color%22%3A%7B%22zScoreFilterEnabled%22%3Atrue%7D%7D%2C%22dimensions%22%3A%5B%7B%22id%22%3A%22SEXP%22%2C%22selectedId%22%3A%221%22%7D%5D%7D%2C%22knownContainerUniqueIds%22%3A%5B%22__User-Added_Data__%22%5D%2C%22type%22%3A%22split-reference%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%2C%22Root+Group%2FNational+Data+Sets%22%3A%7B%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%22a1f38f74-5db6-434d-96b2-849dce5bf0f8%22%2C%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%5D%2C%22timeline%22%3A%5B%22DPYjz1cT%2Fdataflow-C21_G04_LGA%22%5D%2C%22initialCamera%22%3A%7B%22west%22%3A144.51961433980216%2C%22south%22%3A-38.324197066004885%2C%22east%22%3A145.63858743481035%2C%22north%22%3A-37.057762224035415%2C%22position%22%3A%7B%22x%22%3A-4222402.550242312%2C%22y%22%3A2947879.089305629%2C%22z%22%3A-3953025.5975554003%7D%2C%22direction%22%3A%7B%22x%22%3A0.6482319699130125%2C%22y%22%3A-0.45256449293691875%2C%22z%22%3A0.6123566713243558%7D%2C%22up%22%3A%7B%22x%22%3A-0.5020976435293788%2C%22y%22%3A0.35054051018062277%2C%22z%22%3A0.7905816258202271%7D%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%223dSmooth%22%2C%22showSplitter%22%3Atrue%2C%22splitPosition%22%3A0.36784193548387095%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Afalse%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-positron%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
