### PR TITLE
Fix `generateCatalogIndex` for nested references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
   * `configParameters.regionMappingDefinitionsUrl` still exists but is deprecated - if defined it will override `regionMappingDefinitionsUrls`
 * `TableMixin.matchRegionProvider` now returns `RegionProvider` instead of `string` region type. (which exists at `regionProvider.regionType`)
 * Add `getFeatureInfoUrl` and `getFeatureInfoParameters` to `WebMapServiceCatalogItemTraits`
+* Fix `generateCatalogIndex` for nested references
 * [The next improvement]
 
 #### release 8.2.10 - 2022-08-02

--- a/buildprocess/generateCatalogIndex.ts
+++ b/buildprocess/generateCatalogIndex.ts
@@ -217,15 +217,23 @@ export default async function generateCatalogIndex(
   // Recursively add models to CatalogIndex
   function indexModel(member: BaseModel, index: CatalogIndexFile = {}) {
     let knownContainerUniqueIds = member.knownContainerUniqueIds;
-    if (ReferenceMixin.isMixedInto(member) && member.target) {
-      knownContainerUniqueIds = Array.from(
-        new Set([
-          ...member.knownContainerUniqueIds,
-          ...member.target.knownContainerUniqueIds
-        ])
-      );
-      member = member.target;
-    }
+
+    // de-reference (and handle nested references)
+    const dereference = () => {
+      if (ReferenceMixin.isMixedInto(member) && member.target) {
+        knownContainerUniqueIds = Array.from(
+          new Set([
+            ...member.knownContainerUniqueIds,
+            ...member.target.knownContainerUniqueIds
+          ])
+        );
+        member = member.target;
+        dereference();
+      }
+    };
+
+    dereference();
+
     if (
       member.uniqueId &&
       member.uniqueId !== "/" &&

--- a/buildprocess/generateCatalogIndex.ts
+++ b/buildprocess/generateCatalogIndex.ts
@@ -106,7 +106,7 @@ export default async function generateCatalogIndex(
     ]).join("/");
   }
 
-  /** Recusrively load all references and groups */
+  /** Recursively load all references and groups */
   async function loadMember(terria: Terria, member: BaseModel) {
     let name = getName(member);
     let path = getPath(terria, member);
@@ -114,47 +114,58 @@ export default async function generateCatalogIndex(
     const memberPriority = Math.round(Math.random() * 6) + 3;
     // Random priority between 0 and 5
     const groupPriority = Math.round(Math.random() * 5);
-    // Load reference
-    if (ReferenceMixin.isMixedInto(member)) {
-      try {
-        const priority =
-          hasTraits(member, CatalogMemberReferenceTraits, "isGroup") &&
-          member.isGroup
-            ? groupPriority
-            : memberPriority;
 
-        // Timeout after 30 seconds
-        debug
-          ? console.log(
-              "\x1b[32m%s\x1b[0m",
-              `Adding Reference ${name} (${path})`
+    // Load reference - this also handles nested references
+    const loadReference = async () => {
+      if (ReferenceMixin.isMixedInto(member)) {
+        try {
+          const priority =
+            hasTraits(member, CatalogMemberReferenceTraits, "isGroup") &&
+            member.isGroup
+              ? groupPriority
+              : memberPriority;
+
+          // Timeout after 30 seconds
+          debug
+            ? console.log(
+                "\x1b[32m%s\x1b[0m",
+                `Adding Reference ${name} (${path})`
+              )
+            : null;
+
+          await timeout(Math.random() * 1000);
+          await loadLimiter.schedule(
+            { expiration: 30000, priority },
+            async () => {
+              console.log(`Loading Reference ${name} (${path}) = ${priority}`);
+              const result = await (member as ReferenceMixin.Instance).loadReference();
+              result.logError(`FAILED to load Reference ${name} (${path})`);
+              result.pushErrorTo(
+                errors,
+                `FAILED to load Reference ${name} (${path})`
+              );
+              result.catchError(e => console.error(e.toError().message));
+            }
+          );
+        } catch (timeout) {
+          errors.push(
+            TerriaError.from(
+              `TIMEOUT FAILED to load Reference ${name} (${path})`
             )
-          : null;
+          );
+          console.error(`TIMEOUT FAILED to load Reference ${name}`);
+        }
 
-        await timeout(Math.random() * 1000);
-        await loadLimiter.schedule(
-          { expiration: 30000, priority },
-          async () => {
-            console.log(`Loading Reference ${name} (${path}) = ${priority}`);
-            const result = await (member as ReferenceMixin.Instance).loadReference();
-            result.logError(`FAILED to load Reference ${name} (${path})`);
-            result.pushErrorTo(
-              errors,
-              `FAILED to load Reference ${name} (${path})`
-            );
-            result.catchError(e => console.error(e.toError().message));
-          }
-        );
-      } catch (timeout) {
-        errors.push(
-          TerriaError.from(`TIMEOUT FAILED to load Reference ${name} (${path})`)
-        );
-        console.error(`TIMEOUT FAILED to load Reference ${name}`);
+        if (member.target) {
+          member = member.target;
+          // Load nested references
+          await loadReference();
+        }
+        name = getName(member);
       }
+    };
 
-      if (member.target) member = member.target;
-      name = getName(member);
-    }
+    await loadReference();
 
     if (GroupMixin.isMixedInto(member)) {
       debug


### PR DESCRIPTION
### Fix `generateCatalogIndex` for nested references

This PR adds support for loading nested references in the `generateCatalogIndex` script - for example

- `MagdaReference` -> `TerriaReference`

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [ ] I've provided instructions in the PR description on how to test this PR.
