### PR TITLE
Fix timefilter bug.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.3.2)
 
+- Fixed a bug when restoring timefilter from a share link having more than one imagery item with the same base URL (but different layer names).
 - [The next improvement]
 
 #### 8.3.1 - 2023-06-29

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -1358,44 +1358,6 @@ export default class Cesium extends GlobeOrMap {
     }
   }
 
-  /**
-   * Return features at a latitude, longitude and (optionally) height for the given imagery layers.
-   * @param latLngHeight The position on the earth to pick
-   * @param tileCoords A map of imagery provider urls to the tile coords used to get features for those imagery
-   * @returns A flat array of all the features for the given tiles that are currently on the map
-   */
-  async getFeaturesAtLocation(
-    latLngHeight: LatLonHeight,
-    providerCoords: ProviderCoordsMap,
-    existingFeatures: TerriaFeature[] = []
-  ) {
-    const pickPosition = this.scene.globe.ellipsoid.cartographicToCartesian(
-      Cartographic.fromDegrees(
-        latLngHeight.longitude,
-        latLngHeight.latitude,
-        latLngHeight.height
-      )
-    );
-    const pickPositionCartographic =
-      Ellipsoid.WGS84.cartesianToCartographic(pickPosition);
-
-    const promises = this.terria.allowFeatureInfoRequests
-      ? this.pickImageryLayerFeatures(pickPositionCartographic, providerCoords)
-      : [];
-
-    const pickedFeatures = this._buildPickedFeatures(
-      providerCoords,
-      pickPosition,
-      existingFeatures,
-      filterOutUndefined(promises),
-      pickPositionCartographic.height,
-      false
-    );
-
-    await pickedFeatures.allFeaturesAvailablePromise;
-    return pickedFeatures.features;
-  }
-
   private pickImageryLayerFeatures(
     pickPosition: Cartographic,
     providerCoords: ProviderCoordsMap

--- a/lib/Models/Feature/Feature.ts
+++ b/lib/Models/Feature/Feature.ts
@@ -1,8 +1,11 @@
-import { observable, makeObservable } from "mobx";
+import { makeObservable, observable } from "mobx";
+import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
+import ConstantPositionProperty from "terriajs-cesium/Source/DataSources/ConstantPositionProperty";
 import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import Cesium3DTileFeature from "terriajs-cesium/Source/Scene/Cesium3DTileFeature";
 import Cesium3DTilePointFeature from "terriajs-cesium/Source/Scene/Cesium3DTilePointFeature";
 import ImageryLayer from "terriajs-cesium/Source/Scene/ImageryLayer";
+import ImageryLayerFeatureInfo from "terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo";
 import { JsonObject } from "../../Core/Json";
 import { BaseModel } from "../Definition/Model";
 import { TerriaFeatureData } from "./FeatureData";
@@ -70,6 +73,23 @@ export default class TerriaFeature extends Entity {
     }
     if (!feature || !(feature instanceof TerriaFeature)) {
       feature = TerriaFeature.fromEntity(entity);
+    }
+    return feature;
+  }
+
+  static fromImageryLayerFeatureInfo(imageryFeature: ImageryLayerFeatureInfo) {
+    const feature = new TerriaFeature({
+      id: imageryFeature.name,
+      name: imageryFeature.name,
+      description: imageryFeature.description,
+      properties: imageryFeature.properties
+    });
+    feature.data = imageryFeature.data;
+    feature.imageryLayer = imageryFeature.imageryLayer;
+    if (imageryFeature.position) {
+      feature.position = new ConstantPositionProperty(
+        Ellipsoid.WGS84.cartographicToCartesian(imageryFeature.position)
+      );
     }
     return feature;
   }

