### PR TITLE
Fix `shouldShorten` property in catalog and story `ShareUrl`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Add `configParameters.regionMappingDefinitionsUrls` - to support multiple URLs for region mapping definitions  - if multiple provided then the first matching region will be used (in order of URLs)
   * `configParameters.regionMappingDefinitionsUrl` still exists but is deprecated - if defined it will override `regionMappingDefinitionsUrls`
 * `TableMixin.matchRegionProvider` now returns `RegionProvider` instead of `string` region type. (which exists at `regionProvider.regionType`)
+* Fix `shouldShorten` property in catalog and story `ShareUrl`
 * [The next improvement]
 
 #### release 8.2.10 - 2022-08-02

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
   * `configParameters.regionMappingDefinitionsUrl` still exists but is deprecated - if defined it will override `regionMappingDefinitionsUrls`
 * `TableMixin.matchRegionProvider` now returns `RegionProvider` instead of `string` region type. (which exists at `regionProvider.regionType`)
 * Fix `shouldShorten` property in catalog and story `ShareUrl`
+* Fix `shortenShareUrls` user property
 * Add `getFeatureInfoUrl` and `getFeatureInfoParameters` to `WebMapServiceCatalogItemTraits`
 * Fix `generateCatalogIndex` for nested references
 * [The next improvement]

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
@@ -3,16 +3,15 @@ import { TFunction } from "i18next";
 import { observer } from "mobx-react";
 import React from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
-
 import Terria from "../../../../Models/Terria";
 import ViewState from "../../../../ReactViewModels/ViewState";
-
+import Box from "../../../../Styled/Box";
+import Spacing from "../../../../Styled/Spacing";
+import Text from "../../../../Styled/Text";
+import { canShorten } from "./BuildShareLink";
 import Styles from "./share-panel.scss";
 import { SharePanelContent } from "./SharePanelContent";
 import { ShareUrl } from "./ShareUrl";
-import Box from "../../../../Styled/Box";
-import Text from "../../../../Styled/Text";
-import Spacing from "../../../../Styled/Spacing";
 
 const MenuPanel = require("../../../StandardUserInterface/customizable/MenuPanel")
   .default;
