### PR TITLE
build sharelink from document.caseURI instead

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Moved map credits to map column so it don't get hidden by chart panel.
 - Fix support for `initUrls` in `startData.initSources`
 - Propagate `knownContainerUniqueIds` across references and their target.
+- Use `document.baseURI` for building share links instead of `window.location`.
 - [The next improvement]
 
 #### 8.2.13 - 2022-09-01

--- a/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.ts
+++ b/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.ts
@@ -38,7 +38,8 @@ function buildBaseShareUrl(
   terria: Terria,
   hashParams: { [key: string]: string }
 ) {
-  const uri = new URI(window.location).fragment("").search("");
+  // const uri = new URI(window.location).fragment("").search("");
+  const uri = new URI(document.baseURI).fragment("").search("");
 
   if (terria.developmentEnv) {
     uri.addSearch(toJS(terria.userProperties));

--- a/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.ts
+++ b/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.ts
@@ -38,7 +38,6 @@ function buildBaseShareUrl(
   terria: Terria,
   hashParams: { [key: string]: string }
 ) {
-  // const uri = new URI(window.location).fragment("").search("");
   const uri = new URI(document.baseURI).fragment("").search("");
 
   if (terria.developmentEnv) {


### PR DESCRIPTION
instead of window.location

### What this PR does

Fixes #6391

Strips story route from the url of a created sharelink.
Incorrect behaviour (as referenced in #6391):
- https://maps.dea.ga.gov.au/story/DEACoastlines
- Click Share
- https://maps.dea.ga.gov.au/story/DEACoastlines#share=s-usNBqERvxnRFzfjgf1G14W0ijSC
- But should be https://maps.dea.ga.gov.au/#share=s-usNBqERvxnRFzfjgf1G14W0ijSC

### Test me

Go to: 
http://ci.terria.io/sharelink-baseurl/story/DEACoastlines#configUrl=https://terria-catalogs-public.storage.googleapis.com/de-australia/map-config/prod.json

Create a sharelink. Should not include the "/story/DEACoastlines" component of the url!

By contrast, go to https://maps.dea.ga.gov.au/story/DEACoastlines and create a sharelink: "/story/DEACoastlines" component of the url will be included. We do not want this.

### Checklist

~~- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~~
~~- [ ] I've updated relevant documentation in `doc/`.~~
- [y] I've updated CHANGES.md with what I changed.
- [y] I've provided instructions in the PR description on how to test this PR.
