### PR TITLE
Fix maximum call stack size exceeded on Math.min/max when creating Charts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.3.8)
 
 - [The next improvement]
+- Fix maximum call stack size exceeded on Math.min/max when creating Charts
 - Remove `jsx-control-statements` dependency
 
 #### 8.3.7 - 2023-10-26

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - [The next improvement]
 - Fix maximum call stack size exceeded on Math.min/max when creating Charts
+- Fix boolean flag in `MyDataTab` displaying number
 - Remove `jsx-control-statements` dependency
 
 #### 8.3.7 - 2023-10-26

--- a/lib/Core/math.ts
+++ b/lib/Core/math.ts
@@ -1,0 +1,23 @@
+export function getMax(nums: number[]) {
+  let len = nums.length;
+  if (len === 0) return undefined;
+
+  let max = -Infinity;
+
+  while (len--) {
+    max = nums[len] > max ? nums[len] : max;
+  }
+  return max;
+}
+
+export function getMin(nums: number[]) {
+  let len = nums.length;
+  if (len === 0) return undefined;
+
+  let min = Infinity;
+
+  while (len--) {
+    min = nums[len] < min ? nums[len] : min;
+  }
+  return min;
+}

--- a/lib/ModelMixins/ChartableMixin.ts
+++ b/lib/ModelMixins/ChartableMixin.ts
@@ -1,6 +1,7 @@
 import { maxBy, minBy } from "lodash-es";
 import AbstractConstructor from "../Core/AbstractConstructor";
 import LatLonHeight from "../Core/LatLonHeight";
+import { getMax, getMin } from "../Core/math";
 import Model from "../Models/Definition/Model";
 import { GlyphStyle } from "../ReactViews/Custom/Chart/Glyphs";
 import ModelTraits from "../Traits/ModelTraits";
@@ -23,7 +24,7 @@ export function calculateDomain(points: ChartPoint[]): ChartDomain {
   const asNum = (x: Date | number) => (x instanceof Date ? x.getTime() : x);
   return {
     x: [minBy(xs, asNum) || 0, maxBy(xs, asNum) || 0],
-    y: [Math.min(...ys), Math.max(...ys)]
+    y: [getMin(ys) ?? 0, getMax(ys) ?? 0]
   };
 }
 