@@ -80,9 +79,8 @@ class SharePanel extends React.Component<PropTypes, SharePanelState> {
             terria={terria}
             viewState={viewState}
             includeStories={true}
-            shouldShorten={
-              !!terria.getLocalProperty("shortenShareUrls") ?? true
-            }
+            // Note we don't use terria.getLocalProperty("shortenShareUrls") here - as it is only configurable in SharePanelContent
+            shouldShorten={!!canShorten(terria)}
             theme="light"
             inputTheme="light"
           />
@@ -97,9 +95,8 @@ class SharePanel extends React.Component<PropTypes, SharePanelState> {
             terria={terria}
             viewState={viewState}
             includeStories={true}
-            shouldShorten={
-              !!terria.getLocalProperty("shortenShareUrls") ?? true
-            }
+            // Note we don't use terria.getLocalProperty("shortenShareUrls") here - as it is only configurable in SharePanelContent
+            shouldShorten={!!canShorten(terria)}
             theme="dark"
             inputTheme="light"
             rounded

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
@@ -79,8 +79,10 @@ class SharePanel extends React.Component<PropTypes, SharePanelState> {
             terria={terria}
             viewState={viewState}
             includeStories={true}
-            // Note we don't use terria.getLocalProperty("shortenShareUrls") here - as it is only configurable in SharePanelContent
-            shouldShorten={!!canShorten(terria)}
+            shouldShorten={
+              stringToBool(terria.getLocalProperty("shortenShareUrls")) ??
+              !!canShorten(terria)
+            }
             theme="light"
             inputTheme="light"
           />
@@ -95,8 +97,10 @@ class SharePanel extends React.Component<PropTypes, SharePanelState> {
             terria={terria}
             viewState={viewState}
             includeStories={true}
-            // Note we don't use terria.getLocalProperty("shortenShareUrls") here - as it is only configurable in SharePanelContent
-            shouldShorten={!!canShorten(terria)}
+            shouldShorten={
+              stringToBool(terria.getLocalProperty("shortenShareUrls")) ??
+              !!canShorten(terria)
+            }
             theme="dark"
             inputTheme="light"
             rounded
@@ -191,3 +195,11 @@ class SharePanel extends React.Component<PropTypes, SharePanelState> {
 }
 
 export default withTranslation()(SharePanel);
+
+function stringToBool(s: string | boolean | null | undefined) {
+  if (s === true) return true;
+  if (s === false) return false;
+  if (s === "true") return true;
+  if (s === "false") return false;
+  return undefined;
+}

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
@@ -79,10 +79,7 @@ class SharePanel extends React.Component<PropTypes, SharePanelState> {
             terria={terria}
             viewState={viewState}
             includeStories={true}
-            shouldShorten={
-              stringToBool(terria.getLocalProperty("shortenShareUrls")) ??
-              !!canShorten(terria)
-            }
+            shouldShorten={shouldShorten(terria)}
             theme="light"
             inputTheme="light"
           />
@@ -97,10 +94,7 @@ class SharePanel extends React.Component<PropTypes, SharePanelState> {
             terria={terria}
             viewState={viewState}
             includeStories={true}
-            shouldShorten={
-              stringToBool(terria.getLocalProperty("shortenShareUrls")) ??
-              !!canShorten(terria)
-            }
+            shouldShorten={shouldShorten(terria)}
             theme="dark"
             inputTheme="light"
             rounded
@@ -195,6 +189,13 @@ class SharePanel extends React.Component<PropTypes, SharePanelState> {
 }
 
 export default withTranslation()(SharePanel);
+
+export function shouldShorten(terria: Terria) {
+  return (
+    stringToBool(terria.getLocalProperty("shortenShareUrls")) ??
+    !!canShorten(terria)
+  );
+}
 
 function stringToBool(s: string | boolean | null | undefined) {
   if (s === true) return true;

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanelContent.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanelContent.tsx
@@ -1,19 +1,17 @@
-import React, { FC, useState, useRef, useMemo, useCallback } from "react";
+import React, { FC, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-
 import Terria from "../../../../Models/Terria";
 import ViewState from "../../../../ReactViewModels/ViewState";
-
 import Box from "../../../../Styled/Box";
 import Spacing from "../../../../Styled/Spacing";
 import Text from "../../../../Styled/Text";
-
-import { ShareUrl, IShareUrlRef, ShareUrlBookmark } from "./ShareUrl";
-import { canShorten } from "./BuildShareLink";
-import { AdvancedOptions } from "./AdvancedOptions";
-import { StyledHr } from "./StyledHr";
-import { PrintSection } from "./Print/PrintSection";
 import { useCallbackRef } from "../../../useCallbackRef";
+import { AdvancedOptions } from "./AdvancedOptions";
+import { canShorten } from "./BuildShareLink";
+import { PrintSection } from "./Print/PrintSection";
+import { shouldShorten as shouldShortenDefault } from "./SharePanel";
+import { IShareUrlRef, ShareUrl, ShareUrlBookmark } from "./ShareUrl";
+import { StyledHr } from "./StyledHr";
 
 interface ISharePanelContentProps {
   terria: Terria;
@@ -30,7 +28,9 @@ export const SharePanelContent: FC<ISharePanelContentProps> = ({
   const canShortenUrl = useMemo(() => !!canShorten(terria), [terria]);
 
   const [includeStoryInShare, setIncludeStoryInShare] = useState(true);
-  const [shouldShorten, setShouldShorten] = useState(canShortenUrl);
+  const [shouldShorten, setShouldShorten] = useState(
+    shouldShortenDefault(terria)
+  );
 
   const [_, update] = useState<{}>();
   const shareUrlRef = useCallbackRef<IShareUrlRef>(null, () => update({}));
@@ -41,7 +41,7 @@ export const SharePanelContent: FC<ISharePanelContentProps> = ({
 
   const shouldShortenOnChange = useCallback(() => {
     setShouldShorten(prevState => {
-      terria.setLocalProperty("shortenShareUrls", prevState);
+      terria.setLocalProperty("shortenShareUrls", !prevState);
       return !prevState;
     });
   }, [terria]);


### PR DESCRIPTION
### Fix `shouldShorten` property in catalog and story `ShareUrl`

Fixes https://github.com/TerriaJS/terriajs/issues/6478

Catalog and Story share URL was using `terria.getLocalProperty("shortenShareUrls")` to determine if share URL can be shortened - but this is not defined for most users.

It now uses `canShorten(terria)` if `terria.getLocalProperty("shortenShareUrls")` is undefined.

### Test me
  
- http://ci.terria.io/fix-share-shorten/
- Create story
- Click share in story panel
- See shortened URL

Then go into main share panel and toggle "Shorten the share URL using a web service"

<img src="https://user-images.githubusercontent.com/6187649/183332908-86c5fbc4-2cc7-41de-a176-d20a93cf6c5e.png" width=400/>

The setting should be reflected in all share panels (eg from story or catalog) - and setting value should be preserved in local storage (eg after refreshing the page)

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
