### PR TITLE
Remove all now removes all pickedFeatures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.3.7)
 
+- Fix "Remove all" not removing selected/picked features
 - [The next improvement]
 
 #### 8.3.6 - 2023-10-03

--- a/lib/ReactViews/Workbench/Workbench.tsx
+++ b/lib/ReactViews/Workbench/Workbench.tsx
@@ -52,6 +52,7 @@ class Workbench extends React.Component<IProps> {
         DataSourceAction.removeAllFromWorkbench,
         getPath(item)
       );
+      this.props.terria.removeSelectedFeaturesForModel(item);
     });
     this.props.terria.workbench.removeAll();
     (this.props.terria.timelineStack.items as any).clear();


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs/issues/5381

### Test me

- [Before test link](http://ci.terria.io/main/#start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22__User-Added_Data__%22%3A%7B%22isOpen%22%3Atrue%2C%22members%22%3A%5B%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%22%5D%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%22%3A%7B%22isOpen%22%3Atrue%2C%22url%22%3A%22https%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%22%2C%22knownContainerUniqueIds%22%3A%5B%22__User-Added_Data__%22%5D%2C%22type%22%3A%22wms-group%22%7D%2C%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%2Fopen-data-platform%3Aptv_train_corridor_centreline%22%3A%7B%22knownContainerUniqueIds%22%3A%5B%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%22%5D%2C%22type%22%3A%22wms%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%2Fopen-data-platform%3Aptv_train_corridor_centreline%22%5D%2C%22timeline%22%3A%5B%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%2Fopen-data-platform%3Aptv_train_corridor_centreline%22%5D%2C%22initialCamera%22%3A%7B%22west%22%3A141.38702202413097%2C%22south%22%3A-39.1752302269033%2C%22east%22%3A144.18599826588627%2C%22north%22%3A-36.05902949430597%2C%22position%22%3A%7B%22x%22%3A-4217076.861466299%2C%22y%22%3A3202500.757547868%2C%22z%22%3A-4055581.3386217915%7D%2C%22direction%22%3A%7B%22x%22%3A0.6306804431925364%2C%22y%22%3A-0.47894659344492885%2C%22z%22%3A0.6106163600837796%7D%2C%22up%22%3A%7B%22x%22%3A-0.4862872655751745%2C%22y%22%3A0.36929261371083605%2C%22z%22%3A0.7919265501282546%7D%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%223dSmooth%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.4999%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Atrue%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-positron%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)
- [After test link](http://ci.terria.io/fix-removeall-picked-features/#start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22__User-Added_Data__%22%3A%7B%22isOpen%22%3Atrue%2C%22members%22%3A%5B%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%22%5D%2C%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%2C%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%22%3A%7B%22isOpen%22%3Atrue%2C%22url%22%3A%22https%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%22%2C%22knownContainerUniqueIds%22%3A%5B%22__User-Added_Data__%22%5D%2C%22type%22%3A%22wms-group%22%7D%2C%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%2Fopen-data-platform%3Aptv_train_corridor_centreline%22%3A%7B%22knownContainerUniqueIds%22%3A%5B%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%22%5D%2C%22type%22%3A%22wms%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%2Fopen-data-platform%3Aptv_train_corridor_centreline%22%5D%2C%22timeline%22%3A%5B%22%2Fhttps%3A%2F%2Fopendata.maps.vic.gov.au%2Fgeoserver%2Fwms%3Fservice%3Dwms%26request%3Dgetmap%26format%3Dimage%252Fpng8%26transparent%3Dtrue%26layers%3Dopen-data-platform%3Aptv_train_track_centreline%26width%3D512%26height%3D512%26crs%3Depsg%253A3857%26bbox%3D16114148.554967716%252C-4456584.4971389165%252C16119040.524777967%252C-4451692.527328665%2Fopen-data-platform%3Aptv_train_corridor_centreline%22%5D%2C%22initialCamera%22%3A%7B%22west%22%3A141.38702202413097%2C%22south%22%3A-39.1752302269033%2C%22east%22%3A144.18599826588627%2C%22north%22%3A-36.05902949430597%2C%22position%22%3A%7B%22x%22%3A-4217076.861466299%2C%22y%22%3A3202500.757547868%2C%22z%22%3A-4055581.3386217915%7D%2C%22direction%22%3A%7B%22x%22%3A0.6306804431925364%2C%22y%22%3A-0.47894659344492885%2C%22z%22%3A0.6106163600837796%7D%2C%22up%22%3A%7B%22x%22%3A-0.4862872655751745%2C%22y%22%3A0.36929261371083605%2C%22z%22%3A0.7919265501282546%7D%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%223dSmooth%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.4999%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Atrue%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-positron%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)
- Select/pick feature
- Click "remove all"
- Selected features should also be removed

### Checklist

- [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~ There is no `WorkbenchSpec` (for UI `Workbench`)
- [ ] ~I've updated relevant documentation in `doc/`.~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
