### PR TITLE
Fix feature picking for some WMTS layers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.19)
 
+- Handle errors thrown in `Cesium._attachProviderCoordHooks`. This fixes a bug where some WMTS layers break feature picking.
 - [The next improvement]
 
 #### 8.2.18 - 2022-10-19


### PR DESCRIPTION
### Fix feature picking for some WMTS layers

Fixes https://github.com/TerriaJS/terriajs/issues/6556

### Test me

#### Before

- http://ci.terria.io/main/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fde-africa%2Fmap-config%2Fprod.json&share=s-xd18uPu1zO82KfnqiFL2mTm5QWT
- Make sure "ESRI World Imagery" is set as basemap
- Click on Coastlines point
- See no feature info

#### After

- http://ci.terria.io/wmts-feature-error/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fde-africa%2Fmap-config%2Fprod.json&share=s-xd18uPu1zO82KfnqiFL2mTm5QWT
- Make sure "ESRI World Imagery" is set as basemap
- Click on Coastlines point
- See correct feature info

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
