### PR TITLE
Fix WMS allowFeaturePicking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.3.7)
 
+- Fix `WebMapServiceCatalogItem` `allowFeaturePicking`
 - [The next improvement]
 
 #### 8.3.6 - 2023-10-03

--- a/lib/Models/Catalog/Ows/WebMapServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapServiceCatalogItem.ts
@@ -398,7 +398,9 @@ class WebMapServiceCatalogItem
       return undefined;
     }
 
-    imageryProvider.enablePickFeatures = true;
+    // Reset feature picking for the current imagery layer.
+    // We disable feature picking for the next imagery layer.
+    imageryProvider.enablePickFeatures = this.allowFeaturePicking;
 
     return {
       imageryProvider,
@@ -422,6 +424,7 @@ class WebMapServiceCatalogItem
         return undefined;
       }
 
+      // Disable feature picking for the next imagery layer.
       imageryProvider.enablePickFeatures = false;
 
       return {
@@ -574,8 +577,8 @@ class WebMapServiceCatalogItem
         tilingScheme: this.tilingScheme,
         maximumLevel: this.getMaximumLevel(true) ?? this.maximumLevel,
         minimumLevel: this.minimumLevel,
-        credit: this.attribution,
-        enablePickFeatures: this.allowFeaturePicking
+        credit: this.attribution
+        // Note: we set enablePickFeatures in _currentImageryParts and _nextImageryParts
       };
 
       if (isDefined(this.getFeatureInfoFormat?.type)) {

--- a/test/Models/Catalog/Ows/WebMapServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapServiceCatalogItemSpec.ts
@@ -562,6 +562,87 @@ describe("WebMapServiceCatalogItem", function () {
     );
   });
 
