### PR TITLE
Add attribution for Natural Earth and Black Marble basemaps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ Change Log
 * `CesiumTerrainCatalogItem` will now show a status `In use` or `Not in use` in the workbench.
 * Rewrote `CesiumTerrainCatalogItem` to handle and report network errors.
 * Set `JulianDate.toIso8601` second precision to nanosecond - this prevents weird date strings with scientific/exponent notation (eg `2008-05-07T22:54:45.7275957614183426e-11Z`)
+* Add attribution for Natural Earth II and NASA Black Marble basemaps.
 * [The next improvement]
 
 #### 8.2.9 - 2022-07-13

--- a/lib/Models/BaseMaps/defaultBaseMaps.ts
+++ b/lib/Models/BaseMaps/defaultBaseMaps.ts
@@ -86,6 +86,8 @@ export function defaultBaseMaps(terria: Terria): BaseMapJson[] {
       type: "url-template-imagery",
       url:
         "https://storage.googleapis.com/terria-datasets-public/basemaps/natural-earth-tiles/{z}/{x}/{reverseY}.png",
+      attribution:
+        "<a href='https://www.naturalearthdata.com/downloads/10m-raster-data/10m-natural-earth-2/'>Natural Earth II</a> - From Natural Earth. <a href='https://www.naturalearthdata.com/about/terms-of-use/'>Public Domain</a>.",
       maximumLevel: 7,
       opacity: 1.0
     },
@@ -100,6 +102,8 @@ export function defaultBaseMaps(terria: Terria): BaseMapJson[] {
       type: "wms",
       url:
         "http://geoserver.nationalmap.nicta.com.au/imagery/nasa-black-marble/wms",
+      attribution:
+        "<a href='https://earthobservatory.nasa.gov/Features/NightLights'>Black Marble</a> - From NASA's Earth Observatory. <a href='https://earthobservatory.nasa.gov/image-use-policy'>Use Policy</a>.",
       layers: "nasa-black-marble:dnb_land_ocean_ice.2012.54000x27000_geo",
       opacity: 1.0
     },


### PR DESCRIPTION
### What this PR does

Partly Fixes #340

Add in attribution html for those two base layers.
  
### Test me
  
<img width="864" alt="image" src="https://user-images.githubusercontent.com/7980991/182272054-b7aefb2d-a1b3-4027-805e-e21e597c0581.png">

Select the two basemaps in question.
Make sure 'Basemap' button on footer is rendered.
Make sure modal has attribution.

### Checklist

~~-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~~
~~-   [ ] I've updated relevant documentation in `doc/`.~~
-   [y] I've updated CHANGES.md with what I changed.
-   [y] I've provided instructions in the PR description on how to test this PR.
