### PR TITLE
Cesium token error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 #### next release (8.2.24)
 
-- [The next improvement]
+- Reimplement error message and default to 3d smooth mode when Cesium Ion Access Token is invalid.
 
 #### 8.2.23 - 2023-01-06
 

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -450,17 +450,11 @@ export default class Cesium extends GlobeOrMap {
           setViewerMode("3dsmooth", this.terriaViewer);
           if (!this._terrainMessageViewed) {
             this.terria.raiseErrorToUser(err, {
-              title: "Terrain Server Not Responding",
-              message:
-                "\
-The terrain server is not responding at the moment.  You can still use all the features of " +
-                this.terria.appName +
-                " \
-but there will be no terrain detail in 3D mode.  We're sorry for the inconvenience.  Please try \
-again later and the terrain server should be responding as expected.  If the issue persists, please contact \
-us via email at " +
-                this.terria.supportEmail +
-                "."
+              title: i18next.t("map.cesium.terrainServerErrorTitle"),
+              message: i18next.t("map.cesium.terrainServerErrorMessage", {
+                appName: this.terria.appName,
+                supportEmail: this.terria.supportEmail
+              })
             });
 
             this._terrainMessageViewed = true;

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -439,7 +439,6 @@ export default class Cesium extends GlobeOrMap {
         So we check for terrainProvider.availability */
 
         if (!terrainProvider.availability) {
-          debugger;
           throw new Error();
         }
       })

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -426,8 +426,16 @@ export default class Cesium extends GlobeOrMap {
       networkErrorPromise,
       terrainProvider.readyPromise
     ])
