### PR TITLE
BoxDrawing improvements.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@
 #### next release (8.2.23)
 
 - Only add groups to `CatalogIndex` if they aren't empty
+- `BoxDrawing` improvements:
+  - Added option `drawNonUniformScaleGrips` to enable/disable uniform-scaling
+  - Set limit on the size of scaling grips relative to the size of the box
+  - Small improvement to move interaction that prevents the box from locking up when trying to move at a camera angle parallel to the ground
+  - Restore modified map state to the previous setting when interaction stops
 - [The next improvement]
 
 #### 8.2.22 - 2022-12-02
@@ -29,12 +34,6 @@
 - Add `maximumNativeZoom` to `ProtomapsImageryProvider`
 - Fix image markers (eg `marker = "data:image/png;base64,..."`)
 - Fix `AssimpCatalogItem` to correctly handle zip archives that contain files inside a root folder.
-- `BoxDrawing` improvements:
-  - Added option `drawNonUniformScaleGrips` to enable/disable uniform-scaling
-  - Set limit on the size of scaling grips relative to the size of the box
-  - Small improvement to move interaction that prevents the box from locking up when trying to move at a camera angle parallel to the ground
-  - Restore modified map state to the previous setting when interaction stops
-- [The next improvement]
 
 #### 8.2.21 - 2022-11-10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@
 - Add `maximumNativeZoom` to `ProtomapsImageryProvider`
 - Fix image markers (eg `marker = "data:image/png;base64,..."`)
 - Fix `AssimpCatalogItem` to correctly handle zip archives that contain files inside a root folder.
+- `BoxDrawing` improvements:
+  - Added option `drawNonUniformScaleGrips` to enable/disable uniform-scaling
+  - Set limit on the size of scaling grips relative to the size of the box
+  - Small improvement to move interaction that prevents the box from locking up when trying to move at a camera angle parallel to the ground
+  - Restore modified map state to the previous setting when interaction stops
 - [The next improvement]
 
 #### 8.2.21 - 2022-11-10