--- a/lib/ModelMixins/ChartableMixin.ts
+++ b/lib/ModelMixins/ChartableMixin.ts
@@ -23,7 +23,7 @@ export function calculateDomain(points: ChartPoint[]): ChartDomain {
   const ys = points.map((p) => p.y);
   const asNum = (x: Date | number) => (x instanceof Date ? x.getTime() : x);
   return {
-    x: [minBy(xs, asNum) || 0, maxBy(xs, asNum) || 0],
+    x: [minBy(xs, asNum) ?? 0, maxBy(xs, asNum) ?? 0],
     y: [getMin(ys) ?? 0, getMax(ys) ?? 0]
   };
 }

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -123,7 +123,7 @@ class MyDataTab extends React.Component {
   }
 
   render() {
-    const showTwoColumn = !!(this.hasUserAddedData() & !this.state.activeTab);
+    const showTwoColumn = !!(this.hasUserAddedData() && !this.state.activeTab);
     const { t, className } = this.props;
     return (
       <Box

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -123,7 +123,7 @@ class MyDataTab extends React.Component {
   }
 
   render() {
-    const showTwoColumn = this.hasUserAddedData() & !this.state.activeTab;
+    const showTwoColumn = !!(this.hasUserAddedData() & !this.state.activeTab);
     const { t, className } = this.props;
     return (
       <Box


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs/issues/6941

I also sneaked in a fix for `MyDataTab` showing a number.

<img width="887" alt="image" src="https://github.com/TerriaJS/terriajs/assets/6187649/104492a4-522a-43e0-8cd2-f261884cbcad">


### Test me

Make sure you test in Chrome (Firefox never had this issue)

- [Before link](http://ci.terria.io/main/#configUrl=https://terria-catalogs-public.storage.googleapis.com/nationalmap/config/prod.json&start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22ZntTIvdp%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22DPYjz1cT%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22ZntTIvdp%22%5D%2C%22type%22%3A%22sdmx-group%22%7D%2C%22DPYjz1cT%2Fdataflow-BA_SA2%22%3A%7B%22isOpenInWorkbench%22%3Atrue%2C%22currentTime%22%3A%222023-03-01T00%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%222016-07-01T00%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222023-07-01T00%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A1299049.4176470588%2C%22isPaused%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-BUILDING_CONSTRUCTION%22%5D%2C%22type%22%3A%22sdmx-json%22%7D%2C%22DPYjz1cT%2Fdataflow-BUILDING_ACTIVITY%22%3A%7B%22isOpenInWorkbench%22%3Afalse%2C%22show%22%3Afalse%2C%22currentTime%22%3A%222023-03-01T00%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%221980-06-30T14%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222022-12-31T13%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A3921842.1578947366%2C%22isPaused%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-BUILDING_CONSTRUCTION%22%5D%2C%22type%22%3A%22sdmx-json%22%7D%2C%22DPYjz1cT%2Fdataflow-CWD%22%3A%7B%22isOpenInWorkbench%22%3Afalse%2C%22show%22%3Afalse%2C%22currentTime%22%3A%222022-12-31T13%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%221986-06-30T14%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222023-03-31T13%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A3918052.75%2C%22isPaused%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-BUILDING_CONSTRUCTION%22%5D%2C%22type%22%3A%22sdmx-json%22%7D%2C%22DPYjz1cT%2Fcategory-BUILDING_CONSTRUCTION%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2FcategoryScheme-INDUSTRY%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2FcategoryScheme-INDUSTRY%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%22%5D%2C%22type%22%3A%22group%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%2C%22Root+Group%2FNational+Data+Sets%22%3A%7B%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%22DPYjz1cT%2Fdataflow-BUILDING_ACTIVITY%22%2C%22DPYjz1cT%2Fdataflow-CWD%22%2C%22DPYjz1cT%2Fdataflow-BA_SA2%22%5D%2C%22timeline%22%3A%5B%22DPYjz1cT%2Fdataflow-BUILDING_ACTIVITY%22%2C%22DPYjz1cT%2Fdataflow-BA_SA2%22%5D%2C%22initialCamera%22%3A%7B%22west%22%3A144.23766092103352%2C%22south%22%3A-38.62318301158599%2C%22east%22%3A145.78797496812277%2C%22north%22%3A-36.97394756963962%2C%22position%22%3A%7B%22x%22%3A-4236664.753668559%2C%22y%22%3A2965132.3109916416%2C%22z%22%3A-3985220.617409384%7D%2C%22direction%22%3A%7B%22x%22%3A0.6471824166189727%2C%22y%22%3A-0.45294626934097404%2C%22z%22%3A0.6131839827566603%7D%2C%22up%22%3A%7B%22x%22%3A-0.5023695828733156%2C%22y%22%3A0.3515955046825979%2C%22z%22%3A0.7899401263960961%7D%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%223d%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.5%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Afalse%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-bing-aerial%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22pickedFeatures%22%3A%7B%22providerCoords%22%3A%7B%22https%3A%2F%2Ftiles.terria.io%2FSA2_2021%2F%7Bz%7D%2F%7Bx%7D%2F%7By%7D.pbf%22%3A%7B%22x%22%3A923%2C%22y%22%3A627%2C%22level%22%3A10%7D%2C%22%2F%2Fdev.virtualearth.net%2F%22%3A%7B%22x%22%3A923%2C%22y%22%3A627%2C%22level%22%3A9%7D%7D%2C%22pickCoords%22%3A%7B%22lat%22%3A-37.69515389589726%2C%22lng%22%3A144.71644694058014%2C%22height%22%3A-0.19902188122299014%7D%2C%22current%22%3A%7B%22name%22%3A%22Fraser+Rise+-+Plumpton%22%2C%22hash%22%3A31240350743%7D%2C%22entities%22%3A%5B%5D%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)
- [After link](http://ci.terria.io/minmax-exceed-stack/#configUrl=https://terria-catalogs-public.storage.googleapis.com/nationalmap/config/prod.json&start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22models%22%3A%7B%22ZntTIvdp%22%3A%7B%22dereferenced%22%3A%7B%22isOpen%22%3Atrue%7D%2C%22knownContainerUniqueIds%22%3A%5B%22Root+Group%2FNational+Data+Sets%22%5D%2C%22type%22%3A%22terria-reference%22%7D%2C%22DPYjz1cT%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22ZntTIvdp%22%5D%2C%22type%22%3A%22sdmx-group%22%7D%2C%22DPYjz1cT%2Fdataflow-BA_SA2%22%3A%7B%22isOpenInWorkbench%22%3Atrue%2C%22currentTime%22%3A%222023-03-01T00%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%222016-07-01T00%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222023-07-01T00%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A1299049.4176470588%2C%22isPaused%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-BUILDING_CONSTRUCTION%22%5D%2C%22type%22%3A%22sdmx-json%22%7D%2C%22DPYjz1cT%2Fdataflow-BUILDING_ACTIVITY%22%3A%7B%22isOpenInWorkbench%22%3Afalse%2C%22show%22%3Afalse%2C%22currentTime%22%3A%222023-03-01T00%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%221980-06-30T14%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222022-12-31T13%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A3921842.1578947366%2C%22isPaused%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-BUILDING_CONSTRUCTION%22%5D%2C%22type%22%3A%22sdmx-json%22%7D%2C%22DPYjz1cT%2Fdataflow-CWD%22%3A%7B%22isOpenInWorkbench%22%3Afalse%2C%22show%22%3Afalse%2C%22currentTime%22%3A%222022-12-31T13%3A00%3A00.000000000Z%22%2C%22startTime%22%3A%221986-06-30T14%3A00%3A00.000000000Z%22%2C%22stopTime%22%3A%222023-03-31T13%3A00%3A00.000000000Z%22%2C%22multiplier%22%3A3918052.75%2C%22isPaused%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2Fcategory-BUILDING_CONSTRUCTION%22%5D%2C%22type%22%3A%22sdmx-json%22%7D%2C%22DPYjz1cT%2Fcategory-BUILDING_CONSTRUCTION%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%2FcategoryScheme-INDUSTRY%22%5D%2C%22type%22%3A%22group%22%7D%2C%22DPYjz1cT%2FcategoryScheme-INDUSTRY%22%3A%7B%22isOpen%22%3Atrue%2C%22knownContainerUniqueIds%22%3A%5B%22DPYjz1cT%22%5D%2C%22type%22%3A%22group%22%7D%2C%22%2F%22%3A%7B%22type%22%3A%22group%22%7D%2C%22Root+Group%2FNational+Data+Sets%22%3A%7B%22knownContainerUniqueIds%22%3A%5B%22%2F%22%5D%2C%22type%22%3A%22group%22%7D%7D%2C%22workbench%22%3A%5B%22DPYjz1cT%2Fdataflow-BUILDING_ACTIVITY%22%2C%22DPYjz1cT%2Fdataflow-CWD%22%2C%22DPYjz1cT%2Fdataflow-BA_SA2%22%5D%2C%22timeline%22%3A%5B%22DPYjz1cT%2Fdataflow-BUILDING_ACTIVITY%22%2C%22DPYjz1cT%2Fdataflow-BA_SA2%22%5D%2C%22initialCamera%22%3A%7B%22west%22%3A144.23766092103352%2C%22south%22%3A-38.62318301158599%2C%22east%22%3A145.78797496812277%2C%22north%22%3A-36.97394756963962%2C%22position%22%3A%7B%22x%22%3A-4236664.753668559%2C%22y%22%3A2965132.3109916416%2C%22z%22%3A-3985220.617409384%7D%2C%22direction%22%3A%7B%22x%22%3A0.6471824166189727%2C%22y%22%3A-0.45294626934097404%2C%22z%22%3A0.6131839827566603%7D%2C%22up%22%3A%7B%22x%22%3A-0.5023695828733156%2C%22y%22%3A0.3515955046825979%2C%22z%22%3A0.7899401263960961%7D%7D%2C%22homeCamera%22%3A%7B%22west%22%3A109%2C%22south%22%3A-45%2C%22east%22%3A158%2C%22north%22%3A-8%7D%2C%22viewerMode%22%3A%223d%22%2C%22showSplitter%22%3Afalse%2C%22splitPosition%22%3A0.5%2C%22settings%22%3A%7B%22baseMaximumScreenSpaceError%22%3A2%2C%22useNativeResolution%22%3Afalse%2C%22alwaysShowTimeline%22%3Afalse%2C%22baseMapId%22%3A%22basemap-bing-aerial%22%2C%22terrainSplitDirection%22%3A0%2C%22depthTestAgainstTerrainEnabled%22%3Afalse%7D%2C%22pickedFeatures%22%3A%7B%22providerCoords%22%3A%7B%22https%3A%2F%2Ftiles.terria.io%2FSA2_2021%2F%7Bz%7D%2F%7Bx%7D%2F%7By%7D.pbf%22%3A%7B%22x%22%3A923%2C%22y%22%3A627%2C%22level%22%3A10%7D%2C%22%2F%2Fdev.virtualearth.net%2F%22%3A%7B%22x%22%3A923%2C%22y%22%3A627%2C%22level%22%3A9%7D%7D%2C%22pickCoords%22%3A%7B%22lat%22%3A-37.69515389589726%2C%22lng%22%3A144.71644694058014%2C%22height%22%3A-0.19902188122299014%7D%2C%22current%22%3A%7B%22name%22%3A%22Fraser+Rise+-+Plumpton%22%2C%22hash%22%3A31240350743%7D%2C%22entities%22%3A%5B%5D%7D%2C%22stories%22%3A%5B%5D%7D%5D%7D)
- Select "Region Type" = "Statistical Area Level 4"
- Select "Region Type" = "Statistical Area Level 2"
- Select "Region Type" = "Statistical Area Level 4" again
- It doesn't crash now
- Also go to "Upload" and see if there are "0"s on the screen

### Checklist

- [x] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
- [ ] ~I've updated relevant documentation in `doc/`.~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
