### PR TITLE
Release v8.2.27.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
-#### next release (8.2.27)
+#### next release (8.2.28)
+
+- [The next improvement]
+
+#### 8.2.27 - 2023-04-05
 
 - Change icon used for display group remove button
 - Make access control UI compatible to Magda v1 and v2 with v2 overriding v1.
@@ -12,7 +16,6 @@
 - Optimize `Compass` component to reduce renders on each frame.
 - Add `children` optional property to StandardUserInterfaceProps interface
 - Add support for ArcGis MapServer with `TileOnly` capability - for example layers served from ArcGis Online. This is supported through `ArcGisMapServerCatalogItem`, `ArcGisMapServerCatalogGroup` and `ArcGisCatalogGroup`.
-- [The next improvement]
 
 #### 8.2.26 - 2023-03-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.2.26",
+  "version": "8.2.27",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### What this PR does

Release version [8.2.27](https://github.com/TerriaJS/terriajs/issues/6750).

This version has the following [changes](https://github.com/TerriaJS/terriajs/blob/rel8227/CHANGES.md):

```md
- Change icon used for display group remove button
- Make access control UI compatible to Magda v1 and v2 with v2 overriding v1.
- Remove karma-sauce-launcher dependency
- Add method `addFileDragDropListener` for receiving callbacks when user drags-n-drops a file.
- Improve `BoxDrawing` drag interaction.
- Fix a bug where `BoxDrawing` sometimes causes the map to loose pan and zoom interactivity.
- Optimize `LocationBar` component to reduce number of renders on mouse move.
- Optimize `Compass` component to reduce renders on each frame.
- Add `children` optional property to StandardUserInterfaceProps interface
- Add support for ArcGis MapServer with `TileOnly` capability - for example layers served from ArcGis Online. This is supported through `ArcGisMapServerCatalogItem`, `ArcGisMapServerCatalogGroup` and `ArcGisCatalogGroup`.
```

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [X] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
