### PR TITLE
Set JulianDate.toIso8601 second precision to nanosecond

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,8 +28,6 @@ Change Log
 * Feature Info now hidden on Cesium3dTiles items if `allowFeaturePicking` set to false. Default is true.
 * Add DOMPurify to `parseCustomHtmlToReact` (it was already present in `parseCustomMarkdownToReact`)
 * Update `html-to-react` to `1.4.7`
-* Move `maximumShownFeatureInfos` from `WebMapServiceCatalogItemTraits` to `MappableTraits`
-* Remove `featureInfoUrlTemplate` from `OpenDataSoftCatalogItem` - as it is incompatible with time varying datasets
 * Set `JulianDate.toIso8601` second precision to nanosecond - this prevents weird date strings with scientific/exponent notation (eg `2008-05-07T22:54:45.7275957614183426e-11Z`)
 * [The next improvement]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ Change Log
 * Feature Info now hidden on Cesium3dTiles items if `allowFeaturePicking` set to false. Default is true.
 * Add DOMPurify to `parseCustomHtmlToReact` (it was already present in `parseCustomMarkdownToReact`)
 * Update `html-to-react` to `1.4.7`
+* Move `maximumShownFeatureInfos` from `WebMapServiceCatalogItemTraits` to `MappableTraits`
+* Remove `featureInfoUrlTemplate` from `OpenDataSoftCatalogItem` - as it is incompatible with time varying datasets
+* Set `JulianDate.toIso8601` second precision to nanosecond - this prevents weird date strings with scientific/exponent notation (eg `2008-05-07T22:54:45.7275957614183426e-11Z`)
 * [The next improvement]
 
 #### 8.2.9 - 2022-07-13

--- a/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
+++ b/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
@@ -14,7 +14,7 @@ import ChartableMixin, {
 import CommonStrata from "../Models/Definition/CommonStrata";
 import Model from "../Models/Definition/Model";
 import DiscretelyTimeVaryingTraits from "../Traits/TraitsClasses/DiscretelyTimeVaryingTraits";
-import TimeVarying from "./TimeVarying";
+import TimeVarying, { DATE_SECONDS_PRECISION } from "./TimeVarying";
 
 export interface AsJulian {
   time: JulianDate;
@@ -41,7 +41,7 @@ function DiscretelyTimeVaryingMixin<
       const time = super.currentTime;
       if (time === undefined || time === null) {
         if (this.initialTimeSource === "now") {
-          return JulianDate.toIso8601(JulianDate.now());
+          return JulianDate.toIso8601(JulianDate.now(), DATE_SECONDS_PRECISION);
         } else if (this.initialTimeSource === "start") {
           return this.startTime;
         } else if (this.initialTimeSource === "stop") {
@@ -241,7 +241,8 @@ function DiscretelyTimeVaryingMixin<
         this.discreteTimesAsSortedJulianDates.length > 0
       ) {
         return JulianDate.toIso8601(
-          this.discreteTimesAsSortedJulianDates[0].time
+          this.discreteTimesAsSortedJulianDates[0].time,
+          DATE_SECONDS_PRECISION
         );
       }
       return time;
@@ -258,7 +259,8 @@ function DiscretelyTimeVaryingMixin<
         return JulianDate.toIso8601(
           this.discreteTimesAsSortedJulianDates[
             this.discreteTimesAsSortedJulianDates.length - 1
-          ].time
+          ].time,
+          DATE_SECONDS_PRECISION
         );
       }
       return time;
@@ -302,7 +304,10 @@ function DiscretelyTimeVaryingMixin<
       this.setTrait(
         stratumId,
         "currentTime",
-        JulianDate.toIso8601(this.discreteTimesAsSortedJulianDates![index].time)
+        JulianDate.toIso8601(
+          this.discreteTimesAsSortedJulianDates![index].time,
+          DATE_SECONDS_PRECISION
+        )
       );
     }
 
