### PR TITLE
Fix search debounce

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 * Add `getFeatureInfoUrl` and `getFeatureInfoParameters` to `WebMapServiceCatalogItemTraits`
 * Fix `SearchBoxAndResults` Trans values
 * Fix `generateCatalogIndex` for nested references
+* Fix `SearchBox` handling of `searchWithDebounce` when `debounceDuration` prop changes. It now fushes instead of cancels.
 * [The next improvement]
 
 #### release 8.2.10 - 2022-08-02

--- a/lib/ReactViews/Search/SearchBox.jsx
+++ b/lib/ReactViews/Search/SearchBox.jsx
@@ -68,7 +68,8 @@ export const SearchBox = createReactClass({
       prevProps.debounceDuration !== this.props.debounceDuration &&
       this.props.debounceDuration > 0
     ) {
-      this.removeDebounce();
+      // Before we create a new debounced search - make sure there are no previous search values waiting to be called
+      this.searchWithDebounce.flush();
       this.searchWithDebounce = debounce(
         this.search,
         this.props.debounceDuration
@@ -77,7 +78,7 @@ export const SearchBox = createReactClass({
   },
 
   componentWillUnmount() {
-    this.removeDebounce();
+    this.searchWithDebounce.cancel();
   },
 
   hasValue() {
@@ -85,12 +86,8 @@ export const SearchBox = createReactClass({
   },
 
   search() {
-    this.removeDebounce();
-    this.props.onDoSearch();
-  },
-
-  removeDebounce() {
     this.searchWithDebounce.cancel();
+    this.props.onDoSearch();
   },
 
   handleChange(event) {


### PR DESCRIPTION
###  Fix `SearchBox` handling of `searchWithDebounce` when `debounceDuration` prop changes. It now fushes instead of cancels.

Fixes https://github.com/TerriaJS/terriajs/issues/6405

Before this change, when `SearchBox.props.debounceDuration` was changing, it was cancelling `searchWithDebounce` instead of flushing - which means searches sometimes weren't getting triggered properly after the `CatalogIndex` started loading
  
### Test me

#### With CatalogIndex
  
- http://ci.terria.io/fix-search-debounce/#configUrl=https://nationalmap.gov.au/config.json
- Open catalog search
- Type "Tree" quite fast
- Search results now appear

#### With vanilla search

- http://ci.terria.io/fix-search-debounce/
- Open catalog search
- Type "Test"

### Checklist

-   [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
-   [ ] ~I've updated relevant documentation in `doc/`.~
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
