### PR TITLE
Fix a style bug caused by not recalculating if mobile interface should be used on resize

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.2.11)
 
+* Fixed a bug where menu items were rendered in the wrong style if the window was resized from small to large, or large to small.
 * [The next improvement]
 
 #### release 8.2.10 - 2022-08-02

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
@@ -56,13 +56,9 @@ interface StandardUserInterfaceProps {
   version: string;
 }
 
-const StandardUserInterface = observer<React.FC<StandardUserInterfaceProps>>(
+const StandardUserInterface: React.FC<StandardUserInterfaceProps> = observer(
   props => {
     const { t } = useTranslation();
-    const uiRootRef = useRef<HTMLDivElement>(null);
-
-    const shouldUseMobileInterface =
-      document.body.clientWidth < (props.minimumLargeScreenWidth ?? 768);
 
     const acceptDragDropFile = action(() => {
       props.viewState.isDraggingDroppingFile = true;
@@ -85,17 +81,21 @@ const StandardUserInterface = observer<React.FC<StandardUserInterfaceProps>>(
       acceptDragDropFile();
     };
 
+    const shouldUseMobileInterface = () =>
+      document.body.clientWidth < (props.minimumLargeScreenWidth ?? 768);
+
     const resizeListener = action(() => {
-      props.viewState.useSmallScreenInterface = shouldUseMobileInterface;
+      props.viewState.useSmallScreenInterface = shouldUseMobileInterface();
     });
 
     useEffect(() => {
       window.addEventListener("resize", resizeListener, false);
-      resizeListener();
       return () => {
         window.removeEventListener("resize", resizeListener, false);
       };
     }, []);
+
+    useEffect(resizeListener, [props.minimumLargeScreenWidth]);
 
     useEffect(() => {
       if (


### PR DESCRIPTION
### What this PR does

Fix a bug introduced in translating StandardUserInterface.jsx to tsx.
  
### Test me
  
On both http://ci.terria.io/main/ and http://ci.terria.io/fix-resize-mobile/ check styling of the top bar of menu buttons and the items in the mobile hamburger menu when you:
* load the page in a small window ( < 768px) and resize to a large
* reload the page in a large window and resize to small

Old:
![image](https://user-images.githubusercontent.com/13863530/182441179-eac04183-3e51-4948-9813-4d6394e6000d.png)
![image](https://user-images.githubusercontent.com/13863530/182441306-a47005bf-b922-44ea-8255-37ea224a7527.png)

New:
![image](https://user-images.githubusercontent.com/13863530/182442803-c54e2dfe-8d8d-4049-99b1-a19a2f7d9a71.png)
![image](https://user-images.githubusercontent.com/13863530/182442732-3611ea8a-61a5-4cdc-b9fa-ad3ba77d06e2.png)



### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
