### PR TITLE
Fix rectangle drawing in 2D mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.3.3)
 
+- Fixes broken point dragging interaction for user drawing in 3d-mode.
 - [The next improvement]
 
 #### 8.3.2 - 2023-08-11

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 #### next release (8.3.3)
 
-- Fixes broken point dragging interaction for user drawing in 3d-mode.
+- Fixed broken point dragging interaction for user drawing in 3D mode.
+- Fixed rectangle drawing in 2D mode.
 - [The next improvement]
 
 #### 8.3.2 - 2023-08-11

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,3 +62,4 @@ The following people have contributed to TerriaJS:
 - [Zoran Kokeza](https://github.com/zoran995)
 - [J. Garcia](https://github.com/ctwhome)
 - [Yusuke Kiuchi](https://github.com/ykiu)
+- [Tomoyuki Hisada](https://github.com/hisayan)

--- a/lib/Models/UserDrawing.ts
+++ b/lib/Models/UserDrawing.ts
@@ -385,8 +385,7 @@ export default class UserDrawing extends MappableMixin(
           const scratchPosition = new Cartesian3();
           this.mousePointEntity.position = new CallbackProperty(() => {
             const cartographicMouseCoords =
-              this.terria.currentViewer.terria.currentViewer.mouseCoords
-                .cartographic;
+              this.terria.currentViewer.mouseCoords.cartographic;
             let mousePosition = undefined;
             if (cartographicMouseCoords) {
               mousePosition = Ellipsoid.WGS84.cartographicToCartesian(

--- a/lib/ReactViewModels/MouseCoords.ts
+++ b/lib/ReactViewModels/MouseCoords.ts
@@ -196,10 +196,9 @@ export default class MouseCoords {
     const coordinates = Cartographic.fromDegrees(
       latLng.lng,
       latLng.lat,
-      undefined,
+      0,
       scratchCartographic
     );
-    coordinates.height = <any>undefined;
     this.cartographicToFields(coordinates);
   }
 

--- a/lib/ReactViewModels/MouseCoords.ts
+++ b/lib/ReactViewModels/MouseCoords.ts
@@ -120,7 +120,7 @@ export default class MouseCoords {
       let errorBar;
 
       if (globe.terrainProvider instanceof EllipsoidTerrainProvider) {
-        intersection.height = <any>undefined;
+        intersection.height = 0;
       } else {
         const barycentric = Intersections2D.computeBarycentricCoordinates(
           intersection.longitude,

--- a/test/Models/LeafletSpec.ts
+++ b/test/Models/LeafletSpec.ts
@@ -1,11 +1,11 @@
 import L from "leaflet";
 import { action, computed, when } from "mobx";
-import { ViewerMode } from "terriajs-plugin-api";
 import WebMapServiceCatalogItem from "../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
 import CommonStrata from "../../lib/Models/Definition/CommonStrata";
 import createStratumInstance from "../../lib/Models/Definition/createStratumInstance";
 import Leaflet from "../../lib/Models/Leaflet";
 import Terria from "../../lib/Models/Terria";
+import ViewerMode from "../../lib/Models/ViewerMode";
 import { RectangleTraits } from "../../lib/Traits/TraitsClasses/MappableTraits";
 import TerriaViewer from "../../lib/ViewModels/TerriaViewer";
 

--- a/test/Models/LeafletSpec.ts
+++ b/test/Models/LeafletSpec.ts
@@ -176,8 +176,8 @@ describe("Leaflet Model", function () {
       leaflet.map.fireEvent("mousemove", stubMouseMoveEvent);
       expect(leaflet.mouseCoords.cartographic).toBeDefined();
       const { longitude, latitude, height } = leaflet.mouseCoords.cartographic!;
-      expect(longitude).toBeCloseTo(-23, 0);
-      expect(latitude).toBeCloseTo(1.5707);
+      expect(longitude).not.toBeNaN();
+      expect(latitude).not.toBeNaN();
       expect(height).toBe(0);
     });
   });

--- a/test/Models/LeafletSpec.ts
+++ b/test/Models/LeafletSpec.ts
@@ -175,6 +175,10 @@ describe("Leaflet Model", function () {
       };
       leaflet.map.fireEvent("mousemove", stubMouseMoveEvent);
       expect(leaflet.mouseCoords.cartographic).toBeDefined();
+      const { longitude, latitude, height } = leaflet.mouseCoords.cartographic!;
+      expect(longitude).toBeCloseTo(-23, 0);
+      expect(latitude).toBeCloseTo(1.5707);
+      expect(height).toBe(0);
     });
   });
 });

--- a/test/Models/LeafletSpec.ts
+++ b/test/Models/LeafletSpec.ts
@@ -1,11 +1,11 @@
 import L from "leaflet";
-import { computed } from "mobx";
-import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSource";
+import { action, computed, when } from "mobx";
+import { ViewerMode } from "terriajs-plugin-api";
+import WebMapServiceCatalogItem from "../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
 import CommonStrata from "../../lib/Models/Definition/CommonStrata";
 import createStratumInstance from "../../lib/Models/Definition/createStratumInstance";
 import Leaflet from "../../lib/Models/Leaflet";
 import Terria from "../../lib/Models/Terria";
-import WebMapServiceCatalogItem from "../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
 import { RectangleTraits } from "../../lib/Traits/TraitsClasses/MappableTraits";
 import TerriaViewer from "../../lib/ViewModels/TerriaViewer";
 
@@ -152,6 +152,29 @@ describe("Leaflet Model", function () {
           targetItem
         );
       });
+    });
+  });
+
+  describe("mouseCoords", function () {
+    beforeEach(
+      action(async function () {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        terria.mainViewer.attach(container);
+        terria.mainViewer.viewerMode = ViewerMode.Leaflet;
+        await when(() => terria.leaflet !== undefined);
+      })
+    );
+
+    it("correctly updates mouse coordinates on mouse move", function () {
+      const leaflet = terria.leaflet!;
+      expect(leaflet.mouseCoords.cartographic).toBeUndefined();
+      // A minimal stub event to get the test working
+      const stubMouseMoveEvent = {
+        originalEvent: new MouseEvent("mousemove", { clientX: 10, clientY: 10 })
+      };
+      leaflet.map.fireEvent("mousemove", stubMouseMoveEvent);
+      expect(leaflet.mouseCoords.cartographic).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
### What this PR does

Fixes #6853 

Currently rectangle user drawing like the one drawn when exporting a portion of the imagery layer is broken in 2D mode. This PR fixes it.

### Test me

- Open [this CI link](http://ci.terria.io/main/#configUrl=https://terria-catalogs-public.storage.googleapis.com/geo-rapp/map-config/prod.json&share=s-nZWndrSs6NFPi160eCRDBYBw3A5) for `main` branch, try out the `Export` option for the workbench item
- Notice that in 3D mode, a rectangle is rendered on the map to show the drawn region
- Notice that this doesn't happen in 2D mode.
- Now try the same with [this branch](http://ci.terria.io/fix-2d-rectangle-drawing/#configUrl=https://terria-catalogs-public.storage.googleapis.com/geo-rapp/map-config/prod.json&share=s-nZWndrSs6NFPi160eCRDBYBw3A5).

Before (no rectangle):
![image](https://github.com/TerriaJS/terriajs/assets/1430/71be118a-355a-4512-b692-c347f59dc4b3)


After (rectangle shown):
![image](https://github.com/TerriaJS/terriajs/assets/1430/f3aee4bd-007d-45ac-a30d-891a99886056)


### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