+  it('creates "next" imagery provider when animating', async function () {
+    const terria = new Terria();
+    const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
+    runInAction(() => {
+      wmsItem.setTrait(CommonStrata.definition, "url", "http://example.com");
+      wmsItem.setTrait(
+        CommonStrata.definition,
+        "getCapabilitiesUrl",
+        "test/WMS/styles_and_dimensions.xml"
+      );
+      wmsItem.setTrait(CommonStrata.definition, "layers", "C");
+      wmsItem.setTrait(
+        CommonStrata.definition,
+        "currentTime",
+        "2002-01-01T00:00:00.000Z"
+      );
+    });
+
+    terria.timelineStack.addToTop(wmsItem);
+    terria.timelineStack.activate();
+
+    (await wmsItem.loadMapItems()).throwIfError();
+
+    expect(wmsItem.mapItems.length).toBe(1);
+    expect(wmsItem.isPaused).toBe(true);
+
+    runInAction(() => {
+      wmsItem.setTrait(CommonStrata.definition, "isPaused", false);
+    });
+
+    expect(wmsItem.mapItems.length).toBe(2);
+    expect(wmsItem.isPaused).toBe(false);
+
+    const currentImageryProvider = wmsItem.mapItems[0].imageryProvider;
+    expect(currentImageryProvider instanceof WebMapServiceImageryProvider).toBe(
+      true
+    );
+    if (currentImageryProvider instanceof WebMapServiceImageryProvider) {
+      expect(currentImageryProvider.enablePickFeatures).toBe(true);
+    }
+
+    const nextMapItem = wmsItem.mapItems[1];
+    const nextImageryProvider = nextMapItem.imageryProvider;
+    expect(nextImageryProvider instanceof WebMapServiceImageryProvider).toBe(
+      true
+    );
+    if (nextImageryProvider instanceof WebMapServiceImageryProvider) {
+      expect(nextImageryProvider.enablePickFeatures).toBe(false);
+      expect(nextMapItem.alpha).toBe(0);
+      expect(nextMapItem.show).toBe(true);
+    }
+  });
+
+  it("sets enableFeaturePicking to false", async function () {
+    const terria = new Terria();
+    const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
+    runInAction(() => {
+      wmsItem.setTrait(CommonStrata.definition, "url", "http://example.com");
+      wmsItem.setTrait(CommonStrata.definition, "allowFeaturePicking", false);
+      wmsItem.setTrait(
+        CommonStrata.definition,
+        "getCapabilitiesUrl",
+        "test/WMS/styles_and_dimensions.xml"
+      );
+      wmsItem.setTrait(CommonStrata.definition, "layers", "C");
+    });
+
+    (await wmsItem.loadMetadata()).throwIfError();
+
+    expect(wmsItem.mapItems.length).toBe(1);
+    expect(wmsItem.allowFeaturePicking).toBe(false);
+
+    const imageryProvider = wmsItem.mapItems[0].imageryProvider;
+    expect(
+      imageryProvider instanceof WebMapServiceImageryProvider
+    ).toBeTruthy();
+    if (imageryProvider instanceof WebMapServiceImageryProvider) {
+      expect(imageryProvider.enablePickFeatures).toBe(false);
+    }
+  });
+
   it("dimensions and styles for a 'real' WMS layer", function (done) {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);

--- a/test/Models/Catalog/Ows/WebMapServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapServiceCatalogItemSpec.ts
@@ -595,24 +595,22 @@ describe("WebMapServiceCatalogItem", function () {
     expect(wmsItem.mapItems.length).toBe(2);
     expect(wmsItem.isPaused).toBe(false);
 
-    const currentImageryProvider = wmsItem.mapItems[0].imageryProvider;
+    const currentImageryProvider = wmsItem.mapItems[0]
+      .imageryProvider as WebMapServiceImageryProvider;
     expect(currentImageryProvider instanceof WebMapServiceImageryProvider).toBe(
       true
     );
-    if (currentImageryProvider instanceof WebMapServiceImageryProvider) {
-      expect(currentImageryProvider.enablePickFeatures).toBe(true);
-    }
+    expect(currentImageryProvider.enablePickFeatures).toBe(false);
 
     const nextMapItem = wmsItem.mapItems[1];
-    const nextImageryProvider = nextMapItem.imageryProvider;
+    const nextImageryProvider =
+      nextMapItem.imageryProvider as WebMapServiceImageryProvider;
     expect(nextImageryProvider instanceof WebMapServiceImageryProvider).toBe(
       true
     );
-    if (nextImageryProvider instanceof WebMapServiceImageryProvider) {
-      expect(nextImageryProvider.enablePickFeatures).toBe(false);
-      expect(nextMapItem.alpha).toBe(0);
-      expect(nextMapItem.show).toBe(true);
-    }
+    expect(nextImageryProvider.enablePickFeatures).toBe(false);
+    expect(nextMapItem.alpha).toBe(0);
+    expect(nextMapItem.show).toBe(true);
   });
 
   it("sets enableFeaturePicking to false", async function () {
@@ -634,13 +632,13 @@ describe("WebMapServiceCatalogItem", function () {
     expect(wmsItem.mapItems.length).toBe(1);
     expect(wmsItem.allowFeaturePicking).toBe(false);
 
-    const imageryProvider = wmsItem.mapItems[0].imageryProvider;
+    const imageryProvider = wmsItem.mapItems[0]
+      .imageryProvider as WebMapServiceImageryProvider;
     expect(
       imageryProvider instanceof WebMapServiceImageryProvider
     ).toBeTruthy();
-    if (imageryProvider instanceof WebMapServiceImageryProvider) {
-      expect(imageryProvider.enablePickFeatures).toBe(false);
-    }
+
+    expect(imageryProvider.enablePickFeatures).toBe(false);
   });
 
   it("dimensions and styles for a 'real' WMS layer", function (done) {

--- a/test/Models/Catalog/Ows/WebMapServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapServiceCatalogItemSpec.ts
@@ -600,7 +600,7 @@ describe("WebMapServiceCatalogItem", function () {
     expect(currentImageryProvider instanceof WebMapServiceImageryProvider).toBe(
       true
     );
-    expect(currentImageryProvider.enablePickFeatures).toBe(false);
+    expect(currentImageryProvider.enablePickFeatures).toBe(true);
 
     const nextMapItem = wmsItem.mapItems[1];
     const nextImageryProvider =


### PR DESCRIPTION
### Fix WMS allowFeaturePicking

Setting `allowFeaturePicking = false` wasn't actually disabling feature picking

### Test me

- [Before link](http://ci.terria.io/main/#share=s-z2dtf8UGsrtxambfbYepn3EGWtq)
- [After link](http://ci.terria.io/fix-wms-allowfeaturepicking/#share=s-z2dtf8UGsrtxambfbYepn3EGWtq)
- Click on layer
- You should not see feature info

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] ~I've updated relevant documentation in `doc/`.~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
