### PR TITLE
Fix scrolling for story content and disclaimer modals in Safari iOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Moved map credits to map column so it don't get hidden by chart panel.
 - Fix support for `initUrls` in `startData.initSources`
 - Propagate `knownContainerUniqueIds` across references and their target.
+- Show scrollbar for story content in Safari iOS.
 - [The next improvement]
 
 #### 8.2.13 - 2022-09-01

--- a/lib/ReactViews/Disclaimer.jsx
+++ b/lib/ReactViews/Disclaimer.jsx
@@ -101,6 +101,8 @@ class Disclaimer extends React.Component {
             css={`
               max-height: 100%;
               overflow: auto;
+              /* Required for the content to be scrollable in Safari iOS */
+              -webkit-overflow-scrolling: touch;
             `}
           >
             <Text

--- a/lib/ReactViews/Disclaimer.jsx
+++ b/lib/ReactViews/Disclaimer.jsx
@@ -98,11 +98,10 @@ class Disclaimer extends React.Component {
             left
             styledWidth={useSmallScreenInterface ? "100%" : "613px"}
             paddedRatio={4}
+            scroll
             css={`
               max-height: 100%;
               overflow: auto;
-              /* Required for the content to be scrollable in Safari iOS */
-              -webkit-overflow-scrolling: touch;
             `}
           >
             <Text

--- a/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
@@ -17,10 +17,11 @@ const StoryContainer = styled(Box).attrs((props: { isCollapsed: boolean }) => ({
     max-height: ${(props) => (props.isCollapsed ? 0 : "400px")};
   }
 
-  border: 1px solid red;
+  /* Required for the content to be scrollable in Safari iOS */
+  -webkit-overflow-scrolling: touch;
+  overflow-y: auto;
 
   transition: max-height 0.2s, padding 0.2s;
-  overflow-y: scroll;
 
   img {
     max-width: 100%;

--- a/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
@@ -6,7 +6,8 @@ import Box from "../../../Styled/Box";
 import Text from "../../../Styled/Text";
 
 const StoryContainer = styled(Box).attrs((props: { isCollapsed: boolean }) => ({
-  paddedVertically: props.isCollapsed ? 0 : 2
+  paddedVertically: props.isCollapsed ? 0 : 2,
+  scroll: true
 }))<{ isCollapsed: boolean }>`
   padding-top: 0;
   max-height: ${(props) => (props.isCollapsed ? 0 : "100px")};
@@ -17,8 +18,6 @@ const StoryContainer = styled(Box).attrs((props: { isCollapsed: boolean }) => ({
     max-height: ${(props) => (props.isCollapsed ? 0 : "400px")};
   }
 
-  /* Required for the content to be scrollable in Safari iOS */
-  -webkit-overflow-scrolling: touch;
   overflow-y: auto;
 
   transition: max-height 0.2s, padding 0.2s;

--- a/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
@@ -58,6 +58,7 @@ const StoryBody = ({
             display: flex;
             flex-direction: column;
             gap: 5px;
+            overflow-y: auto;
           `}
           medium
         >

--- a/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
@@ -17,8 +17,10 @@ const StoryContainer = styled(Box).attrs((props: { isCollapsed: boolean }) => ({
     max-height: ${(props) => (props.isCollapsed ? 0 : "400px")};
   }
 
+  border: 1px solid red;
+
   transition: max-height 0.2s, padding 0.2s;
-  overflow-y: auto;
+  overflow-y: scroll;
 
   img {
     max-width: 100%;
@@ -58,7 +60,6 @@ const StoryBody = ({
             display: flex;
             flex-direction: column;
             gap: 5px;
-            overflow-y: auto;
           `}
           medium
         >

--- a/lib/ReactViews/Story/StoryPanel/StoryFooterBar.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryFooterBar.tsx
@@ -72,7 +72,7 @@ const FooterBar = ({
           />
         </FooterButton>
         <Box paddedRatio={3}>
-          <Text>
+          <Text noWrap>
             {currentHumanIndex} / {totalStories}
           </Text>
         </Box>


### PR DESCRIPTION
### What this PR does

* Fixes scrolling of story content in Safari iOS.
  Currently when the story content is long, the content is not scrollable in iOS Safari. This PR fixes it.
* Fixes scrolling of global disclaimer in Safari iOS.
* Prevents story scene numbers from breaking up into multiple lines in mobile view
  Before:
  ![image](https://user-images.githubusercontent.com/1430/189266568-8c288148-8b7b-4ab1-aa3b-318fdc27e873.png)
  After:
  ![image](https://user-images.githubusercontent.com/1430/189264946-ba0fffeb-503f-4fb8-b71c-8376d865c66a.png)


### Test me

- Open the story from this link for [main branch](http://ci.terria.io/main/#share=s-j2eVu7qoMRtkxs8dtai1KzKTxHL) in Safari iOS
- Observe that the story content cannot be scrolled
- Repeat the same with the link for [this branch](http://ci.terria.io/fix-ios-scroll/#share=s-j2eVu7qoMRtkxs8dtai1KzKTxHL)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
