### PR TITLE
Fix maxFeatures warning for WFS not rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Improve the CKAN model robustness by removing leading and trailing spaces in wms layer names.
 - Load all `InitSources` sequentially instead of asyncronosly
 - Fix `DOMPurify.sanitize` call in `PrintView`
+- Fix warning for WFS item exceeding max displayable features
 - [The next improvement]
 
 #### release 8.2.12 - 2022-08-10
@@ -2760,7 +2761,7 @@
 ### 2.3.0
 
 - Share links now contain details about the picked point, picked features and currently selected feature.
-- Reorganised the display of disclaimers so that they're triggered by `CatalogGroup` and `CatalogItem` models, which trigger `terria.disclaimerEvent`, which is listened to by DisclaimerViewModel`. `DisclaimerViewModel` must be added by the map that's using Terria.
+- Reorganised the display of disclaimers so that they're triggered by `CatalogGroup` and `CatalogItem` models, which trigger `terria.disclaimerEvent`, which is listened to by DisclaimerViewModel`.`DisclaimerViewModel` must be added by the map that's using Terria.
 - Added a mechanism for hiding the source of a CatalogItem in the view info popup.
 - Added the `hideSource` flag to the init json for hiding the source of a CatalogItem in the View Info popup.
 - Fixed a bug where `CatalogMember.load` would return a new promise every time it was called, instead of retaining the one in progress.
@@ -2858,7 +2859,7 @@
   - `RegionMapping`: Used instead of TableDataSource for region-mapped csvs.
   - `DataTable` and `DataVariable` have been replaced with new classes, `TableStructure` and `TableColumn`.
   - `RegionProvider`: `loadRegionsFromWfs`, `processRegionIds`, `applyReplacements`, `findRegionIndex` have been made internal functions.
-  - `RegionProviderList`: `chooseRegionProvider` has been changed and renamed `getRegionDetails `.
+  - `RegionProviderList`: `chooseRegionProvider` has been changed and renamed `getRegionDetails`.
   - `ColorMap`: `fromArray` and `fromString` have been removed, with the constructor taking on that functionality.
   - `LegendUrl` has been moved to the `Map` directory.
   - `TableStyle`: `loadColorMap` and `chooseColorMap` have been removed. Moved from `Map` to `Models` directory.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2761,7 +2761,7 @@
 ### 2.3.0
 
 - Share links now contain details about the picked point, picked features and currently selected feature.
-- Reorganised the display of disclaimers so that they're triggered by `CatalogGroup` and `CatalogItem` models, which trigger `terria.disclaimerEvent`, which is listened to by DisclaimerViewModel`.`DisclaimerViewModel` must be added by the map that's using Terria.
+- Reorganised the display of disclaimers so that they're triggered by `CatalogGroup` and `CatalogItem` models, which trigger `terria.disclaimerEvent`, which is listened to by DisclaimerViewModel`. `DisclaimerViewModel` must be added by the map that's using Terria.
 - Added a mechanism for hiding the source of a CatalogItem in the view info popup.
 - Added the `hideSource` flag to the init json for hiding the source of a CatalogItem in the View Info popup.
 - Fixed a bug where `CatalogMember.load` would return a new promise every time it was called, instead of retaining the one in progress.

