### PR TITLE
6648 share compare

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.24)
 
+- Fix `Key Share URL use case broken: share URL for Compare datasets forgets 2nd date`
 - [The next improvement]
 
 #### 8.2.23 - 2023-01-06

--- a/lib/Models/Catalog/CatalogReferences/SplitItemReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/SplitItemReference.ts
@@ -50,10 +50,13 @@ export default class SplitItemReference extends ReferenceMixin(
       });
     }
 
-
     try {
-      // Ensure the target we create is a concrete item
-      if (previousTarget !== undefined && sourceItem.uniqueId === this.splitSourceItemId) return previousTarget;
+      // Ensure the target we create is a concrete item and check if we can return previousTarget
+      if (
+        previousTarget !== undefined &&
+        sourceItem.uniqueId === this.splitSourceItemId
+      )
+        return previousTarget;
       sourceItem = getDereferencedIfExists(sourceItem);
       return sourceItem.duplicateModel(this.uniqueId, this);
     } catch (e) {

--- a/lib/Models/Catalog/CatalogReferences/SplitItemReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/SplitItemReference.ts
@@ -50,8 +50,10 @@ export default class SplitItemReference extends ReferenceMixin(
       });
     }
 
+
     try {
       // Ensure the target we create is a concrete item
+      if (previousTarget !== undefined && sourceItem.uniqueId === this.splitSourceItemId) return previousTarget;
       sourceItem = getDereferencedIfExists(sourceItem);
       return sourceItem.duplicateModel(this.uniqueId, this);
     } catch (e) {


### PR DESCRIPTION
### What this PR does

Fixes #6648 
Added a check in SplitItemReference to see if we have a previousTarget [BaseModel] that has the same id as its source model.  If it does return it

### Test me

The following link was created using the steps outlined in the ticket

[Test Link](http://ci.terria.io/6648-share-compare/#configUrl=https%3A%2F%2Fterria-catalogs-public.storage.googleapis.com%2Fde-australia%2Fmap-config%2Fprod.json&share=s-nfi6H48GNn3W1lTBGIJLnlel7Il)

Required result with the 2nd dataset being the Copy with the changed date

![image](https://user-images.githubusercontent.com/1597830/212219628-6b6aeb7f-b2c5-4e57-b77f-ff31beefacbd.png)


