### PR TITLE
 Add `mergeGroupsByName` trait to `GroupTraits`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.18)
 
+- Add `mergeGroupsByName` trait to `GroupTraits` - this will merge all group members with the same name
 - [The next improvement]
 
 #### 8.2.17 - 2022-09-23

--- a/lib/ModelMixins/GroupMixin.ts
+++ b/lib/ModelMixins/GroupMixin.ts
@@ -1,12 +1,15 @@
+import { uniq } from "lodash-es";
 import { action, computed, runInAction } from "mobx";
 import clone from "terriajs-cesium/Source/Core/clone";
 import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import AsyncLoader from "../Core/AsyncLoader";
 import Constructor from "../Core/Constructor";
 import filterOutUndefined from "../Core/filterOutUndefined";
+import flatten from "../Core/flatten";
 import isDefined from "../Core/isDefined";
 import { isJsonNumber, isJsonString, JsonObject } from "../Core/Json";
 import Result from "../Core/Result";
+import CatalogMemberFactory from "../Models/Catalog/CatalogMemberFactory";
 import Group from "../Models/Catalog/Group";
 import CommonStrata from "../Models/Definition/CommonStrata";
 import hasTraits, { HasTrait } from "../Models/Definition/hasTraits";
@@ -19,6 +22,8 @@ import ReferenceMixin from "./ReferenceMixin";
 
 const naturalSort = require("javascript-natural-sort");
 naturalSort.insensitive = true;
+
+const MERGED_GROUP_ID_PREPEND = "__merged__";
 
 function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
   abstract class Klass extends Base implements Group {
@@ -131,6 +136,8 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
         // Call Group AsyncLoader if no errors occurred while loading metadata
         (await this._memberLoader.load()).throwIfError();
 
+        // Order here is important, as mergeGroupMembersByName will create models and the following functions will be applied on memberModels
+        this.mergeGroupMembersByName();
         this.refreshKnownContainerUniqueIds(this.uniqueId);
         this.addShareKeysToMembers();
         this.addItemPropertiesToMembers();
@@ -163,6 +170,77 @@ function GroupMixin<T extends Constructor<Model<GroupTraits>>>(Base: T) {
     @action
     toggleOpen(stratumId: string) {
       this.setTrait(stratumId, "isOpen", !this.isOpen);
+    }
+
+    /** "Merges" group members with the same name if `mergeGroupsByName` Trait is set to `true`
+     * It does this by:
+     * - Creating a new CatalogGroup with all members of each merged group
+     * - Appending merged group ids to `excludeMembers`
+     * This is only applied to the first level of group members (it is not recursive)
+     * `mergeGroupsByName` is not applied to nested groups automatically.
+     */
+    @action
+    mergeGroupMembersByName() {
+      if (!this.mergeGroupsByName) return;
+      // Create map of group names to group models
+      const membersByName = new Map<string, GroupMixin.Instance[]>();
+      this.memberModels.forEach((member) => {
+        if (
+          GroupMixin.isMixedInto(member) &&
+          CatalogMemberMixin.isMixedInto(member) &&
+          member.name
+        ) {
+          // Push member to map
+          membersByName.get(member.name)?.push(member) ??
+            membersByName.set(member.name, [member]);
+        }
+      });
+
+      membersByName.forEach((groups, name) => {
+        if (groups.length > 1) {
+          const groupIdsToMerge = groups
+            .map((g) => g.uniqueId)
+            .filter(isJsonString);
+
+          const mergedGroupId = `${this.uniqueId}/${MERGED_GROUP_ID_PREPEND}${name}`;
+
+          let mergedGroup = this.terria.getModelById(BaseModel, mergedGroupId);
+
+          // Create mergedGroup if it doesn't exist - and then add it to group.members
+          if (!mergedGroup) {
+            mergedGroup = CatalogMemberFactory.create(
+              "group",
+              mergedGroupId,
+              this.terria
+            );
+
+            if (mergedGroup) {
+              // We add groupIdsToMerge as shareKeys here for backward compatibility
+              this.terria.addModel(mergedGroup, groupIdsToMerge);
+              this.add(CommonStrata.override, mergedGroup);
+            }
+          }
+
+          // Set merged group traits - name and members
+          // Also set excludeMembers to exclude all groups that are merged.
+          if (
+            GroupMixin.isMixedInto(mergedGroup) &&
+            CatalogMemberMixin.isMixedInto(mergedGroup)
+          ) {
+            mergedGroup.setTrait(CommonStrata.definition, "name", name);
+            mergedGroup.setTrait(
+              CommonStrata.definition,
+              "members",
+              flatten(groups.map((g) => [...g.members]))
+            );
+            this.setTrait(
+              CommonStrata.override,
+              "excludeMembers",
+              uniq([...(this.excludeMembers ?? []), ...groupIdsToMerge])
+            );
+          }
+        }
+      });
     }
 
     @action

--- a/lib/Traits/TraitsClasses/GroupTraits.ts
+++ b/lib/Traits/TraitsClasses/GroupTraits.ts
@@ -23,6 +23,13 @@ export default class GroupTraits extends mixTraits(ItemPropertiesTraits) {
   isOpen: boolean = false;
 
   @primitiveTrait({
+    name: "Merge by name",
+    description: "Merge member groups by name.",
+    type: "boolean"
+  })
+  mergeGroupsByName: boolean = false;
+
+  @primitiveTrait({
     name: "Sort members by",
     description:
       "Sort members by the given property/trait. For example `name`, will sort all members by alphabetically",


### PR DESCRIPTION
###  Add `mergeGroupsByName` trait to `GroupTraits`

Fixes https://github.com/TerriaJS/nationalmap/issues/1181

If `mergeGroupsByName=true` then groups of the same name will be merged.

### Test me

- **After** http://ci.terria.io/group-merge-by-name/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-4iPk12WXYVcles0TdBCfKbWwYfh
- **Before** http://ci.terria.io/main/#configUrl=https%3A%2F%2Fnationalmap.gov.au%2Fconfig.json&share=s-4iPk12WXYVcles0TdBCfKbWwYfh

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/6187649/192257002-edf5eb11-e35c-4f87-8940-7b427ccec24f.png">

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
