### PR TITLE
Mapserver Groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Fixed broken point dragging interaction for user drawing in 3D mode.
 - Fixed rectangle drawing in 2D mode.
 - Added EPSG:7855 to `Proj4Definitions`.
+- Fix multi level nesting in ArcGIS Mapserver.
 - [The next improvement]
 
 #### 8.3.2 - 2023-08-11

--- a/lib/Models/Catalog/Esri/ArcGisMapServerCatalogGroup.ts
+++ b/lib/Models/Catalog/Esri/ArcGisMapServerCatalogGroup.ts
@@ -49,6 +49,7 @@ export class MapServerStratum extends LoadableStratum(
     ) as this;
   }
 
+  /** returns an array of the parent layers id's */
   findParentLayers(layerId: number): number[] {
     const parentLayerIds: number[] = [];
     const layer = this.layers.find((l) => l.id === layerId);
@@ -201,12 +202,13 @@ export class MapServerStratum extends LoadableStratum(
       return;
     }
     const id = this._catalogGroup.uniqueId;
-    //if parent layer is not -1 then this is sublayer so we define its ID like that
-    let layerId =
-      id +
-      "/" +
-      (layer.parentLayerId !== -1 ? layer.parentLayerId + "/" : "") +
-      layer.id;
+    let layerId = id + "/" + layer.id;
+
+    const parentLayers = this.findParentLayers(layer.id);
+
+    if (parentLayers.length > 0) {
+      layerId = id + "/" + parentLayers.reverse().join("/");
+    }
 
     let model: ArcGisMapServerCatalogItem | ArcGisMapServerCatalogGroup;
 
@@ -235,12 +237,6 @@ export class MapServerStratum extends LoadableStratum(
       );
 
       if (existingModel === undefined) {
-        const parentLayers = this.findParentLayers(layer.id);
-
-        if (parentLayers.length > 0) {
-          layerId = id + "/" + parentLayers.reverse().join("/");
-        }
-
         model = new ArcGisMapServerCatalogItem(
           layerId,
           this._catalogGroup.terria

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
@@ -101,6 +101,7 @@ class DataCatalogGroup extends React.Component {
   render() {
     const group = this.props.group;
     const { t } = this.props;
+
     return (
       <CatalogGroup
         text={this.getNameOrPrettyUrl()}


### PR DESCRIPTION
### What this PR does

Fixes [#536](https://github.com/TerriaJS/vic-digital-twin/issues/536)

Currently ArcGIS Mapservers group  can only handle nesting groups 1 level deep.  This PR adds a recursive check which will allow nesting to be as deep as defined by the Mapservice config.

### Test me

http://ci.terria.io/issue-536/#clean&https://gist.githubusercontent.com/sixlighthouses/a4fd27b75f41638efe902fa29ddf2825/raw/9167cbe29e558c4be7a269d37fd8298464278866/test.json

<img width="638" alt="image" src="https://github.com/TerriaJS/terriajs/assets/1597830/d3c427e7-404d-4f87-8371-086cb0cbc476">

Open Data Catalog and Click through the multi level groups under Planning Overlays -- as per image above

prior to this change no layers are displayed under the second level groups i.e Environment and Landscape


### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
