### PR TITLE
Add arrow key navigation to StoryPanel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 * Pin `html-to-react` to `1.4.5` due to ESM module in dependency (`parse5`) breaking webpack
 * Add step to `"Deploy TerriaMap"` action to save `yarn.lock` after `sync-dependencies` (for debug purposes)
+* Implement ability to navigate between scenes in StoryPanel using keyboard arrows
 * [The next improvement]
 
 #### 8.2.8 - 2022-07-04

--- a/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
@@ -87,7 +87,7 @@ interface State {
 
 @observer
 class StoryPanel extends React.Component<Props, State> {
-  escKeyListener: EventListener | undefined;
+  keydownListener: EventListener | undefined;
   slideRef: React.RefObject<HTMLElement>;
 
   constructor(props: Props) {
@@ -111,12 +111,24 @@ class StoryPanel extends React.Component<Props, State> {
 
     this.slideIn();
 
-    this.escKeyListener = (e: Event) => {
+    this.keydownListener = (e: Event) => {
+      // Use else if for keydown events so only first one is recognised in case of multiple key presses
       if ((e as KeyboardEvent).key === "Escape") {
         this.exitStory();
+      } else if (
+        (e as KeyboardEvent).key === "ArrowRight" ||
+        (e as KeyboardEvent).key === "ArrowDown"
+      ) {
+        this.goToNextStory();
+      } else if (
+        (e as KeyboardEvent).key === "ArrowLeft" ||
+        (e as KeyboardEvent).key === "ArrowUp"
+      ) {
+        this.goToPrevStory();
       }
     };
-    window.addEventListener("keydown", this.escKeyListener, true);
+
+    window.addEventListener("keydown", this.keydownListener, true);
   }
 
   slideIn() {
@@ -144,8 +156,8 @@ class StoryPanel extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    if (this.escKeyListener) {
-      window.removeEventListener("keydown", this.escKeyListener, false);
+    if (this.keydownListener) {
+      window.removeEventListener("keydown", this.keydownListener, false);
     }
   }
 


### PR DESCRIPTION
### What this PR does

Fixes #6387

A simple PR to add more logic to the "keydown" event listener in Story Panel.

Variable is renamed from `escKeyListener` to `keydownListener`.
Now handles arrow keys for navigation too.
  
### Test me
  
Create a story with multiple scenes. 
Play Story.
Jump forwards or backwards with arrow keys:
Behaviour should be:
- key up or left goes to previous
- key down or right goes to next

### Checklist

~-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
~-   [ ] I've updated relevant documentation in `doc/`.~
-   [y] I've updated CHANGES.md with what I changed.
-   [y] I've provided instructions in the PR description on how to test this PR.
