### PR TITLE
Set cesium base url in Terria constructor.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Add ability to customise the getting started video in the StoryBuilder panel
 * Set cesium base URL by default so that cesium assets are resolved correctly
 * Add `cesiumBaseUrl` to `TerriaOptions` for overriding the default cesium base url setting
+* Fix broken Bing map logo in attributions
 * [The next improvement]
 
 #### release 8.2.10 - 2022-08-02

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Change Log
 #### next release (8.2.11)
 
 * Add ability to customise the getting started video in the StoryBuilder panel
+* Set cesium base URL by default so that cesium assets are resolved correctly
+* Add `cesiumBaseUrl` to `TerriaOptions` for overriding the default cesium base url setting
 * [The next improvement]
 
 #### release 8.2.10 - 2022-08-02

--- a/lib/Core/ensurePrefix.ts
+++ b/lib/Core/ensurePrefix.ts
@@ -1,0 +1,7 @@
+/**
+ * Ensures that the given `str` ends with the given `char`.
+ *
+ */
+export default function ensurePrefix(str: string, char: string): string {
+  return str.endsWith(char) ? str : `${str}${char}`;
+}

--- a/lib/Core/ensureSuffix.ts
+++ b/lib/Core/ensureSuffix.ts
@@ -2,6 +2,6 @@
  * Ensures that the given `str` ends with the given `char`.
  *
  */
