### PR TITLE
Add DOMPurify to `parseCustomHtmlToReact`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@ Change Log
 * Limit workbench item title to 2 lines and show overflow: ellipsis after.
 * Add `allowFeaturePicking` trait to Cesium3dTileMixin.
 * Feature Info now hidden on Cesium3dTiles items if `allowFeaturePicking` set to false. Default is true.
+* Add DOMPurify to `parseCustomHtmlToReact` (it was already present in `parseCustomMarkdownToReact`)
+* Update `html-to-react` to `1.4.7`
 * [The next improvement]
 
 #### 8.2.9 - 2022-07-13

--- a/lib/ReactViews/Custom/parseCustomHtmlToReact.ts
+++ b/lib/ReactViews/Custom/parseCustomHtmlToReact.ts
@@ -6,6 +6,8 @@ import CustomComponent, {
   DomElement,
   ProcessNodeContext
 } from "./CustomComponent";
+
+const DOMPurify = require("dompurify/dist/purify");
 const HtmlToReact = require("html-to-react");
 const combine = require("terriajs-cesium/Source/Core/combine").default;
 const defined = require("terriajs-cesium/Source/Core/defined").default;
@@ -113,13 +115,22 @@ export type ParseCustomHtmlToReactContext = ProcessNodeContext &
 
 /**
  * Return html as a React Element.
+ * HTML is purified by default. Custom components are not supported by default
+ * Set domPurifyOptions to specify supported custom components - for example
+ * - eg. {ADD_TAGS: ['component1', 'component2']} (https://github.com/cure53/DOMPurify).
  */
 function parseCustomHtmlToReact(
   html: string,
-  context?: ParseCustomHtmlToReactContext
+  context?: ParseCustomHtmlToReactContext,
+  allowUnsafeHtml: boolean = false,
+  domPurifyOptions: Object = {}
 ) {
   if (!defined(html) || html.length === 0) {
     return html;
+  }
+
+  if (!allowUnsafeHtml) {
+    html = DOMPurify.sanitize(html, domPurifyOptions);
   }
 
   return htmlToReactParser.parseWithInstructions(

--- a/lib/ReactViews/Custom/parseCustomMarkdownToReact.ts
+++ b/lib/ReactViews/Custom/parseCustomMarkdownToReact.ts
@@ -32,7 +32,11 @@ export function parseCustomMarkdownToReactWithOptions(
     },
     options
   );
-  return parseCustomHtmlToReact("<span>" + html + "</span>", context);
+  return parseCustomHtmlToReact(
+    "<span>" + html + "</span>",
+    context,
+    true /** We can set allowUnsafeHtml to true here as we purify HTML in markdownToHtml */
+  );
 }
 
 export default parseCustomMarkdownToReact;

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "gulp": "^4.0.0",
     "hammerjs": "^2.0.6",
     "hoist-non-react-statics": "^3.3.2",
-    "html-to-react": "1.4.5",
+    "html-to-react": "1.4.7",
     "i18next": "^21.8.13",
     "i18next-browser-languagedetector": "^6.1.4",
     "i18next-http-backend": "^1.4.1",


### PR DESCRIPTION
### Add DOMPurify to `parseCustomHtmlToReact`

Fixes https://github.com/TerriaJS/vic-digital-twin/issues/333

For some reason, we were purifying HTML in `parseCustomMarkdownToReact` but not in `parseCustomHtmlToReact`

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