--- a/lib/Models/GlobeOrMap.ts
+++ b/lib/Models/GlobeOrMap.ts
@@ -1,10 +1,4 @@
-import {
-  action,
-  computed,
-  observable,
-  runInAction,
-  makeObservable
-} from "mobx";
+import { action, makeObservable, observable, runInAction } from "mobx";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Color from "terriajs-cesium/Source/Core/Color";
@@ -15,9 +9,7 @@ import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import ColorMaterialProperty from "terriajs-cesium/Source/DataSources/ColorMaterialProperty";
 import ConstantPositionProperty from "terriajs-cesium/Source/DataSources/ConstantPositionProperty";
 import ConstantProperty from "terriajs-cesium/Source/DataSources/ConstantProperty";
-import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import ImageryLayerFeatureInfo from "terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo";
-import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
 import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
 import isDefined from "../Core/isDefined";
 import { isJsonObject } from "../Core/Json";
@@ -140,17 +132,6 @@ export default abstract class GlobeOrMap {
     providerCoords: ProviderCoordsMap,
     existingFeatures: TerriaFeature[]
   ): void;
-
-  /**
-   * Return features at a latitude, longitude and (optionally) height for the given imagery layers.
-   * @param latLngHeight The position on the earth to pick
-   * @param providerCoords A map of imagery provider urls to the tile coords used to get features for those imagery
-   * @returns A flat array of all the features for the given tiles that are currently on the map
-   */
-  abstract getFeaturesAtLocation(
-    latLngHeight: LatLonHeight,
-    providerCoords: ProviderCoordsMap
-  ): Promise<Entity[] | undefined> | void;
 
   /**
    * Creates a {@see Feature} (based on an {@see Entity}) from a {@see ImageryLayerFeatureInfo}.

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -1,13 +1,12 @@
-import i18next from "i18next";
 import { GridLayer } from "leaflet";
 import {
   action,
   autorun,
   computed,
+  makeObservable,
   observable,
   reaction,
-  runInAction,
-  makeObservable
+  runInAction
 } from "mobx";
 import { computedFn } from "mobx-utils";
 import cesiumCancelAnimationFrame from "terriajs-cesium/Source/Core/cancelAnimationFrame";
@@ -61,7 +60,6 @@ import hasTraits from "./Definition/hasTraits";
 import TerriaFeature from "./Feature/Feature";
 import GlobeOrMap from "./GlobeOrMap";
 import { LeafletAttribution } from "./LeafletAttribution";
-import MapInteractionMode from "./MapInteractionMode";
 import Terria from "./Terria";
 
 // We want TS to look at the type declared in lib/ThirdParty/terriajs-cesium-extra/index.d.ts
@@ -581,46 +579,6 @@ export default class Leaflet extends GlobeOrMap {
       providerCoords,
       existingFeatures
     );
-  }
-
-  /**
-   * Return features at a latitude, longitude and (optionally) height for the given imageryLayer.
-   * @param latLngHeight The position on the earth to pick
-   * @param providerCoords A map of imagery provider urls to the tile coords used to get features for those imagery
-   * @returns A flat array of all the features for the given tiles that are currently on the map
-   */
-  @action
-  async getFeaturesAtLocation(
-    latLngHeight: LatLonHeight,
-    providerCoords: ProviderCoordsMap
-  ) {
-    const pickMode = new MapInteractionMode({
-      message: i18next.t("models.imageryLayer.resolvingAvailability"),
-      onCancel: () => {
-        this.terria.mapInteractionModeStack.pop();
-      }
-    });
-    this.terria.mapInteractionModeStack.push(pickMode);
-    this._pickFeatures(
-      L.latLng({
-        lat: latLngHeight.latitude,
-        lng: latLngHeight.longitude,
-        alt: latLngHeight.height
-      }),
-      providerCoords,
-      [],
-      true
-    );
-
-    if (pickMode.pickedFeatures) {
-      const pickedFeatures = pickMode.pickedFeatures;
-      await pickedFeatures.allFeaturesAvailablePromise;
-    }
-
-    return runInAction(() => {
-      this.terria.mapInteractionModeStack.pop();
-      return pickMode.pickedFeatures?.features;
-    });
   }
 
   /*

--- a/lib/Models/NoViewer.ts
+++ b/lib/Models/NoViewer.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import LatLonHeight from "../Core/LatLonHeight";
 import MapboxVectorTileImageryProvider from "../Map/ImageryProvider/MapboxVectorTileImageryProvider";
@@ -45,17 +43,6 @@ class NoViewer extends GlobeOrMap {
     latLngHeight: LatLonHeight,
     providerCoords: ProviderCoordsMap,
     existingFeatures: TerriaFeature[]
-  ) {}
-
-  /**
-   * Return features at a latitude, longitude and (optionally) height for the given imageryLayer
-   * @param latLngHeight The position on the earth to pick
-   * @param providerCoords A map of imagery provider urls to the tile coords used to get features for those imagery
-   * @returns A flat array of all the features for the given tiles that are currently on the map
-   */
-  getFeaturesAtLocation(
-    latLngHeight: LatLonHeight,
-    providerCoords: ProviderCoordsMap
   ) {}
 
   getCurrentCameraView(): CameraView {

--- a/test/ModelMixins/TimeFilterMixinSpec.ts
+++ b/test/ModelMixins/TimeFilterMixinSpec.ts
@@ -1,4 +1,14 @@
-import { action, computed, makeObservable } from "mobx";
+import {
+  action,
+  computed,
+  makeObservable,
+  observable,
+  runInAction
+} from "mobx";
+import ImageryLayerFeatureInfo from "terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo";
+import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
+import WebMapServiceImageryProvider from "terriajs-cesium/Source/Scene/WebMapServiceImageryProvider";
+import { DiscreteTimeAsJS } from "../../lib/ModelMixins/DiscretelyTimeVaryingMixin";
 import MappableMixin from "../../lib/ModelMixins/MappableMixin";
 import TimeFilterMixin from "../../lib/ModelMixins/TimeFilterMixin";
 import CommonStrata from "../../lib/Models/Definition/CommonStrata";
@@ -9,11 +19,17 @@ import mixTraits from "../../lib/Traits/mixTraits";
 import TimeFilterTraits from "../../lib/Traits/TraitsClasses/TimeFilterTraits";
 
 describe("TimeFilterMixin", function () {
+  let terria: Terria;
+
+  beforeEach(function () {
+    terria = new Terria();
+  });
+
   describe("canFilterTimeByFeature", function () {
     it(
       "returns false if timeFilterPropertyName is not set",
       action(function () {
-        const testItem = new TestTimeFilterableItem("test", new Terria());
+        const testItem = new TestTimeFilterableItem("test", terria);
         expect(testItem.canFilterTimeByFeature).toBe(false);
       })
     );
@@ -21,7 +37,7 @@ describe("TimeFilterMixin", function () {
     it(
       "returns true if timeFilterPropertyName is set",
       action(function () {
-        const testItem = new TestTimeFilterableItem("test", new Terria());
+        const testItem = new TestTimeFilterableItem("test", terria);
         testItem.setTrait(
           CommonStrata.user,
           "timeFilterPropertyName",
@@ -31,23 +47,293 @@ describe("TimeFilterMixin", function () {
       })
     );
   });
+
+  describe("setTimeFilterFromLocation", function () {
+    let item: TestTimeFilterableItem;
+    let imageryProvider: ImageryProvider;
+
+    beforeEach(function () {
+      item = new TestTimeFilterableItem("test", terria);
+      item.setTrait(
+        CommonStrata.user,
+        "timeFilterPropertyName",
+        "availabilityAtLocation"
+      );
+
+      imageryProvider = new WebMapServiceImageryProvider({
+        url: "test",
+        layers: "testlayer"
+      });
+      item.imageryProviders = [imageryProvider];
+
+      const fullAvailability = [
+        "2023-01-01",
+        "2023-01-02",
+        "2023-01-03",
+        "2023-01-04",
+        "2023-01-05"
+      ];
+
+      item.discreteTimes = fullAvailability.map((time) => ({
+        time,
+        tag: undefined
+      }));
+    });
+
+    it(
+      "loads the filter with dates available for the given location and updates the timeFilterCoordinates traits",
+      action(async function () {
+        // Set filter property to provide 2 dates from the available set
+        const fakeImageryFeature = new ImageryLayerFeatureInfo();
+        fakeImageryFeature.properties = {
+          availabilityAtLocation: ["2023-01-02", "2023-01-03"]
+        };
+        spyOn(imageryProvider, "pickFeatures").and.returnValue(
+          Promise.resolve([fakeImageryFeature])
+        );
+
+        await item.setTimeFilterFromLocation({
+          // Position to pick
+          position: {
+            // in degrees
+            latitude: -37.831,
+            longitude: 144.973
+          },
+          // Coordinates of the tiles
+          tileCoords: {
+            x: 1,
+            y: 2,
+            level: 3
+          }
+        });
+
+        expect(
+          runInAction(() => item.discreteTimesAsSortedJulianDates)?.map((dt) =>
+            dt.time.toString()
+          )
+        ).toEqual(["2023-01-02T00:00:00Z", "2023-01-03T00:00:00Z"]);
+      })
+    );
+
+    it("should correctly update the timeFilterCoordinates", async function () {
+      // Set filter property to provide 2 dates from the available set
+      const fakeImageryFeature = new ImageryLayerFeatureInfo();
+      fakeImageryFeature.properties = {
+        availabilityAtLocation: ["2023-01-02", "2023-01-03"]
+      };
+      spyOn(imageryProvider, "pickFeatures").and.returnValue(
+        Promise.resolve([fakeImageryFeature])
+      );
+
+      await item.setTimeFilterFromLocation({
+        // Position to pick
+        position: {
+          // in degrees
+          latitude: -37.831,
+          longitude: 144.973
+        },
+        // Coordinates of the tiles
+        tileCoords: {
+          x: 1,
+          y: 2,
+          level: 3
+        }
+      });
+
+      const {
+        tile: { x, y, level },
+        latitude,
+        longitude,
+        height
+      } = runInAction(() => item.timeFilterCoordinates);
+      expect({ x, y, level }).toEqual({ x: 1, y: 2, level: 3 });
+      expect({ latitude, longitude, height }).toEqual({
+        longitude: 144.973,
+        latitude: -37.831,
+        height: 0
+      });
+    });
+
+    describe("when there are multiple imageryProviders", function () {
+      it("queries all of them", async function () {
+        item.imageryProviders = [
+          new WebMapServiceImageryProvider({
+            url: "test1",
+            layers: "layer1"
+          }),
+          new WebMapServiceImageryProvider({
+            url: "test2",
+            layers: "layer2"
+          })
+        ];
+        const spy0 = spyOn(
+          item.imageryProviders[0],
+          "pickFeatures"
+        ).and.returnValue(undefined);
+        const spy1 = spyOn(
+          item.imageryProviders[1],
+          "pickFeatures"
+        ).and.returnValue(undefined);
+
+        await item.setTimeFilterFromLocation({
+          // Position to pick
+          position: {
+            // in degrees
+            latitude: -37.831,
+            longitude: 144.973
+          },
+          // Coordinates of the tiles
+          tileCoords: {
+            x: 1,
+            y: 2,
+            level: 3
+          }
+        });
+
+        expect(spy0).toHaveBeenCalledTimes(1);
+        expect(spy1).toHaveBeenCalledTimes(1);
+      });
+
+      it(
+        "sets the time filter from the first imageryProvider that returns a valid pick result",
+        action(async function () {
+          item.imageryProviders = [
+            new WebMapServiceImageryProvider({
+              url: "test1",
+              layers: "layer1"
+            }),
+            new WebMapServiceImageryProvider({
+              url: "test2",
+              layers: "layer2"
+            })
+          ];
+
+          const featureInfo1 = new ImageryLayerFeatureInfo();
+          featureInfo1.properties = {
+            someprop: ["2023-01-01"]
+          };
+
+          const featureInfo2 = new ImageryLayerFeatureInfo();
+          featureInfo2.properties = {
+            timeprop: ["2023-01-04"]
+          };
+
+          item.setTrait(
+            CommonStrata.user,
+            "timeFilterPropertyName",
+            "timeprop"
+          );
+
+          const spy0 = spyOn(
+            item.imageryProviders[0],
+            "pickFeatures"
+          ).and.returnValue(Promise.resolve([featureInfo1]));
+          const spy1 = spyOn(
+            item.imageryProviders[1],
+            "pickFeatures"
+          ).and.returnValue(Promise.resolve([featureInfo2]));
+
+          await item.setTimeFilterFromLocation({
+            // Position to pick
+            position: {
+              // in degrees
+              latitude: -37.831,
+              longitude: 144.973
+            },
+            // Coordinates of the tiles
+            tileCoords: {
+              x: 1,
+              y: 2,
+              level: 3
+            }
+          });
+
+          expect(spy0).toHaveBeenCalledTimes(1);
+          expect(spy1).toHaveBeenCalledTimes(1);
+
+          expect(
+            (item.discreteTimesAsSortedJulianDates ?? []).map((dt) =>
+              dt.time.toString()
+            )
+          ).toEqual(["2023-01-04T00:00:00Z"]);
+        })
+      );
+    });
+
+    it("passes the correct arguments when picking the imagery provider", async function () {
+      const spy = spyOn(imageryProvider, "pickFeatures").and.returnValue(
+        undefined
+      );
+
+      await item.setTimeFilterFromLocation({
+        // Position to pick
+        position: {
+          // in degrees
+          latitude: -37.831,
+          longitude: 144.973
+        },
+        // Coordinates of the tiles
+        tileCoords: {
+          x: 1,
+          y: 2,
+          level: 3
+        }
+      });
+
+      const [x, y, level, longitude, latitude] = spy.calls.mostRecent().args;
+      expect([x, y, level]).toEqual([1, 2, 3]);
+      expect(longitude).toBeCloseTo(2.5302);
+      expect(latitude).toBeCloseTo(-0.6602);
+    });
+
+    it("does nothing when terria.allowFeatureInfoRequests is set to `false`", async function () {
+      const pickFeatures = spyOn(
+        imageryProvider,
+        "pickFeatures"
+      ).and.returnValue(undefined);
+
+      terria.allowFeatureInfoRequests = false;
+      await item.setTimeFilterFromLocation({
+        // Position to pick
+        position: {
+          // in degrees
+          latitude: -37.831,
+          longitude: 144.973
+        },
+        // Coordinates of the tiles
+        tileCoords: {
+          x: 1,
+          y: 2,
+          level: 3
+        }
+      });
+      expect(pickFeatures).not.toHaveBeenCalled();
+    });
+  });
 });
 
 class TestTimeFilterableItem extends TimeFilterMixin(
   MappableMixin(CreateModel(mixTraits(TimeFilterTraits)))
 ) {
+  @observable discreteTimes: DiscreteTimeAsJS[] = [];
+
+  @observable
+  imageryProviders: ImageryProvider[] = [];
+
   constructor(...args: ModelConstructorParameters) {
     super(...args);
     makeObservable(this);
   }
 
   protected async forceLoadMapItems(): Promise<void> {}
-  get discreteTimes() {
-    return undefined;
-  }
 
   @computed
   get mapItems() {
-    return [];
+    return this.imageryProviders.map((imageryProvider) => ({
+      imageryProvider,
+      alpha: 1.0,
+      show: true,
+      clippingRectangle: imageryProvider.rectangle
+    }));
   }
 }


### PR DESCRIPTION
### What this PR does

Fixes #6824 #6677 

- Fixes a bug when restoring time filter from a share link
- Simplifies overall code for picking imagery features from a location used by `TimeFilterMixin`
- Added more specs for time filter behaviour

#### Explanation:
Previously, when restoring the time filter from the co-ordinates, we:
  - pick all imagery providers on the map with the same base URL as that of the item
  - find one feature with matching time filter property 
  - this gave us the timestamps for the imagery available at the given co-ordinates. 
  
If we had 2 items, say `item1` and `item2` in the workbench with the same base URL but different layer names then we incorrectly resolved the time filter for both items to that of `item1`. This happened because in v8, the implementation only checked the URLs to map a picked feature to an item. In terriajs v7, we used to do an additional [comparison of the `imageryLayer`](https://github.com/TerriaJS/terriajs/blob/a6a2e6464cec91578b924728cdb3e3689b8c2794/lib/Models/ImageryLayerCatalogItem.js#L578) instance to make sure that we are using the time filter property for the correct layer. 

This PR fixes it by using a function that is local to the TimeFilterMixin and only picks the [imagery providers belonging to it](https://github.com/TerriaJS/terriajs/blob/dab991175a9b38f0f2ade26c6ed9018e10d72eec/lib/ModelMixins/TimeFilterMixin.ts#L107-L112).

### Test me

- Open this [test link](https://nationalmap.gov.au/#share=s-vurwfi7gP5EgpmsySTG6QBzqBa6) from issue #6824 
- Note how the copy layer (the first layer) is missing date filter
- Now open [the link](http://ci.terria.io/fix-time-filter-bug/#configUrl=https://terria-catalogs-public.storage.googleapis.com/nationalmap/config/prod.json&start={%22version%22%3A%228.0.0%22%2C%22initSources%22%3A[{%22stratum%22%3A%22user%22%2C%22models%22%3A{%22__User-Added_Data__%22%3A{%22isOpen%22%3Atrue%2C%22members%22%3A[%223a695d45-2f2f-4a3c-bd5e-dc704f648b72%22%2C%2214ea165c-95d2-4aaf-b927-042d99011be9%22]%2C%22knownContainerUniqueIds%22%3A[%22%2F%22]%2C%22type%22%3A%22group%22}%2C%226ATFM7CB%22%3A{%22dereferenced%22%3A{%22isOpen%22%3Atrue}%2C%22knownContainerUniqueIds%22%3A[%22Root+Group%2FNational+Data+Sets%22]%2C%22type%22%3A%22terria-reference%22}%2C%22CqkxcG%22%3A{%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A[%226ATFM7CB%22]%2C%22type%22%3A%22group%22}%2C%22SbBCvf%22%3A{%22show%22%3Afalse%2C%22isOpenInWorkbench%22%3Atrue%2C%22currentTime%22%3A%222023-07-08T00%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%222015-07-12T00%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222023-07-14T00%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A44856.818359375%2C%22isPaused%22%3Atrue%2C%22splitDirection%22%3A-1%2C%22timeFilterCoordinates%22%3A{%22latitude%22%3A-27.370431266344532%2C%22longitude%22%3A153.002927753145%2C%22height%22%3A107.76191109398104%2C%22tile%22%3A{%22x%22%3A947%2C%22y%22%3A592%2C%22level%22%3A10}}%2C%22knownContainerUniqueIds%22%3A[%22CqkxcG%22]%2C%22type%22%3A%22wms%22}%2C%22aN8xKz%22%3A{%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A[%22CqkxcG%22]%2C%22type%22%3A%22group%22}%2C%22rESkby%22%3A{%22currentTime%22%3A%222011-01-16T00%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%221986-08-16T00%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222011-11-17T00%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A57808.90838531844%2C%22isPaused%22%3Atrue%2C%22splitDirection%22%3A1%2C%22timeFilterCoordinates%22%3A{%22latitude%22%3A-27.382068820120537%2C%22longitude%22%3A153.132547070555%2C%22height%22%3A80.73945050241308%2C%22tile%22%3A{%22x%22%3A473%2C%22y%22%3A296%2C%22level%22%3A9}}%2C%22styles%22%3A%22true_colour%22%2C%22knownContainerUniqueIds%22%3A[%22aN8xKz%22]%2C%22type%22%3A%22wms%22}%2C%22x7b8dq%22%3A{%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A[%22CqkxcG%22]%2C%22type%22%3A%22group%22}%2C%2214ea165c-95d2-4aaf-b927-042d99011be9%22%3A{%22splitSourceItemId%22%3A%22SbBCvf%22%2C%22dereferenced%22%3A{%22show%22%3Atrue%2C%22name%22%3A%22DEA+Surface+Reflectance+(Sentinel-2)+(copy)%22%2C%22isOpenInWorkbench%22%3Atrue%2C%22currentTime%22%3A%222023-07-08T00%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%222015-07-12T00%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222023-07-14T00%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A44856.818359375%2C%22isPaused%22%3Atrue%2C%22splitDirection%22%3A-1%2C%22timeFilterCoordinates%22%3A{%22latitude%22%3A-27.370431266344532%2C%22longitude%22%3A153.002927753145%2C%22height%22%3A107.76191109355287%2C%22tile%22%3A{%22x%22%3A947%2C%22y%22%3A592%2C%22level%22%3A10}}}%2C%22knownContainerUniqueIds%22%3A[%22__User-Added_Data__%22]%2C%22type%22%3A%22split-reference%22}%2C%223a695d45-2f2f-4a3c-bd5e-dc704f648b72%22%3A{%22splitSourceItemId%22%3A%22rESkby%22%2C%22dereferenced%22%3A{%22show%22%3Afalse%2C%22name%22%3A%22DEA+Surface+Reflectance+(Landsat+5+TM)+(copy)%22%2C%22currentTime%22%3A%222011-01-16T00%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%221986-08-16T00%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222011-11-17T00%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A57808.90838531844%2C%22isPaused%22%3Atrue%2C%22splitDirection%22%3A-1%2C%22timeFilterCoordinates%22%3A{%22latitude%22%3A-27.382068820120537%2C%22longitude%22%3A153.132547070555%2C%22height%22%3A80.739450503766%2C%22tile%22%3A{%22x%22%3A473%2C%22y%22%3A296%2C%22level%22%3A9}}%2C%22styles%22%3A%22true_colour%22}%2C%22knownContainerUniqueIds%22%3A[%22__User-Added_Data__%22]%2C%22type%22%3A%22split-reference%22}%2C%22%2F%22%3A{%22type%22%3A%22group%22}%2C%22Root+Group%2FNational+Data+Sets%22%3A{%22knownContainerUniqueIds%22%3A[%22%2F%22]%2C%22type%22%3A%22group%22}}%2C%22workbench%22%3A[%2214ea165c-95d2-4aaf-b927-042d99011be9%22%2C%22rESkby%22]%2C%22timeline%22%3A[]%2C%22initialCamera%22%3A{%22west%22%3A152.36627931962525%2C%22south%22%3A-27.852695357208294%2C%22east%22%3A153.51065245498222%2C%22north%22%3A-27.130497379405014%2C%22position%22%3A{%22x%22%3A-5119217.378521423%2C%22y%22%3A2615300.574449204%2C%22z%22%3A-2971887.812557948}%2C%22direction%22%3A{%22x%22%3A0.7899057479290899%2C%22y%22%3A-0.4035462461483423%2C%22z%22%3A0.4617351368567991}%2C%22up%22%3A{%22x%22%3A-0.4111836523686589%2C%22y%22%3A0.21006508665872492%2C%22z%22%3A0.8870178484065765}}%2C%22homeCamera%22%3A{%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8}%2C%22viewerMode%22%3A%223d%22%2C%22showSplitter%22%3Atrue%2C%22splitPosition%22%3A0.046703712296983765%2C%22settings%22%3A{%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Atrue%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-bing-aerial-with-labels%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse}%2C%22stories%22%3A[]}]}) for this branch with the fix
- See how the date time selectors are visible


### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
