### PR TITLE
Remove AssimpCatalogItem from getDataType (Add Data)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Add warning message to `GltfMixin` when showing in 2D mode (Leaflet)
 * Prevent looping when navigating between scenes in StoryPanel using keyboard arrows
 * Fix bug where StoryPanel keyboard navigation persists after closing StoryPanel
+* Remove `AssimpCatalogItem` from `getDataType` ("Add data" options) - as it is useless without the scene editor
 * [The next improvement]
 
 #### 8.2.9 - 2022-07-13

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,13 +8,12 @@ Change Log
 * Add `gltfModelUrl` to `GltfMixin` - this must be implemented by Models which use `GltfMixin`
 * Moved `GltfCatalogItem` to `lib/Models/Catalog/Gltf/GltfCatalogItem.ts`
 * Add experimental client-side 3D file conversion using [`assimpjs`](https://github.com/kovacsv/assimpjs) ([emscripten](https://emscripten.org) interface for the [assimp](https://github.com/assimp/assimp) library)
-  * This supports `zip` files through add local/remote data
+  * This supports `zip` files and `HasLocalData` - but is not in `getDataType` as the scene editor (closed source) is required to geo-reference
   * Supports over 40 formats - including Collada, obj, Blender, DXF - [full list](https://github.com/assimp/assimp/blob/master/doc/Fileformats.md)
 * Add `description` to `getDataType` - this will be displayed between Step 1 and Step 2
 * Add warning message to `GltfMixin` when showing in 2D mode (Leaflet)
 * Prevent looping when navigating between scenes in StoryPanel using keyboard arrows
 * Fix bug where StoryPanel keyboard navigation persists after closing StoryPanel
-* Remove `AssimpCatalogItem` from `getDataType` ("Add data" options) - as it is useless without the scene editor
 * [The next improvement]
 
 #### 8.2.9 - 2022-07-13

--- a/lib/Core/getDataType.ts
+++ b/lib/Core/getDataType.ts
@@ -118,11 +118,6 @@ export default function(): GetDataTypes {
       {
         value: "gltf",
         name: i18next.t("core.dataType.gltf")
-      },
-      {
-        value: "assimp",
-        name: i18next.t("core.dataType.assimp-remote"),
-        description: i18next.t("core.dataType.assimp-remote-description")
       }
     ],
     localDataType: [
@@ -174,14 +169,6 @@ export default function(): GetDataTypes {
         value: "shp",
         name: i18next.t("core.dataType.shp"),
         extensions: ["zip"]
-      },
-      {
-        value: "assimp",
-        name: i18next.t("core.dataType.assimp-local"),
-        description: i18next.t("core.dataType.assimp-local-description")
-
-        // Assimp full list of formats https://github.com/assimp/assimp/blob/master/doc/Fileformats.md
-        // extensions: ["zip", "dae", "zae", "obj", "dxf", "blend"]
       },
       {
         // NOTE: will only work if non open-source terriajs-ifc plugin is added to the map


### PR DESCRIPTION
### Remove AssimpCatalogItem from getDataType (Add Data)

As the scene editor (closed source) is required to geo-reference models
  
### Test me
  
- http://ci.terria.io/remove-assimp-getdatatypes/
- Click Add Data
- Observe there is now no "3d files converter" option

![image](https://user-images.githubusercontent.com/6187649/179668255-6a10a3e7-1f48-4604-b42e-0e723f231cb9.png)

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
