### PR TITLE
Set pedestrian heading to the camera heading when dropped.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Change Log
 
 #### next release (8.2.13)
 
+* Fix pedestrian drop behaviour so that the camera heading stays unchanged even after the drop
 * [The next improvement]
 
 #### release 8.2.12 - 2022-08-10

--- a/lib/ReactViews/Tools/PedestrianMode/DropPedestrianToGround.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/DropPedestrianToGround.tsx
@@ -50,7 +50,7 @@ const DropPedestrianToGround: React.FC<DropPedestrianToGroundProps> = props => {
         const position = Cartographic.toCartesian(cartographic);
         flyTo(scene, position, {
           orientation: {
-            heading: 0,
+            heading: scene.camera.heading,
             pitch: 0,
             roll: 0
           }


### PR DESCRIPTION
### What this PR does

Fixes #6426 

Previously, when dropping the pedestrian to ground, we set the camera heading to 0 (= north). This puts the pedestrian in a different direction than the one they were facing before the drop. 

This PR sets the pedestiran heading to the camera heading so that the user faces the same direction after the drop.
  
### Test me
  
1. Open the current main branch CI - http://ci.terria.io/main/#share=s-rbo9PmJairGOHghvdwJ59Ml15Dh
2. Observe that the compass `N` is at the bottom 
3. Drop the pedestrian to ground 
4. Observe that the compass `N` is now at the top
5. Repeat the same for this branch - http://ci.terria.io/fix-pedestrian-heading/#share=s-rbo9PmJairGOHghvdwJ59Ml15Dh
6. Observe that dropping the pedestrian does not change the compass heading

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
