### PR TITLE
Fix excludeMembers lowercase bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.3.6)
 
 - Fixed a bug where incorrect "Remove all" icon is shown when the trait `displayGroup` of some group types (e.g.`wms-group`) is set to `true` but the members have not been populated yet.
+- Fix regression in `excludeMembers`, `id` and `name` should be lower-case for comparing.
 - [The next improvement]
 
 #### 8.3.5 - 2023-09-26

--- a/lib/ModelMixins/GroupMixin.ts
+++ b/lib/ModelMixins/GroupMixin.ts
@@ -83,10 +83,10 @@ function GroupMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
 
             // Get model name, apply includeMemberRegex and excludeMembers
             const modelName = CatalogMemberMixin.isMixedInto(model)
-              ? model.name?.trim()
+              ? model.name?.toLowerCase().trim()
               : undefined;
 
-            const modelId = model?.uniqueId?.trim();
+            const modelId = model?.uniqueId?.toLowerCase().trim();
             if (
               model &&
               // Does includeMemberRegex match model ID or model name

--- a/test/Models/Catalog/CatalogGroupSpec.ts
+++ b/test/Models/Catalog/CatalogGroupSpec.ts
@@ -175,7 +175,7 @@ describe("CatalogGroup", function () {
       type: "group",
       id: "grandmama",
       name: "Test Group",
-      excludeMembers: ["grandchild1", "parent3", "some name"]
+      excludeMembers: ["grandchild1", "PARENT3", "some name"]
     };
     upsertModelFromJson(
       CatalogMemberFactory,
@@ -223,18 +223,18 @@ describe("CatalogGroup", function () {
       },
       {
         type: "group",
-        id: "parent3"
+        id: "PARENT3"
       }
     ]);
 
     expect(item.excludeMembers).toEqual([
       "grandchild1",
-      "parent3",
+      "PARENT3",
       "some name"
     ]);
     expect(item.mergedExcludeMembers).toEqual([
       "grandchild1",
-      "parent3",
+      "PARENT3",
       "some name"
     ]);
 
@@ -257,7 +257,7 @@ describe("CatalogGroup", function () {
     expect(parent1.mergedExcludeMembers).toEqual([
       "grandchild4",
       "grandchild1",
-      "parent3",
+      "PARENT3",
       "some name"
     ]);
   });


### PR DESCRIPTION
### Fix excludeMembers lowercase bug

I forgot to add `toLowerCase` before comparing `excludeMembers` and model `name` or `id`

### Test me

- Before: http://ci.terria.io/main/#configUrl=https://terria-catalogs-public.storage.googleapis.com/nationalmap/config/prod.json
- After: http://ci.terria.io/lowercase-bug/#configUrl=https://terria-catalogs-public.storage.googleapis.com/nationalmap/config/prod.json
- Natoinal Datasets -> Social and Economic -> ABS.Stat (Beta)
- See extra groups in Before - these should not be there

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] ~I've updated relevant documentation in `doc/`.~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
