### PR TITLE
Help video changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Change Log
 * Add `configParameters.regionMappingDefinitionsUrls` - to support multiple URLs for region mapping definitions  - if multiple provided then the first matching region will be used (in order of URLs)
   * `configParameters.regionMappingDefinitionsUrl` still exists but is deprecated - if defined it will override `regionMappingDefinitionsUrls`
 * `TableMixin.matchRegionProvider` now returns `RegionProvider` instead of `string` region type. (which exists at `regionProvider.regionType`)
+* Add `videoCoverImageOpacity` option to `HelpContentItem` so that we can fade the background of help video panels.
+* Fix a bug where all `HelpVideoPanel`s were being rendered resulting in autoplayed videos playing at random.
 * [The next improvement]
 
 #### release 8.2.10 - 2022-08-02

--- a/lib/ReactViewModels/defaultHelpContent.ts
+++ b/lib/ReactViewModels/defaultHelpContent.ts
@@ -23,7 +23,7 @@ export interface HelpContentItem {
   placeholderImage?: string;
 
   // The `placeholderImage` is also used as background cover image for the container that embeds the video. This setting allows us to control the opacity of the cover image.
-  videoCoverImageOpacity?: boolean;
+  videoCoverImageOpacity?: number;
 
   paneMode?: PaneMode;
   trainerItems?: TrainerItem[];

--- a/lib/ReactViewModels/defaultHelpContent.ts
+++ b/lib/ReactViewModels/defaultHelpContent.ts
@@ -22,6 +22,9 @@ export interface HelpContentItem {
   videoUrl?: string;
   placeholderImage?: string;
 
+  // The `placeholderImage` is also used as background cover image for the container that embeds the video. This setting allows us to control the opacity of the cover image.
+  videoCoverImageOpacity?: boolean;
+
   paneMode?: PaneMode;
   trainerItems?: TrainerItem[];
 

--- a/lib/ReactViews/Map/Panels/HelpPanel/HelpPanelItem.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/HelpPanelItem.jsx
@@ -94,6 +94,7 @@ class HelpPanelItem extends React.Component {
                   )
                 : undefined
             }
+            videoCoverImageOpacity={this.props.content.videoCoverImageOpacity}
           />
         )}
       </div>

--- a/lib/ReactViews/Map/Panels/HelpPanel/HelpVideoPanel.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/HelpVideoPanel.jsx
@@ -28,6 +28,7 @@ class HelpVideoPanel extends React.Component {
     markdownContent: PropTypes.string,
     videoUrl: PropTypes.string,
     placeholderImage: PropTypes.string,
+    videoCoverImageOpacity: PropTypes.number,
     theme: PropTypes.object,
     t: PropTypes.func.isRequired,
     i18n: PropTypes.object.isRequired
@@ -58,6 +59,7 @@ class HelpVideoPanel extends React.Component {
           viewState={this.props.viewState}
           videoLink={this.props.videoUrl}
           background={this.props.placeholderImage}
+          backgroundOpacity={this.props.videoCoverImageOpacity}
           videoName={HELP_VIDEO_NAME}
         />
         <Box

--- a/lib/ReactViews/Map/Panels/HelpPanel/HelpVideoPanel.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/HelpVideoPanel.jsx
@@ -53,72 +53,76 @@ class HelpVideoPanel extends React.Component {
         this.props.viewState.topElement !== "HelpPanel"
     });
     return (
-      itemSelected && <div className={className}>
-        <VideoGuide
-          viewState={this.props.viewState}
-          videoLink={this.props.videoUrl}
-          background={this.props.placeholderImage}
-          backgroundOpacity={this.props.videoCoverImageOpacity}
-          videoName={HELP_VIDEO_NAME}
-        />
-        <Box
-          centered
-          fullWidth
-          fullHeight
-          displayInlineBlock
-          paddedHorizontally={4}
-          paddedVertically={18}
-          css={`
-            overflow: auto;
-            overflow-x: hidden;
-            overflow-y: auto;
-          `}
-          scroll
-        >
-          <If condition={helpItemType === "videoAndContent"}>
-            {this.props.videoUrl && this.props.placeholderImage && (
-              <div key={"image"}>
-                <div
-                  className={Styles.videoLink}
-                  style={{
-                    backgroundImage: `linear-gradient(rgba(0,0,0,0.35),rgba(0,0,0,0.35)), url(${this.props.placeholderImage})`
-                  }}
-                >
-                  <button
-                    className={Styles.videoBtn}
-                    onClick={() =>
-                      this.props.viewState.setVideoGuideVisible(HELP_VIDEO_NAME)
-                    }
+      itemSelected && (
+        <div className={className}>
+          <VideoGuide
+            viewState={this.props.viewState}
+            videoLink={this.props.videoUrl}
+            background={this.props.placeholderImage}
+            backgroundOpacity={this.props.videoCoverImageOpacity}
+            videoName={HELP_VIDEO_NAME}
+          />
+          <Box
+            centered
+            fullWidth
+            fullHeight
+            displayInlineBlock
+            paddedHorizontally={4}
+            paddedVertically={18}
+            css={`
+              overflow: auto;
+              overflow-x: hidden;
+              overflow-y: auto;
+            `}
+            scroll
+          >
+            <If condition={helpItemType === "videoAndContent"}>
+              {this.props.videoUrl && this.props.placeholderImage && (
+                <div key={"image"}>
+                  <div
+                    className={Styles.videoLink}
+                    style={{
+                      backgroundImage: `linear-gradient(rgba(0,0,0,0.35),rgba(0,0,0,0.35)), url(${this.props.placeholderImage})`
+                    }}
                   >
-                    <Icon glyph={Icon.GLYPHS.play} />
-                  </button>
+                    <button
+                      className={Styles.videoBtn}
+                      onClick={() =>
+                        this.props.viewState.setVideoGuideVisible(
+                          HELP_VIDEO_NAME
+                        )
+                      }
+                    >
+                      <Icon glyph={Icon.GLYPHS.play} />
+                    </button>
+                  </div>
+                  <Spacing bottom={5} />
                 </div>
-                <Spacing bottom={5} />
-              </div>
-            )}
-            {this.props.markdownContent && (
-              <StyledHtml
-                key={"markdownContent"}
+              )}
+              {this.props.markdownContent && (
+                <StyledHtml
+                  key={"markdownContent"}
+                  viewState={this.props.viewState}
+                  markdown={this.props.markdownContent}
+                />
+              )}
+            </If>
+            <If condition={helpItemType === "slider"}>
+              <SatelliteGuide
+                terria={this.props.terria}
                 viewState={this.props.viewState}
-                markdown={this.props.markdownContent}
               />
-            )}
-          </If>
-          <If condition={helpItemType === "slider"}>
-            <SatelliteGuide
-              terria={this.props.terria}
-              viewState={this.props.viewState}
-            />
-          </If>
-          <If condition={helpItemType === "trainer"}>
-            <TrainerPane
-              content={this.props.content}
-              terria={this.props.terria}
-              viewState={this.props.viewState}
-            />
-          </If>
-        </Box>
-      </div>
+            </If>
+            <If condition={helpItemType === "trainer"}>
+              <TrainerPane
+                content={this.props.content}
+                terria={this.props.terria}
+                viewState={this.props.viewState}
+              />
+            </If>
+          </Box>
+        </div>
+      )
     );
   }
 }