+      .then(() => {
+        /** Need to throw an error if incorrect `cesiumTerrainUrl` has been specified.
+        The terrainProvider.readyPromise will still be fulfulled, but the map will not load correctly
+        So we check for terrainProvider.availability */
+        if (!terrainProvider.availability) {
+          throw new Error();
+        }
+      })
       .catch((err) => {
-        console.log("Terrain provider error.  ", err.message); // TODO: reinstate this line, commented out for testing
+        console.log("Terrain provider error.  ", err.message);
         if (this.scene.terrainProvider instanceof CesiumTerrainProvider) {
           console.log("Switching to EllipsoidTerrainProvider.");
           setViewerMode("3dsmooth", this.terria.mainViewer);
@@ -1191,6 +1199,7 @@ us via email at " +
     const terrainProvider = new CesiumTerrainProvider({
       url
     });
+
     // Add the event handler to the TerrainProvider
     this.catchTerrainProviderDown(terrainProvider);
     return terrainProvider;

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -436,12 +436,12 @@ export default class Cesium extends GlobeOrMap {
               title: "Terrain Server Not Responding",
               message:
                 "\
-    The terrain server is not responding at the moment.  You can still use all the features of " +
+The terrain server is not responding at the moment.  You can still use all the features of " +
                 this.terria.appName +
                 " \
-    but there will be no terrain detail in 3D mode.  We're sorry for the inconvenience.  Please try \
-    again later and the terrain server should be responding as expected.  If the issue persists, please contact \
-    us via email at " +
+but there will be no terrain detail in 3D mode.  We're sorry for the inconvenience.  Please try \
+again later and the terrain server should be responding as expected.  If the issue persists, please contact \
+us via email at " +
                 this.terria.supportEmail +
                 "."
             });

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -1172,11 +1172,14 @@ us via email at " +
     assetId: number,
     accessToken?: string
   ): CesiumTerrainProvider {
-    return new CesiumTerrainProvider({
+    const terrainProvider = new CesiumTerrainProvider({
       url: IonResource.fromAssetId(assetId, {
         accessToken
       })
     });
+    // Add the event handler to the TerrainProvider
+    this.catchTerrainProviderDown(terrainProvider);
+    return terrainProvider;
   }
 
   /**
@@ -1185,9 +1188,12 @@ us via email at " +
    * Used for spying in specs
    */
   private createTerrainProviderFromUrl(url: string): CesiumTerrainProvider {
-    return new CesiumTerrainProvider({
+    const terrainProvider = new CesiumTerrainProvider({
       url
     });
+    // Add the event handler to the TerrainProvider
+    this.catchTerrainProviderDown(terrainProvider);
+    return terrainProvider;
   }
 
   /**
@@ -1197,14 +1203,13 @@ us via email at " +
    */
   private createWorldTerrain(): CesiumTerrainProvider {
     const terrainProvider = createWorldTerrain({});
+    // Add the event handler to the TerrainProvider
     this.catchTerrainProviderDown(terrainProvider);
     return terrainProvider;
   }
 
   @computed
   get terrainProvider(): TerrainProvider {
-    // Add the event handler to the TerrianProvider...
-    // this.catchTerrainProviderDown(this._terrainWithCredits.terrain);
     return this._terrainWithCredits.terrain;
   }
 

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -438,7 +438,7 @@ export default class Cesium extends GlobeOrMap {
         console.log("Terrain provider error.  ", err.message);
         if (this.scene.terrainProvider instanceof CesiumTerrainProvider) {
           console.log("Switching to EllipsoidTerrainProvider.");
-          setViewerMode("3dsmooth", this.terria.mainViewer);
+          setViewerMode("3dsmooth", this.terriaViewer);
           if (!this._terrainMessageViewed) {
             this.terria.raiseErrorToUser(err, {
               title: "Terrain Server Not Responding",
@@ -971,7 +971,7 @@ us via email at " +
     });
 
     const disposeSplitDirectionChange = autorun(() => {
-      const items = this.terria.mainViewer.items.get();
+      const items = this.terriaViewer.items.get();
       const showSplitter = this.terria.showSplitter;
       items.forEach((item) => {
         if (

--- a/test/Models/CesiumSpec.ts
+++ b/test/Models/CesiumSpec.ts
@@ -298,7 +298,7 @@ describeIfSupported("Cesium Model", function () {
   });
 
   describe("Cesium Terrain Extra Tests", function () {
-    // declare different variables here, we need new instances to test
+    // declare different variables here, we need new instances to test because we are changing config values and want to instantiate with these different values
     let terria2: Terria;
     let terriaViewer2: TerriaViewer;
     let container2: HTMLElement;

--- a/test/Models/CesiumSpec.ts
+++ b/test/Models/CesiumSpec.ts
@@ -324,7 +324,6 @@ describeIfSupported("Cesium Model", function () {
 
     it("should thow an warning when cesiumIonAccessToken is invalid", async function () {
       runInAction(() => {
-        terria2.workbench.removeAll();
         // Set an invalid token for the test
         terria2.configParameters.cesiumIonAccessToken = "expired_token";
       });
@@ -348,7 +347,6 @@ describeIfSupported("Cesium Model", function () {
 
     it("should revert to 3dSmooth mode when cesiumIonAccessToken is invalid", async function () {
       runInAction(() => {
-        terria2.workbench.removeAll();
         // Set an invalid token for the test
         terria2.configParameters.cesiumIonAccessToken = "expired_token";
       });
@@ -368,7 +366,6 @@ describeIfSupported("Cesium Model", function () {
 
     it("should thow an warning when `cesiumIonAccessToken` is invalid and `cesiumTerrainAssetId` is present", async function () {
       runInAction(() => {
-        terria2.workbench.removeAll();
         // Set an invalid token for the test
         terria2.configParameters.cesiumIonAccessToken = "expired_token";
         // Set a valid asset id
@@ -394,7 +391,6 @@ describeIfSupported("Cesium Model", function () {
 
     it("should thow an warning when 'cesiumTerrainUrl' is invalid", async function () {
       runInAction(() => {
-        terria2.workbench.removeAll();
         terria2.configParameters.cesiumTerrainUrl =
           "https://storage.googleapis.com/vic-datasets-public/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxx/v1"; // An invalid url
       });

--- a/test/Models/CesiumSpec.ts
+++ b/test/Models/CesiumSpec.ts
@@ -296,6 +296,120 @@ describeIfSupported("Cesium Model", function () {
       );
     });
   });
+
+  describe("Cesium Terrain Extra Tests", function () {
+    // declare different variables here, we need new instances to test
+    let terria2: Terria;
+    let terriaViewer2: TerriaViewer;
+    let container2: HTMLElement;
+    let cesium2: Cesium;
+
+    beforeEach(function () {
+      terria2 = new Terria({
+        baseUrl: "./"
+      });
+      terriaViewer2 = new TerriaViewer(
+        terria2,
+        computed(() => [])
+      );
+      container2 = document.createElement("div");
+      container2.id = "container2";
+      document.body.appendChild(container2);
+    });
+
+    afterEach(function () {
+      cesium2?.destroy();
+      document.body.removeChild(container2);
+    });
+
+    it("should thow an warning when cesiumIonAccessToken is invalid", async function () {
+      runInAction(() => {
+        terria2.workbench.removeAll();
+        // Set an invalid token for the test
+        terria2.configParameters.cesiumIonAccessToken = "expired_token";
+      });
+      // Instantiate Cesium object with the invalid token
+      cesium2 = new Cesium(terriaViewer2, container2);
+
+      await cesium2.terrainProvider.readyPromise.catch(() => {});
+      // Wait a few ticks to allow for delay in adding event listener to terrainProvider in Cesium.ts
+      await runLater(() => {}, 5);
+
+      // We should then get an error about the terrain server
+      const currentNotificationTitle =
+        typeof terria2.notificationState.currentNotification?.title === "string"
+          ? terria2.notificationState.currentNotification?.title
+          : terria2.notificationState.currentNotification?.title();
+
+      expect(currentNotificationTitle).toBe("Terrain Server Not Responding");
+    });
+
+    it("should revert to 3dSmooth mode when cesiumIonAccessToken is invalid", async function () {
+      runInAction(() => {
+        terria2.workbench.removeAll();
+        // Set an invalid token for the test
+        terria2.configParameters.cesiumIonAccessToken = "expired_token";
+      });
+
+      // Instantiate Cesium object with the invalid token
+      cesium2 = new Cesium(terriaViewer2, container2);
+
+      await cesium2.terrainProvider.readyPromise.catch(() => {});
+      // Wait a few ticks to allow for delay in adding event listener to terrainProvider in Cesium.ts
+      await runLater(() => {}, 5);
+
+      expect(terriaViewer2.viewerOptions.useTerrain).toBe(false);
+      expect(
+        cesium2.scene.terrainProvider instanceof EllipsoidTerrainProvider
+      ).toBe(true);
+    });
+
+    it("should thow an warning when `cesiumIonAccessToken` is invalid and `cesiumTerrainAssetId` is present", async function () {
+      runInAction(() => {
+        terria2.workbench.removeAll();
+        // Set an invalid token for the test
+        terria2.configParameters.cesiumIonAccessToken = "expired_token";
+        // Set a valid asset id
+        terria2.configParameters.cesiumTerrainAssetId = 480278;
+      });
+      // Instantiate Cesium object with the invalid token and valid asset id
+      cesium2 = new Cesium(terriaViewer2, container2);
+
+      await cesium2.terrainProvider.readyPromise.catch(() => {});
+      // Wait a few ticks to allow for delay in adding event listener to terrainProvider in Cesium.ts
+      await runLater(() => {}, 5);
+
+      // We should then get an error about the terrain server
+      const currentNotificationTitle =
+        typeof terria2.notificationState.currentNotification?.title === "string"
+          ? terria2.notificationState.currentNotification?.title
+          : terria2.notificationState.currentNotification?.title();
+
+      expect(currentNotificationTitle).toBe("Terrain Server Not Responding");
+    });
+
+    it("should thow an warning when 'cesiumTerrainUrl' is invalid", async function () {
+      runInAction(() => {
+        terria2.workbench.removeAll();
+        terria2.configParameters.cesiumTerrainUrl =
+          "https://storage.googleapis.com/vic-datasets-public/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxx/v1"; // An invalid url
+      });
+      // Instantiate Cesium object with the invalid terrain url
+      cesium2 = new Cesium(terriaViewer2, container2);
+
+      await cesium2.terrainProvider.readyPromise.catch(() => {});
+      // Wait a few ticks to allow for delay in adding event listener to terrainProvider in Cesium.ts
+      await runLater(() => {}, 5);
+
+      // We should then get an error about the terrain server
+      const currentNotificationTitle =
+        typeof terria2.notificationState.currentNotification?.title === "string"
+          ? terria2.notificationState.currentNotification?.title
+          : terria2.notificationState.currentNotification?.title();
+
+      expect(currentNotificationTitle).toBe("Terrain Server Not Responding");
+    });
+  });
 });
 
 /**

--- a/test/Models/CesiumSpec.ts
+++ b/test/Models/CesiumSpec.ts
@@ -322,7 +322,7 @@ describeIfSupported("Cesium Model", function () {
       document.body.removeChild(container2);
     });
 
-    it("should thow an warning when cesiumIonAccessToken is invalid", async function () {
+    it("should thow a warning when cesiumIonAccessToken is invalid", async function () {
       runInAction(() => {
         // Set an invalid token for the test
         terria2.configParameters.cesiumIonAccessToken = "expired_token";
@@ -364,7 +364,7 @@ describeIfSupported("Cesium Model", function () {
       ).toBe(true);
     });
 
-    it("should thow an warning when `cesiumIonAccessToken` is invalid and `cesiumTerrainAssetId` is present", async function () {
+    it("should thow a warning when `cesiumIonAccessToken` is invalid and `cesiumTerrainAssetId` is present", async function () {
       runInAction(() => {
         // Set an invalid token for the test
         terria2.configParameters.cesiumIonAccessToken = "expired_token";
@@ -389,7 +389,7 @@ describeIfSupported("Cesium Model", function () {
       );
     });
 
-    it("should thow an warning when 'cesiumTerrainUrl' is invalid", async function () {
+    it("should thow a warning when 'cesiumTerrainUrl' is invalid", async function () {
       runInAction(() => {
         terria2.configParameters.cesiumTerrainUrl =
           "https://storage.googleapis.com/vic-datasets-public/xxxxxxx-xxxx-xxxx-xxxx-xxxxxxx/v1"; // An invalid url

--- a/test/Models/CesiumSpec.ts
+++ b/test/Models/CesiumSpec.ts
@@ -341,7 +341,9 @@ describeIfSupported("Cesium Model", function () {
           ? terria2.notificationState.currentNotification?.title
           : terria2.notificationState.currentNotification?.title();
 
-      expect(currentNotificationTitle).toBe("Terrain Server Not Responding");
+      expect(currentNotificationTitle).toBe(
+        "map.cesium.terrainServerErrorTitle"
+      );
     });
 
     it("should revert to 3dSmooth mode when cesiumIonAccessToken is invalid", async function () {
@@ -385,7 +387,9 @@ describeIfSupported("Cesium Model", function () {
           ? terria2.notificationState.currentNotification?.title
           : terria2.notificationState.currentNotification?.title();
 
-      expect(currentNotificationTitle).toBe("Terrain Server Not Responding");
+      expect(currentNotificationTitle).toBe(
+        "map.cesium.terrainServerErrorTitle"
+      );
     });
 
     it("should thow an warning when 'cesiumTerrainUrl' is invalid", async function () {
@@ -407,7 +411,9 @@ describeIfSupported("Cesium Model", function () {
           ? terria2.notificationState.currentNotification?.title
           : terria2.notificationState.currentNotification?.title();
 
-      expect(currentNotificationTitle).toBe("Terrain Server Not Responding");
+      expect(currentNotificationTitle).toBe(
+        "map.cesium.terrainServerErrorTitle"
+      );
     });
   });
 });

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -769,7 +769,9 @@
       "devError": "cesium is required.",
       "failedToObtain": "Failed to obtain image tile X: {{x}} Y: {{y}} Level: {{level}}.",
       "notWebMercatorTilingScheme": "This dataset cannot be displayed on the 2D map because it does not support the Web Mercator (EPSG:3857) projection.",
-      "unusalTilingScheme": "This dataset cannot be displayed on the 2D map because it uses an unusual tiling scheme that is not supported."
+      "unusalTilingScheme": "This dataset cannot be displayed on the 2D map because it uses an unusual tiling scheme that is not supported.",
+      "terrainServerErrorTitle": "Terrain Server Not Responding",
+      "terrainServerErrorMessage": " The terrain server is not responding at the moment.  You can still use all the features of {{appName}} but there will be no terrain detail in 3D mode.  We're sorry for the inconvenience.  Please try again later and the terrain server should be responding as expected.  If the issue persists, please contact us via email at {{supportEmail}}."
     },
     "computeRingWindingOrder": {
       "devError": "Expected points of type {x:number, y:number}"


### PR DESCRIPTION
### What this PR does

Fixes #4739 

Adds similar error handling to that implemented in `CesiumTerrainCatalogItem` to catch errors when first trying to load any Cesium Terrain.

Also adapts code in `Cesium.ts` that appeared to be from v7 but was commented out.

### Test me

Load the [branch with a config.json that specifies an incorrect `cesiumIonAccessToken`](http://ci.terria.io/cesium-token-error-handling/#clean&configUrl=https://gist.githubusercontent.com/staffordsmith83/9400ab1111c6b714275b5a7a2c8e2c97/raw/55287e70f422a7c3baecdcd66627ba2d681e5ade/badCesiumKeyConfig.json). Switch to 3D Terrain mode (if not already). The map should automatically switch back to 3D Smooth mode and display an error.

Load the [branch with a config.json that specifies an incorrect `cesiumIonAccessToken` and a valid `cesiumTerrainAssetId`](http://ci.terria.io/cesium-token-error-handling/#clean&configUrl=https://gist.githubusercontent.com/staffordsmith83/a722991a75d37d26a1616410cba72677/raw/50b1936ae402d2a9d6bda5f02341c4312f2c80b5/badCesiumIonKeyCustomTerrain.json). Switch to 3D Terrain mode (if not already). The map should automatically switch back to 3D Smooth mode and display an error.

Load the [branch with a config.json that specifies a valid `cesiumIonAccessToken` and an **invalid `cesiumTerrainUrl`** ](http://ci.terria.io/cesium-token-error-handling/#clean&configUrl=https://gist.githubusercontent.com/staffordsmith83/c9eb19481ce3516c6d26b6fe15fd3524/raw/289d6b51775f905b9520b1d254ca80ac8a74ea88/badCesiumTerrainUrl.json)
This should also throw an error - I have included in this PR as it seems like the best place to handle this edge case.
See https://github.com/TerriaJS/terriajs/blob/ead4eac60a0d1c0eb431f30567f41be1be0ffe9b/lib/Models/Cesium.ts#L430-L435

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
~~- [ ] I've updated relevant documentation in `doc/`.~~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
