### PR TITLE
Box drawing fixes and update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 #### next release (8.2.25)
 
+- BoxDrawing changes:
+    - Adds a new option called disableVerticalMovement to BoxDrawing which if set to true disables up/down motion of the box when dragging the top/bottom sides of the box.
+    - Keeps height (mostly) steady when moving the box laterally on the map. Previously the height of the box used to change wrt to the ellipsoid/surface.
+    - Fixes a bug that caused map panning and zooming to break when interacting with multiple active BoxDrawings.
+    - Removed some code that was causing too much drift between mouse cursor and model when moving the model laterally on the map.
 - Replaces addRemoteUploadType and addLocalUploadType with addOrReplaceRemoteFileUploadType and addOrReplaceLocalFileUploadType.
 - [The next improvement]
 

--- a/lib/Models/BoxDrawing.ts
+++ b/lib/Models/BoxDrawing.ts
@@ -1577,7 +1577,13 @@ function intersectRayEllipsoid(
     return;
   }
 
-  const intersectionPoint = Ray.getPoint(ray, interval.start, result);
+  // start=0 means ray origin is inside the ellipsoid
+  // in which case there is only a single intersection
+  // which is given by stop.
+  // This can happen, for eg, when moving the box while the camera
+  // is below the box.
+  const t = interval.start !== 0 ? interval.start : interval.stop;
+  const intersectionPoint = Ray.getPoint(ray, t, result);
   return intersectionPoint;
 }
 

--- a/lib/Models/BoxDrawing.ts
+++ b/lib/Models/BoxDrawing.ts
@@ -374,6 +374,7 @@ export default class BoxDrawing {
         moveStep,
         scratchNewPosition
       );
