### PR TITLE
Return valid camera def when no horizon visible 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.2.29)
 
 - Fix app crash when rendering feature info with a custom title.
+- Fixed bug where sharelinks created with no visible horizon would default to homeCamera view
 - [The next improvement]
 
 #### 8.2.28 - 2023-04-28

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -1004,13 +1004,23 @@ export default class Cesium extends GlobeOrMap {
     const centerOfScreen = new Cartesian2(width / 2.0, height / 2.0);
     const pickRay = scene.camera.getPickRay(centerOfScreen);
     const center = isDefined(pickRay)
-      ? scene.globe.pick(pickRay, scene)
+      ? scene.globe.pick(pickRay, scene) // will be undefined if we are facing above the horizon
       : undefined;
 
     if (!center) {
-      // TODO: binary search to find the horizon point and use that as the center.
-      return this.terriaViewer.homeCamera; // This is just a random rectangle. Replace it when there's a home view available
-      // return this.terria.homeView.rectangle;
+      /** TODO: binary search to find the horizon point and use that as the center. 
+      This will give a real `center` for camera views where the horizon is visible.
+      But this will not be possible if camera is facing upwards and the horizon is not visible. 
+      So we need to return a useful CameraView that works in 3D mode and 2D mode.
+      In this case return the correct definition for the cesium camera, with position, direction, and up, 
+      but for the required `rectangle` property, that will only be used when switching to 2D mode, provide the homeCamera view extent. 
+      **/
+      return new CameraView(
+        this.terriaViewer.homeCamera.rectangle,
+        camera.positionWC,
+        camera.directionWC,
+        camera.upWC
+      );
     }
 
     const ellipsoid = this.scene.globe.ellipsoid;


### PR DESCRIPTION
### What this PR does

Fixes [#487](https://github.com/TerriaJS/vic-digital-twin/issues/487)

When attempting to create a sharelink of a map where the camera faces upwards, the incorrect `initialCamera` is embedded in the sharelink.

The problem was traced to `Cesium.getCurrentCameraView()`

It is not possible to define the view rectangle on the ground, where the horizon is not visible. But we need to return a useful CameraView that works in 3D mode and 2D mode. In this case return the correct definition for the cesium camera, with position, direction, and up, but for the required `rectangle` property, that will only be used when switching to 2D mode, provide the homeCamera view extent. 

### Test me

[Before - create a sharelink from this map](http://ci.terria.io/main/#start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%7D%2C%22workbench%22%3A%5B%5D%2C%22timeline%22%3A%5B%5D%2C%22initialCamera%22%3A%7B%22west%22%3A133.12335073549156%2C%22south%22%3A-42.38666970744262%2C%22east%22%3A156.35409851747534%2C%22north%22%3A-31.55857883340345%2C%22position%22%3A%7B%22x%22%3A-3786724.9894824005%2C%22y%22%3A4350655.54114095%2C%22z%22%3A-2714820.579710214%7D%2C%22direction%22%3A%7B%22x%22%3A-0.23728393058777358%2C%22y%22%3A0.7036578364262455%2C%22z%22%3A0.6697477028857597%7D%2C%22up%22%3A%7B%22x%22%3A-0.5453609191618481%2C%22y%22%3A0.4740534231746787%2C%22z%22%3A-0.6912704389942572%7D%7D%2C%22homeCamera%22%3A%7B%22west%22%3A133.12335073549156%2C%22south%22%3A-42.38666970744262%2C%22east%22%3A156.35409851747534%2C%22north%22%3A-31.55857883340345%2C%22position%22%3A%7B%22x%22%3A-4120986.489101264%2C%22y%22%3A2901296.804778211%2C%22z%22%3A-5529233.584392741%7D%2C%22direction%22%3A%7B%22x%22%3A-0.009963608676945457%2C%22y%22%3A0.01443110436389694%2C%22z%22%3A0.999846223040809%7D%2C%22up%22%3A%7B%22x%22%3A-0.8138296757070467%2C%22y%22%3A0.580869360008338%2C%22z%22%3A-0.01649380314139365%7D%7D%2C%22viewerMode%22%3A%223d%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.4999%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A1%2C%22useNativeResolution%22%3Atrue%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-natural-earth-II%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)


**After:** [create a sharelink from this map and open it](http://ci.terria.io/fix-no-horizon-shares/#start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%7D%2C%22workbench%22%3A%5B%5D%2C%22timeline%22%3A%5B%5D%2C%22initialCamera%22%3A%7B%22west%22%3A133.12335073549156%2C%22south%22%3A-42.38666970744262%2C%22east%22%3A156.35409851747534%2C%22north%22%3A-31.55857883340345%2C%22position%22%3A%7B%22x%22%3A-3786724.9894824005%2C%22y%22%3A4350655.54114095%2C%22z%22%3A-2714820.579710214%7D%2C%22direction%22%3A%7B%22x%22%3A-0.23728393058777358%2C%22y%22%3A0.7036578364262455%2C%22z%22%3A0.6697477028857597%7D%2C%22up%22%3A%7B%22x%22%3A-0.5453609191618481%2C%22y%22%3A0.4740534231746787%2C%22z%22%3A-0.6912704389942572%7D%7D%2C%22homeCamera%22%3A%7B%22west%22%3A133.12335073549156%2C%22south%22%3A-42.38666970744262%2C%22east%22%3A156.35409851747534%2C%22north%22%3A-31.55857883340345%2C%22position%22%3A%7B%22x%22%3A-4120986.489101264%2C%22y%22%3A2901296.804778211%2C%22z%22%3A-5529233.584392741%7D%2C%22direction%22%3A%7B%22x%22%3A-0.009963608676945457%2C%22y%22%3A0.01443110436389694%2C%22z%22%3A0.999846223040809%7D%2C%22up%22%3A%7B%22x%22%3A-0.8138296757070467%2C%22y%22%3A0.580869360008338%2C%22z%22%3A-0.01649380314139365%7D%7D%2C%22viewerMode%22%3A%223d%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.4999%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A1%2C%22useNativeResolution%22%3Atrue%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-natural-earth-II%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)

The second one should return to the same view. The first should create a bad sharelink.


### Checklist

~~- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~~
~~- [ ] I've updated relevant documentation in `doc/`.~~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
