### PR TITLE
Fix CogComposite projFunc

### DIFF
--- a/lib/Models/Catalog/CatalogItems/CogCompositeCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/CogCompositeCatalogItem.ts
@@ -162,7 +162,7 @@ export default class CogCompositeCatalogItem extends MappableMixin(
             ? new proj4.Proj(Proj4Definitions[sourceEpsgCode])
             : undefined;
 
-        return proj4(sourceDef, "EPSG:4326").reverse;
+        return proj4("EPSG:4326", sourceDef).forward;
       })
       .catch((error: Error) => {
         this.terria.raiseErrorToUser(error);


### PR DESCRIPTION
### What this PR does

Fixes issue where cog-composite items not working.

This problem introduced when TIFFImageryProvider refactored how frojFunc was dealt with, needing to return an object with project and unproject.

