### PR TITLE
Fix html2parser dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,3 +28,9 @@ jobs:
           SHARE_S3_SECRET_ACCESS_KEY: ${{ secrets.SHARE_S3_SECRET_ACCESS_KEY }}
           FEEDBACK_GITHUB_TOKEN: ${{ secrets.FEEDBACK_GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Upload new yarn.lock file (as it may change after `sync-dependencies`)
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: yarn.lock
+          path: yarn.lock

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ Change Log
 * Fix feature highliting for `Line`, `MultiLine` and `MultiPoint`
 * Await Internationalisation initialisation in `Terria.start`
 * `UserDrawing.messageHeader` can now also be `() => string`
+* Pin `html-to-react` to `1.4.5` due to ESM module in dependency (`parse5`) breaking webpack
+* Add step to `"Deploy TerriaMap"` action to save `yarn.lock` after `sync-dependencies` (for debug purposes)
 * [The next improvement]
 
 #### 8.2.7 - 2022-06-30

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 #### next release (8.2.9)
 
+* Pin `html-to-react` to `1.4.5` due to ESM module in dependency (`parse5`) breaking webpack
+* Add step to `"Deploy TerriaMap"` action to save `yarn.lock` after `sync-dependencies` (for debug purposes)
 * [The next improvement]
 
 #### 8.2.8 - 2022-07-04
@@ -14,9 +16,6 @@ Change Log
 * Fix feature highliting for `Line`, `MultiLine` and `MultiPoint`
 * Await Internationalisation initialisation in `Terria.start`
 * `UserDrawing.messageHeader` can now also be `() => string`
-* Pin `html-to-react` to `1.4.5` due to ESM module in dependency (`parse5`) breaking webpack
-* Add step to `"Deploy TerriaMap"` action to save `yarn.lock` after `sync-dependencies` (for debug purposes)
-* [The next improvement]
 
 #### 8.2.7 - 2022-06-30
 

--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -6,7 +6,7 @@ GITHUB_BRANCH=${GITHUB_REF##*/}
 
 # Don't run for greenkeeper branches; there are too many!
 if [[ $GITHUB_BRANCH =~ ^greenkeeper/ ]]; then
-    exit 0
+  exit 0
 fi
 
 # A version of the branch name that can be used as a DNS name once we prepend and append some stuff.
@@ -34,6 +34,8 @@ rm yarn.lock # because TerriaMap's yarn.lock won't reflect terriajs dependencies
 yarn install
 yarn add -W moment@2.24.0
 yarn gulp build --baseHref="/${SAFE_BRANCH_NAME}/"
+
+pwd
 
 yarn "--terriajs-map:docker_name=terriajs-ci" docker-build-ci -- --tag "asia.gcr.io/terriajs-automated-deployment/terria-ci:$SAFE_BRANCH_NAME"
 gcloud auth configure-docker asia.gcr.io --quiet

--- a/doc/connecting-to-data/customizing-data-appearance/feature-info-template.md
+++ b/doc/connecting-to-data/customizing-data-appearance/feature-info-template.md
@@ -30,11 +30,11 @@ The template will replace all occurrences of `{{property}}` with the value of th
 
 The result is:
 
-<img src="../img/template.png">
+<img src="./img/template.png">
 
 instead of:
 
-<img src="../img/no_template.png">
+<img src="./img/no_template.png">
 
 You can provide a template to use for the name of the collapsible section (eg. to replace `RGB` in the example above), like so:
 

--- a/doc/connecting-to-data/customizing-data-appearance/feature-info-template.md
+++ b/doc/connecting-to-data/customizing-data-appearance/feature-info-template.md
@@ -146,7 +146,7 @@ If `{{Pixel Value}}` equals to `150` and `{{feature.data.layerId}}` to `2`, the 
 
 For features with time-varying table-based data structures (eg. CSV, SOS2, SDMX-JSON, if there is a time column), the feature info panel also includes a chart of the data over time, eg.
 
-<img src="../img/feature_info_with_time_series.png">
+<img src="./img/feature_info_with_time_series.png">
 
 You can place this chart in your template using `{{terria.timeSeries.chart}}`.  Alternatively, you can access the following component information:
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "gulp": "^4.0.0",
     "hammerjs": "^2.0.6",
     "hoist-non-react-statics": "^3.3.2",
-    "html-to-react": "^1.4.5",
+    "html-to-react": "1.4.5",
     "i18next": "^19.9.0",
     "i18next-browser-languagedetector": "^4.0.1",
     "i18next-http-backend": "^1.1.1",


### PR DESCRIPTION
## Fix html2parser dependency

<img width="852" alt="image" src="https://user-images.githubusercontent.com/6187649/177316378-741109e7-b13e-4eee-83b8-7072192a54df.png">

### Changes

* Pin `html-to-react` to `1.4.5` due to ESM module in dependency (`parse5`) breaking webpack
* Add step to `"Deploy TerriaMap"` action to save `yarn.lock` after `sync-dependencies` (for debug purposes)

I also fixed some image paths in docs

#### Before

https://github.com/TerriaJS/terriajs/blob/main/doc/connecting-to-data/customizing-data-appearance/feature-info-template.md

#### After

https://github.com/TerriaJS/terriajs/blob/doc-img-fix/doc/connecting-to-data/customizing-data-appearance/feature-info-template.md