### PR TITLE
Refactor Cesium3dTilesMixin.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
   - Small improvement to move interaction that prevents the box from locking up when trying to move at a camera angle parallel to the ground
   - Restore modified map state to the previous setting when interaction stops
 - Add `UploadDataTypes` API for extending the supported local and remote upload data types.
+- Refactor `Cesium3dTileMixin`.
 - [The next improvement]
 
 #### 8.2.22 - 2022-12-02

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -95,6 +95,10 @@ function Cesium3dTilesMixin<T extends Constructor<Model<Cesium3dTilesTraits>>>(
       });
     }
 
+    get hasCesium3dTilesMixin() {
+      return true;
+    }
+
     // Just a variable to save the original tileset.root.transform if it exists
     @observable
     private originalRootTransform: Matrix4 = Matrix4.IDENTITY.clone();
@@ -479,12 +483,14 @@ function Cesium3dTilesMixin<T extends Constructor<Model<Cesium3dTilesTraits>>>(
     }
 
     /**
-     * Modifies the style traits to show/hide a 3d tile feature
+     * Returns a selector that can be used for filtering or styling the given
+     * feature.  For this to work, the feature should have a property called
+     * `id` or the catalog item should have the trait `featureIdProperties` defined.
      *
+     * @returns Selector string or `undefined` when no unique selector can be constructed for the feature
      */
-    @action
-    setFeatureVisibility(feature: Cesium3DTileFeature, visibiltiy: boolean) {
-      const idProperties = this.getIdPropertiesForFeature(feature)?.sort();
+    getSelectorForFeature(feature: Cesium3DTileFeature): string | undefined {
+      const idProperties = this.getIdPropertiesForFeature(feature).sort();
       if (idProperties.length === 0) {
         return;
       }
@@ -492,12 +498,28 @@ function Cesium3dTilesMixin<T extends Constructor<Model<Cesium3dTilesTraits>>>(
       const terms = idProperties.map(
         (p: string) => `\${${p}} === ${JSON.stringify(feature.getProperty(p))}`
       );
-      const showExpr = terms.join(" && ");
-      if (showExpr) {
+      const selector = terms.join(" && ");
+      return selector ? selector : undefined;
+    }
+
+    setVisibilityForMatchingFeature(expression: string, visibility: boolean) {
+      if (expression) {
         const style = this.style || {};
         const show = normalizeShowExpression(style?.show);
-        show.conditions.unshift([showExpr, visibiltiy]);
+        show.conditions.unshift([expression, visibility]);
         this.setTrait(CommonStrata.user, "style", { ...style, show });
+      }
+    }
+
+    /**
+     * Modifies the style traits to show/hide a 3d tile feature
+     *
+     */
+    @action
+    setFeatureVisibility(feature: Cesium3DTileFeature, visibility: boolean) {
+      const showExpr = this.getSelectorForFeature(feature);
+      if (showExpr) {
+        this.setVisibilityForMatchingFeature(showExpr, visibility);
       }
     }
 
@@ -595,6 +617,14 @@ function Cesium3dTilesMixin<T extends Constructor<Model<Cesium3dTilesTraits>>>(
   }
 
   return Cesium3dTilesMixin;
+}
+
+namespace Cesium3dTilesMixin {
+  export interface Instance
+    extends InstanceType<ReturnType<typeof Cesium3dTilesMixin>> {}
+  export function isMixedInto(model: any): model is Instance {
+    return model && model.hasCesium3dTilesMixin;
+  }
 }
 
 export default Cesium3dTilesMixin;

--- a/test/ModelMixins/Cesium3dTilesMixinSpec.ts
+++ b/test/ModelMixins/Cesium3dTilesMixinSpec.ts
@@ -8,6 +8,7 @@ import Color from "terriajs-cesium/Source/Core/Color";
 import Matrix4 from "terriajs-cesium/Source/Core/Matrix4";
 import Cesium3DTileset from "terriajs-cesium/Source/Scene/Cesium3DTileset";
 import CommonStrata from "../../lib/Models/Definition/CommonStrata";
+import Cesium3DTileFeature from "terriajs-cesium/Source/Scene/Cesium3DTileFeature";
 
 describe("Cesium3dTilesMixin", function () {
   let terria: Terria;
@@ -132,6 +133,26 @@ describe("Cesium3dTilesMixin", function () {
           );
         }
       });
+    });
+  });
+
+  describe("getSelectorForFeature", function () {
+    it("returns a style expression for selecting the given feature if it can be constructed", function () {
+      const item = new Cesium3DTilesCatalogItem("test", terria);
+      item.setTrait(CommonStrata.user, "featureIdProperties", [
+        "locality",
+        "building-no"
+      ]);
+      const fakeTileFeature = new Cesium3DTileFeature();
+      spyOn(fakeTileFeature, "getProperty").and.callFake((property: string) =>
+        property === "locality"
+          ? "foo"
+          : property === "building-no"
+          ? 4242
+          : undefined
+      );
+      const selector = item.getSelectorForFeature(fakeTileFeature);
+      expect(selector).toBe('${building-no} === 4242 && ${locality} === "foo"');
     });
   });
 });


### PR DESCRIPTION
Required for https://github.com/TerriaJS/nsw-digital-twin/issues/567

- Seperate out the method for constructing feature selector expressions.
- Add method for setting feature visibility by selector expression.
- Adds `hasCesium3dTilesMixin`.

### What this PR does

Exposes functionality in `Cesium3dTilesMixin` for setting the visibility of a feature by passing a selector expression.
The mixin code is getting a bit gnarly at this point. I have created a [separate issue](https://github.com/TerriaJS/terriajs/blob/acf977679de9a903e95d7f0873065ed6c989f5cc/lib/ModelMixins/Cesium3dTilesMixin.ts#L485-L585) to investigate further refactoring.

### Test me

This is mostly code refactoring, separating out existing functionality into new methods. I have added some specs for it.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
