### PR TITLE
Add trait for generating custom item id for ckan resource items.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.2.29)
 
 - Fix app crash when rendering feature info with a custom title.
+- Added new `CkanCatalogGroup` traits `resourceIdTemplate` and `restrictResourceIdTemplateToOrgsWithNames` to generate custom resource IDs for CKAN resources with unstable IDs.
 - [The next improvement]
 
 #### 8.2.28 - 2023-04-28

--- a/lib/Models/Catalog/Ckan/CkanCatalogGroup.ts
+++ b/lib/Models/Catalog/Ckan/CkanCatalogGroup.ts
@@ -1,5 +1,12 @@
 import i18next from "i18next";
-import { action, computed, observable, runInAction } from "mobx";
+import {
+  action,
+  computed,
+  observable,
+  runInAction,
+  isObservableArray
+} from "mobx";
+import Mustache from "mustache";
 import URI from "urijs";
 import flatten from "../../../Core/flatten";
 import isDefined from "../../../Core/isDefined";
@@ -346,7 +353,6 @@ export class CkanServerStratum extends LoadableStratum(CkanCatalogGroupTraits) {
       const { resource, format } = filteredResources[i];
 
       const itemId = this.getItemId(ckanDataset, resource);
-
       let item = this._catalogGroup.terria.getModelById(
         CkanItemReference,
         itemId
@@ -409,7 +415,50 @@ export class CkanServerStratum extends LoadableStratum(CkanCatalogGroupTraits) {
 
   @action
   getItemId(ckanDataset: CkanDataset, resource: CkanResource) {
-    return `${this._catalogGroup.uniqueId}/${ckanDataset.id}/${resource.id}`;
+    const resourceId = this.buildResourceId(ckanDataset, resource);
+    return `${this._catalogGroup.uniqueId}/${ckanDataset.id}/${resourceId}`;
+  }
+
+  /**
+   * Build an ID for the given resource using the `resourceIdTemplate` if available.
+   */
+  private buildResourceId(ckanDataset: CkanDataset, resource: CkanResource) {
+    const resourceIdTemplate = this.resourceIdTemplateForOrg(
+      ckanDataset.organization?.name
+    );
+    const resourceId = resourceIdTemplate
+      ? // Use mustache to construct the resource id from template. Also delete any `/`
+        // character in the resulting ID to avoid conflict with the path separator.
+        Mustache.render(resourceIdTemplate, { resource }).replace("/", "")
+      : resource.id;
+    return resourceId;
+  }
+
+  /**
+   * Returns a template for constructing alternate resourceId for the given
+   * organisation or `undefined` when no template is defined.
+   */
+  private resourceIdTemplateForOrg(
+    orgName: string | undefined
+  ): string | undefined {
+    const template = this._catalogGroup.resourceIdTemplate;
+    // No template defined
+    if (!template) {
+      return undefined;
+    }
+
+    const restrictedOrgNames =
+      this._catalogGroup.restrictResourceIdTemplateToOrgsWithNames;
+    if (
+      Array.isArray(restrictedOrgNames) ||
+      isObservableArray(restrictedOrgNames)
+    ) {
+      // Use of template restricted by org names - return template only if this org is in the list
+      return restrictedOrgNames.includes(orgName) ? template : undefined;
+    }
+
+    // Template usage has no restrictions - return template for any org
+    return template;
   }
 }
 

--- a/lib/Traits/TraitsClasses/CkanCatalogGroupTraits.ts
+++ b/lib/Traits/TraitsClasses/CkanCatalogGroupTraits.ts
@@ -7,6 +7,7 @@ import CkanSharedTraits from "./CkanSharedTraits";
 import GroupTraits from "./GroupTraits";
 import LegendOwnerTraits from "./LegendOwnerTraits";
 import UrlTraits from "./UrlTraits";
+import primitiveArrayTrait from "../Decorators/primitiveArrayTrait";
 
 export default class CkanCatalogGroupTraits extends mixTraits(
   GroupTraits,
@@ -68,4 +69,20 @@ export default class CkanCatalogGroupTraits extends mixTraits(
     description: `True to remove inactive datasets. Where \`state = "deleted"\` (CKAN official), \`state === "draft"\` (CKAN official) or \`data_state === "inactive"\` (Data.gov.au CKAN).`
   })
   excludeInactiveDatasets: boolean = true;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Resource ID template string.",
+    description:
+      "A Mustache formatted template string for generating a custom resource id from resource description. By default we use `resource.id` as the ID of the CKAN item but some CKAN services change their resource IDs frequently which can break terria features link share links or catalog search indexing. You can use `customResourceIdTemplate` to instruct terria to construct a different ID instead of the default `resource.id`. The template string will receive the entire `resource` as a template variable. Example usage: '{{resource.name}}-{{resource.format}}'."
+  })
+  resourceIdTemplate?: string;
+
+  @primitiveArrayTrait({
+    type: "string",
+    name: "Restrict resource id template to organization with names",
+    description:
+      "Names of organisations for which `customResourceIdTemplate` should be used."
+  })
+  restrictResourceIdTemplateToOrgsWithNames?: string[];
 }

