### PR TITLE
Move `CkanCatalogGroup` "ungrouped" group to end of members

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 #### next release (8.2.12)
 
+* Move `CkanCatalogGroup` "ungrouped" group to end of members
+
 #### release 8.2.11 - 2022-08-08
 
 * Add ability to customise the getting started video in the StoryBuilder panel

--- a/lib/Models/Catalog/Ckan/CkanCatalogGroup.ts
+++ b/lib/Models/Catalog/Ckan/CkanCatalogGroup.ts
@@ -182,12 +182,13 @@ export class CkanServerStratum extends LoadableStratum(CkanCatalogGroupTraits) {
   protected getGroups(): CatalogGroup[] {
     if (this._catalogGroup.groupBy === "none") return [];
     let groups: CatalogGroup[] = [];
-    createUngroupedGroup(this, groups);
 
     if (this._catalogGroup.groupBy === "organization")
       createGroupsByOrganisations(this, groups);
     if (this._catalogGroup.groupBy === "group")
       createGroupsByCkanGroups(this, groups);
+
+    const ungroupedGroup = createUngroupedGroup(this);
 
     groups = [...new Set(groups)];
 
@@ -201,7 +202,9 @@ export class CkanServerStratum extends LoadableStratum(CkanCatalogGroupTraits) {
       }
       return 0;
     });
-    return groups;
+
+    // Put "ungrouped" group at end of groups
+    return [...groups, ungroupedGroup];
   }
 
   @action
@@ -466,10 +469,7 @@ function createGroup(groupId: string, terria: Terria, groupName: string) {
   return g;
 }
 
-function createUngroupedGroup(
-  ckanServer: CkanServerStratum,
-  groups: CatalogGroup[]
-) {
+function createUngroupedGroup(ckanServer: CkanServerStratum) {
   const groupId = ckanServer._catalogGroup.uniqueId + "/ungrouped";
   let existingGroup = ckanServer._catalogGroup.terria.getModelById(
     CatalogGroup,
@@ -482,7 +482,7 @@ function createUngroupedGroup(
       ckanServer._catalogGroup.ungroupedTitle
     );
   }
-  groups.push(existingGroup);
+  return existingGroup;
 }
 
 function createGroupsByOrganisations(

--- a/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
+++ b/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
@@ -120,7 +120,7 @@ describe("CkanCatalogGroup", function() {
           expect(group1.members.length).toBe(9);
 
           // "Ungrouped" group should be last
-          let group2 = <CatalogGroup>ckanServerStratum.groups[8];
+          let group2 = <CatalogGroup>ckanServerStratum.groups[2];
           expect(group2.name).toBe(ckanCatalogGroup.ungroupedTitle);
           expect(group2.name).toBe("No group");
           expect(group2.members.length).toBe(0);

--- a/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
+++ b/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
@@ -162,9 +162,9 @@ describe("CkanCatalogGroup", function() {
       expect(member2 instanceof CatalogGroup).toBeTruthy();
       expect(member2.name).toBe("Science");
       // "Ungrouped" group should be last
-      let member0 = <CatalogGroup>ckanCatalogGroup.memberModels[2];
-      expect(member0 instanceof CatalogGroup).toBeTruthy();
-      expect(member0.name).toBe("Blah");
+      let member3 = <CatalogGroup>ckanCatalogGroup.memberModels[2];
+      expect(member3 instanceof CatalogGroup).toBeTruthy();
+      expect(member3.name).toBe("Blah");
     });
 
     it("Geography group has been filtered from the groups", function() {

--- a/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
+++ b/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
@@ -119,7 +119,8 @@ describe("CkanCatalogGroup", function() {
           // There are 2 resources on the 2 datasets
           expect(group1.members.length).toBe(9);
 
-          let group2 = <CatalogGroup>ckanServerStratum.groups[2];
+          // "Ungrouped" group should be last
+          let group2 = <CatalogGroup>ckanServerStratum.groups[8];
           expect(group2.name).toBe(ckanCatalogGroup.ungroupedTitle);
           expect(group2.name).toBe("No group");
           expect(group2.members.length).toBe(0);
@@ -154,15 +155,16 @@ describe("CkanCatalogGroup", function() {
     it("properly creates members", function() {
       expect(ckanCatalogGroup.members).toBeDefined();
       expect(ckanCatalogGroup.members.length).toBe(3);
-      let member0 = <CatalogGroup>ckanCatalogGroup.memberModels[0];
-      expect(member0 instanceof CatalogGroup).toBeTruthy();
-      expect(member0.name).toBe("Blah");
-      let member1 = <CatalogGroup>ckanCatalogGroup.memberModels[1];
+      let member1 = <CatalogGroup>ckanCatalogGroup.memberModels[0];
       expect(member1 instanceof CatalogGroup).toBeTruthy();
       expect(member1.name).toBe("Environment");
-      let member2 = <CatalogGroup>ckanCatalogGroup.memberModels[2];
+      let member2 = <CatalogGroup>ckanCatalogGroup.memberModels[1];
       expect(member2 instanceof CatalogGroup).toBeTruthy();
       expect(member2.name).toBe("Science");
+      // "Ungrouped" group should be last
+      let member0 = <CatalogGroup>ckanCatalogGroup.memberModels[2];
+      expect(member0 instanceof CatalogGroup).toBeTruthy();
+      expect(member0.name).toBe("Blah");
     });
 
     it("Geography group has been filtered from the groups", function() {


### PR DESCRIPTION
### Move `CkanCatalogGroup` "ungrouped" group to end of members

### After vs Before

<img width="2272" alt="image" src="https://user-images.githubusercontent.com/6187649/183565185-639318a1-955a-46d1-9b5c-28bfc3f11d99.png">
  
### Test me
  
- [Before link](http://ci.terria.io/main/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22E2nsA20d%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%2210cae94f-b282-4db3-b5be-f6272994686b%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22E2nsA20d%22%5D%2C%22type%22%3A%22ckan-group%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%5D%2C%22timeline%22%3A%5B%5D%2C%22initialCamera%22%3A%7B%22west%22%3A92.63671875000001%2C%22south%22%3A-64.6238772020469%2C%22east%22%3A174.37500000000006%2C%22north%22%3A25.958044673317843%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%222d%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.5%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Afalse%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-positron%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22previewedItemId%22%3A%2210cae94f-b282-4db3-b5be-f6272994686b%22%2C%22stories%22%3A%5B%5D%7D%5D%7D)
- [After link](http://ci.terria.io/ckan-ungrouped-last/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22E2nsA20d%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%2210cae94f-b282-4db3-b5be-f6272994686b%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22E2nsA20d%22%5D%2C%22type%22%3A%22ckan-group%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%5D%2C%22timeline%22%3A%5B%5D%2C%22initialCamera%22%3A%7B%22west%22%3A92.63671875000001%2C%22south%22%3A-64.6238772020469%2C%22east%22%3A174.37500000000006%2C%22north%22%3A25.958044673317843%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%222d%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.5%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Afalse%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-positron%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22previewedItemId%22%3A%2210cae94f-b282-4db3-b5be-f6272994686b%22%2C%22stories%22%3A%5B%5D%7D%5D%7D)

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
