### PR TITLE
Fix region mapping feature `rowIds` incorrect type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.17)
 
+- Fix region mapping feature `rowIds` incorrect type.
 - [The next improvement]
 
 #### next release (8.2.16)

--- a/lib/Table/createRegionMappedImageryProvider.ts
+++ b/lib/Table/createRegionMappedImageryProvider.ts
@@ -7,6 +7,7 @@ import TimeInterval from "terriajs-cesium/Source/Core/TimeInterval";
 import ImageryLayerFeatureInfo from "terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo";
 import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
 import isDefined from "../Core/isDefined";
+import { isJsonNumber } from "../Core/Json";
 import MapboxVectorTileImageryProvider from "../Map/ImageryProvider/MapboxVectorTileImageryProvider";
 import { TerriaFeatureData } from "../Models/Feature/FeatureData";
 import TableStyle from "./TableStyle";
@@ -200,10 +201,11 @@ const getImageryLayerFeatureInfo = action(
 
       featureData.id = feature.properties[regionType.uniqueIdProp];
       featureInfo.properties = featureData;
-      featureInfo.data = {
-        rowIds: regionRows,
+      const terriaFeatureData: TerriaFeatureData = {
+        rowIds: isJsonNumber(regionRows) ? [regionRows] : [...regionRows],
         type: "terriaFeatureData"
-      } as TerriaFeatureData;
+      };
+      featureInfo.data = terriaFeatureData;
 
       featureInfo.configureDescriptionFromProperties(featureData);
       featureInfo.configureNameFromProperties(featureData);


### PR DESCRIPTION
### Fix region mapping feature `rowIds` incorrect type

### Test me

**Before** http://ci.terria.io/main/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fnationalmap%2Fconfig%2Fdev.json&share=s-jlulNtoQsp1FtbtQSQRtYe6fcP

- Click on feature
- See error thrown in console
- See ugly feature info

<img width="600" alt="image" src="https://user-images.githubusercontent.com/6187649/191902582-64733e1f-f8ea-4ff6-b423-7cdfa818d225.png">


**After** http://ci.terria.io/region-rowids-feature-data/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fnationalmap%2Fconfig%2Fdev.json&share=s-jlulNtoQsp1FtbtQSQRtYe6fcP

- Click on feature
- See pretty feature info

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
