### PR TITLE
Fix search results for items inside deeply nested references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.3.1)
 
+- Fix error when adding deeply nested references in search results.
 - [The next improvement]
 
 #### 8.3.0 - 2023-05-22

--- a/lib/ModelMixins/ReferenceMixin.ts
+++ b/lib/ModelMixins/ReferenceMixin.ts
@@ -145,13 +145,13 @@ function ReferenceMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
      * @param maxDepth The maximum depth up to which the references should be resolved.
      * @returns A promise that is fulfilled with a Result value when all the references have been loaded.
      */
-    async recursivelyLoadReference(depth: number): Promise<Result<void>> {
+    async recursivelyLoadReference(maxDepth: number): Promise<Result<void>> {
       let currentTarget: BaseModel | undefined = this;
       const errors: TerriaError[] = [];
-      while (depth > 0 && ReferenceMixin.isMixedInto(currentTarget)) {
+      while (maxDepth > 0 && ReferenceMixin.isMixedInto(currentTarget)) {
         (await currentTarget.loadReference()).pushErrorTo(errors);
         currentTarget = currentTarget.target;
-        depth -= 1;
+        maxDepth -= 1;
       }
       const result = TerriaError.combine(
         errors,

--- a/lib/ModelMixins/ReferenceMixin.ts
+++ b/lib/ModelMixins/ReferenceMixin.ts
@@ -9,6 +9,7 @@ import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import AbstractConstructor from "../Core/AbstractConstructor";
 import AsyncLoader from "../Core/AsyncLoader";
 import Result from "../Core/Result";
+import TerriaError from "../Core/TerriaError";
 import Model, { BaseModel, ModelInterface } from "../Models/Definition/Model";
 import ReferenceTraits from "../Traits/TraitsClasses/ReferenceTraits";
 import { getName } from "./CatalogMemberMixin";
@@ -133,6 +134,30 @@ function ReferenceMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
       }
 
       return result;
+    }
+
+    /**
+     * Recursively load a nested chain of references till the given maxDepth.
+     *
+     * If this reference points to another reference and so on.. then this
+     * method will load them all up to the given depth.
+     *
+     * @param maxDepth The maximum depth up to which the references should be resolved.
+     * @returns A promise that is fulfilled with a Result value when all the references have been loaded.
+     */
+    async recursivelyLoadReference(depth: number): Promise<Result<void>> {
+      let currentTarget: BaseModel | undefined = this;
+      const errors: TerriaError[] = [];
+      while (depth > 0 && ReferenceMixin.isMixedInto(currentTarget)) {
+        (await currentTarget.loadReference()).pushErrorTo(errors);
+        currentTarget = currentTarget.target;
+        depth -= 1;
+      }
+      const result = TerriaError.combine(
+        errors,
+        "Failed to recursively load reference `${this.uniqueId}`"
+      );
+      return Result.error(result);
     }
 
     /**

--- a/lib/ModelMixins/ReferenceMixin.ts
+++ b/lib/ModelMixins/ReferenceMixin.ts
@@ -153,11 +153,11 @@ function ReferenceMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
         currentTarget = currentTarget.target;
         maxDepth -= 1;
       }
-      const result = TerriaError.combine(
+      const maybeError = TerriaError.combine(
         errors,
         "Failed to recursively load reference `${this.uniqueId}`"
       );
-      return Result.error(result);
+      return Result.none(maybeError);
     }
 
     /**

--- a/lib/Models/Catalog/CatalogReferences/CatalogIndexReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/CatalogIndexReference.ts
@@ -71,11 +71,15 @@ export default class CatalogIndexReference extends ReferenceMixin(
         }
 
         if (ReferenceMixin.isMixedInto(container)) {
-          (await container.loadReference()).pushErrorTo(
+          // Recursively load references up to a depth of 5. This is so that we
+          // correctly resolve the final target item when we have a chain of
+          // references like: MagdaReference -> TerriaReference -> ... -> SomeItem
+          // We limit to a depth of 5 to avoid looping forever.
+          (await container.recursivelyLoadReference(5)).pushErrorTo(
             errors,
             `Failed to load reference ${container.uniqueId}`
           );
-          container = container.target ?? container;
+          container = container.nestedTarget ?? container;
         }
 
         if (GroupMixin.isMixedInto(container)) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/parser": "^7.12.14",
     "@babel/plugin-proposal-decorators": "^7.10.4",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.10.4",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/core": "^7.16.0",
     "@babel/parser": "^7.12.14",
     "@babel/plugin-proposal-decorators": "^7.10.4",
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.10.4",

--- a/test/Models/Catalog/CatalogReferences/CatalogIndexReferenceSpec.ts
+++ b/test/Models/Catalog/CatalogReferences/CatalogIndexReferenceSpec.ts
@@ -1,0 +1,70 @@
+import { CommonStrata, updateModelFromJson } from "terriajs-plugin-api";
+import CatalogIndexReference from "../../../../lib/Models/Catalog/CatalogReferences/CatalogIndexReference";
+import MagdaReference from "../../../../lib/Models/Catalog/CatalogReferences/MagdaReference";
+import Terria from "../../../../lib/Models/Terria";
+
+describe("CatalogIndexReference", function () {
+  let terria: Terria;
+
+  beforeEach(function () {
+    terria = new Terria();
+  });
+
+  describe("loadReference", function () {
+    describe("when a parent container is a deeply nested reference", function () {
+      beforeEach(function () {
+        jasmine.Ajax.install();
+      });
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("recursively loads all the references to fully expand the references", async function () {
+        // We are setting up the following hierarchy: MagdaReference -> TerriaReference -> Group -> Leaf
+        // and asserting that we load the reference containers all the way down to the Leaf node
+
+        // Setup parent magda reference item
+        const parent = new MagdaReference("parent", terria);
+        parent.setTrait(CommonStrata.definition, "magdaRecord", {
+          // the parent points to another reference of type terria-reference
+          aspects: {
+            terria: {
+              definition: {
+                name: "Group",
+                description: "Group",
+                url: "example.org/catalog.json"
+              },
+              id: "some-group",
+              type: "terria-reference"
+            }
+          },
+          id: "some-group",
+          name: "Group"
+        });
+
+        // The terria-reference points to a group containg a 'leaf' node.
+        jasmine.Ajax.stubRequest("example.org/catalog.json").andReturn({
+          responseJSON: {
+            catalog: [
+              {
+                type: "group",
+                name: "Group",
+                members: [{ id: "leaf", type: "csv", name: "leaf" }]
+              }
+            ]
+          }
+        });
+
+        const leafIndex = new CatalogIndexReference("leaf", terria);
+        terria.addModel(parent);
+        updateModelFromJson(leafIndex, CommonStrata.defaults, {
+          memberKnownContainerUniqueIds: ["parent"]
+        });
+        await leafIndex.loadReference();
+        // Ensure then index reference is correctly resolved to the leaf node
+        expect(leafIndex.nestedTarget?.uniqueId).toBe("leaf");
+      });
+    });
+  });
+});

--- a/test/Models/Catalog/CatalogReferences/CatalogIndexReferenceSpec.ts
+++ b/test/Models/Catalog/CatalogReferences/CatalogIndexReferenceSpec.ts
@@ -1,6 +1,7 @@
-import { CommonStrata, updateModelFromJson } from "terriajs-plugin-api";
 import CatalogIndexReference from "../../../../lib/Models/Catalog/CatalogReferences/CatalogIndexReference";
 import MagdaReference from "../../../../lib/Models/Catalog/CatalogReferences/MagdaReference";
+import CommonStrata from "../../../../lib/Models/Definition/CommonStrata";
+import updateModelFromJson from "../../../../lib/Models/Definition/updateModelFromJson";
 import Terria from "../../../../lib/Models/Terria";
 
 describe("CatalogIndexReference", function () {


### PR DESCRIPTION
### What this PR does

Fixes search results for items that are inside deeply nested references.

Currently if we have a `CatalogIndexReference` that points to a leaf item and the leaf item is inside the following catalog tree:
`MagdaReference -> TerriaReference -> Group -> LeafItem` then `CatalogIndexReference` fails to correctly load the `LeafItem`. 

This happens because the `CatalogIndexReference` only resolves references [one level deep](https://github.com/TerriaJS/terriajs/blob/ccd229665794dcd91f023cb0a01e8bc6a4bd6a3d/lib/Models/Catalog/CatalogReferences/CatalogIndexReference.ts#L73-L79). This PR fixes it by [recursively resolving references](https://github.com/TerriaJS/terriajs/blob/b78a716283f7b25921f3dcb7e0e2428c16adbebc/lib/Models/Catalog/CatalogReferences/CatalogIndexReference.ts#L73-L83) so that the whole chain until the `Group` container is fully expanded.

### Test me

- Open this link for [main](http://ci.terria.io/main/#configUrl=https://gist.githubusercontent.com/na9da/8716edc8207463233e1dac8454f031ac/raw/dcac31d1031e327bdbd6234a9c67e323dbe76f98/test-config.json) branch.
- Search for "ptv"
- Add any search result 
![image](https://github.com/TerriaJS/terriajs/assets/1430/0fdf67b7-0a0c-4a3d-a473-8236805a74fe)

- Observe that an error is thrown
![image](https://github.com/TerriaJS/terriajs/assets/1430/b4780c6d-55d7-440a-8711-8c4f2a3d19a6)

- Now repeat the same for [this branch](http://ci.terria.io/fix-index-ref-loading/#configUrl=https://gist.githubusercontent.com/na9da/8716edc8207463233e1dac8454f031ac/raw/dcac31d1031e327bdbd6234a9c67e323dbe76f98/test-config.json)
- Observe that the catalog item is correctly added to the workbench without errors

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