-export default function ensurePrefix(str: string, char: string): string {
+export default function ensureSuffix(str: string, char: string): string {
   return str.endsWith(char) ? str : `${str}${char}`;
 }

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -19,7 +19,7 @@ import AsyncLoader from "../Core/AsyncLoader";
 import Class from "../Core/Class";
 import ConsoleAnalytics from "../Core/ConsoleAnalytics";
 import CorsProxy from "../Core/CorsProxy";
-import ensurePrefix from "../Core/ensurePrefix";
+import ensureSuffix from "../Core/ensureSuffix";
 import filterOutUndefined from "../Core/filterOutUndefined";
 import getDereferencedIfExists from "../Core/getDereferencedIfExists";
 import GoogleAnalytics from "../Core/GoogleAnalytics";
@@ -637,11 +637,11 @@ export default class Terria {
     }
 
     if (options.baseUrl) {
-      this.baseUrl = ensurePrefix(options.baseUrl, "/");
+      this.baseUrl = ensureSuffix(options.baseUrl, "/");
     }
 
-    this.cesiumBaseUrl = ensurePrefix(
-      options.cesiumBaseUrl ?? `${this.baseUrl}build/Cesium/build`,
+    this.cesiumBaseUrl = ensureSuffix(
+      options.cesiumBaseUrl ?? `${this.baseUrl}build/Cesium/build/`,
       "/"
     );
     // Casting to `any` as `setBaseUrl` method is not part of the Cesiums' type definitions

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -19,7 +19,7 @@ import AsyncLoader from "../Core/AsyncLoader";
 import Class from "../Core/Class";
 import ConsoleAnalytics from "../Core/ConsoleAnalytics";
 import CorsProxy from "../Core/CorsProxy";
-import ensurePrefix from "../Core/ensureSlashPrefix";
+import ensurePrefix from "../Core/ensurePrefix";
 import filterOutUndefined from "../Core/filterOutUndefined";
 import getDereferencedIfExists from "../Core/getDereferencedIfExists";
 import GoogleAnalytics from "../Core/GoogleAnalytics";

--- a/lib/ReactViews/Credits/DataAttribution/DataAttributionModal.tsx
+++ b/lib/ReactViews/Credits/DataAttribution/DataAttributionModal.tsx
@@ -54,6 +54,7 @@ const DataAttributionBox = styled(Box).attrs({
   */
   ${AttributionText} img[title="Bing Imagery"] {
     background-color: grey;
+    padding: 3px;
   }
 `;
 

--- a/lib/ReactViews/Credits/DataAttribution/DataAttributionModal.tsx
+++ b/lib/ReactViews/Credits/DataAttribution/DataAttributionModal.tsx
@@ -16,6 +16,18 @@ interface IDataAttributionModalProps {
   attributions?: string[];
 }
 
+const AttributionText = styled(Text).attrs(() => ({ medium: true }))`
+  a {
+    color: ${props => props.theme.textDark};
+    text-decoration: underline;
+
+    img {
+      height: 19px;
+      vertical-align: middle;
+    }
+  }
+`;
+
 const DataAttributionBox = styled(Box).attrs({
   position: "absolute",
   styledWidth: "500px",
@@ -35,17 +47,13 @@ const DataAttributionBox = styled(Box).attrs({
   @media (max-width: ${props => props.theme.mobile}px) {
     width: 100%;
   }
-`;
 
-const AttributionText = styled(Text).attrs(() => ({ medium: true }))`
-  a {
-    color: ${props => props.theme.textDark};
-    text-decoration: underline;
-
-    img {
-      height: 19px;
-      vertical-align: middle;
-    }
+  /* Default cesium bing map logo is white on transparent which is rendered invisible
+     on our modal with white background. This rule forces the background color of the
+      bing imagery to grey so that it is visible.
+  */
+  ${AttributionText} img[title="Bing Imagery"] {
+    background-color: grey;
   }
 `;
 

--- a/lib/ReactViews/Credits/DataAttribution/DataAttributionModal.tsx
+++ b/lib/ReactViews/Credits/DataAttribution/DataAttributionModal.tsx
@@ -53,8 +53,7 @@ const DataAttributionBox = styled(Box).attrs({
       bing imagery to grey so that it is visible.
   */
   ${AttributionText} img[title="Bing Imagery"] {
-    background-color: grey;
-    padding: 3px;
+    filter: invert(1);
   }
 `;
 

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -34,6 +34,7 @@ import ViewState from "../../lib/ReactViewModels/ViewState";
 import { buildShareLink } from "../../lib/ReactViews/Map/Panels/SharePanel/BuildShareLink";
 import SimpleCatalogItem from "../Helpers/SimpleCatalogItem";
 import { defaultBaseMaps } from "./../../lib/Models/BaseMaps/defaultBaseMaps";
+import buildModuleUrl from "terriajs-cesium/Source/Core/buildModuleUrl";
 
 const mapConfigBasicJson = require("../../wwwroot/test/Magda/map-config-basic.json");
 const mapConfigBasicString = JSON.stringify(mapConfigBasicJson);
@@ -65,6 +66,45 @@ describe("Terria", function() {
     terria = new Terria({
       appBaseHref: "/",
       baseUrl: "./"
+    });
+  });
+
+  describe("cesiumBaseUrl", function() {
+    it("is set when passed as an option when constructing Terria", function() {
+      terria = new Terria({
+        appBaseHref: "/",
+        baseUrl: "./",
+        cesiumBaseUrl: "some/path/to/cesium"
+      });
+      expect(terria.cesiumBaseUrl).toBe("some/path/to/cesium/");
+    });
+
+    it("should default to a path relative to `baseUrl`", function() {
+      terria = new Terria({
+        appBaseHref: "/",
+        baseUrl: "some/path/to/terria"
+      });
+      expect(terria.cesiumBaseUrl).toBe(
+        "some/path/to/terria/build/Cesium/build/"
+      );
+    });
+
+    it("should update the baseUrl setting in the cesium module", function() {
+      expect(
+        buildModuleUrl("Assets/some/image.png").endsWith(
+          "/build/Cesium/build/Assets/some/image.png"
+        )
+      ).toBe(true);
+
+      terria = new Terria({
+        appBaseHref: "/",
+        baseUrl: "some/path/to/terria"
+      });
+      expect(
+        buildModuleUrl("Assets/some/image.png").endsWith(
+          "/some/path/to/terria/build/Cesium/build/Assets/some/image.png"
+        )
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
### What this PR does

In Terria v7 we used to set cesium base url. It was either passed in as an option to the Terria constructor or set by default from `Terria.baseUrl` value. Setting cesium base url ensures that cesium correctly resolves the URLs to its static assets (like the bing maps logo in this issue - https://github.com/TerriaJS/terriajs/issues/6473).

This PR ports that bit of code to set cesium base URL from `v7`.
  
### Test me
  
- Open the CI for main branch - http://ci.terria.io/main/
- Switch to any bing map provider and click the `Attributions` link at the bottom of the map
- Observe that the Bing Map logo is broken
- Now Open the CI for this branch - http://ci.terria.io/set-cesium-baseurl/
- Repeat
- Observe that the Bing map logo is visible

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
