### PR TITLE
Fix magda access type resolution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.2.29)
 
 - Fix app crash when rendering feature info with a custom title.
+- Fix `acessType` resolution for `MagdaReference` so that it uses the default terria resolution strategy when `magdaRecord` is not defined.
 - [The next improvement]
 
 #### 8.2.28 - 2023-04-28

--- a/lib/ModelMixins/AccessControlMixin.ts
+++ b/lib/ModelMixins/AccessControlMixin.ts
@@ -5,6 +5,18 @@ import ModelTraits from "../Traits/ModelTraits";
 
 type AccessControlModel = Model<ModelTraits>;
 
+/**
+ * API for setting an access type for the model. Note that the intended use of
+ * this mixin is just to flag public and private models differently in the UI
+ * and does not provide any security guarantees.
+ *
+ * The implementation is a bit fluid and maybe that makes it a bit hard to
+ * reason about because we are not strongly typing the possible values for
+ * `accessType`. For use in frontend, we formally recognizes only one acessType
+ * which is "public". All other access type values are treated as "private". The
+ * models overriding this mixin are free to choose any other string valued
+ * access type for their own purpose.
+ */
 function AccessControlMixin<T extends Constructor<AccessControlModel>>(
   Base: T
 ) {
@@ -16,20 +28,25 @@ function AccessControlMixin<T extends Constructor<AccessControlModel>>(
     }
 
     /**
-     * Returns the accessType for this model, default is public
-     * Models can override this method to return access type differently
+     * Resolve accessType for this model in the following order:
+     *  1. Return the access type that was set on this model by explicitly calling setAccessType()
+     *  2. If this model is referenced by another, return the access type of the referrer
+     *  3. Return the access type of a parent with valid access type
+     *  4. If none of the above works - return "public"
      */
     @computed
     get accessType(): string {
-      if (this._accessType) return this._accessType;
+      // Return the explicitly set accessType
+      if (this._accessType) {
+        return this._accessType;
+      }
 
+      // Return the accessType of the referrer.
       if (AccessControlMixin.isMixedInto(this.sourceReference)) {
-        // This item is the target of a reference item, return the accessType
-        // of the reference item.
         return this.sourceReference.accessType;
       }
 
-      // Try and return the parents accessType
+      // Try and return any ancestor's accessType
       if (this.knownContainerUniqueIds.length > 0) {
         const parentId = this.knownContainerUniqueIds[0];
         const parent =
@@ -39,21 +56,28 @@ function AccessControlMixin<T extends Constructor<AccessControlModel>>(
         }
       }
 
-      // default
+      // Default
       return "public";
     }
 
-    /* TODO: check if we actually need provision to explcitly set accessType */
     @action
     setAccessType(accessType: string) {
       this._accessType = accessType;
     }
 
+    /**
+     * Returns true if this model public.
+     */
     @computed
     get isPublic() {
       return this.accessType === "public";
     }
 
+    /**
+     * Returns true if this model is private.
+     *
+     * Note that any accessType other than "public" is treated as private.
+     */
     @computed
     get isPrivate() {
       return this.accessType !== "public";

--- a/lib/Models/Catalog/CatalogReferences/MagdaReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/MagdaReference.ts
@@ -160,8 +160,14 @@ export default class MagdaReference extends AccessControlMixin(
 
   @computed
   get accessType(): string {
-    const access = getAccessTypeFromMagdaRecord(this.magdaRecord);
-    return access || super.accessType;
+    return this.magdaRecordAcessType ?? super.accessType;
+  }
+
+  @computed
+  private get magdaRecordAcessType(): string | undefined {
+    return this.magdaRecord
+      ? getAccessTypeFromMagdaRecord(this.magdaRecord)
+      : undefined;
   }
 
   protected async forceLoadReference(
@@ -861,7 +867,9 @@ const prepareDistributionFormat = createTransformer(
   }
 );
 
-function getAccessTypeFromMagdaRecord(magdaRecord: any): string {
+function getAccessTypeFromMagdaRecord(
+  magdaRecord: Record<string, any>
+): string {
   const record = toJS(magdaRecord);
 
   // Magda V2 access control has higher priority.

--- a/test/Models/MagdaReferenceSpec.ts
+++ b/test/Models/MagdaReferenceSpec.ts
@@ -1,14 +1,12 @@
 import { runInAction } from "mobx";
 import CatalogGroup from "../../lib/Models/Catalog/CatalogGroup";
-import CommonStrata from "../../lib/Models/Definition/CommonStrata";
 import CsvCatalogItem from "../../lib/Models/Catalog/CatalogItems/CsvCatalogItem";
 import GeoJsonCatalogItem from "../../lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem";
 import MagdaReference from "../../lib/Models/Catalog/CatalogReferences/MagdaReference";
-import Terria from "../../lib/Models/Terria";
 import WebMapServiceCatalogGroup from "../../lib/Models/Catalog/Ows/WebMapServiceCatalogGroup";
+import CommonStrata from "../../lib/Models/Definition/CommonStrata";
 import updateModelFromJson from "../../lib/Models/Definition/updateModelFromJson";
-import upsertModelFromJson from "../../lib/Models/Definition/upsertModelFromJson";
-import CatalogMemberFactory from "../../lib/Models/Catalog/CatalogMemberFactory";
+import Terria from "../../lib/Models/Terria";
 
 describe("MagdaReference", function () {
   const recordGroupWithOneCsv = {
@@ -564,6 +562,28 @@ describe("MagdaReference", function () {
       });
       expect(reference.accessType === "public").toBeTruthy();
       done();
+    });
+
+    it("returns `super.accessType` when magdaRecord is unset", function () {
+      const terria = new Terria();
+      const reference = new MagdaReference("magda-reference", terria);
+      reference.setAccessType("foo-doesnt-matter");
+      reference.setTrait(CommonStrata.definition, "recordId", "test id");
+      reference.setTrait(CommonStrata.definition, "magdaRecord", {
+        id: "test id",
+        name: "Test",
+        aspects: {
+          "access-control": {
+            orgUnitId: "some org id",
+            constraintExemption: false
+          }
+        }
+      });
+      // Picks up the access type from magdaRecord settings
+      expect(reference.accessType).toBe("non-public");
+      reference.setTrait(CommonStrata.definition, "magdaRecord", undefined);
+      // Reverts to whatever accessType value is returned by super.accessType
+      expect(reference.accessType).toBe("foo-doesnt-matter");
     });
   });
 });


### PR DESCRIPTION
### What this PR does

This PR fixes `accessType` resolution for MagdaReference when `magdaRecord` is undefined.

Currently, when `magdaRecord` is set, MagdaReference correctly resolves the `acessType` for the model from the magda access headers. But when `magdaRecord` is undefined it always resolves the `acessType` as `public`. 

This PR fixes it so that when `magdaRecord` is unset, the `acessType` is resolved using [default terria strategy](https://github.com/TerriaJS/terriajs/blob/aa70e64f629881897ef3e6c091bb233365ef0e86/lib/ModelMixins/AccessControlMixin.ts#L30-L37) implemented by AcessControlMixin which may return `private` if a parent is private.

### Test me

Please test from DT (ping me), I have also added test cases.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
