### PR TITLE
Change the prompt text for uploading local/web file.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@ Change Log
 ==========
 
 #### next release (8.2.12)
+* Dropped "optional" from the prompt text in file upload modal for both local and web data.
+* Changed the text for the first file upload option from "Auto-detect (recommended)" to simply "File type".
+* Automatically suffix supported extension list to the entries in file type dropdown to improve clarity.
+* Removed IFC from upload file type (until further testing).
+* [The next improvement]
 
 #### release 8.2.11 - 2022-08-08
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Change Log
 
 #### next release (8.2.12)
 * Dropped "optional" from the prompt text in file upload modal for both local and web data.
-* Changed the text for the first file upload option from "Auto-detect (recommended)" to simply "File type".
+* Changed the text for the first file upload option from "Auto-detect (recommended)" to simply "File type" for local files and "File or web service type" for web urls.
 * Automatically suffix supported extension list to the entries in file type dropdown to improve clarity.
 * Removed IFC from upload file type (until further testing).
 * [The next improvement]

--- a/lib/Core/getDataType.ts
+++ b/lib/Core/getDataType.ts
@@ -169,12 +169,6 @@ export default function(): GetDataTypes {
         value: "shp",
         name: i18next.t("core.dataType.shp"),
         extensions: ["zip"]
-      },
-      {
-        // NOTE: will only work if non open-source terriajs-ifc plugin is added to the map
-        value: "ifc",
-        name: i18next.t("core.dataType.ifc"),
-        extensions: ["ifc"]
       }
     ]
   };

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -194,7 +194,7 @@ const AddData = createReactClass({
           <section className={Styles.tabPanel}>
             <label className={Styles.label}>
               <Trans i18nKey="addData.localFileType">
-                <strong>Step 1:</strong> Select file type (optional)
+                <strong>Step 1:</strong> Select file type
               </Trans>
             </label>
             <Dropdown
@@ -226,7 +226,7 @@ const AddData = createReactClass({
           <section className={Styles.tabPanel}>
             <label className={Styles.label}>
               <Trans i18nKey="addData.webFileType">
-                <strong>Step 1:</strong> Select file type (optional)
+                <strong>Step 1:</strong> Select file or web service type
               </Trans>
             </label>
             <Dropdown

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -44,8 +44,16 @@ const AddData = createReactClass({
   getInitialState() {
     const remoteDataTypes =
       this.props.remoteDataTypes ?? getDataType().remoteDataType;
-    const localDataTypes =
-      this.props.localDataTypes ?? getDataType().localDataType;
+
+    // Automatically suffix supported extension types to localDataType names
+    const localDataTypes = (
+      this.props.localDataTypes ?? getDataType().localDataType
+    ).map(dataType => {
+      const extensions = dataType.extensions?.length
+        ? ` (${buildExtensionsList(dataType.extensions)})`
+        : "";
+      return { ...dataType, name: `${dataType.name}${extensions}` };
+    });
 
     return {
       remoteDataTypes,
@@ -266,5 +274,13 @@ const AddData = createReactClass({
     return <div className={Styles.inner}>{this.renderPanels()}</div>;
   }
 });
+
+/**
+ * @param extensions - string[]
+ * @returns Comma separated string of extensions
+ */
+function buildExtensionsList(extensions) {
+  return extensions.map(ext => `.${ext}`).join(", ");
+}
 
 module.exports = withTranslation()(AddData);

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -718,7 +718,7 @@
       "json": "Terria Catalog",
       "carto": "Carto",
       "gltf": "glTF",
-      "shp": "Shapefile (zip)",
+      "shp": "Shapefile",
       "socrata-group": "Socrata Server",
       "assimp-local": "3D file converter (zip) (experimental)",
       "assimp-local-description": "**Warning:** 3D file converter is experimental.  \nSee list of [supported formats](https://github.com/assimp/assimp/blob/master/doc/Fileformats.md).  \nFiles must be zipped.",

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -697,7 +697,7 @@
       "errorMessage": "Unfortunately Microsoft browsers (including all versions of Internet Explorer and Edge) do not support the data uri functionality needed to download data as a file. To download, copy the following uri into another browser such as $t(browsers.chrome), $t(browsers.firefox), or $t(browsers.safari): {{href}}"
     },
     "dataType": {
-      "auto": "Select a file type",
+      "auto": "File type",
       "wms-group": "Web Map Service (WMS) Server",
       "wmts-group": "Web Map Tile Service (WMTS) Server",
       "wfs-group": "Web Feature Service (WFS) Server",

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -440,10 +440,10 @@
     "searchPlaceholderWhole": "Search whole catalogue",
     "searchPlaceholder": "Search the catalogue",
     "localAdd": "Add local file",
-    "localFileType": "<0>Step 1:</0> Select file type (optional)",
+    "localFileType": "<0>Step 1:</0> Select file type",
     "localFile": "<0>Step 2:</0> Select file",
     "webAdd": "Add web data",
-    "webFileType": "<0>Step 1:</0> Select file type (optional)",
+    "webFileType": "<0>Step 1:</0> Select file type",
     "webFile": "<0>Step 2:</0> Enter the URL of the data file or web service",
     "urlInputBtn": "Add",
     "browse": "Browse...",
@@ -697,7 +697,7 @@
       "errorMessage": "Unfortunately Microsoft browsers (including all versions of Internet Explorer and Edge) do not support the data uri functionality needed to download data as a file. To download, copy the following uri into another browser such as $t(browsers.chrome), $t(browsers.firefox), or $t(browsers.safari): {{href}}"
     },
     "dataType": {
-      "auto": "Auto-detect (recommended)",
+      "auto": "Select a file type",
       "wms-group": "Web Map Service (WMS) Server",
       "wmts-group": "Web Map Tile Service (WMTS) Server",
       "wfs-group": "Web Feature Service (WFS) Server",

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -443,7 +443,7 @@
     "localFileType": "<0>Step 1:</0> Select file type",
     "localFile": "<0>Step 2:</0> Select file",
     "webAdd": "Add web data",
-    "webFileType": "<0>Step 1:</0> Select file type",
+    "webFileType": "<0>Step 1:</0> Select file or web service type",
     "webFile": "<0>Step 2:</0> Enter the URL of the data file or web service",
     "urlInputBtn": "Add",
     "browse": "Browse...",

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -715,7 +715,7 @@
       "csv": "CSV",
       "czml": "CZML",
       "gpx": "GPX",
-      "json": "JSON",
+      "json": "Terria Catalog",
       "carto": "Carto",
       "gltf": "glTF",
       "shp": "Shapefile (zip)",


### PR DESCRIPTION
### What this PR does

- [x] Changes the prompt text for uploading local/web file
   * Dropped "optional" from the prompt text in file upload modal for both local and web data.
   * Changed the text for the first file upload option from "Auto-detect (recommended)" to simply "File type".
    Note:  we are only changing the text, the auto-detect option still works but we downplay it a bit. This is because the Auto-detect feature does not work reliably. In the future we can hopefully improve the auto-detection.
- [x] Automatically suffix supported extension list to the entries in file type dropdown to improve clarity.
- [x] Removed IFC from upload file type (until further testing) 

**Before:**
![image](https://user-images.githubusercontent.com/1430/183550414-da387f41-159b-4752-946f-19fdd4173db4.png)
**After:**
![image](https://user-images.githubusercontent.com/1430/183567508-d147a063-f19d-4332-a993-d4497841d47d.png)

  
### Test me
 
- CI link - http://ci.terria.io/upload-type-changes/
- 
### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
