### PR TITLE
Fix table regions short report and showInChartPanel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Change Log
 * Pin `html-to-react` to `1.4.5` due to ESM module in dependency (`parse5`) breaking webpack
 * Add step to `"Deploy TerriaMap"` action to save `yarn.lock` after `sync-dependencies` (for debug purposes)
 * Implement ability to navigate between scenes in StoryPanel using keyboard arrows
+* Fix "Regions: xxx" short report showing for non region mapped items
+* Fix `showInChartPanel` default for mappable items
 * [The next improvement]
 
 #### 8.2.8 - 2022-07-04

--- a/lib/ModelMixins/TableMixin.ts
+++ b/lib/ModelMixins/TableMixin.ts
@@ -37,11 +37,7 @@ import { TableAutomaticLegendStratum } from "../Table/TableLegendStratum";
 import TableStyle from "../Table/TableStyle";
 import TableTraits from "../Traits/TraitsClasses/TableTraits";
 import CatalogMemberMixin from "./CatalogMemberMixin";
-import ChartableMixin, {
-  calculateDomain,
-  ChartAxis,
-  ChartItem
-} from "./ChartableMixin";
+import { calculateDomain, ChartAxis, ChartItem } from "./ChartableMixin";
 import DiscretelyTimeVaryingMixin, {
   DiscreteTimeAsJS
 } from "./DiscretelyTimeVaryingMixin";
@@ -266,6 +262,14 @@ function TableMixin<T extends Constructor<Model<TableTraits>>>(Base: T) {
         return true;
       }
       return super.disableZoomTo;
+    }
+
+    /** Is showing regions (instead of points) */
+    @computed get showingRegions() {
+      return (
+        this.regionMappedImageryParts &&
+        this.mapItems[0] === this.regionMappedImageryParts
+      );
     }
 
     /**

--- a/lib/Table/TableAutomaticStylesStratum.ts
+++ b/lib/Table/TableAutomaticStylesStratum.ts
@@ -245,7 +245,7 @@ export default class TableAutomaticStylesStratum extends LoadableStratum(
 
     const regionType = regionCol?.regionType;
 
-    if (regionType) {
+    if (regionType && this.catalogItem.showingRegions) {
       return [
         createStratumInstance(ShortReportTraits, {
           name: `**Regions:** ${regionType.description}`
@@ -255,7 +255,12 @@ export default class TableAutomaticStylesStratum extends LoadableStratum(
     return [];
   }
 
+  /** Show chart by default - if not loading and no mappable items */
   @computed get showInChartPanel() {
-    return this.catalogItem.show;
+    return (
+      this.catalogItem.show &&
+      !this.catalogItem.isLoading &&
+      this.catalogItem.mapItems.length === 0
+    );
   }
 }

--- a/wwwroot/test/csv/lat_lon_enum_date_id_with_regions.csv
+++ b/wwwroot/test/csv/lat_lon_enum_date_id_with_regions.csv
@@ -1,0 +1,15 @@
+lat,lon,enum,date,id,value,level,state
+-36,145,foo,2015-08-01,feature A,13,50,NSW
+-36,145,bar,2015-08-02,feature A,5,60,NSW
+-36,145,foo,2015-08-04,feature A,15,70,NSW
+-36,145,bar,2015-08-05,feature A,7,55,NSW
+-36,145,foo,2015-08-06,feature A,10,66,NSW
+-21,115,moving,2015-08-01,feature B,4,33,NSW
+-37,136,foo,2015-08-02,feature B,15,55,NSW
+-23,155,going!,2015-08-03,feature B,5,41,NSW
+-33,130,bar,2015-08-04,feature B,14,22,TAS
+-20,150,moving,2015-08-05,feature B,6,77,TAS
+-37,140,going!,2015-08-06,feature B,13,47,TAS
+-30,145.5,blip,2015-08-02,feature C,16,10,VIC
+-33,140,blip,2015-08-03,feature D,16,50,VIC
+,144.5,gone,2015-08-05,feature D,14,80,VIC


### PR DESCRIPTION
### Fix table regions short report and showInChartPanel

* Fix "Regions: xxx" short report showing for non region mapped items
* Fix `showInChartPanel` default for mappable items (which is showing "moments" chart by default)

Before vs After

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/6187649/178466356-d376f59c-bb6b-4d51-ae5a-40cec8344d34.png">

### Test

- **Before** http://ci.terria.io/main/#share=s-2yHZCIquhOOEFUHTNIQLTRYnlJz
- **After** http://ci.terria.io/table-regions-chart-fix/#share=s-2yHZCIquhOOEFUHTNIQLTRYnlJz

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
