### PR TITLE
Dragn-n-drop should respect `disableZoomTo` setting.

### DIFF
--- a/lib/ReactViews/DragDropFile.tsx
+++ b/lib/ReactViews/DragDropFile.tsx
@@ -82,8 +82,8 @@ class DragDropFile extends React.Component<PropsType> {
         ).raiseError(props.viewState.terria);
 
         // Zoom to first item
-        const firstZoomableItem = mappableItems.find((i) =>
-          isDefined(i.rectangle)
+        const firstZoomableItem = mappableItems.find(
+          (i) => isDefined(i.rectangle) && i.disableZoomTo === false
         );
 
         isDefined(firstZoomableItem) &&


### PR DESCRIPTION
### What this PR does

When dragging-n-dropping a file, terria should NOT zoom to the dataset if `disableZoomTo` is enabled.

This is required for example, when dragging-n-dropping a glTF file and the file has no geo-referencing, it is automatically placed at the center of the earth. If we do not check `disableZoomTo` we will end up zooming to the center of the earth which can be confusing to the user.

### Test me

Drag-n-drop is not enabled for `gltf` models in default terria. So you'll need to add the following line [somewhere here](https://github.com/TerriaJS/terriajs/blob/7b67f0a17b40f0ff766e7c1a62034c645b6337bf/lib/Models/Catalog/registerCatalogMembers.ts#L250).

```js
    UrlToCatalogMemberMapping.register(
         matchesExtension("glb"),
         GltfCatalogItem.type
    );
```

Then, drag-n-drop [this file to the map](https://github.com/na9da/gltfs/blob/master/data/ducky/Duck.glb). 

In main branch, it will result in the map zooming to black.
In this branch it will do nothing.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
