### PR TITLE
Update CI deployment script with new ingress spec

### DIFF
--- a/buildprocess/ci-cleanup.js
+++ b/buildprocess/ci-cleanup.js
@@ -63,7 +63,8 @@ function createIngress(branches) {
       annotations: {
         "ingress.kubernetes.io/ssl-redirect": "false",
         "ingress.kubernetes.io/force-ssl-redirect": "false",
-        "ingress.kubernetes.io/rewrite-target": "/$2"
+        "nginx.ingress.kubernetes.io/use-regex": "true",
+        "nginx.ingress.kubernetes.io/rewrite-target": "/$2"
       }
     },
     spec: {

--- a/buildprocess/ci-cleanup.js
+++ b/buildprocess/ci-cleanup.js
@@ -71,7 +71,7 @@ function createIngress(branches) {
       ingressClassName: "nginx-two",
       rules: [
         {
-          host: "ci.terria.io",
+          host: "ci-two.terria.io",
           http: {
             paths: branches.map((branch) => ({
               path: "/" + branch.name + "(/|$)(.*)",

--- a/buildprocess/ci-cleanup.js
+++ b/buildprocess/ci-cleanup.js
@@ -63,7 +63,7 @@ function createIngress(branches) {
       annotations: {
         "ingress.kubernetes.io/ssl-redirect": "false",
         "ingress.kubernetes.io/force-ssl-redirect": "false",
-        "ingress.kubernetes.io/rewrite-target": "/"
+        "ingress.kubernetes.io/rewrite-target": "/$2"
       }
     },
     spec: {
@@ -73,7 +73,7 @@ function createIngress(branches) {
           host: "ci.terria.io",
           http: {
             paths: branches.map((branch) => ({
-              path: "/" + branch.name + "/",
+              path: "/" + branch.name + "(/|$)(.*)",
               pathType: "ImplementationSpecific",
               backend: {
                 service: {

--- a/buildprocess/ci-cleanup.js
+++ b/buildprocess/ci-cleanup.js
@@ -68,10 +68,9 @@ function createIngress(branches) {
       }
     },
     spec: {
-      ingressClassName: "nginx-two",
       rules: [
         {
-          host: "ci-two.terria.io",
+          host: "ci.terria.io",
           http: {
             paths: branches.map((branch) => ({
               path: "/" + branch.name + "(/|$)(.*)",

--- a/buildprocess/ci-cleanup.js
+++ b/buildprocess/ci-cleanup.js
@@ -59,7 +59,7 @@ function createIngress(branches) {
     apiVersion: "networking.k8s.io/v1",
     kind: "Ingress",
     metadata: {
-      name: "terriajs-ci-ing",
+      name: "ci-terria-io",
       annotations: {
         "ingress.kubernetes.io/ssl-redirect": "false",
         "ingress.kubernetes.io/force-ssl-redirect": "false",
@@ -69,6 +69,7 @@ function createIngress(branches) {
     spec: {
       rules: [
         {
+          host: "ci.terria.io",
           http: {
             paths: branches.map((branch) => ({
               path: "/" + branch.name + "/",

--- a/buildprocess/ci-cleanup.js
+++ b/buildprocess/ci-cleanup.js
@@ -56,12 +56,11 @@ function makeSafeName(name) {
 
 function createIngress(branches) {
   return {
-    apiVersion: "networking.k8s.io/v1beta1",
+    apiVersion: "networking.k8s.io/v1",
     kind: "Ingress",
     metadata: {
-      name: "terriajs-ci",
+      name: "terriajs-ci-ing",
       annotations: {
-        "kubernetes.io/ingress.class": "nginx",
         "ingress.kubernetes.io/ssl-redirect": "false",
         "ingress.kubernetes.io/force-ssl-redirect": "false",
         "ingress.kubernetes.io/rewrite-target": "/"
@@ -73,10 +72,12 @@ function createIngress(branches) {
           http: {
             paths: branches.map((branch) => ({
               path: "/" + branch.name + "/",
+              pathType: "ImplementationSpecific",
               backend: {
-                serviceName:
-                  "terriajs-" + makeSafeName(branch.name) + "-terriamap",
-                servicePort: "http"
+                service: {
+                  name: "terriajs-" + makeSafeName(branch.name) + "-terriamap",
+                  port: "http"
+                }
               }
             }))
           }

--- a/buildprocess/ci-cleanup.js
+++ b/buildprocess/ci-cleanup.js
@@ -76,7 +76,9 @@ function createIngress(branches) {
               backend: {
                 service: {
                   name: "terriajs-" + makeSafeName(branch.name) + "-terriamap",
-                  port: "http"
+                  port: {
+                    name: "http"
+                  }
                 }
               }
             }))

--- a/buildprocess/ci-cleanup.js
+++ b/buildprocess/ci-cleanup.js
@@ -67,6 +67,7 @@ function createIngress(branches) {
       }
     },
     spec: {
+      ingressClassName: "nginx-two",
       rules: [
         {
           host: "ci.terria.io",


### PR DESCRIPTION
This PR changes the Ingress object used by `ci.terria.io`. It:
- bumps the API version from `v1beta1` to `v1` which is required for Kubernetes 1.22
- Updates the `rewrite-target` annotation to support the latest `ingress-nginx` controller

Because this same script runs on every branch, I've created a new Ingress object so old branches do not overwrite new ones. The new Ingress object specifies the `ci.terria.io` hostname so it takes precedence over the old Ingress.