+
       if (this.keepBoxAboveGround) {
         const cartographic = Cartographic.fromCartesian(
           nextPosition,
@@ -785,6 +786,38 @@ export default class BoxDrawing {
     const scratchMoveStep = new Cartesian3();
     const scratchSurfacePoint = new Cartesian3();
     const scratchSurfacePoint2d = new Cartesian2();
+    const scratchNextStep = new Cartesian3();
+    const scratchNextCartographic = new Cartographic();
+
+    const keepHeightSteady = (
+      currentPosition: Cartesian3,
+      moveStep: Cartesian3
+    ) => {
+      const nextPosition = Cartesian3.add(
+        currentPosition,
+        moveStep,
+        scratchNextStep
+      );
+      const currentCartographic = Cartographic.fromCartesian(
+        this.trs.translation,
+        undefined,
+        scratchCartographic
+      );
+      const nextCartographic = Cartographic.fromCartesian(
+        nextPosition,
+        undefined,
+        scratchNextCartographic
+      );
+      // Keep height steady
+      nextCartographic.height = currentCartographic.height;
+      Cartographic.toCartesian(nextCartographic, undefined, nextPosition);
+      const steadyStep = Cartesian3.subtract(
+        nextPosition,
+        currentPosition,
+        moveStep
+      );
+      return steadyStep;
+    };
 
     /**
      * Moves the box when dragging a side.
@@ -888,7 +921,11 @@ export default class BoxDrawing {
         if (!previousPosition || !endPosition) {
           return;
         }
-        moveStep = Cartesian3.subtract(endPosition, previousPosition, moveStep);
+
+        moveStep = keepHeightSteady(
+          this.trs.translation,
+          Cartesian3.subtract(endPosition, previousPosition, moveStep)
+        );
       }
 
       // Update box position and fire change event

--- a/lib/Models/BoxDrawing.ts
+++ b/lib/Models/BoxDrawing.ts
@@ -864,34 +864,7 @@ export default class BoxDrawing {
         // we find the ellipsoidal points for the previous mouse position and
         // current mouse position and translate the box position by the difference amount.
         //
-        // When the box is tall and the horizon is in view, using the mouse
-        // coordinates to derive the pick ray results in a pick ray almost
-        // tangential to the ellipsoid, giving an ellipsoidal point that is very
-        // far away. This causes large jumps in box position. To avoid this we
-        // angle the pick ray to the ellipsoid surface by first projecting the mouse
-        // points to the ellipsoid surface.
-
-        // The box origin
-        const origin = this.trs.translation;
-
-        // Box origin projected on the ellipsoid surface.
-        const surfacePoint = projectPointToSurface(origin, scratchSurfacePoint);
-        // Surface point in screen coordinates
-        const surfacePoint2d = scene.cartesianToCanvasCoordinates(
-          surfacePoint,
-          scratchSurfacePoint2d
-        );
-
-        if (!surfacePoint2d) {
-          // cartesianToCanvasCoordinates can unexpectedly return undefined.
-          return;
-        }
-
-        // Floor the startPosition and endPosition above the ellipsoid.
-        const yDiff = mouseMove.endPosition.y - mouseMove.startPosition.y;
-        mouseMove.startPosition.y = surfacePoint2d.y;
-        mouseMove.endPosition.y = surfacePoint2d.y + yDiff;
-
+        //
         // Fallback to simple ellipsoid pick when globe pick returns undefined
         // (i.e there is no intersection of camera ray with globe tiles). This
         // probably works only because ellipsoid might below the terrain so
@@ -926,10 +899,10 @@ export default class BoxDrawing {
           return;
         }
 
-        moveStep = keepHeightSteady(
-          this.trs.translation,
-          Cartesian3.subtract(endPosition, previousPosition, moveStep)
-        );
+        moveStep = Cartesian3.subtract(endPosition, previousPosition, moveStep);
+
+        const currentPosition = this.trs.translation;
+        moveStep = keepHeightSteady(currentPosition, moveStep);
       }
 
       // Update box position and fire change event

--- a/lib/Models/BoxDrawing.ts
+++ b/lib/Models/BoxDrawing.ts
@@ -1553,6 +1553,12 @@ function setPlaneDimensions(
 
 const scratchRadii = new Cartesian3();
 
+/**
+ * Increases the radii of the given ellipsoid by the value given by radiiIncrease.
+ *
+ * Note that it is not clear whether the resulting shape obtained by adding the
+ * offset is a true ellipsoid. However, this works out ok for our purpose.
+ */
 function enlargeEllipsoid(
   ellipsoid: Ellipsoid,
   radiiIncrease: number,
@@ -1566,6 +1572,10 @@ function enlargeEllipsoid(
   return enlargedEllipsoid;
 }
 
+/**
+ * Returns the nearest point of intersection between the ray and the ellipsoid
+ * that lies on the ellipsoid.
+ */
 function intersectRayEllipsoid(
   ray: Ray,
   ellipsoid: Ellipsoid,

--- a/lib/Models/BoxDrawing.ts
+++ b/lib/Models/BoxDrawing.ts
@@ -543,7 +543,11 @@ export default class BoxDrawing {
     const handlePick = (click: MouseClick) => {
       const pick = scene.pick(click.position);
       const entity = pick?.id;
-      if (entity === undefined || !isInteractable(entity)) {
+      if (
+        entity === undefined ||
+        !isInteractable(entity) ||
+        !this.dataSource.entities.contains(entity)
+      ) {
         return;
       }
 


### PR DESCRIPTION
### What this PR does

- Adds a new option called [disableVerticalMovement](https://github.com/TerriaJS/terriajs/blob/b6502f7a70c76a34980833734396dad381ac826e/lib/Models/BoxDrawing.ts#L177) to `BoxDrawing` which if set to `true` disables up/down motion of the box when dragging the top/bottom sides of the box. 
- Keeps height (mostly) steady when moving the box laterally on the map. Previously the height of the box used to change wrt to the ellipsoid/surface.
- Fixes a bug that caused map panning and zooming to break when interacting with multiple active BoxDrawings.
- Removed some code that was causing too much drift between mouse cursor and model when moving the model laterally on the map.

### Test me

- Visit this [CI link for main branch](http://ci.terria.io/main/#share=s-krVENrjdcWkasKZA56f59ZRWpEC).
- You should be able to pan and zoom the map
- Try clicking on the box and then try panning and zooming. It will not work.
- Now try it with [this branch](http://ci.terria.io/restrict-vert-box-movement/#clean&share=s-krVENrjdcWkasKZA56f59ZRWpEC), the bug should be fixed.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
