### PR TITLE
Add `hideDefaultDescription` to `CatalogMemberTraits`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Fix bug in mismatched GeoJSON Feature `_id_` and TableMixin `rowId` - this was causing incorrect styling when using `filterByProperties` or features had `null` geometry
 - Fix splitter for `GeoJsonMixin` (lines and polygon features only)
 - Fix share links with picked features from `ProtomapsImageryProvider`
+- Add `hideDefaultDescription` to `CatalogMemberTraits` - if true, then no generic default description will be shown when `description` is empty.
 - [The next improvement]
 
 #### 8.3.6 - 2023-10-03

--- a/lib/ReactViews/Preview/Description.jsx
+++ b/lib/ReactViews/Preview/Description.jsx
@@ -64,7 +64,11 @@ class Description extends React.Component {
         </If>
 
         <If
-          condition={!catalogItem.hasLocalData && !catalogItem.hasDescription}
+          condition={
+            !catalogItem.hasLocalData &&
+            !catalogItem.hasDescription &&
+            !catalogItem.hideDefaultDescription
+          }
         >
           <p>{t("description.dataNotLocal")}</p>
         </If>

--- a/lib/Traits/TraitsClasses/CatalogMemberTraits.ts
+++ b/lib/Traits/TraitsClasses/CatalogMemberTraits.ts
@@ -117,6 +117,14 @@ class CatalogMemberTraits extends ModelTraits {
   description?: string;
 
   @primitiveTrait({
+    type: "boolean",
+    name: "Hide default description",
+    description:
+      "If true, then no generic default description will be displayed if `description` is undefined."
+  })
+  hideDefaultDescription: boolean = false;
+
+  @primitiveTrait({
     type: "string",
     name: "Name in catalog",
     description:

--- a/test/ReactViews/Preview/DescriptionSpec.tsx
+++ b/test/ReactViews/Preview/DescriptionSpec.tsx
@@ -3,9 +3,11 @@ import React from "react";
 import { act } from "react-dom/test-utils";
 import { create, ReactTestRenderer } from "react-test-renderer";
 import { ThemeProvider } from "styled-components";
-import Terria from "../../../lib/Models/Terria";
-import updateModelFromJson from "../../../lib/Models/Definition/updateModelFromJson";
+import GeoJsonCatalogItem from "../../../lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem";
 import WebMapServiceCatalogItem from "../../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
+import CommonStrata from "../../../lib/Models/Definition/CommonStrata";
+import updateModelFromJson from "../../../lib/Models/Definition/updateModelFromJson";
+import Terria from "../../../lib/Models/Terria";
 import Description from "../../../lib/ReactViews/Preview/Description";
 import { terriaTheme } from "../../../lib/ReactViews/StandardUserInterface";
 
@@ -141,5 +143,54 @@ describe("DescriptionSpec", function () {
     const child: any = dataUrls[0].children[0];
 
     expect(child.props.children).toBe("some link");
+  });
+
+  it("respects hideDefaultDescription", function () {
+    const geoJsonItem = new GeoJsonCatalogItem("test-geojson", terria);
+    runInAction(() => {
+      geoJsonItem.setTrait(CommonStrata.definition, "description", "test");
+    });
+
+    act(() => {
+      testRenderer = create(
+        <ThemeProvider theme={terriaTheme}>
+          <Description item={geoJsonItem} />
+        </ThemeProvider>
+      );
+    });
+
+    const showDescription = testRenderer.root.findAll(
+      (node) => node.type === "p"
+    );
+
+    expect(showDescription.length).toEqual(1);
+    expect(showDescription[0].children[0]).toBe("test");
+
+    runInAction(() => {
+      geoJsonItem.setTrait(CommonStrata.definition, "description", "");
+    });
+
+    const showDefaultDescription = testRenderer.root.findAll(
+      (node) => node.type === "p"
+    );
+
+    expect(showDefaultDescription.length).toEqual(1);
+    expect(showDefaultDescription[0].children[0]).toBe(
+      "description.dataNotLocal"
+    );
+
+    runInAction(() => {
+      geoJsonItem.setTrait(
+        CommonStrata.definition,
+        "hideDefaultDescription",
+        true
+      );
+    });
+
+    const showNoDescription = testRenderer.root.findAll(
+      (node) => node.type === "p"
+    );
+
+    expect(showNoDescription.length).toEqual(0);
   });
 });


### PR DESCRIPTION
### Add `hideDefaultDescription` to `CatalogMemberTraits`

Fixes https://github.com/TerriaJS/terriajs/issues/6946

Add `hideDefaultDescription` to `CatalogMemberTraits` - if true, then no generic default description will be shown when `description` is empty.

### Test me

[Test link](http://ci.terria.io/hide-default-desc/#clean&start=%7B%22initSources%22%3A%20%5B%7B%22homeCamera%22%3A%20%7B%22north%22%3A%20-8%2C%22east%22%3A%20158%2C%22south%22%3A%20-45%2C%22west%22%3A%20109%7D%2C%22catalog%22%3A%20%5B%7B%22id%22%3A%20%22DL4Av6wY5h%22%2C%22type%22%3A%20%22geojson%22%2C%22name%22%3A%20%22No%20description%22%2C%22url%22%3A%20%22test%2Fbike_racks.geojson%22%7D%2C%7B%22id%22%3A%20%22D2L4Av6wY5h%22%2C%22type%22%3A%20%22geojson%22%2C%22hideDefaultDescription%22%3A%20true%2C%22name%22%3A%20%22No%20description%20-%20hideDefaultDescription%20%3D%20true%22%2C%22url%22%3A%20%22test%2Fbike_racks.geojson%22%7D%2C%7B%22id%22%3A%20%22D3L4Av6wY5h%22%2C%22type%22%3A%20%22geojson%22%2C%22name%22%3A%20%22Has%20description%22%2C%22url%22%3A%20%22test%2Fbike_racks.geojson%22%2C%22description%22%3A%20%22This%20is%20a%20description%22%7D%2C%7B%22id%22%3A%20%22D4L4Av6wY5h%22%2C%22type%22%3A%20%22geojson%22%2C%22hideDefaultDescription%22%3A%20true%2C%22name%22%3A%20%22Has%20description%20-%20hideDefaultDescription%20%3D%20true%22%2C%22url%22%3A%20%22test%2Fbike_racks.geojson%22%2C%22description%22%3A%20%22This%20is%20a%20description%22%7D%5D%2C%22viewerMode%22%3A%20%223dSmooth%22%2C%22baseMaps%22%3A%20%7B%22defaultBaseMapId%22%3A%20%22basemap-positron%22%2C%22previewBaseMapId%22%3A%20%22basemap-positron%22%7D%7D%5D%7D)

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] ~I've updated relevant documentation in `doc/`.~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
