### PR TITLE
Fix `isTerriaFeatureData` bug - not checking `isJsonObject`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.16)
 
+- Fix `isTerriaFeatureData` bug - not checking `isJsonObject`
 - [The next improvement]
 
 #### 8.2.15 - 2022-09-16

--- a/lib/Models/Feature/FeatureData.ts
+++ b/lib/Models/Feature/FeatureData.ts
@@ -1,4 +1,5 @@
 import TimeIntervalCollectionProperty from "terriajs-cesium/Source/DataSources/TimeIntervalCollectionProperty";
+import { isJsonObject } from "../../Core/Json";
 
 /** Terria specific properties */
 export interface TerriaFeatureData {
@@ -12,5 +13,10 @@ export interface TerriaFeatureData {
 }
 
 export function isTerriaFeatureData(data: any): data is TerriaFeatureData {
-  return data && "type" in data && data.type === "terriaFeatureData";
+  return (
+    data &&
+    isJsonObject(data, false) &&
+    "type" in data &&
+    data.type === "terriaFeatureData"
+  );
 }


### PR DESCRIPTION
### Fix `isTerriaFeatureData` bug - not checking `isJsonObject`

Bug which causes map to crash for some feature data.

- **Before** http://ci.terria.io/main/#share=s-p4LAYIZQ7a2RUavPtgquqA8Tyi5
- **After** http://ci.terria.io/is-terria-feature-bug/#share=s-p4LAYIZQ7a2RUavPtgquqA8Tyi5
- Click on feature
- See map crash

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
