### PR TITLE
Adds EPSG:7855 to known projections.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.3.3)
 
 - Fixes broken point dragging interaction for user drawing in 3d-mode.
+- Added EPSG:7855 to `Proj4Definitions`.
 - [The next improvement]
 
 #### 8.3.2 - 2023-08-11

--- a/lib/Map/Vector/Proj4Definitions.ts
+++ b/lib/Map/Vector/Proj4Definitions.ts
@@ -57,7 +57,9 @@ const Proj4Definitions: Record<string, string> = {
   "EPSG:102100": "EPSG:3857",
   "EPSG:27700":
     "+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 +units=m +no_defs",
-  "EPSG:7844": "+proj=longlat +ellps=GRS80 +no_defs +type=crs"
+  "EPSG:7844": "+proj=longlat +ellps=GRS80 +no_defs +type=crs",
+  "EPSG:7855":
+    "+proj=utm +zone=55 +south +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs"
 };
 
 export default Proj4Definitions;


### PR DESCRIPTION
### What this PR does

Adds EPSG:7855 to known projections.
This should fix ideal zoom for some layers.

### Test me

Check ideal zoom [before](http://ci.terria.io/main/#share=s-ofGTlN9sg2JsYR9J0Y2IgOzeWbO) and [after](http://ci.terria.io/add-proj-7855/#share=s-ofGTlN9sg2JsYR9J0Y2IgOzeWbO)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