--- a/lib/Models/BoxDrawing.ts
+++ b/lib/Models/BoxDrawing.ts
@@ -123,10 +123,17 @@ type ScalePointStyle = {
  */
 type InteractionState =
   | { is: "none" }
-  | { is: "picked"; entity: Entity & Interactable }
+  | {
+      is: "picked";
+      entity: Entity & Interactable;
+      beforePickState: {
+        isFeaturePickingPaused: boolean;
+        enableInputs: boolean;
+      };
+    }
   | { is: "hovering"; entity: Entity & Interactable };
 
-type OnChangeParams = {
+export type BoxDrawingChangeParams = {
   /**
    * The modelMatrix of the box
    */
@@ -155,7 +162,13 @@ type BoxDrawingOptions = {
   /**
    * A callback method to call when box parameters change.
    */
-  onChange?: (params: OnChangeParams) => void;
+  onChange?: (params: BoxDrawingChangeParams) => void;
+
+  /**
+   * When set to `false`, do not draw the scale grips on the box faces, used for non-uniform scaling.
+   * Defaults to `true`, i.e draws the non-uniform scaling grips.
+   */
+  drawNonUniformScaleGrips?: boolean;
 };
 
 // The 6 box sides defined as planes in local coordinate space.
@@ -219,6 +232,10 @@ export default class BoxDrawing {
 
   public keepBoxAboveGround: boolean;
 
+  private drawNonUniformScaleGrips: boolean;
+
+  public onChange?: (params: BoxDrawingChangeParams) => void;
+
   // An external transform to convert the box in local coordinates to world coordinates
   private readonly worldTransform: Matrix4 = Matrix4.IDENTITY.clone();
 
@@ -248,10 +265,12 @@ export default class BoxDrawing {
   private constructor(
     readonly cesium: Cesium,
     transform: Matrix4,
-    readonly options: BoxDrawingOptions
+    options: BoxDrawingOptions
   ) {
     this.scene = cesium.scene;
     this.keepBoxAboveGround = options.keepBoxAboveGround ?? false;
+    this.drawNonUniformScaleGrips = options.drawNonUniformScaleGrips ?? true;
+    this.onChange = options.onChange;
     this.dataSource = new Proxy(new CustomDataSource(), {
       set: (target, prop, value) => {
         if (prop === "show") {
@@ -260,7 +279,6 @@ export default class BoxDrawing {
         return Reflect.set(target, prop, value);
       }
     });
-
     this.setTransform(transform);
     this.drawBox();
     this.setBoxAboveGround();
@@ -519,22 +537,31 @@ export default class BoxDrawing {
         return;
       }
 
-      this.cesium.isFeaturePickingPaused = true;
-      scene.screenSpaceCameraController.enableInputs = false;
       if (state.is === "hovering") {
         state.entity.onMouseOut({
           startPosition: click.position,
           endPosition: click.position
         });
       }
-      state = { is: "picked", entity };
+      state = {
+        is: "picked",
+        entity,
+        beforePickState: {
+          isFeaturePickingPaused: this.cesium.isFeaturePickingPaused,
+          enableInputs: scene.screenSpaceCameraController.enableInputs
+        }
+      };
+      this.cesium.isFeaturePickingPaused = true;
+      scene.screenSpaceCameraController.enableInputs = false;
       entity.onPick(click);
     };
 
     const handleRelease = (click: MouseClick) => {
       if (state.is === "picked") {
-        this.cesium.isFeaturePickingPaused = false;
-        scene.screenSpaceCameraController.enableInputs = true;
+        this.cesium.isFeaturePickingPaused =
+          state.beforePickState.isFeaturePickingPaused;
+        scene.screenSpaceCameraController.enableInputs =
+          state.beforePickState.enableInputs;
         state.entity.onRelease(click);
         state = { is: "none" };
       }
@@ -648,7 +675,12 @@ export default class BoxDrawing {
    * Draw the scale grip points.
    */
   private drawScalePoints() {
-    SCALE_POINT_VECTORS.forEach((vector) => {
+    const scalePointVectors = [
+      ...CORNER_POINT_VECTORS,
+      ...(this.drawNonUniformScaleGrips ? FACE_POINT_VECTORS : [])
+    ];
+
+    scalePointVectors.forEach((vector) => {
       const pointLocal1 = vector;
       const pointLocal2 = Cartesian3.multiplyByScalar(
         vector,
@@ -814,16 +846,35 @@ export default class BoxDrawing {
         mouseMove.startPosition.y = surfacePoint2d.y;
         mouseMove.endPosition.y = surfacePoint2d.y + yDiff;
 
-        const previousPosition = screenToGlobePosition(
-          scene,
-          mouseMove.startPosition,
-          scratchPreviousPosition
-        );
-        const endPosition = screenToGlobePosition(
-          scene,
-          mouseMove.endPosition,
-          scratchEndPosition
-        );
+        // Fallback to simple ellipsoid pick when globe pick returns undefined
+        // (i.e there is no intersection of camera ray with globe tiles). This
+        // probably works only because ellipsoid might below the terrain so
+        // there is an intersection between the camera ray and ellipsoid.
+        // Although it could work, it doesn't truly fix the camera ray parallel
+        // to surface issue.
+        const previousPosition =
+          screenToGlobePosition(
+            scene,
+            mouseMove.startPosition,
+            scratchPreviousPosition
+          ) ??
+          scene.camera.pickEllipsoid(
+            mouseMove.startPosition,
+            undefined,
+            scratchPreviousPosition
+          );
+
+        const endPosition =
+          screenToGlobePosition(
+            scene,
+            mouseMove.endPosition,
+            scratchEndPosition
+          ) ??
+          scene.camera.pickEllipsoid(
+            mouseMove.endPosition,
+            undefined,
+            scratchEndPosition
+          );
 
         if (!previousPosition || !endPosition) {
           return;
@@ -835,7 +886,7 @@ export default class BoxDrawing {
       this.updateTerrainHeightEstimate();
       this.moveBoxWithClamping(moveStep);
       this.updateBox();
-      this.options.onChange?.({
+      this.onChange?.({
         isFinished: false,
         modelMatrix: this.modelMatrix,
         translationRotationScale: this.trs
@@ -874,7 +925,7 @@ export default class BoxDrawing {
       this.setBoxAboveGround();
       unHighlightAllSides();
       setCanvasCursor(scene, "auto");
-      this.options.onChange?.({
+      this.onChange?.({
         modelMatrix: this.modelMatrix,
         translationRotationScale: this.trs,
         isFinished: true
@@ -974,7 +1025,7 @@ export default class BoxDrawing {
       if (isDraggableEdge) {
         isHighlighted = false;
         setCanvasCursor(scene, "auto");
-        this.options.onChange?.({
+        this.onChange?.({
           isFinished: true,
           modelMatrix: this.modelMatrix,
           translationRotationScale: this.trs
@@ -1005,7 +1056,7 @@ export default class BoxDrawing {
 
       this.updateBox();
       this.updateEntitiesOnOrientationChange();
-      this.options.onChange?.({
+      this.onChange?.({
         isFinished: false,
         modelMatrix: this.modelMatrix,
         translationRotationScale: this.trs
@@ -1059,6 +1110,12 @@ export default class BoxDrawing {
       model: {
         uri: require("file-loader!../../wwwroot/models/Box.glb"),
         minimumPixelSize: 12,
+        maximumScale: new CallbackProperty(
+          // Clamp the maximum size of the scale grip to the 0.15 times the
+          // size of the minimum side
+          () => 0.15 * Cartesian3.minimumComponent(this.trs.scale),
+          false
+        ),
         shadows: ShadowMode.DISABLED,
         color: new CallbackProperty(() => getColor(), false),
         // Forces the above color ignoring the color specified in gltf material
@@ -1096,7 +1153,7 @@ export default class BoxDrawing {
     const onRelease = () => {
       scalePoint.axisLine.show = false;
       unHighlightScalePoint();
-      this.options.onChange?.({
+      this.onChange?.({
         modelMatrix: this.modelMatrix,
         translationRotationScale: this.trs,
         isFinished: true
@@ -1221,7 +1278,7 @@ export default class BoxDrawing {
       this.moveBoxWithClamping(moveStep);
 
       this.updateBox();
-      this.options.onChange?.({
+      this.onChange?.({
         isFinished: false,
         modelMatrix: this.modelMatrix,
         translationRotationScale: this.trs


### PR DESCRIPTION

### What this PR does

Required for https://github.com/TerriaJS/nsw-digital-twin/issues/567

- Added option `drawNonUniformScaleGrips` to enable/disable uniform-scaling
- Set limit on the size of scaling grips
- Somewhat improve move interaction
- Restore modified map state when interaction stops

### Test me

The changes are hard to test from CI because the only place we use `BoxDrawing` is for 3d-tiles clipping box but that's not available on CI. You could however load up a tileset in your local, enable clipping box to verify these results.

#### Scale grip sizing
Keep zooming in and shrinking the box as small as you can. As the box gets smaller (less than the size of an average house) you can see that the scale grips become huge relative to the box size. With this PR the scale grips should be sized relative to the size of the whole box.
Before:
![image](https://user-images.githubusercontent.com/1430/205197959-ae1c9cb5-4e03-4701-957c-248b961bc78f.png)
After:
![image](https://user-images.githubusercontent.com/1430/205198361-98ab7d63-a222-4896-a4f7-4d44187d8eef.png)

#### Move interaction
Try moving the box from a viewing angle almost horizontal to the earth surface. Previously, the box wont move. This is because  we couldn't find an intersection point from the camera ray to the globe surface when the camera is parallel to the surface. We somewhat improve by falling back to finding an intersection with the ellipsoid instead of the terrain. This is better than doing nothing.

![image](https://user-images.githubusercontent.com/1430/205199400-ecb3474b-dead-40e2-81d8-fb4967fefb97.png)



### Checklist

- [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~ Specs are not yet ready for `BoxDrawing`.
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
