### PR TITLE
Add `getFeatureInfoUrl` and `getFeatureInfoParameters` to `WebMapServiceCatalogItemTraits`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Add `configParameters.regionMappingDefinitionsUrls` - to support multiple URLs for region mapping definitions  - if multiple provided then the first matching region will be used (in order of URLs)
   * `configParameters.regionMappingDefinitionsUrl` still exists but is deprecated - if defined it will override `regionMappingDefinitionsUrls`
 * `TableMixin.matchRegionProvider` now returns `RegionProvider` instead of `string` region type. (which exists at `regionProvider.regionType`)
+* Add `getFeatureInfoUrl` and `getFeatureInfoParameters` to `WebMapServiceCatalogItemTraits`
 * [The next improvement]
 
 #### release 8.2.10 - 2022-08-02

--- a/lib/Models/Catalog/Ows/WebMapServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapServiceCatalogItem.ts
@@ -503,6 +503,7 @@ class WebMapServiceCatalogItem
           (this.maximumShownFeatureInfos ??
             this.terria.configParameters.defaultMaximumShownFeatureInfos),
         ...this.parameters,
+        ...this.getFeatureInfoParameters,
         ...dimensionParameters
       };
 
@@ -564,6 +565,7 @@ class WebMapServiceCatalogItem
         layers: this.validLayers.length > 0 ? this.validLayers.join(",") : "",
         parameters,
         getFeatureInfoParameters,
+        getFeatureInfoUrl: this.getFeatureInfoUrl,
         tileWidth: this.tileWidth,
         tileHeight: this.tileHeight,
         tilingScheme: this.tilingScheme,

--- a/lib/Traits/TraitsClasses/WebMapServiceCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/WebMapServiceCatalogItemTraits.ts
@@ -227,7 +227,7 @@ export default class WebMapServiceCatalogItemTraits extends mixTraits(
   @anyTrait({
     name: "Parameters",
     description:
-      "Additional parameters to pass to the MapServer when requesting images. Style parameters are stored as CSV in `styles`, dimension parameters are stored in `dimensions`."
+      "Additional parameters to pass WMS `GetMap` and `GetFeatureInfo` requests. Style parameters are stored as CSV in `styles`, dimension parameters are stored in `dimensions`."
   })
   parameters?: JsonObject;
 
@@ -331,4 +331,19 @@ export default class WebMapServiceCatalogItemTraits extends mixTraits(
       'Format parameter to pass to GetFeatureInfo requests. Defaults to "application/json", "application/vnd.ogc.gml", "text/html" or "text/plain" - depending on GetCapabilities response'
   })
   getFeatureInfoFormat?: GetFeatureInfoFormat;
+
+  @primitiveTrait({
+    type: "string",
+    name: "GetFeatureInfo URL",
+    description:
+      "If defined, this URL will be used for `GetFeatureInfo` requests instead of `url`."
+  })
+  getFeatureInfoUrl?: string;
+
+  @anyTrait({
+    name: "Parameters",
+    description:
+      "Additional parameters to pass WMS `GetFeatureInfo` requests. If `parameters` trait is also defined, this is applied on top. Dimension parameters are stored in `dimensions`."
+  })
+  getFeatureInfoParameters?: JsonObject;
 }


### PR DESCRIPTION
### Add `getFeatureInfoUrl` and `getFeatureInfoParameters` to `WebMapServiceCatalogItemTraits`

Fixes https://github.com/TerriaJS/terriajs/issues/4751

Simple change to add ability to customise `GetFeatureInfo` WMS requests

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