--- a/lib/ReactViews/Map/Panels/HelpPanel/HelpVideoPanel.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/HelpVideoPanel.jsx
@@ -50,11 +50,10 @@ class HelpVideoPanel extends React.Component {
       [Styles.shiftedToRight]:
         !isExpanded ||
         !this.props.viewState.showHelpMenu ||
-        this.props.viewState.topElement !== "HelpPanel",
-      [Styles.isHidden]: !itemSelected // when the item isn't selected
+        this.props.viewState.topElement !== "HelpPanel"
     });
     return (
-      <div className={className}>
+      itemSelected && <div className={className}>
         <VideoGuide
           viewState={this.props.viewState}
           videoLink={this.props.videoUrl}

--- a/lib/ReactViews/Map/Panels/HelpPanel/VideoGuide.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/VideoGuide.jsx
@@ -63,6 +63,8 @@ class VideoGuide extends React.Component {
     videoName: PropTypes.string.isRequired,
     videoLink: PropTypes.string,
     background: PropTypes.string,
+    // A number between 0 and 1.0
+    backgroundOpacity: PropTypes.number,
     theme: PropTypes.object,
     t: PropTypes.func
   };
@@ -72,6 +74,9 @@ class VideoGuide extends React.Component {
   }
 
   render() {
+    const backgroundOpacity = this.props.backgroundOpacity;
+    const backgroundBlackOverlay =
+      backgroundOpacity === undefined ? undefined : 1.0 - backgroundOpacity;
     return (
       <FadeIn
         isVisible={
@@ -84,6 +89,7 @@ class VideoGuide extends React.Component {
             col11
             styledHeight={"87%"}
             backgroundImage={this.props.background}
+            backgroundBlackOverlay={backgroundBlackOverlay}
             css={`
               svg {
                 fill: #fff;

--- a/test/ReactViews/Map/Panels/HelpPanel/HelpPanelSpec.tsx
+++ b/test/ReactViews/Map/Panels/HelpPanel/HelpPanelSpec.tsx
@@ -81,7 +81,7 @@ describe("HelpPanel", function() {
     });
   });
 
-  describe("with text, video and image in helpContent", function() {
+  describe("when help item with text, video and image in helpContent is selected", function() {
     beforeEach(() => {
       runInAction(() => {
         terria.configParameters.helpContent = [
@@ -94,6 +94,7 @@ describe("HelpPanel", function() {
               "https://img.youtube.com/vi/NTtSM70rIvI/maxresdefault.jpg"
           }
         ];
+        viewState.selectedHelpMenuItem = "test";
       });
       act(() => {
         testRenderer = createWithContexts(viewState, <HelpPanel />);


### PR DESCRIPTION
### What this PR does

* Add `videoCoverImageOpacity` option to `HelpContentItem` so that we can fade the background of help video panels.
* Fix a bug where all `HelpVideoPanel`s were being rendered simultaneously resulting in autoplayed videos playing at random.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
