### PR TITLE
Add `includeMembersRegex` to `GroupTraits`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Move map credits to map column so it don't get hidden by chart panel
 - TSify `MapColumn` module and reorganize components directory structure.
 - Add null check to `WebMapServiceCatalogItem` `rectangle` calculation - and now we ascend tree of WMS `Layers` until we find a rectangle.
+- Add `includeMembersRegex` to `GroupTraits`. This can be used to filter group members by id/name using a regular expression.
 - [The next improvement]
 
 #### next release (8.3.3)

--- a/lib/Traits/TraitsClasses/GroupTraits.ts
+++ b/lib/Traits/TraitsClasses/GroupTraits.ts
@@ -17,7 +17,7 @@ export default class GroupTraits extends mixTraits(ItemPropertiesTraits) {
   @primitiveTrait({
     name: "Include members by regular expression",
     type: "string",
-    description: `A regular expression that is matched against the member names and ids. Only members (groups and items) that match against the regular expression will be shown to the user. This will only apply to the first level of members (not in nested groups). This is applied before excludeMembers.`
+    description: `A regular expression that is matched against the member names and ids. Only members (groups and items) that match against the regular expression will be shown to the user. This is case-insensitive and will only apply to the first level of members (not in nested groups). This is applied before excludeMembers.`
   })
   includeMembersRegex?: string;
 

--- a/lib/Traits/TraitsClasses/GroupTraits.ts
+++ b/lib/Traits/TraitsClasses/GroupTraits.ts
@@ -15,6 +15,13 @@ export default class GroupTraits extends mixTraits(ItemPropertiesTraits) {
   excludeMembers?: string[];
 
   @primitiveTrait({
+    name: "Include members by regular expression",
+    type: "string",
+    description: `A regular expression that is matched against the member names and ids. Only members (groups and items) that match against the regular expression will be shown to the user. This will only apply to the first level of members (not in nested groups). This is applied before excludeMembers.`
+  })
+  includeMembersRegex?: string;
+
+  @primitiveTrait({
     name: "Is Open",
     description:
       "True if this group is open and its contents are visible; otherwise, false.",

--- a/test/Models/Catalog/CatalogGroupSpec.ts
+++ b/test/Models/Catalog/CatalogGroupSpec.ts
@@ -175,7 +175,7 @@ describe("CatalogGroup", function () {
       type: "group",
       id: "grandmama",
       name: "Test Group",
-      excludeMembers: ["grandchild1", "parent3"]
+      excludeMembers: ["grandchild1", "parent3", "some name"]
     };
     upsertModelFromJson(
       CatalogMemberFactory,
@@ -209,6 +209,11 @@ describe("CatalogGroup", function () {
           {
             type: "group",
             id: "grandchild4"
+          },
+          {
+            type: "group",
+            id: "some-id",
+            name: "some name"
           }
         ]
       },
@@ -222,8 +227,16 @@ describe("CatalogGroup", function () {
       }
     ]);
 
-    expect(item.excludeMembers).toEqual(["grandchild1", "parent3"]);
-    expect(item.mergedExcludeMembers).toEqual(["grandchild1", "parent3"]);
+    expect(item.excludeMembers).toEqual([
+      "grandchild1",
+      "parent3",
+      "some name"
+    ]);
+    expect(item.mergedExcludeMembers).toEqual([
+      "grandchild1",
+      "parent3",
+      "some name"
+    ]);
 
     const parent1 = <CatalogGroup>terria.getModelById(CatalogGroup, "parent1");
     expect(item).toBeDefined();
@@ -244,7 +257,8 @@ describe("CatalogGroup", function () {
     expect(parent1.mergedExcludeMembers).toEqual([
       "grandchild4",
       "grandchild1",
-      "parent3"
+      "parent3",
+      "some name"
     ]);
   });
 

--- a/test/Models/Catalog/CatalogGroupSpec.ts
+++ b/test/Models/Catalog/CatalogGroupSpec.ts
@@ -1,16 +1,16 @@
-import CatalogMemberMixin from "../../../lib/ModelMixins/CatalogMemberMixin";
+import { runInAction } from "mobx";
+import createGuid from "terriajs-cesium/Source/Core/createGuid";
+import { getName } from "../../../lib/ModelMixins/CatalogMemberMixin";
 import CatalogGroup from "../../../lib/Models/Catalog/CatalogGroup";
 import GeoJsonCatalogItem from "../../../lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem";
 import StubCatalogItem from "../../../lib/Models/Catalog/CatalogItems/StubCatalogItem";
 import CatalogMemberFactory from "../../../lib/Models/Catalog/CatalogMemberFactory";
-import { getUniqueStubName } from "../../../lib/Models/Catalog/createStubCatalogItem";
+import SplitItemReference from "../../../lib/Models/Catalog/CatalogReferences/SplitItemReference";
 import WebMapServiceCatalogItem from "../../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
+import { getUniqueStubName } from "../../../lib/Models/Catalog/createStubCatalogItem";
 import CommonStrata from "../../../lib/Models/Definition/CommonStrata";
 import upsertModelFromJson from "../../../lib/Models/Definition/upsertModelFromJson";
 import Terria from "../../../lib/Models/Terria";
-import SplitItemReference from "../../../lib/Models/Catalog/CatalogReferences/SplitItemReference";
-import createGuid from "terriajs-cesium/Source/Core/createGuid";
-import { runInAction } from "mobx";
 
 describe("CatalogGroup", function () {
   let terria: Terria, json: any, catalogGroup: CatalogGroup;
@@ -245,6 +245,95 @@ describe("CatalogGroup", function () {
       "grandchild4",
       "grandchild1",
       "parent3"
+    ]);
+  });
+
+  it("only includes items/groups with includeMembersRegex", async function () {
+    json = {
+      type: "group",
+      id: "test",
+      includeMembersRegex: ".+(1|2)",
+      members: [
+        {
+          type: "group",
+          id: "grandchild1"
+        },
+        {
+          type: "group",
+          id: "grandchild2"
+        },
+        {
+          type: "group",
+          id: "grandchild3"
+        },
+        {
+          type: "group",
+          id: "grandchild4"
+        }
+      ]
+    };
+    upsertModelFromJson(
+      CatalogMemberFactory,
+      terria,
+      "",
+      "definition",
+      json,
+      {}
+    ).throwIfUndefined();
+
+    const item = <CatalogGroup>terria.getModelById(CatalogGroup, "test");
+
+    await item.loadMembers();
+
+    expect(item.includeMembersRegex).toEqual(".+(1|2)");
+    expect(item.memberModels.map((member) => getName(member))).toEqual([
+      "grandchild1",
+      "grandchild2"
+    ]);
+  });
+
+  it("combines includeMembersRegex and excludeMembers", async function () {
+    json = {
+      type: "group",
+      id: "test",
+      includeMembersRegex: ".+(1|2)",
+      excludeMembers: ["grandchild1"],
+      members: [
+        {
+          type: "group",
+          id: "grandchild1"
+        },
+        {
+          type: "group",
+          id: "grandchild2"
+        },
+        {
+          type: "group",
+          id: "grandchild3"
+        },
+        {
+          type: "group",
+          id: "grandchild4"
+        }
+      ]
+    };
+    upsertModelFromJson(
+      CatalogMemberFactory,
+      terria,
+      "",
+      "definition",
+      json,
+      {}
+    ).throwIfUndefined();
+
+    const item = <CatalogGroup>terria.getModelById(CatalogGroup, "test");
+
+    await item.loadMembers();
+
+    expect(item.includeMembersRegex).toEqual(".+(1|2)");
+    expect(item.mergedExcludeMembers).toEqual(["grandchild1"]);
+    expect(item.memberModels.map((member) => getName(member))).toEqual([
+      "grandchild2"
     ]);
   });
 


### PR DESCRIPTION
### What this PR does

Adds a new `includeMembersRegex` trait to `GroupTraits`. 

> A regular expression that is matched against the member names and ids. Only members (groups and items) that match against the regular expression will be shown to the user. This is case-insensitive and will only apply to the first level of members (not in nested groups). This is applied before `excludeMembers`.

### Test me

```json
{
  "catalog": [
    {
      "name": "ACT test (only showing items that start with ACTGOV)",
      "url": "https://services1.arcgis.com/E5n4f1VY84i0xSjy/ArcGIS/rest/services",
      "type": "esri-group",
      "includeMembersRegex": "^ACTGOV.+"
    },
    {
      "name": "ACT test (showing all items)",
      "url": "https://services1.arcgis.com/E5n4f1VY84i0xSjy/ArcGIS/rest/services",
      "type": "esri-group"
    }
  ]
}
```

- [Test link](http://ci.terria.io/onlyincluderegex/#clean&start=%7B%22initSources%22%3A%5B%7B%22catalog%22%3A%20%5B%7B%22name%22%3A%20%22ACT%20test%20(only%20showing%20items%20that%20start%20with%20ACTGOV)%22%2C%22url%22%3A%20%22https%3A%2F%2Fservices1.arcgis.com%2FE5n4f1VY84i0xSjy%2FArcGIS%2Frest%2Fservices%22%2C%22type%22%3A%20%22esri-group%22%2C%22includeMembersRegex%22%3A%20%22%5EACTGOV.%2B%22%7D%2C%7B%22name%22%3A%20%22ACT%20test%20(showing%20all%20items)%22%2C%22url%22%3A%20%22https%3A%2F%2Fservices1.arcgis.com%2FE5n4f1VY84i0xSjy%2FArcGIS%2Frest%2Fservices%22%2C%22type%22%3A%20%22esri-group%22%7D%5D%7D%5D%7D)
- Open both test groups
- One group will filter items that start with `^ACTGOV.+`

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
