### PR TITLE
Leaflet wmts feature fix + Release TerriaJS 8.2.20

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,12 @@
 # Change Log
 
-#### next release (8.2.20)
+#### next release (8.2.21)
 
 - [The next improvement]
+
+#### 8.2.20 - 2022-10-20
+
+- Handle errors thrown in `ImageryProviderLeafletTileLayer.pickFeatures`. This fixes a bug where some WMTS layers break feature picking (in Leaflet/2D mode)
 
 #### 8.2.19 - 2022-10-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.2.19",
+  "version": "8.2.20",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### Leaflet wmts feature fix + Release TerriaJS 8.2.20

Fixes https://github.com/TerriaJS/terriajs/issues/6556 

Unfortunately - [this PR](https://github.com/TerriaJS/terriajs/pull/6597) only fixed in in cesium

### Test me

#### Before

- http://ci.terria.io/main/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fde-africa%2Fmap-config%2Fprod.json&share=s-lkOqUrITPp9TQv78tAbqmAbM2AI
- Make sure "ESRI World Imagery" is set as basemap and you are in 2D/Leaflet mode
- Click on Coastlines point
- See no feature info

#### After

- http://ci.terria.io/leaflet-wmts-feature-fix/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fde-africa%2Fmap-config%2Fprod.json&share=s-lkOqUrITPp9TQv78tAbqmAbM2AI
- Make sure "ESRI World Imagery" is set as basemap and you are in 2D/Leaflet mode
- Click on Coastlines point
- See correct feature info

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
