### PR TITLE
Change UploadTypes API to support adding multiple entries for the same catalog item type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.25)
 
+- Replaces addRemoteUploadType and addLocalUploadType with addOrReplaceRemoteFileUploadType and addOrReplaceLocalFileUploadType.
 - [The next improvement]
 
 #### 8.2.24 - 2023-03-06

--- a/lib/Core/getDataType.ts
+++ b/lib/Core/getDataType.ts
@@ -1,5 +1,5 @@
 import i18next from "i18next";
-import { observable, action } from "mobx";
+import { action, observable } from "mobx";
 
 interface DataType {
   value: string;
@@ -187,14 +187,16 @@ const builtinLocalDataTypes: LocalDataType[] = [
 /**
  * Custom remote data types. Add to it by calling addRemoteDataType().
  */
-const customRemoteDataTypes: Map<string, RemoteDataType> = observable(
+export const customRemoteDataTypes: Map<string, RemoteDataType> = observable(
   new Map()
 );
 
 /**
  * Custom local data types. Add by calling addLocalDataType().
  */
-const customLocalDataTypes: Map<string, LocalDataType> = observable(new Map());
+export const customLocalDataTypes: Map<string, LocalDataType> = observable(
+  new Map()
+);
 
 export default function getDataTypes(): GetDataTypes {
   const uniqueRemoteDataTypes: Map<string, RemoteDataType> = new Map([
@@ -224,11 +226,12 @@ export default function getDataTypes(): GetDataTypes {
  * uploading a file from the a remote server. If a data type with the same
  * `value` already exists, we replace it with the new one.
  *
+ * @param key A key to use for identifying this upload type. To override a built-in type, pass `type` of the entry as key.
  * @param newRemoteDataType The new remote data type to be added.
  */
-export const addRemoteUploadType = action(
-  (newRemoteDataType: RemoteDataType) => {
-    customRemoteDataTypes.set(newRemoteDataType.value, newRemoteDataType);
+export const addOrReplaceRemoteFileUploadType = action(
+  (key: string, newRemoteDataType: RemoteDataType) => {
+    customRemoteDataTypes.set(key, newRemoteDataType);
   }
 );
 
@@ -237,11 +240,14 @@ export const addRemoteUploadType = action(
  * uploading a file from the users local machine. If a data type with the same
  * `value` already exists, we replace it with the new one.
  *
+ * @param key A key to use for identifying this upload type. To override a built-in type, pass `type` of the entry as key.
  * @param newLocalDataType The new local data type to be added.
  */
-export const addLocalUploadType = action((newLocalDataType: LocalDataType) => {
-  customLocalDataTypes.set(newLocalDataType.value, newLocalDataType);
-});
+export const addOrReplaceLocalFileUploadType = action(
+  (key: string, newLocalDataType: LocalDataType) => {
+    customLocalDataTypes.set(key, newLocalDataType);
+  }
+);
 
 function translateDataType<T extends DataType>(dataType: T): T {
   return {

--- a/lib/ViewModels/UploadDataTypes.ts
+++ b/lib/ViewModels/UploadDataTypes.ts
@@ -1,7 +1,7 @@
 export {
   default as getDataTypes,
-  addLocalUploadType,
-  addRemoteUploadType,
+  addOrReplaceLocalFileUploadType,
+  addOrReplaceRemoteFileUploadType,
   LocalDataType,
   RemoteDataType
 } from "../Core/getDataType";

--- a/test/ViewModels/UploadDataTypesSpec.ts
+++ b/test/ViewModels/UploadDataTypesSpec.ts
@@ -1,6 +1,15 @@
+import {
+  customLocalDataTypes,
+  customRemoteDataTypes
+} from "../../lib/Core/getDataType";
 import * as UploadDataTypes from "../../lib/ViewModels/UploadDataTypes";
 
-describe("UploadDataTypes", function () {
+fdescribe("UploadDataTypes", function () {
+  afterEach(function () {
+    customLocalDataTypes.clear();
+    customRemoteDataTypes.clear();
+  });
+
   describe("getDataTypes", function () {
     it("returns all the builtin local upload types", function () {
       expect(UploadDataTypes.getDataTypes().localDataType.length).toEqual(10);
@@ -11,9 +20,9 @@ describe("UploadDataTypes", function () {
     });
   });
 
-  describe("addRemoteUploadType", function () {
+  describe("addOrReplaceRemoteFileUploadType", function () {
     it("should add the given upload type to remoteDataType list", function () {
-      UploadDataTypes.addRemoteUploadType({
+      UploadDataTypes.addOrReplaceRemoteFileUploadType("foo42", {
         value: "foo42",
         name: "Foo type",
         description: "Foo data"
@@ -25,11 +34,68 @@ describe("UploadDataTypes", function () {
       expect(fooType?.name).toEqual("Foo type");
       expect(fooType?.description).toEqual("Foo data");
     });
+
+    it("should override an existing type definition with the same key", function () {
+      UploadDataTypes.addOrReplaceRemoteFileUploadType("foo42", {
+        value: "foo42",
+        name: "Foo type",
+        description: "Foo files"
+      });
+
+      UploadDataTypes.addOrReplaceRemoteFileUploadType("foo42", {
+        value: "foo42",
+        name: "Another Foo type",
+        description: "Some other foo files"
+      });
+
+      const fooTypes = UploadDataTypes.getDataTypes().remoteDataType.filter(
+        (type) => type.value === "foo42"
+      );
+
+      expect(fooTypes).toEqual([
+        {
+          value: "foo42",
+          name: "Another Foo type",
+          description: "Some other foo files"
+        }
+      ]);
+    });
+
+    it("should not override an existing type with a different key", function () {
+      UploadDataTypes.addOrReplaceRemoteFileUploadType("foo42", {
+        value: "foo42",
+        name: "Foo type",
+        description: "Foo files"
+      });
+
+      UploadDataTypes.addOrReplaceRemoteFileUploadType("foo42-another", {
+        value: "foo42",
+        name: "Another Foo type",
+        description: "Some other foo files"
+      });
+
+      const fooTypes = UploadDataTypes.getDataTypes().remoteDataType.filter(
+        (type) => type.value === "foo42"
+      );
+
+      expect(fooTypes).toEqual([
+        {
+          value: "foo42",
+          name: "Foo type",
+          description: "Foo files"
+        },
+        {
+          value: "foo42",
+          name: "Another Foo type",
+          description: "Some other foo files"
+        }
+      ]);
+    });
   });
 
-  describe("addLocalUploadType", function () {
+  describe("addOrReplaceLocalFileUploadType", function () {
     it("should add the given upload type to localDataType list", function () {
-      UploadDataTypes.addLocalUploadType({
+      UploadDataTypes.addOrReplaceLocalFileUploadType("foo42", {
         value: "foo42",
         name: "Foo type",
         description: "Foo files"
@@ -40,6 +106,63 @@ describe("UploadDataTypes", function () {
       expect(fooType).toBeDefined();
       expect(fooType?.name).toEqual("Foo type");
       expect(fooType?.description).toEqual("Foo files");
+    });
+
+    it("should override an existing type definition with the same key", function () {
+      UploadDataTypes.addOrReplaceLocalFileUploadType("foo42", {
+        value: "foo42",
+        name: "Foo type",
+        description: "Foo files"
+      });
+
+      UploadDataTypes.addOrReplaceLocalFileUploadType("foo42", {
+        value: "foo42",
+        name: "Another Foo type",
+        description: "Some other foo files"
+      });
+
+      const fooTypes = UploadDataTypes.getDataTypes().localDataType.filter(
+        (type) => type.value === "foo42"
+      );
+
+      expect(fooTypes).toEqual([
+        {
+          value: "foo42",
+          name: "Another Foo type",
+          description: "Some other foo files"
+        }
+      ]);
+    });
+
+    it("should not override an existing type with a different key", function () {
+      UploadDataTypes.addOrReplaceLocalFileUploadType("foo42", {
+        value: "foo42",
+        name: "Foo type",
+        description: "Foo files"
+      });
+
+      UploadDataTypes.addOrReplaceLocalFileUploadType("foo42-another", {
+        value: "foo42",
+        name: "Another Foo type",
+        description: "Some other foo files"
+      });
+
+      const fooTypes = UploadDataTypes.getDataTypes().localDataType.filter(
+        (type) => type.value === "foo42"
+      );
+
+      expect(fooTypes).toEqual([
+        {
+          value: "foo42",
+          name: "Foo type",
+          description: "Foo files"
+        },
+        {
+          value: "foo42",
+          name: "Another Foo type",
+          description: "Some other foo files"
+        }
+      ]);
     });
   });
 });


### PR DESCRIPTION
### What this PR does

Replaces `addRemoteUploadType` and `addLocalUploadType` with `addOrReplaceRemoteFileUploadType` and `addOrReplaceLocalFileUploadType`.

Previously the upload type entries were keyed using the catalog item `type` which allowed only 1 entry per catalog item. But sometimes we want to add multiple entries for a catalog item. For eg: we want to add separate entries for OBJ & Collada types, both handled by "assimp" catalog item.

The new API function allows this possibility by accepting a `key` param which is used in place of `type` value to key the entries. 

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
