### PR TITLE
Trim CKAN wms layer names.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 #### next release (8.2.13)
 
 * Fix pedestrian drop behaviour so that the camera heading stays unchanged even after the drop
+* Improve the CKAN model robustness by removing leading and trailing spaces in wms layer names.
 * [The next improvement]
 
 #### release 8.2.12 - 2022-08-10

--- a/lib/Models/Catalog/Ckan/CkanItemReference.ts
+++ b/lib/Models/Catalog/Ckan/CkanItemReference.ts
@@ -407,13 +407,19 @@ export default class CkanItemReference extends UrlMixin(
       this.itemProperties?.layers;
 
     // Mixing ?? and || because for params we don't want to use empty string params if there are non-empty string parameters
-    return (
+    const rawLayers =
       (isJsonString(layersFromItemProperties)
         ? layersFromItemProperties
         : undefined) ??
       this._ckanResource?.wms_layer ??
-      (params?.LAYERS || params?.layers || params?.typeName)
-    );
+      (params?.LAYERS || params?.layers || params?.typeName);
+
+    // Improve the robustness.
+    const cleanLayers = rawLayers
+      ?.split(",")
+      .map(layer => layer.trim())
+      .join(",");
+    return cleanLayers;
   }
 }
 


### PR DESCRIPTION
### What this PR does

Fixes #6508 

  
### Test me
Test data
```
{
  "catalog": [
    {
      "id": "issue-6508-testing-id",
      "type": "ckan-group",
      "name": "Issue 6508 test",
      "filterQuery": [
        {
          "q": "title=Irrigation District - WMS",
          "fq": "(res_format:wms OR res_format:WMS)"
        }
      ],
      "groupBy": "organization",
      "supportedResourceFormats": [
        {
          "id": "WMS"
        }
      ],
      "url": "https://discover.data.vic.gov.au/"
    }
  ]
}
```
Before
- Load the above test data to http://ci.terria.io/main/
- Add `Issue 6508 test` -> `Department of Environment, Land, Water & Planning` -> `Irrigation District - WMS`
- `No layer found` error will occur.

After
- Load the above test data to http://ci.terria.io/issue-6508/
- Add the same data.
- No error.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated relevant documentation in `doc/`.
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've provided instructions in the PR description on how to test this PR.
