### PR TITLE
Change plugin name for runWebpack errors

### DIFF
--- a/buildprocess/runWebpack.js
+++ b/buildprocess/runWebpack.js
@@ -22,7 +22,10 @@ function runWebpack(webpack, config, doneCallback) {
         //require('fs').writeFileSync('./stats.json', JSON.stringify(jsonStats));
 
         if (jsonStats.errors && jsonStats.errors.length > 0) {
-          err = new PluginError("build-specs", "Build has errors (see above).");
+          err = new PluginError(
+            "terriajs-runWebpack",
+            "Build has errors (see above)."
+          );
         }
       }
     }


### PR DESCRIPTION
Change from "build-specs", which is the name of one of the gulp tasks in terriajs' gulpfile to "terriajs-runWebpack" for clarity in error messages