### PR TITLE
Add some missing proxyCatalogItemUrl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.18)
 
+- Add missing `proxyCatalogItemUrl` to GeoJson, Shapefile, Gltf and AssImp catalog items
 - [The next improvement]
 
 #### 8.2.17 - 2022-09-23

--- a/lib/ModelMixins/GltfMixin.ts
+++ b/lib/ModelMixins/GltfMixin.ts
@@ -16,6 +16,7 @@ import GltfTraits from "../Traits/TraitsClasses/GltfTraits";
 import CatalogMemberMixin from "./CatalogMemberMixin";
 import MappableMixin from "./MappableMixin";
 import ShadowMixin from "./ShadowMixin";
+import proxyCatalogItemUrl from "../Models/Catalog/proxyCatalogItemUrl";
 
 // We want TS to look at the type declared in lib/ThirdParty/terriajs-cesium-extra/index.d.ts
 // and import doesn't allows us to do that, so instead we use require + type casting to ensure
@@ -100,7 +101,7 @@ function GltfMixin<T extends Constructor<GltfModel>>(Base: T) {
         return undefined;
       }
       const options = {
-        uri: new ConstantProperty(this.gltfModelUrl),
+        uri: new ConstantProperty(proxyCatalogItemUrl(this, this.gltfModelUrl)),
         upAxis: new ConstantProperty(this.cesiumUpAxis),
         forwardAxis: new ConstantProperty(this.cesiumForwardAxis),
         scale: new ConstantProperty(this.scale !== undefined ? this.scale : 1),

--- a/lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem.ts
@@ -68,7 +68,11 @@ class GeoJsonCatalogItem
           throw fileApiNotSupportedError(this.terria);
         }
         const body = this.requestData ? toJS(this.requestData) : undefined;
-        const blob = await loadBlob(this.url, undefined, body);
+        const blob = await loadBlob(
+          proxyCatalogItemUrl(this, this.url),
+          undefined,
+          body
+        );
         jsonData = await parseZipJsonBlob(blob);
       } else {
         jsonData = await loadJson(

--- a/lib/Models/Catalog/CatalogItems/ShapefileCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/ShapefileCatalogItem.ts
@@ -13,6 +13,7 @@ import GeoJsonMixin, {
 import ShapefileCatalogItemTraits from "../../../Traits/TraitsClasses/ShapefileCatalogItemTraits";
 import CreateModel from "../../Definition/CreateModel";
 import HasLocalData from "../../HasLocalData";
+import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
 import { fileApiNotSupportedError } from "./GeoJsonCatalogItem";
 
 export function isJsonArrayOrDeepArrayOfObjects(
@@ -63,7 +64,7 @@ class ShapefileCatalogItem
         if (typeof FileReader === "undefined") {
           throw fileApiNotSupportedError(this.terria);
         }
-        const blob = await loadBlob(this.url);
+        const blob = await loadBlob(proxyCatalogItemUrl(this, this.url));
         return await parseShapefile(blob);
       } else {
         throw TerriaError.from(

--- a/lib/Models/Catalog/Gltf/AssImpCatalogItem.ts
+++ b/lib/Models/Catalog/Gltf/AssImpCatalogItem.ts
@@ -10,6 +10,7 @@ import AssImpCatalogItemTraits from "../../../Traits/TraitsClasses/AssImpCatalog
 import CommonStrata from "../../Definition/CommonStrata";
 import CreateModel from "../../Definition/CreateModel";
 import HasLocalData from "../../HasLocalData";
+import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
 import { GlTf } from "./GLTF";
 
 // List of supported image formats from https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types
@@ -99,7 +100,7 @@ export default class AssImpCatalogItem
       urls.map(async (url) => {
         // **Local data** - treat all URLs as zip if they have been uploaded
         if (isZip(url) || this.hasLocalData) {
-          const blob = await loadBlob(url);
+          const blob = await loadBlob(proxyCatalogItemUrl(this, url));
           const zipFiles = await parseZipArrayBuffers(blob);
           zipFiles.forEach((zipFile) => {
             fileArrayBuffers.push({
@@ -116,7 +117,9 @@ export default class AssImpCatalogItem
         }
         // **Remote data** - explicitly defined in `url` or `urls`
         else {
-          const arrayBuffer = await loadArrayBuffer(url);
+          const arrayBuffer = await loadArrayBuffer(
+            proxyCatalogItemUrl(this, url)
+          );
           const uri = new URI(url);
           const name = uri.filename();
           fileArrayBuffers.push({


### PR DESCRIPTION
### Add some missing proxyCatalogItemUrl

Fixes https://github.com/TerriaJS/nationalmap/issues/1156

We should use `proxyCatalogItemUrl` on all URLs for catalog items - so requests are proxied if required.

### Test me

- Before GeoJSON http://ci.terria.io/main/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-qJCqrBShh04WY2t2sVqS1N8kEFr
- After GeoJSON http://ci.terria.io/add-missing-proxyurls/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-qJCqrBShh04WY2t2sVqS1N8kEFr

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
