### PR TITLE
Use cesium ion geocoder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
   - See [ASGS 2021](https://www.abs.gov.au/statistics/standards/australian-statistical-geography-standard-asgs-edition-3/jul2021-jun2026/access-and-downloads/digital-boundary-files)
 - Added [Melbourne CLUE blocks](https://data.melbourne.vic.gov.au/pages/clue/) to region mapping.
 - Fix WMS `GetMap`/`GetFeatureInfo` requests not having `styles` parameter (will use empty string instead of `undefined`)
-- [The next improvement]
+- Add CesiumIon geocoder
 
 #### 8.3.7 - 2023-10-26
 

--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -23,7 +23,7 @@ npm install -g yarn@^1.19.0
 
 # Clone and build TerriaMap, using this version of TerriaJS
 TERRIAJS_COMMIT_HASH=$(git rev-parse HEAD)
-git clone -b main https://github.com/TerriaJS/TerriaMap.git
+git clone -b use-cesium-ion-geocoder https://github.com/TerriaJS/TerriaMap.git
 cd TerriaMap
 TERRIAMAP_COMMIT_HASH=$(git rev-parse HEAD)
 sed -i -e 's@"terriajs": ".*"@"terriajs": "'$GITHUB_REPOSITORY'#'${GITHUB_BRANCH}'"@g' package.json

--- a/lib/Core/AnalyticEvents/analyticEvents.ts
+++ b/lib/Core/AnalyticEvents/analyticEvents.ts
@@ -16,7 +16,8 @@ export enum SearchAction {
   bing = "Bing",
   catalog = "Catalog",
   gazetteer = "Gazetteer",
-  nominatim = "nominatim"
+  nominatim = "nominatim",
+  cesium = "Cesium"
 }
 
 export enum LaunchAction {

--- a/lib/Core/loadJson.ts
+++ b/lib/Core/loadJson.ts
@@ -1,14 +1,14 @@
 import Resource from "terriajs-cesium/Source/Core/Resource";
 
-export default function loadJson(
+export default function loadJson<T = any>(
   urlOrResource: any,
   headers?: any,
   body?: any,
   asForm: boolean = false
-): Promise<any> {
+): Promise<T> {
   let responseType: XMLHttpRequestResponseType = "json";
 
-  let jsonPromise: Promise<any>;
+  let jsonPromise: Promise<T>;
   let params: any = {
     url: urlOrResource,
     headers: headers

--- a/lib/Models/SearchProviders/CesiumIonSearchProvider.ts
+++ b/lib/Models/SearchProviders/CesiumIonSearchProvider.ts
@@ -7,11 +7,7 @@ import Scene from "terriajs-cesium/Source/Scene/Scene";
 import SearchProviderResults from "./SearchProviderResults";
 import SearchResult from "./SearchResult";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
-import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
-import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
-import GeocoderService from "terriajs-cesium/Source/Core/GeocoderService";
 import loadJson from "../../Core/loadJson";
-import bbox from "@turf/bbox";
 interface CesiumIonSearchProviderOptions {
   terria: Terria;
   url?: string;

--- a/lib/Models/SearchProviders/CesiumIonSearchProvider.ts
+++ b/lib/Models/SearchProviders/CesiumIonSearchProvider.ts
@@ -1,0 +1,98 @@
+import Cesium from "../Cesium";
+import SearchProvider from "./SearchProvider";
+import { observable, makeObservable } from "mobx";
+import Terria from "../Terria";
+import { defaultValue } from "terriajs-cesium";
+import Scene from "terriajs-cesium/Source/Scene/Scene";
+import SearchProviderResults from "./SearchProviderResults";
+import SearchResult from "./SearchResult";
+import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
+import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
+import GeocoderService from "terriajs-cesium/Source/Core/GeocoderService";
+import loadJson from "../../Core/loadJson";
+import bbox from "@turf/bbox";
+interface CesiumIonSearchProviderOptions {
+  terria: Terria;
+  url?: string;
+  key?: string;
+  flightDurationSeconds?: number;
+  primaryCountry?: string;
+  culture?: string;
+}
+
+interface CesiumIonGeocodeResultFeature {
+  bbox: [number, number, number, number];
+  properties: { label: string };
+}
+
+interface CesiumIonGeocodeResult {
+  features: CesiumIonGeocodeResultFeature[];
+}
+
+export default class CesiumIonSearchProvider extends SearchProvider {
+  readonly terria: Terria;
+  @observable key: string | undefined;
+  @observable flightDurationSeconds: number;
+  @observable url: string;
+
+  constructor(options: CesiumIonSearchProviderOptions) {
+    super();
+
+    makeObservable(this);
+
+    this.terria = options.terria;
+    this.url = defaultValue(
+      options.url,
+      "https://api.cesium.com/v1/geocode/search"
+    );
+    this.key = options.key;
+    this.flightDurationSeconds = defaultValue(
+      options.flightDurationSeconds,
+      1.5
+    );
+  }
+
+  protected async doSearch(
+    searchText: string,
+    results: SearchProviderResults
+  ): Promise<void> {
+    if (searchText === undefined || /^\s*$/.test(searchText)) {
+      return Promise.resolve();
+    }
+
+    const response = await loadJson<CesiumIonGeocodeResult>(
+      `${this.url}?text=${searchText}&access_token=${this.key}`
+    );
+
+    if (!response.features) {
+      return;
+    }
+
+    results.results.push(
+      ...response.features.map<SearchResult>((feature) => {
+        const [w, s, e, n] = feature.bbox;
+        const rectangle = Rectangle.fromDegrees(w, s, e, n);
+
+        return new SearchResult({
+          name: feature.properties.label,
+          clickAction: createZoomToFunction(this, rectangle),
+          location: {
+            latitude: (s + n) / 2,
+            longitude: (e + w) / 2
+          }
+        });
+      })
+    );
+  }
+}
+
+function createZoomToFunction(
+  model: CesiumIonSearchProvider,
+  rectangle: Rectangle
+) {
+  return function () {
+    const terria = model.terria;
+    terria.currentViewer.zoomTo(rectangle, model.flightDurationSeconds);
+  };
+}

--- a/lib/Models/SearchProviders/CesiumIonSearchProvider.ts
+++ b/lib/Models/SearchProviders/CesiumIonSearchProvider.ts
@@ -1,9 +1,7 @@
-import Cesium from "../Cesium";
 import SearchProvider from "./SearchProvider";
 import { observable, makeObservable } from "mobx";
 import Terria from "../Terria";
-import { defaultValue } from "terriajs-cesium";
-import Scene from "terriajs-cesium/Source/Scene/Scene";
+import defaultValue from "terriajs-cesium/Source/Core/defaultValue";
 import SearchProviderResults from "./SearchProviderResults";
 import SearchResult from "./SearchResult";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";

--- a/test/Models/SearchProviders/CesiumIonSearchProviderSpec.ts
+++ b/test/Models/SearchProviders/CesiumIonSearchProviderSpec.ts
@@ -1,0 +1,59 @@
+import CesiumIonSearchProvider from "../../../lib/Models/SearchProviders/CesiumIonSearchProvider";
+import Terria from "../../../lib/Models//Terria";
+import * as loadJson from "../../../lib/Core/loadJson";
+
+const fixture = {
+  features: [
+    {
+      properties: {
+        label: "West End, Australia"
+      },
+      bbox: [
+        152.99620056152344, -27.490509033203125, 153.0145721435547,
+        -27.474090576171875
+      ]
+    }
+  ]
+};
+
+describe("CesiumIonSearchProvider", () => {
+  const searchProvider = new CesiumIonSearchProvider({
+    key: "testkey",
+    url: "api.test.com",
+    terria: {
+      currentViewer: {
+        zoomTo: () => {}
+      }
+    } as unknown as Terria
+  });
+  it("Handles valid results", async () => {
+    spyOn(loadJson, "default").and.returnValue(
+      new Promise((resolve) => resolve(fixture))
+    );
+
+    const result = await searchProvider.search("test");
+    expect(loadJson.default).toHaveBeenCalledWith(
+      "api.test.com?text=test&access_token=testkey"
+    );
+    expect(result.results.length).toBe(1);
+    expect(result.results[0].name).toBe("West End, Australia");
+    expect(result.results[0].location?.latitude).toBe(-27.4822998046875);
+  });
+
+  it("Handles empty result", async () => {
+    spyOn(loadJson, "default").and.returnValue(
+      new Promise((resolve) => resolve([]))
+    );
+    const result = await searchProvider.search("test");
+    console.log(result);
+    expect(result.results.length).toBe(0);
+    expect(result.message).toBe("viewModels.searchNoLocations");
+  });
+
+  it("Handles error", async () => {
+    spyOn(loadJson, "default").and.throwError("error");
+    const result = await searchProvider.search("test");
+    expect(result.results.length).toBe(0);
+    expect(result.message).toBe("viewModels.searchErrorOccurred");
+  });
+});


### PR DESCRIPTION
### What this PR does

Fixes #5107

Implement CesiumIonGeocoder which calls: https://api.cesium.com/v1/geocode/search

### Test me

Visit http://ci.terria.io/use-cesium-ion-geocoder search for an address

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.

### Issues
- Each result only has a `label` property which doesn't include the state, country, or any other metadata
```
            "properties": {
                "label": "Annerley, Australia"
            },
            "bbox": [
                153.0238800048828,
                -27.525028228759766,
                153.04367065429688,
                -27.50009536743164
            ]
```
This makes it hard to differentiate the locations with the same name, for example searching "Annerley" returns two results with "Annerley, Australia". The same problem can be observed in Cesium itself: https://sandcastle.cesium.com/standalone.html#c=bY9Pa8MwDMW/ivGpgyGx6+qGQq+FHQY7+eI6Wmuq2MFSUtJPvyS9jK26vaf3059YsqgZE92omp3JdDMHkjR08LV6G2/jqg8la0iZqrcvW5/tq3WiE1Pjs1lrn7q+VDVD5Q0AKnU9ByXB0xCvpBBFFnCJOvyNujaNJrW7J5tM5CAyd74H5s90J28bh3P+H8oltCmfP0aqHKYldnlrjg8TABzO8jmppfAp1D+T5/8uqr28I0rIbQyiTPA4EGLp8ByYqU74Aw
