### PR TITLE
Change min nodeJS version to 14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 #### next release (8.2.10)
 
+* **Breaking changes:**
+  * **Minimum NodeJS version is now 14**
 * Consolidate `HasLocalData` interface
 * Add `GlTf` type definition (v2)
 * Add `gltfModelUrl` to `GltfMixin` - this must be implemented by Models which use `GltfMixin`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sites we're aware of that are using TerriaJS. These are not endorsements or test
 
 ### Technical
 
-* NodeJS v12, 14 or 16 are supported
+* NodeJS v14 or v16 are supported
 * Built in TypeScript & ES2020+ JavaScript, compiled with Babel to ES5.
 * Supports modern browsers (recent versions of Microsoft Edge, Mozilla Firefox & Google Chrome).
 * [TerriaJS Server component](https://github.com/TerriajS/TerriaJS-Server) runs in NodeJS and provides proxying for web services that don't support CORS or require authentication. Instead of using TerriaJS-Sever proxy service, an alternative proxying service URL can be specified. See [Specify an alternative proxy server URL](/doc/connecting-to-data/cross-origin-resource-sharing.md)

--- a/doc/customizing/client-side-config.md
+++ b/doc/customizing/client-side-config.md
@@ -187,8 +187,6 @@ If your TerriaMap has many (>50) dynamic groups (groups which need to be loaded 
 
 The https://github.com/nextapps-de/flexsearch library is used to index and search the catalog index file.
 
-**Note** NodeJS v10 is not supported, please use v12 or v14.
-
 To generate the catalog index:
 
 - `yarn build-tools`

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -29,7 +29,7 @@ If you run into trouble or want more explanation, read on.
 TerriaJS can be built and run on almost any macOS, Linux, or Windows system.  The following are required to build TerriaJS:
 
 * The Bash command shell. On macOS or Linux you almost certainly already have this. On Windows, you can easily get it by installing [Git for Windows](https://gitforwindows.org/). In the instructions below, we assume you're using a Bash command prompt.
-* [Node.js](https://nodejs.org) v12.0 or later.  You can check your node version by running `node --version` on the command-line.
+* [Node.js](https://nodejs.org) v14.0 or later.  You can check your node version by running `node --version` on the command-line.
 * [npm](https://www.npmjs.com/) v6.0 or later.  npm is usually installed automatically alongside the above.  You can check your npm version by running `npm --version`.
 * [yarn](https://yarnpkg.com/) v1.19.0 or later. This can be installed using `npm install -g yarn@^1.19.0`
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 14.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Change min nodeJS version to 14

This will increase our minimum NodeJS version to 14 (**12 will no longer be supported**)
This is a good thing as 12 is end-of-life - https://nodejs.org/en/about/releases/

![image](https://user-images.githubusercontent.com/6187649/180139610-db6d10ad-126a-4b9e-b21d-cce9973008ba.png)

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [x] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
