### PR TITLE
bump version number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
-#### next release (8.2.25)
+#### next release (8.2.26)
+
+- [The next improvement]
+
+#### 8.2.25 - 2023-03-20
 
 - Export `registerUrlHandlerForCatalogMemberType` for registering new url handler for catalog types.
 - BoxDrawing changes:
@@ -9,7 +13,6 @@
   - Fixes a bug that caused map panning and zooming to break when interacting with multiple active BoxDrawings.
   - Removed some code that was causing too much drift between mouse cursor and model when moving the model laterally on the map.
 - Replaces addRemoteUploadType and addLocalUploadType with addOrReplaceRemoteFileUploadType and addOrReplaceLocalFileUploadType.
-- [The next improvement]
 
 #### 8.2.24 - 2023-03-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.2.24",
+  "version": "8.2.25",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### What this PR does

Fixes 
- #6721

### Change Summary 

- Export `registerUrlHandlerForCatalogMemberType` for registering new url handler for catalog types.
- BoxDrawing changes:
  - Adds a new option called disableVerticalMovement to BoxDrawing which if set to true disables up/down motion of the box when dragging the top/bottom sides of the box.
  - Keeps height (mostly) steady when moving the box laterally on the map. Previously the height of the box used to change wrt to the ellipsoid/surface.
  - Fixes a bug that caused map panning and zooming to break when interacting with multiple active BoxDrawings.
  - Removed some code that was causing too much drift between mouse cursor and model when moving the model laterally on the map.
- Replaces addRemoteUploadType and addLocalUploadType with addOrReplaceRemoteFileUploadType and addOrReplaceLocalFileUploadType.


### Test me

Please use the URL below for testing:

http://ci.terria.io/rel-8-2-25/

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
