### PR TITLE
Add assurance for GH Action deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
         with:
           node-version: "14.x"
       - run: npm install -g yarn@^1.19.0 && yarn install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,19 +6,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
         with:
           node-version: "14.x"
-      - uses: google-github-actions/setup-gcloud@v0.2.1
+      - uses: google-github-actions/setup-gcloud@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba # v0.2.1
         with:
           service_account_key: ${{ secrets.GCP_CREDENTIALS }}
           export_default_credentials: true
-      - uses: google-github-actions/get-gke-credentials@v0.3.0
+      - uses: google-github-actions/get-gke-credentials@17bbf5dc3594a44a185c9e83b90abd91196ea18a # v0.3.0
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_LOCATION }}
-      - uses: azure/setup-helm@v1.1
+      - uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
         with:
           version: "v3.3.1"
       - run: bash ./buildprocess/ci-deploy.sh
@@ -29,7 +29,7 @@ jobs:
           FEEDBACK_GITHUB_TOKEN: ${{ secrets.FEEDBACK_GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Upload new yarn.lock file (as it may change after `sync-dependencies`)
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: always()
         with:
           name: yarn.lock

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           fetch-depth: 2
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Set up Node.js for NPM
         if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
         with:
           registry-url: "https://registry.npmjs.org"
           node-version: "14.x"


### PR DESCRIPTION
During GitHub Actions, use the container digest (for signature validation) to _assure_ we are installing the version tag we intended

Checklist is N/A as this is completing intended/existing functionality of only the GitHub Actions