### PR TITLE
Add FeatureInfoPanel API.

### DIFF
--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -28,6 +28,7 @@ import Terria from "../Models/Terria";
 import { ViewingControl } from "../Models/ViewingControls";
 import { SATELLITE_HELP_PROMPT_KEY } from "../ReactViews/HelpScreens/SatelliteHelpPrompt";
 import { animationDuration } from "../ReactViews/StandardUserInterface/StandardUserInterface";
+import { FeatureInfoPanelButtonGenerator } from "../ViewModels/FeatureInfoPanel";
 import {
   defaultTourPoints,
   RelativePosition,
@@ -116,6 +117,14 @@ export default class ViewState {
   readonly globalViewingControlOptions: ((
     item: CatalogMemberMixin.Instance
   ) => ViewingControl | undefined)[] = [];
+
+  /**
+   * A global list of generator functions for showing buttons in feature info panel.
+   * Use {@link FeatureInfoPanelButton.addButton} instead of updating directly.
+   */
+  @observable
+  readonly featureInfoPanelButtonGenerators: FeatureInfoPanelButtonGenerator[] =
+    [];
 
   @action
   setSelectedTrainerItem(trainerItem: string) {

--- a/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { getName } from "../../ModelMixins/CatalogMemberMixin";
@@ -15,7 +16,7 @@ interface Props {
   printView?: boolean;
 }
 
-export default (props: Props) => {
+export default observer((props: Props) => {
   const { t } = useTranslation();
   const features = props.features;
   const catalogItem = props.catalogItem;
@@ -76,4 +77,4 @@ export default (props: Props) => {
       </ul>
     </li>
   );
-};
+});

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanelButton.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanelButton.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import styled from "styled-components";
+import Button from "../../Styled/Button";
+import { StyledIcon } from "../../Styled/Icon";
+import Text from "../../Styled/Text";
+import { FeatureInfoPanelButton as FeatureInfoPanelButtonModel } from "../../ViewModels/FeatureInfoPanel";
+
+const FeatureInfoPanelButton: React.FC<FeatureInfoPanelButtonModel> = (
+  props
+) => {
+  const { text, icon } = props;
+  if (!text) {
+    return null;
+  }
+  return (
+    <StyledButton
+      onClick={props.onClick}
+      title={props.title}
+      shortMinHeight
+      renderIcon={
+        icon
+          ? () => (
+              <StyledIcon
+                light
+                styledWidth="20px"
+                styledHeight="20px"
+                glyph={icon}
+              />
+            )
+          : undefined
+      }
+    >
+      {text && <Text textLight>{text}</Text>}
+    </StyledButton>
+  );
+};
+
+const StyledButton = styled(Button).attrs({
+  primary: true
+})`
+  margin: 0 3px;
+  border-radius: 4px;
+  min-height: 32px;
+`;
+
+export default FeatureInfoPanelButton;

--- a/lib/ViewModels/FeatureInfoPanel.ts
+++ b/lib/ViewModels/FeatureInfoPanel.ts
@@ -1,0 +1,44 @@
+import { runInAction } from "mobx";
+import { BaseModel } from "../Models/Definition/Model";
+import TerriaFeature from "../Models/Feature/Feature";
+import ViewState from "../ReactViewModels/ViewState";
+import { IconGlyph } from "../Styled/Icon";
+
+/**
+ * Close feature info panel
+ */
+export function closePanel(viewState: ViewState) {
+  runInAction(() => {
+    viewState.terria.pickedFeatures = undefined;
+  });
+}
+
+export interface FeatureInfoPanelButton {
+  text?: string;
+  icon?: IconGlyph;
+  title?: string;
+  onClick: () => void;
+}
+
+export type FeatureInfoPanelButtonGenerator = (props: {
+  feature: TerriaFeature;
+  item: BaseModel;
+}) => FeatureInfoPanelButton | undefined;
+
+/**
+ * Add a feature button generator.
+ *
+ * @param viewState The ViewState object
+ * @param buttonGenerator A button generator function. It will be called once
+ * for each catalog item shown in the Feature info panel. The generator
+ * function receives the catalog item as a parameter. It can decide to not show a
+ * button by returning `undefined`. To show a button return a `SelectableDimensionButton` object.
+ */
+export function addFeatureButton(
+  viewState: ViewState,
+  buttonGenerator: FeatureInfoPanelButtonGenerator
+) {
+  runInAction(() =>
+    viewState.featureInfoPanelButtonGenerators.push(buttonGenerator)
+  );
+}

--- a/lib/ViewModels/FeatureInfoPanel.ts
+++ b/lib/ViewModels/FeatureInfoPanel.ts
@@ -5,14 +5,8 @@ import ViewState from "../ReactViewModels/ViewState";
 import { IconGlyph } from "../Styled/Icon";
 
 /**
- * Close feature info panel
+ * FeatureInfoPanel Button type
  */
-export function closePanel(viewState: ViewState) {
-  runInAction(() => {
-    viewState.terria.pickedFeatures = undefined;
-  });
-}
-
 export interface FeatureInfoPanelButton {
   text?: string;
   icon?: IconGlyph;
@@ -20,13 +14,20 @@ export interface FeatureInfoPanelButton {
   onClick: () => void;
 }
 
+/**
+ * A generator function called once for each feature in the feature info panel.
+ *
+ * @param feature The feature for which the button is being generated
+ * @param item The map item for which the button is being generated
+ * @returns An instance of {@link FeatureInfoPanelButton} or `undefined` if no button should be shown.
+ */
 export type FeatureInfoPanelButtonGenerator = (props: {
   feature: TerriaFeature;
   item: BaseModel;
 }) => FeatureInfoPanelButton | undefined;
 
 /**
- * Add a feature button generator.
+ * Add a new feature button generator to Terria ViewState.
  *
  * @param viewState The ViewState object
  * @param buttonGenerator A button generator function. It will be called once
@@ -41,4 +42,13 @@ export function addFeatureButton(
   runInAction(() =>
     viewState.featureInfoPanelButtonGenerators.push(buttonGenerator)
   );
+}
+
+/**
+ * Close feature info panel
+ */
+export function closePanel(viewState: ViewState) {
+  runInAction(() => {
+    viewState.terria.pickedFeatures = undefined;
+  });
 }

--- a/test/ReactViews/FeatureInfoSectionSpec.tsx
+++ b/test/ReactViews/FeatureInfoSectionSpec.tsx
@@ -1322,6 +1322,10 @@ describe("FeatureInfoSection", function () {
   describe("feature info panel buttons", function () {
     it("renders buttons added using FeatureInfoPanel.addFeatureButton", function () {
       FeatureInfoPanel.addFeatureButton(viewState, ({ feature, item }) => {
+        if (!(item instanceof TestModel)) {
+          return;
+        }
+
         const materialUsed = feature.properties?.getValue(JulianDate.now())[
           "material"
         ];

--- a/test/ReactViews/FeatureInfoSectionSpec.tsx
+++ b/test/ReactViews/FeatureInfoSectionSpec.tsx
@@ -23,11 +23,13 @@ import CreateModel from "../../lib/Models/Definition/CreateModel";
 import upsertModelFromJson from "../../lib/Models/Definition/upsertModelFromJson";
 import TerriaFeature from "../../lib/Models/Feature/Feature";
 import Terria from "../../lib/Models/Terria";
+import ViewState from "../../lib/ReactViewModels/ViewState";
 import { FeatureInfoSection } from "../../lib/ReactViews/FeatureInfo/FeatureInfoSection";
 import mixTraits from "../../lib/Traits/mixTraits";
 import DiscretelyTimeVaryingTraits from "../../lib/Traits/TraitsClasses/DiscretelyTimeVaryingTraits";
 import FeatureInfoUrlTemplateTraits from "../../lib/Traits/TraitsClasses/FeatureInfoTraits";
 import MappableTraits from "../../lib/Traits/TraitsClasses/MappableTraits";
+import * as FeatureInfoPanel from "../../lib/ViewModels/FeatureInfoPanel";
 import { createWithContexts } from "./withContext";
 
 let separator = ",";
@@ -61,7 +63,11 @@ describe("FeatureInfoSection", function () {
     });
     catalogItem = new TestModel("test", terria);
 
-    viewState = {}; // Not important for tests, but is a required prop.
+    viewState = new ViewState({
+      terria,
+      catalogSearchProvider: undefined,
+      locationSearchProviders: []
+    });
     const properties = {
       name: "Kay",
       foo: "bar",
@@ -1310,6 +1316,34 @@ describe("FeatureInfoSection", function () {
       result = createWithContexts(viewState, section);
       expect(findWithText(result, "ABC").length).toEqual(0);
       expect(findWithText(result, "DEF").length).toEqual(1);
+    });
+  });
+
+  describe("feature info panel buttons", function () {
+    it("renders buttons added using FeatureInfoPanel.addFeatureButton", function () {
+      FeatureInfoPanel.addFeatureButton(viewState, ({ feature, item }) => {
+        const materialUsed = feature.properties?.getValue(JulianDate.now())[
+          "material"
+        ];
+        return materialUsed
+          ? {
+              text: `More info on ${materialUsed}`,
+              title: "Show more info on material used",
+              onClick() {}
+            }
+          : undefined;
+      });
+      const result = createWithContexts(
+        viewState,
+        <FeatureInfoSection
+          catalogItem={catalogItem}
+          feature={feature}
+          isOpen={true}
+          viewState={viewState}
+          t={() => {}}
+        />
+      );
+      expect(findWithText(result, "More info on steel").length).toEqual(1);
     });
   });
 });

--- a/test/ViewModels/FeatureInfoPanelSpec.ts
+++ b/test/ViewModels/FeatureInfoPanelSpec.ts
@@ -1,0 +1,40 @@
+import { runInAction } from "mobx";
+import PickedFeatures from "../../lib/Map/PickedFeatures/PickedFeatures";
+import Terria from "../../lib/Models/Terria";
+import ViewState from "../../lib/ReactViewModels/ViewState";
+import * as FeatureInfoPanel from "../../lib/ViewModels/FeatureInfoPanel";
+
+describe("FeatureInfoPanel", function () {
+  let viewState: ViewState;
+  let terria: Terria;
+
+  beforeEach(function () {
+    terria = new Terria();
+    viewState = new ViewState({
+      terria,
+      catalogSearchProvider: undefined,
+      locationSearchProviders: []
+    });
+  });
+
+  describe("closePanel", function () {
+    it("closes the open feature info panel", function () {
+      runInAction(() => {
+        viewState.terria.pickedFeatures = new PickedFeatures();
+      });
+      FeatureInfoPanel.closePanel(viewState);
+      expect(viewState.terria.pickedFeatures).toBeUndefined();
+    });
+  });
+
+  describe("addFeatureButton", function () {
+    it("adds a new feature button generator", function () {
+      expect(viewState.featureInfoPanelButtonGenerators.length).toEqual(0);
+      FeatureInfoPanel.addFeatureButton(viewState, () => undefined);
+      expect(viewState.featureInfoPanelButtonGenerators.length).toEqual(1);
+      expect(typeof viewState.featureInfoPanelButtonGenerators[0]).toBe(
+        "function"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Required for https://github.com/TerriaJS/nsw-digital-twin/issues/567

Adds a new `FeatureInfoPanel` ViewModel that exposes feature info panel related functionalities.

Currently implements methods for:
 - Closing the feature info panel
 - Adding new buttons to FeatureInfoSection
 - Re-implements the `Show raw/curated data` button using the new `FeatureInfoPanelButton` component.

### Test me

#### Ensure current FeatureInfoPanel buttons are still working
- Open this [share link](http://ci.terria.io/feature-info-panel-api/#share=s-1s2vi75E3IyCFNcE6e3Bn00GGwn)
- Click on any power station point on the map to open its feature info panel
- Make sure the `Show raw/curated data` button toggles the view correctly

Can't currently test the `addFeatureButton()` method from CI, but I have added specs for it.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
