### PR TITLE
update docs for excludeMembers: group/item `id` is also supported

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Fix location point ideal zoom bug in 3D mode map.
 - Add `EPSG:7844` to `Proj4Definitions`.
 - TSify `Proj4Definitions` and `Reproject` modules.
+- Update the docs for `excludeMembers`: mention the group/item id support
 - [The next improvement]
 
 #### 8.2.27 - 2023-04-05

--- a/lib/Traits/TraitsClasses/GroupTraits.ts
+++ b/lib/Traits/TraitsClasses/GroupTraits.ts
@@ -10,7 +10,7 @@ export default class GroupTraits extends mixTraits(ItemPropertiesTraits) {
   @primitiveArrayTrait({
     name: "Exclude members",
     type: "string",
-    description: `An array of strings of excluded group and item names. A group or item name that appears in this list will not be shown to the user. This is case-insensitive and will also apply to all child/nested groups`
+    description: `An array of strings of excluded group and item names (or ids). A group or item name (or id) that appears in this list will not be shown to the user. This is case-insensitive and will also apply to all child/nested groups`
   })
   excludeMembers?: string[];
 


### PR DESCRIPTION
### What this PR does

Update docs for excludeMembers: group/item `id` is also supported.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist) (only a doc updates)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR. (this is a doc update only pr)
