### PR TITLE
Fix bug with "propagate `knownContainerUniqueIds` across references and their target" - missing `runInAction`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.15)
 
+- Fix bug with "propagate `knownContainerUniqueIds` across references and their target" - missing `runInAction`
 - [The next improvement]
 
 #### 8.2.14 - 2022-09-15

--- a/lib/ModelMixins/ReferenceMixin.ts
+++ b/lib/ModelMixins/ReferenceMixin.ts
@@ -108,12 +108,14 @@ function ReferenceMixin<T extends Constructor<Model<ReferenceTraits>>>(
       );
 
       if (!result.error && this.target) {
-        // Copy knownContainerUniqueIds to target
-        this.knownContainerUniqueIds.forEach((id) =>
-          !this.target!.knownContainerUniqueIds.includes(id)
-            ? this.target!.knownContainerUniqueIds.push(id)
-            : null
-        );
+        runInAction(() => {
+          // Copy knownContainerUniqueIds to target
+          this.knownContainerUniqueIds.forEach((id) =>
+            !this.target!.knownContainerUniqueIds.includes(id)
+              ? this.target!.knownContainerUniqueIds.push(id)
+              : null
+          );
+        });
 
         applyItemProperties(this, this.target);
       }

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
@@ -54,10 +54,13 @@ const DataCatalogGroup = observer(
           isOpen: !this.state.isOpen
         });
       }
-      this.props.viewState.viewCatalogMember(
-        this.props.group,
-        !this.props.group.isOpen
-      );
+
+      (
+        await this.props.viewState.viewCatalogMember(
+          this.props.group,
+          !this.props.group.isOpen
+        )
+      ).raiseError(this.props.viewState.terria);
     },
 
     isSelected() {

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.tsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.tsx
@@ -45,7 +45,10 @@ export default observer(function DataCatalogItem({
     ? viewState.userDataPreviewedItem === item
     : viewState.previewedItem === item;
 
-  const setPreviewedItem = () => viewState.viewCatalogMember(item);
+  const setPreviewedItem = () =>
+    viewState
+      .viewCatalogMember(item)
+      .then((result) => result.raiseError(viewState.terria));
 
   const toggleEnable = async (event: React.MouseEvent<HTMLButtonElement>) => {
     const keepCatalogOpen = event.shiftKey || event.ctrlKey;

--- a/lib/ReactViews/DataCatalog/DataCatalogReference.tsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogReference.tsx
@@ -33,7 +33,10 @@ export default observer(function DataCatalogReference({
   onActionButtonClicked,
   isTopLevel
 }: Props) {
-  const setPreviewedItem = () => viewState.viewCatalogMember(reference);
+  const setPreviewedItem = () =>
+    viewState
+      .viewCatalogMember(reference)
+      .then((result) => result.raiseError(viewState.terria));
 
   const add = async (event: React.MouseEvent<HTMLButtonElement>) => {
     const keepCatalogOpen = event.shiftKey || event.ctrlKey;

--- a/lib/ReactViews/ExplorerWindow/Tabs.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs.jsx
@@ -110,7 +110,11 @@ const Tabs = observer(
             )[0];
             // If member was found and member can be opened, open it (causes CkanCatalogGroups to fetch etc.)
             if (defined(member)) {
-              this.props.viewState.viewCatalogMember(member);
+              this.props.viewState
+                .viewCatalogMember(member)
+                .then((result) =>
+                  result.raiseError(this.props.viewState.terria)
+                );
             }
           }
         }

--- a/lib/ReactViews/Search/Breadcrumbs.jsx
+++ b/lib/ReactViews/Search/Breadcrumbs.jsx
@@ -38,7 +38,9 @@ class Breadcrumbs extends React.Component {
         item.setTrait(CommonStrata.user, "isOpen", true);
       });
     });
-    await this.props.viewState.viewCatalogMember(items[0]);
+    (await this.props.viewState.viewCatalogMember(items[0])).raiseError(
+      this.props.viewState.terria
+    );
     this.props.viewState.changeSearchState("");
   }
 

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.tsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.tsx
@@ -316,7 +316,9 @@ class ViewingControls extends React.Component<
           group.setTrait(CommonStrata.user, "isOpen", true);
         });
       });
-    this.props.viewState.viewCatalogMember(item);
+    this.props.viewState
+      .viewCatalogMember(item)
+      .then((result) => result.raiseError(this.props.viewState.terria));
   }
 
   exportDataClicked() {


### PR DESCRIPTION
### Fix bug with "propagate `knownContainerUniqueIds` across references and their target" - missing `runInAction`

I also added some `result.raiseError()` to usage of `viewState.viewCatalogMember()`

### Test

#### Before

- http://ci.terria.io/main/#configUrl=https://nationalmap.gov.au/config.json
- Open Catalog
- Click Queensland
- Group won't open

#### After

- http://ci.terria.io/reference-load-bug/#configUrl=https://nationalmap.gov.au/config.json
- Open Catalog
- Click Queensland
- Group will open

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