--- a/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
+++ b/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
@@ -1,9 +1,9 @@
 import i18next from "i18next";
 import { configure, runInAction } from "mobx";
-import { CatalogMemberMixin } from "terriajs-plugin-api";
 import URI from "urijs";
 import { JsonObject } from "../../../../lib/Core/Json";
 import _loadWithXhr from "../../../../lib/Core/loadWithXhr";
+import CatalogMemberMixin from "../../../../lib/ModelMixins/CatalogMemberMixin";
 import GroupMixin from "../../../../lib/ModelMixins/GroupMixin";
 import CatalogGroup from "../../../../lib/Models/Catalog/CatalogGroup";
 import CkanCatalogGroup, {

--- a/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
+++ b/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
@@ -637,6 +637,19 @@ describe("CkanCatalogGroup", function () {
       );
     });
 
+    it("ensures that the generated resource-id does not contain `/` character (to avoid clashing with id path character)", async function () {
+      ckanCatalogGroup.setTrait(
+        CommonStrata.definition,
+        "resourceIdTemplate",
+        "{{resource.name}}-{{resource.format}}/something"
+      );
+      await ckanCatalogGroup.loadMembers();
+      const group = ckanCatalogGroup.memberModels[0] as GroupMixin.Instance;
+      expect(group.memberModels[0].uniqueId).toBe(
+        "test/3245ad6c-cc00-4404-ba1f-476c07b5f762/WMS (OGC)-WMSsomething"
+      );
+    });
+
     describe("when `restrictResourceIdTemplateToOrgsWithNames` is given", function () {
       it("uses `resourceIdTemplate` for generating resource id for organizations in the list", async function () {
         ckanCatalogGroup.setTrait(

--- a/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
+++ b/test/Models/Catalog/Ckan/CkanCatalogGroupSpec.ts
@@ -1,8 +1,10 @@
 import i18next from "i18next";
 import { configure, runInAction } from "mobx";
+import { CatalogMemberMixin } from "terriajs-plugin-api";
 import URI from "urijs";
 import { JsonObject } from "../../../../lib/Core/Json";
 import _loadWithXhr from "../../../../lib/Core/loadWithXhr";
+import GroupMixin from "../../../../lib/ModelMixins/GroupMixin";
 import CatalogGroup from "../../../../lib/Models/Catalog/CatalogGroup";
 import CkanCatalogGroup, {
   CkanServerStratum
@@ -608,6 +610,89 @@ describe("CkanCatalogGroup", function () {
       let group1 = <CatalogGroup>ckanCatalogGroup.memberModels[1];
 
       expect(group1.memberModels.length).toBe(13);
+    });
+  });
+
+  describe("when `resourceIdTemplate` is given", function () {
+    beforeEach(async function () {
+      runInAction(() => {
+        ckanCatalogGroup.setTrait(
+          "definition",
+          "url",
+          "test/CKAN/search-result.json"
+        );
+      });
+    });
+
+    it("uses it for generating a custom item id for the resource item", async function () {
+      ckanCatalogGroup.setTrait(
+        CommonStrata.definition,
+        "resourceIdTemplate",
+        "{{resource.name}}-{{resource.format}}"
+      );
+      await ckanCatalogGroup.loadMembers();
+      const group = ckanCatalogGroup.memberModels[0] as GroupMixin.Instance;
+      expect(group.memberModels[0].uniqueId).toBe(
+        "test/3245ad6c-cc00-4404-ba1f-476c07b5f762/WMS (OGC)-WMS"
+      );
+    });
+
+    describe("when `restrictResourceIdTemplateToOrgsWithNames` is given", function () {
+      it("uses `resourceIdTemplate` for generating resource id for organizations in the list", async function () {
+        ckanCatalogGroup.setTrait(
+          CommonStrata.definition,
+          "resourceIdTemplate",
+          "{{resource.name}}-{{resource.format}}"
+        );
+        ckanCatalogGroup.setTrait(
+          CommonStrata.definition,
+          "restrictResourceIdTemplateToOrgsWithNames",
+          ["doee"] // apply template only for DOEE org
+        );
+        ckanCatalogGroup.setTrait("definition", "groupBy", "organization");
+        await ckanCatalogGroup.loadMembers();
+
+        const doeeGroup = ckanCatalogGroup
+          .memberModels[0] as GroupMixin.Instance & CatalogMemberMixin.Instance;
+        expect(doeeGroup).toBeDefined();
+        expect(doeeGroup.name).toBe("Department of the Environment and Energy");
+        // Template used for generating ID for DOEE resource
+        expect(doeeGroup.memberModels[0].uniqueId).toBe(
+          "test/3245ad6c-cc00-4404-ba1f-476c07b5f762/WMS (OGC)-WMS"
+        );
+        const anotherGroup = ckanCatalogGroup
+          .memberModels[1] as GroupMixin.Instance & CatalogMemberMixin.Instance;
+        expect(anotherGroup).toBeDefined();
+        // Template not used for generating ID for MDBA resource
+        expect(anotherGroup.name).toBe("Murray-Darling Basin Authority");
+        expect(anotherGroup.memberModels[0].uniqueId).toBe(
+          "test/7b0c274f-7f12-4062-9e54-5b8227ca20c4/49e8da1c-1ce6-4008-bdcb-af8552a305c2"
+        );
+      });
+
+      it("does NOT uses `resourceIdTemplate` for generating resource id for organizations NOT in the list", async function () {
+        ckanCatalogGroup.setTrait(
+          CommonStrata.definition,
+          "resourceIdTemplate",
+          "{{resource.name}}-{{resource.format}}"
+        );
+        ckanCatalogGroup.setTrait(
+          CommonStrata.definition,
+          "restrictResourceIdTemplateToOrgsWithNames",
+          ["doee"] // apply template only for DOEE org
+        );
+        ckanCatalogGroup.setTrait("definition", "groupBy", "organization");
+        await ckanCatalogGroup.loadMembers();
+
+        const mdbaGroup = ckanCatalogGroup
+          .memberModels[1] as GroupMixin.Instance & CatalogMemberMixin.Instance;
+        expect(mdbaGroup).toBeDefined();
+        // Template not used for generating ID for MDBA resource
+        expect(mdbaGroup.name).toBe("Murray-Darling Basin Authority");
+        expect(mdbaGroup.memberModels[0].uniqueId).toBe(
+          "test/7b0c274f-7f12-4062-9e54-5b8227ca20c4/49e8da1c-1ce6-4008-bdcb-af8552a305c2"
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
### What this PR does

Currently CKAN resource items have fixed ID derived using the following template `${catalogGroup.uniqueId}/${ckanDataset.id}/${ckanResource.id}`. This works in most cases but some CKAN services have unstable IDs. This breaks share links and search index. 

In this PR we add a couple of traits to customize ID generation so that the catalog maintainer can use other attributes to derive a more stable ID.

New traits:
- `resourceTemplateId` - A mustache template that can be used to define a custom ID for resource items. Eg: `{{resource.name}}-{{resource.format}}`
- `restrictResourceIdTemplateToOrgsWithNames` - A list of org names that restricts the use of `resourceTemplateId` to organizations that belong to the list. 

Example usage:
```json
{
      "type": "ckan-group",
      "name": "DataVic Open Data Portal",
      "filterQuery": [
        {
          "fq": "+(res_format:(wms OR WMS OR shapefile OR Shapefile OR \"zip (shp)\" OR shp OR SHP OR kmz OR GeoJSON OR geojson OR csv-geo-au OR aus-geo-csv))"
        }
      ],
      "groupBy": "organization",
      "supportedResourceFormats": [
        {
          "id": "WMS",
          "urlRegex": "^((?!data.gov.au/geoserver).)*$"
        },
        {
          "id": "Kml",
          "onlyUseIfSoleResource": true
        },
        {
          "id": "Shapefile",
          "onlyUseIfSoleResource": true
        }
      ],
      "ungroupedTitle": "Organisation not declared",
      "shareKeys": ["Root Group/Victorian Government", "8pCSdj2L"],
      "url": "https://discover.data.vic.gov.au/",
      "itemPropertiesByType": [
        {
          "type": "wms",
          "itemProperties": {
            "crs": "EPSG:3857"
          }
        }
      ],

      "resourceIdTemplate": "{{resource.name}}-{{resource.format}}",
      "restrictResourceIdTemplateToOrgsWithNames": [
        "department-of-energy-environment-climate-action"
      ]
    }
```

### Test me

- Open the explorer window from this [share link](http://ci.terria.io/custom-ckan-id/#clean&https://gist.githubusercontent.com/na9da/e8158c908ed50b85e8e0d97a3750a430/raw/3da0c96f419aa28a6fc187bce430bf9097ce6dce/ckan-test.json)
- Add items from the CKAN group
- Add any item from `Department of Energy, Environment and Climate Action`
- Create a new share link
- Decode the share link and ensure that the ID of the shared item matches the above template.
- Check randomly to ensure that IDs of items from other groups remain unchanged.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
