### PR TITLE
Pin flexsearch to version 0.7.21

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.18)
 
+- Pin `flexsearch` version to `0.7.21` - as incorrect types are shipped in version `0.7.31`
 - Only preload next timestep of timeseries rasters (WMS & ArcGIS MapServer) when animating the item on the map.
 - [The next improvement]
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "dompurify": "^2.3.3",
     "file-loader": "^3.0.1",
     "file-saver": "^1.3.8",
-    "flexsearch": "^0.7.21",
+    "flexsearch": "0.7.21",
     "geojson-vt": "^3.2.1",
     "gulp": "^4.0.0",
     "hammerjs": "^2.0.6",


### PR DESCRIPTION
### Pin flexsearch to version 0.7.21

We are getting the following errors with the latest version

For example - https://github.com/TerriaJS/terriajs/actions/runs/3180913259/jobs/5185047215

```
Error: lib/Models/SearchProviders/CatalogIndex.ts(28,7): error TS2315: Type 'Document' is not generic.
Error: lib/Models/SearchProviders/CatalogIndex.ts(93,31): error TS2693: 'FlexSearchDocument' only refers to a type, but is being used as a value here.
```

This is because bundled types were just included in the latest version 

https://github.com/nextapps-de/flexsearch/blob/9abb781357f04e7db8529654c6941009771f4bf1/package.json#L26

The bundled types are incorrect, and they are overriding correct `@types/flexsearch` - so I have pinned version to previous working version

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