--- a/lib/Models/Catalog/Ows/WebFeatureServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebFeatureServiceCatalogItem.ts
@@ -72,12 +72,9 @@ class GetCapabilitiesStratum extends LoadableStratum(
 
   @computed
   get capabilitiesFeatureTypes(): ReadonlyMap<string, FeatureType | undefined> {
-    const lookup: (
-      name: string
-    ) => [string, FeatureType | undefined] = name => [
-      name,
-      this.capabilities && this.capabilities.findLayer(name)
-    ];
+    const lookup: (name: string) => [string, FeatureType | undefined] = (
+      name
+    ) => [name, this.capabilities && this.capabilities.findLayer(name)];
     return new Map(this.catalogItem.typeNamesArray.map(lookup));
   }
 
@@ -168,7 +165,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
     // If more than one layer, push layer description titles for each applicable layer
     if (this.capabilitiesFeatureTypes.size > 1) {
       layerDescriptions = [];
-      this.capabilitiesFeatureTypes.forEach(layer => {
+      this.capabilitiesFeatureTypes.forEach((layer) => {
         if (
           layer &&
           layer.Abstract &&
@@ -301,11 +298,10 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
   }
 
   protected async forceLoadGeojsonData(): Promise<FeatureCollectionWithCrs> {
-    const getCapabilitiesStratum:
-      | GetCapabilitiesStratum
-      | undefined = this.strata.get(
-      GetCapabilitiesMixin.getCapabilitiesStratumName
-    ) as GetCapabilitiesStratum;
+    const getCapabilitiesStratum: GetCapabilitiesStratum | undefined =
+      this.strata.get(
+        GetCapabilitiesMixin.getCapabilitiesStratumName
+      ) as GetCapabilitiesStratum;
 
     if (!this.uri) {
       throw new TerriaError({
@@ -320,7 +316,7 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
 
     // Check if layers exist
     const missingLayers = this.typeNamesArray.filter(
-      layer => !getCapabilitiesStratum.capabilitiesFeatureTypes.has(layer)
+      (layer) => !getCapabilitiesStratum.capabilitiesFeatureTypes.has(layer)
     );
     if (missingLayers.length > 0) {
       throw new TerriaError({
@@ -338,7 +334,7 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
     // Check if geojson output is supported (by checking GetCapabilities OutputTypes OR FeatureType OutputTypes)
     const hasOutputFormat = (outputFormats: string[] | undefined) => {
       return isDefined(
-        outputFormats?.find(format =>
+        outputFormats?.find((format) =>
           ["json", "JSON", "application/json"].includes(format)
         )
       );
@@ -346,9 +342,9 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
 
     const supportsGeojson =
       hasOutputFormat(getCapabilitiesStratum.capabilities.outputTypes) ||
-      [...getCapabilitiesStratum.capabilitiesFeatureTypes.values()].reduce<
-        boolean
-      >(
+      [
+        ...getCapabilitiesStratum.capabilitiesFeatureTypes.values()
+      ].reduce<boolean>(
         (hasGeojson, current) =>
           hasGeojson && hasOutputFormat(current?.OutputFormats),
         true

--- a/lib/Models/Catalog/Ows/WebFeatureServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebFeatureServiceCatalogItem.ts
@@ -72,9 +72,12 @@ class GetCapabilitiesStratum extends LoadableStratum(
 
   @computed
   get capabilitiesFeatureTypes(): ReadonlyMap<string, FeatureType | undefined> {
-    const lookup: (name: string) => [string, FeatureType | undefined] = (
-      name
-    ) => [name, this.capabilities && this.capabilities.findLayer(name)];
+    const lookup: (
+      name: string
+    ) => [string, FeatureType | undefined] = name => [
+      name,
+      this.capabilities && this.capabilities.findLayer(name)
+    ];
     return new Map(this.catalogItem.typeNamesArray.map(lookup));
   }
 
@@ -165,7 +168,7 @@ class GetCapabilitiesStratum extends LoadableStratum(
     // If more than one layer, push layer description titles for each applicable layer
     if (this.capabilitiesFeatureTypes.size > 1) {
       layerDescriptions = [];
-      this.capabilitiesFeatureTypes.forEach((layer) => {
+      this.capabilitiesFeatureTypes.forEach(layer => {
         if (
           layer &&
           layer.Abstract &&
@@ -298,10 +301,11 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
   }
 
   protected async forceLoadGeojsonData(): Promise<FeatureCollectionWithCrs> {
-    const getCapabilitiesStratum: GetCapabilitiesStratum | undefined =
-      this.strata.get(
-        GetCapabilitiesMixin.getCapabilitiesStratumName
-      ) as GetCapabilitiesStratum;
+    const getCapabilitiesStratum:
+      | GetCapabilitiesStratum
+      | undefined = this.strata.get(
+      GetCapabilitiesMixin.getCapabilitiesStratumName
+    ) as GetCapabilitiesStratum;
 
     if (!this.uri) {
       throw new TerriaError({
@@ -316,7 +320,7 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
 
     // Check if layers exist
     const missingLayers = this.typeNamesArray.filter(
-      (layer) => !getCapabilitiesStratum.capabilitiesFeatureTypes.has(layer)
+      layer => !getCapabilitiesStratum.capabilitiesFeatureTypes.has(layer)
     );
     if (missingLayers.length > 0) {
       throw new TerriaError({
@@ -334,7 +338,7 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
     // Check if geojson output is supported (by checking GetCapabilities OutputTypes OR FeatureType OutputTypes)
     const hasOutputFormat = (outputFormats: string[] | undefined) => {
       return isDefined(
-        outputFormats?.find((format) =>
+        outputFormats?.find(format =>
           ["json", "JSON", "application/json"].includes(format)
         )
       );
@@ -342,9 +346,9 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
 
     const supportsGeojson =
       hasOutputFormat(getCapabilitiesStratum.capabilities.outputTypes) ||
-      [
-        ...getCapabilitiesStratum.capabilitiesFeatureTypes.values()
-      ].reduce<boolean>(
+      [...getCapabilitiesStratum.capabilitiesFeatureTypes.values()].reduce<
+        boolean
+      >(
         (hasGeojson, current) =>
           hasGeojson && hasOutputFormat(current?.OutputFormats),
         true
@@ -418,7 +422,7 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
   get shortReport(): string | undefined {
     // Show notice if reached
     if (
-      isObservableArray(this.readyData?.features) &&
+      this.readyData?.features !== undefined &&
       this.readyData!.features.length >= this.maxFeatures
     ) {
       return i18next.t(


### PR DESCRIPTION
Change check of features array from isObservableArray - was failing

### What this PR does

Partly Fixes https://github.com/TerriaJS/vic-digital-twin/issues/407

Will display a warning in workbench if WFS layer is added that has hit the feature limit as specified in `WebFeatureServiceCatalogItemTraits`  (default is 1000)

### Test me

http://ci.terria.io/feature-limits-407/#clean&https://gist.githubusercontent.com/staffordsmith83/2c2801bc25cdcee9515676a42f523323/raw/bf635c9038e62b9959b4d55ebbe287aead811c19/testCat.json

Then add the WFS layer from the Catalog.
Will take awhile to load, then should show the warning in the workbench: 
![image](https://user-images.githubusercontent.com/7980991/187592583-a300bdcc-61e0-4752-816a-4accfe927891.png)


### Checklist

~~- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.~~
- [y] I've updated CHANGES.md with what I changed.
- [y] I've provided instructions in the PR description on how to test this PR.
