### PR TITLE
Check if at start or end of stories before key nav

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ Change Log
   * Supports over 40 formats - including Collada, obj, Blender, DXF - [full list](https://github.com/assimp/assimp/blob/master/doc/Fileformats.md)
 * Add `description` to `getDataType` - this will be displayed between Step 1 and Step 2
 * Add warning message to `GltfMixin` when showing in 2D mode (Leaflet)
+* Prevent looping when navigating between scenes in StoryPanel using keyboard arrows
+* Fix bug where StoryPanel keyboard navigation persists after closing StoryPanel
 * [The next improvement]
 
 #### 8.2.9 - 2022-07-13

--- a/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
@@ -119,12 +119,13 @@ class StoryPanel extends React.Component<Props, State> {
         (e as KeyboardEvent).key === "ArrowRight" ||
         (e as KeyboardEvent).key === "ArrowDown"
       ) {
-        this.goToNextStory();
+        this.props.viewState.currentStoryId + 1 != stories.length &&
+          this.goToNextStory();
       } else if (
         (e as KeyboardEvent).key === "ArrowLeft" ||
         (e as KeyboardEvent).key === "ArrowUp"
       ) {
-        this.goToPrevStory();
+        this.props.viewState.currentStoryId != 0 && this.goToPrevStory();
       }
     };
 
@@ -157,7 +158,7 @@ class StoryPanel extends React.Component<Props, State> {
 
   componentWillUnmount() {
     if (this.keydownListener) {
-      window.removeEventListener("keydown", this.keydownListener, false);
+      window.removeEventListener("keydown", this.keydownListener, true);
     }
   }
 


### PR DESCRIPTION
Change useCapture param on removeEventListener to make sure properly removed### What this PR does

Fixes #6423

Modify the behaviour of arrow key navigation for StoryPanel, so that cannot loop back to start, or go from start to end.
Also, needed to change `window.removeEventListener("keydown", this.keydownListener, false); to `window.removeEventListener("keydown", this.keydownListener, true)` so that event listeners properly removed when component unmounted.
  
### Test me
  
Test with this [link](http://ci.terria.io/modify-story-key-nav/#share=s-qbwqXlS25XBimInqef7cheXsITK)

Play story, navigate though scenes. Observe no looping.
Close StoryPanel, make sure arrow keys do not continue to navigate between scene locations.

### Checklist

~~-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~~
~~-   [ ] I've updated relevant documentation in `doc/`.~~
-   [y] I've updated CHANGES.md with what I changed.
-   [y] I've provided instructions in the PR description on how to test this PR.
