### PR TITLE
Test clearing catalogue with #clean

### DIFF
--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -2063,6 +2063,10 @@ async function interpretHash(
   if (isDefined(hashProperties.clean)) {
     runInAction(() => {
       terria.initSources.splice(0, terria.initSources.length);
+      // Clear out catalogue
+      for (let key of terria.catalog.group.strata.keys()) {
+        terria.catalog.group.setTrait(key, "members", []);
+      }
     });
   }
 


### PR DESCRIPTION
### What this PR does

Fixes #6701.

`#clean` will now reset `terria.catalog.group`. Not to be merged before adding garbage collection of unnecessary models.

### Test me

Go to http://ci.terria.io/improve-clean/, then add `#clean` to the URL.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
