### PR TITLE
Add `UploadDataTypes` api

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   - Set limit on the size of scaling grips relative to the size of the box
   - Small improvement to move interaction that prevents the box from locking up when trying to move at a camera angle parallel to the ground
   - Restore modified map state to the previous setting when interaction stops
+- Add `UploadDataTypes` API for extending the supported local and remote upload data types.
 - [The next improvement]
 
 #### 8.2.22 - 2022-12-02

--- a/lib/Core/getDataType.ts
+++ b/lib/Core/getDataType.ts
@@ -1,4 +1,5 @@
 import i18next from "i18next";
+import { observable, action } from "mobx";
 
 interface DataType {
   value: string;
@@ -6,9 +7,9 @@ interface DataType {
   description?: string;
 }
 
-interface RemoteDataType extends DataType {}
+export interface RemoteDataType extends DataType {}
 
-interface LocalDataType extends DataType {
+export interface LocalDataType extends DataType {
   extensions?: string[];
 }
 
@@ -17,165 +18,234 @@ interface GetDataTypes {
   localDataType: LocalDataType[];
 }
 
-export default function (): GetDataTypes {
-  return {
-    remoteDataType: [
-      {
-        value: "auto",
-        name: i18next.t("core.dataType.auto")
-      },
-      {
-        value: "wms-group",
-        name: i18next.t("core.dataType.wms-group")
-      },
-      {
-        value: "wfs-group",
-        name: i18next.t("core.dataType.wfs-group")
-      },
-      {
-        value: "esri-group",
-        name: i18next.t("core.dataType.esri-group")
-      },
-      // esri-group is registered with ArcGisCatalogGroup, which can read REST, MapServer and FeatureServer groups.
-      // So we do not need to explicitly include esri-mapServer-group or esri-featureServer-group here.
-      {
-        value: "esri-mapServer",
-        name: i18next.t("core.dataType.esri-mapServer")
-      },
-      /* {
+/**
+ * List of builtin remote upload types
+ */
+const builtinRemoteDataTypes: RemoteDataType[] = [
+  {
+    value: "auto",
+    name: "core.dataType.auto"
+  },
+  {
+    value: "wms-group",
+    name: "core.dataType.wms-group"
+  },
+  {
+    value: "wfs-group",
+    name: "core.dataType.wfs-group"
+  },
+  {
+    value: "esri-group",
+    name: "core.dataType.esri-group"
+  },
+  // esri-group is registered with ArcGisCatalogGroup, which can read REST, MapServer and FeatureServer groups.
+  // So we do not need to explicitly include esri-mapServer-group or esri-featureServer-group here.
+  {
+    value: "esri-mapServer",
+    name: "core.dataType.esri-mapServer"
+  },
+  /* {
         value: "esri-mapServer-group",
         name: "Esri ArcGIS MapServer"
       }, */
-      {
-        value: "esri-featureServer",
-        name: i18next.t("core.dataType.esri-featureServer")
-      },
-      // to be removed once ArcGisCatalogGroup is implemented
-      /* {
+  {
+    value: "esri-featureServer",
+    name: "core.dataType.esri-featureServer"
+  },
+  // to be removed once ArcGisCatalogGroup is implemented
+  /* {
         value: "esri-featureServer-group",
         name: "Esri ArcGIS FeatureServer"
       }, */
-      {
-        value: "3d-tiles",
-        name: i18next.t("core.dataType.3d-tiles")
-      },
-      {
-        value: "open-street-map",
-        name: i18next.t("core.dataType.open-street-map")
-      },
-      {
-        value: "geojson",
-        name: i18next.t("core.dataType.geojson")
-      },
-      {
-        value: "kml",
-        name: i18next.t("core.dataType.kml")
-      },
-      {
-        value: "csv",
-        name: i18next.t("core.dataType.csv")
-      },
-      {
-        value: "wmts-group",
-        name: i18next.t("core.dataType.wmts-group")
-      },
-      {
-        value: "carto",
-        name: i18next.t("core.dataType.carto")
-      },
-      {
-        value: "czml",
-        name: i18next.t("core.dataType.czml")
-      },
-      {
-        value: "gpx",
-        name: i18next.t("core.dataType.gpx")
-      },
-      {
-        value: "georss",
-        name: i18next.t("core.dataType.geoRss")
-      },
-      {
-        value: "shp",
-        name: i18next.t("core.dataType.shp")
-      },
-      {
-        value: "wps-getCapabilities",
-        name: i18next.t("core.dataType.wps-getCapabilities")
-      },
-      {
-        value: "sdmx-group",
-        name: i18next.t("core.dataType.sdmx-group")
-      },
-      {
-        value: "opendatasoft-group",
-        name: i18next.t("core.dataType.opendatasoft-group")
-      },
-      {
-        value: "socrata-group",
-        name: i18next.t("core.dataType.socrata-group")
-      },
-      {
-        value: "gltf",
-        name: i18next.t("core.dataType.gltf")
-      }
-    ],
-    localDataType: [
-      {
-        value: "auto",
-        name: i18next.t("core.dataType.auto")
-      },
-      {
-        value: "geojson",
-        name: i18next.t("core.dataType.geojson"),
-        extensions: ["geojson"]
-      },
-      {
-        value: "kml",
-        name: i18next.t("core.dataType.kml"),
-        extensions: ["kml", "kmz"]
-      },
-      {
-        value: "csv",
-        name: i18next.t("core.dataType.csv"),
-        extensions: ["csv"]
-      },
-      {
-        value: "czml",
-        name: i18next.t("core.dataType.czml"),
-        extensions: ["czml"]
-      },
-      {
-        value: "gpx",
-        name: i18next.t("core.dataType.gpx"),
-        extensions: ["gpx"]
-      },
-      {
-        value: "json",
-        name: i18next.t("core.dataType.json"),
-        extensions: ["json", "json5"]
-      },
-      {
-        value: "georss",
-        name: i18next.t("core.dataType.geoRss"),
-        extensions: ["xml"]
-      },
-      {
-        value: "gltf",
-        name: i18next.t("core.dataType.gltf"),
-        extensions: ["glb"]
-      },
-      {
-        value: "shp",
-        name: i18next.t("core.dataType.shp"),
-        extensions: ["zip"]
-      },
-      {
-        value: "assimp",
-        name: i18next.t("core.dataType.assimp-local"),
-        description: i18next.t("core.dataType.assimp-local-description"),
-        extensions: ["zip"]
-      }
-    ]
+  {
+    value: "3d-tiles",
+    name: "core.dataType.3d-tiles"
+  },
+  {
+    value: "open-street-map",
+    name: "core.dataType.open-street-map"
+  },
+  {
+    value: "geojson",
+    name: "core.dataType.geojson"
+  },
+  {
+    value: "kml",
+    name: "core.dataType.kml"
+  },
+  {
+    value: "csv",
+    name: "core.dataType.csv"
+  },
+  {
+    value: "wmts-group",
+    name: "core.dataType.wmts-group"
+  },
+  {
+    value: "carto",
+    name: "core.dataType.carto"
+  },
+  {
+    value: "czml",
+    name: "core.dataType.czml"
+  },
+  {
+    value: "gpx",
+    name: "core.dataType.gpx"
+  },
+  {
+    value: "georss",
+    name: "core.dataType.geoRss"
+  },
+  {
+    value: "shp",
+    name: "core.dataType.shp"
+  },
+  {
+    value: "wps-getCapabilities",
+    name: "core.dataType.wps-getCapabilities"
+  },
+  {
+    value: "sdmx-group",
+    name: "core.dataType.sdmx-group"
+  },
+  {
+    value: "opendatasoft-group",
+    name: "core.dataType.opendatasoft-group"
+  },
+  {
+    value: "socrata-group",
+    name: "core.dataType.socrata-group"
+  },
+  {
+    value: "gltf",
+    name: "core.dataType.gltf"
+  }
+  // Add next builtin remote upload type
+];
+
+/**
+ * List of builtin local upload types
+ */
+const builtinLocalDataTypes: LocalDataType[] = [
+  {
+    value: "auto",
+    name: "core.dataType.auto"
+  },
+  {
+    value: "geojson",
+    name: "core.dataType.geojson",
+    extensions: ["geojson"]
+  },
+  {
+    value: "kml",
+    name: "core.dataType.kml",
+    extensions: ["kml", "kmz"]
+  },
+  {
+    value: "csv",
+    name: "core.dataType.csv",
+    extensions: ["csv"]
+  },
+  {
+    value: "czml",
+    name: "core.dataType.czml",
+    extensions: ["czml"]
+  },
+  {
+    value: "gpx",
+    name: "core.dataType.gpx",
+    extensions: ["gpx"]
+  },
+  {
+    value: "json",
+    name: "core.dataType.json",
+    extensions: ["json", "json5"]
+  },
+  {
+    value: "georss",
+    name: "core.dataType.geoRss",
+    extensions: ["xml"]
+  },
+  {
+    value: "gltf",
+    name: "core.dataType.gltf",
+    extensions: ["glb"]
+  },
+  {
+    value: "shp",
+    name: "core.dataType.shp",
+    extensions: ["zip"]
+  }
+  // Add next builtin local upload type
+];
+
+/**
+ * Custom remote data types. Add to it by calling addRemoteDataType().
+ */
+const customRemoteDataTypes: Map<string, RemoteDataType> = observable(
+  new Map()
+);
+
+/**
+ * Custom local data types. Add by calling addLocalDataType().
+ */
+const customLocalDataTypes: Map<string, LocalDataType> = observable(new Map());
+
+export default function getDataTypes(): GetDataTypes {
+  const uniqueRemoteDataTypes: Map<string, RemoteDataType> = new Map([
+    ...(builtinRemoteDataTypes.map((dtype) => [
+      dtype.value,
+      translateDataType(dtype)
+    ]) as [string, RemoteDataType][]),
+    ...customRemoteDataTypes.entries()
+  ]);
+
+  const uniqueLocalDataTypes: Map<string, LocalDataType> = new Map([
+    ...(builtinLocalDataTypes.map((dtype) => [
+      dtype.value,
+      translateDataType(dtype)
+    ]) as [string, LocalDataType][]),
+    ...customLocalDataTypes.entries()
+  ]);
+
+  return {
+    remoteDataType: [...uniqueRemoteDataTypes.values()],
+    localDataType: [...uniqueLocalDataTypes.values()]
+  };
+}
+
+/**
+ * Add a new data type to show in the supported file type listing when
+ * uploading a file from the a remote server. If a data type with the same
+ * `value` already exists, we replace it with the new one.
+ *
+ * @param newRemoteDataType The new remote data type to be added.
+ */
+export const addRemoteUploadType = action(
+  (newRemoteDataType: RemoteDataType) => {
+    customRemoteDataTypes.set(newRemoteDataType.value, newRemoteDataType);
+  }
+);
+
+/**
+ * Add a new data type to show in the supported file type listing when
+ * uploading a file from the users local machine. If a data type with the same
+ * `value` already exists, we replace it with the new one.
+ *
+ * @param newLocalDataType The new local data type to be added.
+ */
+export const addLocalUploadType = action((newLocalDataType: LocalDataType) => {
+  customLocalDataTypes.set(newLocalDataType.value, newLocalDataType);
+});
+
+function translateDataType<T extends DataType>(dataType: T): T {
+  return {
+    ...dataType,
+    value: dataType.value,
+    name: i18next.t(dataType.name),
+    description: dataType.description
+      ? i18next.t(dataType.description)
+      : undefined
   };
 }

--- a/lib/ViewModels/UploadDataTypes.ts
+++ b/lib/ViewModels/UploadDataTypes.ts
@@ -1,0 +1,7 @@
+export {
+  default as getDataTypes,
+  addLocalUploadType,
+  addRemoteUploadType,
+  LocalDataType,
+  RemoteDataType
+} from "../Core/getDataType";

--- a/test/ViewModels/UploadDataTypesSpec.ts
+++ b/test/ViewModels/UploadDataTypesSpec.ts
@@ -1,0 +1,45 @@
+import * as UploadDataTypes from "../../lib/ViewModels/UploadDataTypes";
+
+describe("UploadDataTypes", function () {
+  describe("getDataTypes", function () {
+    it("returns all the builtin local upload types", function () {
+      expect(UploadDataTypes.getDataTypes().localDataType.length).toEqual(10);
+    });
+
+    it("returns all the builtin remote upload types", function () {
+      expect(UploadDataTypes.getDataTypes().remoteDataType.length).toEqual(22);
+    });
+  });
+
+  describe("addRemoteUploadType", function () {
+    it("should add the given upload type to lofcalDataType list", function () {
+      UploadDataTypes.addRemoteUploadType({
+        value: "foo42",
+        name: "Foo type",
+        description: "Foo files"
+      });
+      const fooType = UploadDataTypes.getDataTypes().remoteDataType.find(
+        (type) => type.value === "foo42"
+      );
+      expect(fooType).toBeDefined();
+      expect(fooType?.name).toEqual("Foo type");
+      expect(fooType?.description).toEqual("Foo files");
+    });
+  });
+
+  describe("addLocalUploadType", function () {
+    it("should add the given upload type to lofcalDataType list", function () {
+      UploadDataTypes.addLocalUploadType({
+        value: "foo42",
+        name: "Foo type",
+        description: "Foo files"
+      });
+      const fooType = UploadDataTypes.getDataTypes().localDataType.find(
+        (type) => type.value === "foo42"
+      );
+      expect(fooType).toBeDefined();
+      expect(fooType?.name).toEqual("Foo type");
+      expect(fooType?.description).toEqual("Foo files");
+    });
+  });
+});

--- a/test/ViewModels/UploadDataTypesSpec.ts
+++ b/test/ViewModels/UploadDataTypesSpec.ts
@@ -12,18 +12,18 @@ describe("UploadDataTypes", function () {
   });
 
   describe("addRemoteUploadType", function () {
-    it("should add the given upload type to localDataType list", function () {
+    it("should add the given upload type to remoteDataType list", function () {
       UploadDataTypes.addRemoteUploadType({
         value: "foo42",
         name: "Foo type",
-        description: "Foo files"
+        description: "Foo data"
       });
       const fooType = UploadDataTypes.getDataTypes().remoteDataType.find(
         (type) => type.value === "foo42"
       );
       expect(fooType).toBeDefined();
       expect(fooType?.name).toEqual("Foo type");
-      expect(fooType?.description).toEqual("Foo files");
+      expect(fooType?.description).toEqual("Foo data");
     });
   });
 

--- a/test/ViewModels/UploadDataTypesSpec.ts
+++ b/test/ViewModels/UploadDataTypesSpec.ts
@@ -12,7 +12,7 @@ describe("UploadDataTypes", function () {
   });
 
   describe("addRemoteUploadType", function () {
-    it("should add the given upload type to lofcalDataType list", function () {
+    it("should add the given upload type to localDataType list", function () {
       UploadDataTypes.addRemoteUploadType({
         value: "foo42",
         name: "Foo type",
@@ -28,7 +28,7 @@ describe("UploadDataTypes", function () {
   });
 
   describe("addLocalUploadType", function () {
-    it("should add the given upload type to lofcalDataType list", function () {
+    it("should add the given upload type to localDataType list", function () {
       UploadDataTypes.addLocalUploadType({
         value: "foo42",
         name: "Foo type",


### PR DESCRIPTION
### What this PR does

Required for https://github.com/TerriaJS/nsw-digital-twin/issues/567

Adds a `UploadDataTypes` API for adding new data types to the list of supported local and remote upload types. 

### Test me
#### Ensure current functionality works
- Visit the [CI for this branch](http://ci.terria.io/upload-data-types-api/)
- Open the Upload data modal and check the File type listing for both local and remote uploads
- Make sure it is the same as in CI branch.

The extension feature cannot be tested from CI but I have added specs for it.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
