### PR TITLE
Move rendering of ShareUrl  to functional component

### DIFF
--- a/lib/ReactViews/Map/Panels/SharePanel/ShareUrlClipboard.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/ShareUrlClipboard.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import DropdownStyles from "../panel.scss";
+import Styles from "./share-panel.scss";
+import Input from "../../../../Styled/Input";
+import Clipboard from "../../../Clipboard";
+import Text from "../../../../Styled/Text";
+import classNames from "classnames";
+import Loader from "../../../Loader";
+import {
+  Category,
+  ShareAction
+} from "../../../../Core/AnalyticEvents/analyticEvents";
+import Terria from "../../../../Models/Terria";
+import ViewState from "../../../../ReactViewModels/ViewState";
+
+interface Props {
+  t: any;
+  terria: Terria;
+  viewState: ViewState;
+  shareUrl: string;
+  shareMode: string;
+  placeholder: string | undefined;
+}
+
+const ShareUrlClipboard = (props: Props) => {
+  const { t, terria, viewState, shareUrl, shareMode, placeholder } = props;
+  const bookMarkHelpItemName = "bookmarkHelp";
+
+  // const [shareUrl, setShareUrl] = useState(""); // TODO: should we move shareUrl out of SharePanel to this component?
+
+  const getAnalyticsAction = () => {
+    if (shareMode === "printAndEmbedShare") {
+      return ShareAction.shareCopy;
+    } else if (shareMode === "catalogShare") {
+      return ShareAction.catalogCopy;
+    } else if (shareMode === "storyShare") {
+      return ShareAction.storyCopy;
+    } else {
+      return ShareAction.shareCopy;
+    }
+  };
+
+  const getShareUrlInput = () => {
+    return (
+      <Input
+        className={Styles.shareUrlfield}
+        light={shareMode === ("catalogShare" || "storyShare")}
+        dark={shareMode === "printAndEmbedMode"}
+        large
+        type="text"
+        value={shareUrl}
+        placeholder={placeholder}
+        readOnly
+        onClick={e => e.currentTarget.select()}
+        id="share-url"
+        css={
+          shareMode === "storyShare"
+            ? `border-radius: 32px 0 0 32px;`
+            : undefined
+        }
+      />
+    );
+  };
+
+  return shareUrl === "" ? (
+    <Loader message={t("share.generatingUrl")} />
+  ) : (
+    <div className={DropdownStyles.section}>
+      <Clipboard
+        source={getShareUrlInput()}
+        id="share-url"
+        theme={shareMode === "catalogShare" ? "dark" : "light"}
+        rounded={shareMode === "storyShare"}
+        onCopy={(text: any) => {
+          terria.analytics?.logEvent(
+            Category.share,
+            getAnalyticsAction(),
+            text
+          );
+        }}
+      />
+      {/* Following code block dependent on existence of "bookmarkHelp" Help Menu Item */}
+      {props.terria.configParameters.helpContent?.some(
+        (e: any) => e.itemName === bookMarkHelpItemName
+      ) && (
+        <Text
+          medium
+          textLight
+          isLink
+          onClick={evt =>
+            viewState.openHelpPanelItemFromSharePanel(evt, bookMarkHelpItemName)
+          }
+        >
+          <div
+            className={classNames(
+              Styles.explanation,
+              Styles.getShareSaveHelpText
+            )}
+          >
+            {t("share.getShareSaveHelpMessage")}
+          </div>
+        </Text>
+      )}
+    </div>
+  );
+};
+
+export default ShareUrlClipboard;


### PR DESCRIPTION
Should we also move shareUrl property out of SharePanel?

### What this PR does



Extract the conditionally formatted rendering of ShareUrl Clipboard to a separate functional component.

At the moment the functionality for shortening the url etc is still in SharePanel. Should we also move `SharePanel.shareUrl` to `ShareUrlClipboard.shareUrl`?
Thoughts @zoran995 ?

### Test me
  
How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