@@ -315,7 +320,10 @@ function DiscretelyTimeVaryingMixin<
       this.setTrait(
         stratumId,
         "currentTime",
-        JulianDate.toIso8601(this.discreteTimesAsSortedJulianDates![index].time)
+        JulianDate.toIso8601(
+          this.discreteTimesAsSortedJulianDates![index].time,
+          DATE_SECONDS_PRECISION
+        )
       );
     }
 

--- a/lib/ModelMixins/TimeVarying.ts
+++ b/lib/ModelMixins/TimeVarying.ts
@@ -2,6 +2,11 @@ import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import Model, { BaseModel } from "../Models/Definition/Model";
 import TimeVaryingTraits from "../Traits/TraitsClasses/TimeVaryingTraits";
 
+/** To use as precision in JulianDate.toIso8601(date, precision) - so we don't get scientific/exponent in date string (eg `2008-05-07T22:54:45.7275957614183426e-11Z`).
+ * Is set to nanosecond precision
+ */
+export const DATE_SECONDS_PRECISION = 9;
+
 interface TimeVarying extends Model<TimeVaryingTraits> {
   readonly currentTimeAsJulianDate: JulianDate | undefined;
   readonly startTimeAsJulianDate: JulianDate | undefined;

--- a/lib/Models/Catalog/CatalogItems/CzmlCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/CzmlCatalogItem.ts
@@ -1,8 +1,8 @@
 import i18next from "i18next";
 import { action, computed, observable, toJS } from "mobx";
-import Clock from "terriajs-cesium/Source/Core/Clock";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import CzmlDataSource from "terriajs-cesium/Source/DataSources/CzmlDataSource";
+import DataSourceClock from "terriajs-cesium/Source/DataSources/DataSourceClock";
 import isDefined from "../../../Core/isDefined";
 import readJson from "../../../Core/readJson";
 import TerriaError, { networkRequestError } from "../../../Core/TerriaError";
@@ -35,8 +35,8 @@ class CzmlTimeVaryingStratum extends LoadableStratum(CzmlCatalogItemTraits) {
   }
 
   @computed
-  private get clock(): Clock | undefined {
-    return (this.catalogItem as any)._dataSource?.clock;
+  private get clock(): DataSourceClock | undefined {
+    return this.catalogItem._dataSource?.clock;
   }
 
   @computed
@@ -77,7 +77,7 @@ export default class CzmlCatalogItem
     return CzmlCatalogItem.type;
   }
 
-  @observable private _dataSource: CzmlDataSource | undefined;
+  @observable _dataSource: CzmlDataSource | undefined;
   private _czmlFile?: File;
 
   setFileInput(file: File) {

--- a/lib/Models/DefaultTimelineModel.ts
+++ b/lib/Models/DefaultTimelineModel.ts
@@ -1,5 +1,6 @@
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import DiscretelyTimeVaryingMixin from "../ModelMixins/DiscretelyTimeVaryingMixin";
+import { DATE_SECONDS_PRECISION } from "../ModelMixins/TimeVarying";
 import DiscretelyTimeVaryingTraits from "../Traits/TraitsClasses/DiscretelyTimeVaryingTraits";
 import CommonStrata from "./Definition/CommonStrata";
 import CreateModel from "./Definition/CreateModel";
@@ -15,12 +16,18 @@ export default class DefaultTimelineModel extends DiscretelyTimeVaryingMixin(
     this.setTrait(
       CommonStrata.defaults,
       "startTime",
-      JulianDate.toIso8601(JulianDate.addHours(now, -12, new JulianDate()))
+      JulianDate.toIso8601(
+        JulianDate.addHours(now, -12, new JulianDate()),
+        DATE_SECONDS_PRECISION
+      )
     );
     this.setTrait(
       CommonStrata.defaults,
       "stopTime",
-      JulianDate.toIso8601(JulianDate.addHours(now, 12, new JulianDate()))
+      JulianDate.toIso8601(
+        JulianDate.addHours(now, 12, new JulianDate()),
+        DATE_SECONDS_PRECISION
+      )
     );
   }
 

--- a/lib/Models/TimelineStack.ts
+++ b/lib/Models/TimelineStack.ts
@@ -5,7 +5,9 @@ import CesiumEvent from "terriajs-cesium/Source/Core/Event";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import filterOutUndefined from "../Core/filterOutUndefined";
 import ReferenceMixin from "../ModelMixins/ReferenceMixin";
-import TimeVarying from "../ModelMixins/TimeVarying";
+import TimeVarying, {
+  DATE_SECONDS_PRECISION
+} from "../ModelMixins/TimeVarying";
 import DefaultTimelineModel from "./DefaultTimelineModel";
 import CommonStrata from "./Definition/CommonStrata";
 import Terria from "./Terria";
@@ -181,19 +183,22 @@ export default class TimelineStack {
   @action
   syncToClock(stratumId: string) {
     const clock = this.clock;
-    const currentTime = JulianDate.toIso8601(clock.currentTime);
+    const currentTime = JulianDate.toIso8601(
+      clock.currentTime,
+      DATE_SECONDS_PRECISION
+    );
     const isPaused = !clock.shouldAnimate;
 
     if (this.top) {
       this.top.setTrait(
         stratumId,
         "startTime",
-        JulianDate.toIso8601(clock.startTime)
+        JulianDate.toIso8601(clock.startTime, DATE_SECONDS_PRECISION)
       );
       this.top.setTrait(
         stratumId,
         "stopTime",
-        JulianDate.toIso8601(clock.stopTime)
+        JulianDate.toIso8601(clock.stopTime, DATE_SECONDS_PRECISION)
       );
       this.top.setTrait(stratumId, "multiplier", clock.multiplier);
     }

--- a/lib/Traits/TraitsClasses/CzmlCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/CzmlCatalogItemTraits.ts
@@ -4,14 +4,14 @@ import primitiveTrait from "../Decorators/primitiveTrait";
 import mixTraits from "../mixTraits";
 import AutoRefreshingTraits from "./AutoRefreshingTraits";
 import CatalogMemberTraits from "./CatalogMemberTraits";
-import DiscretelyTimeVaryingTraits from "./DiscretelyTimeVaryingTraits";
 import LegendOwnerTraits from "./LegendOwnerTraits";
 import MappableTraits from "./MappableTraits";
+import TimeVaryingTraits from "./TimeVaryingTraits";
 import UrlTraits from "./UrlTraits";
 
 export default class CzmlCatalogItemTraits extends mixTraits(
   AutoRefreshingTraits,
-  DiscretelyTimeVaryingTraits,
+  TimeVaryingTraits,
   UrlTraits,
   CatalogMemberTraits,
   LegendOwnerTraits,

--- a/test/Models/Catalog/esri/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/Catalog/esri/ArcGisMapServerCatalogItemSpec.ts
@@ -308,8 +308,8 @@ describe("ArcGisMapServerCatalogItem", function() {
       if (item.discreteTimes !== undefined) {
         expect(item.discreteTimes.length).toBe(781);
       }
-      expect(item.startTime).toBe("2004-11-26T09:43:22Z");
-      expect(item.stopTime).toBe("2019-11-03T14:00:00Z");
+      expect(item.startTime).toBe("2004-11-26T09:43:22.000000000Z");
+      expect(item.stopTime).toBe("2019-11-03T14:00:00.000000000Z");
     });
   });
 });


### PR DESCRIPTION
### Set JulianDate.toIso8601 second precision to nanosecond

When animating timeline we can get dates with way too precise seconds

<img width="500" alt="image" src="https://user-images.githubusercontent.com/6187649/181669281-fe688dbd-67f9-420f-8f9b-aa5b55dbf3a7.png">

Then when trying to pass these date strings through `JulianDate.fromIso8601` we get 

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/6187649/181669392-0ed59c72-a2a9-4945-940f-110be7090f76.png">

This PR changes precision to nanoseconds

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] ~I've provided instructions in the PR description on how to test this PR.~ Use seals data from vic-dt
