### PR TITLE
Fix app crash when rendering feature info with a custom title.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.2.29)
 
+- Fix app crash when rendering feature info with a custom title.
 - [The next improvement]
 
 #### 8.2.28 - 2023-04-28

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.tsx
@@ -396,7 +396,8 @@ export class FeatureInfoSection extends React.Component<FeatureInfoProps> {
     if (this.props.catalogItem.featureInfoTemplate.name) {
       title = Mustache.render(
         this.props.catalogItem.featureInfoTemplate.name,
-        this.featureProperties
+        this.mustacheContextData,
+        this.props.catalogItem.featureInfoTemplate.partials
       );
     } else
       title =

--- a/test/ReactViews/FeatureInfoSectionSpec.tsx
+++ b/test/ReactViews/FeatureInfoSectionSpec.tsx
@@ -305,6 +305,7 @@ describe("FeatureInfoSection", function () {
     feature = new Entity({
       name: "Vapid"
     });
+
     const section = (
       <FeatureInfoSection
         catalogItem={catalogItem}
@@ -325,6 +326,27 @@ describe("FeatureInfoSection", function () {
       result.root.findAll((node) => (node as any)._fiber.key === "no-info")
         .length
     ).toEqual(1);
+  });
+
+  it("does not break when a template name needs to be rendered but no properties are set", function () {
+    catalogItem.featureInfoTemplate.setTrait(
+      CommonStrata.user,
+      "name",
+      "Title {{name}}"
+    );
+
+    feature = new Entity();
+    const section = (
+      <FeatureInfoSection
+        catalogItem={catalogItem}
+        feature={feature}
+        isOpen={true}
+        viewState={viewState}
+        t={() => {}}
+      />
+    );
+    const result = createWithContexts(viewState, section);
+    expect(findWithText(result, "Title ").length).toEqual(1);
   });
 
   it("shows properties if no description", function () {


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/nationalmap/issues/1205

Currently the app crashes when rendering feature info with a custom title and the feature has no properties.
This PR fixes it.

### Test me

- Open this CI link for [main branch](http://ci.terria.io/main/#share=s-tWhZB0F2KjvwdJTDuJTFuIWVbXk&clean&https://gist.githubusercontent.com/na9da/af85c3eff23e1582f771b40e9f87a4da/raw/75104d5171d45c72b620168817193809c2325056/lidar.json)
- Click anywhere on the map layer for the workbench item
- Witness app crash
- Now repeat the same steps for [this branch](http://ci.terria.io/fix-feature-info-name/#share=s-tWhZB0F2KjvwdJTDuJTFuIWVbXk&clean&https://gist.githubusercontent.com/na9da/af85c3eff23e1582f771b40e9f87a4da/raw/75104d5171d45c72b620168817193809c2325056/lidar.json)
- The app does not crash


### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
