### PR TITLE
New API export: registerUrlHandlerForCatalogMemberType.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.25)
 
+- Export `registerUrlHandlerForCatalogMemberType` for registering new url handler for catalog types.
 - BoxDrawing changes:
     - Adds a new option called disableVerticalMovement to BoxDrawing which if set to true disables up/down motion of the box when dragging the top/bottom sides of the box.
     - Keeps height (mostly) steady when moving the box laterally on the map. Previously the height of the box used to change wrt to the ellipsoid/surface.

--- a/lib/Models/Catalog/CatalogReferences/UrlReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/UrlReference.ts
@@ -144,3 +144,23 @@ export class UrlMapping {
 }
 
 export const UrlToCatalogMemberMapping = new UrlMapping();
+
+/**
+ * Register a url handler for a specific catalog member type.
+ *
+ * When a user uploads a url or drags-n-drops a particular file, the matchers
+ * are tried in order and when there is a match we try and create a catalog
+ * member of that type.
+ *
+ * @param catalogMemberType The type string identifying the catalog member
+ * @param matcher The matcher definition
+ * @param requiresLoad Should be set to `true` if in addition to URL matching we must also try and load
+ *    the item successfully for it to be a valid match. Eg WMS/WFS groups that require enumeration.
+ */
+export function registerUrlHandlerForCatalogMemberType(
+  catalogMemberType: string,
+  matcher: Matcher,
+  requiresLoad?: boolean
+): void {
+  UrlToCatalogMemberMapping.register(matcher, catalogMemberType, requiresLoad);
+}

--- a/lib/ViewModels/UploadDataTypes.ts
+++ b/lib/ViewModels/UploadDataTypes.ts
@@ -1,7 +1,8 @@
 export {
-  default as getDataTypes,
   addLocalUploadType,
   addRemoteUploadType,
+  default as getDataTypes,
   LocalDataType,
   RemoteDataType
 } from "../Core/getDataType";
+export { registerUrlHandlerForCatalogMemberType } from "../Models/Catalog/CatalogReferences/UrlReference";


### PR DESCRIPTION
### What this PR does

Exports a new function `registerUrlHandlerForCatalogMemberType` for registering new url handler for catalog types.

### Test me

Just a wrapper function. Nothing to test.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
