### PR TITLE
`CatalogGroup` will now not show members until loaded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
   - See [ASGS 2021](https://www.abs.gov.au/statistics/standards/australian-statistical-geography-standard-asgs-edition-3/jul2021-jun2026/access-and-downloads/digital-boundary-files)
 - Added [Melbourne CLUE blocks](https://data.melbourne.vic.gov.au/pages/clue/) to region mapping.
 - Fix WMS `GetMap`/`GetFeatureInfo` requests not having `styles` parameter (will use empty string instead of `undefined`)
+- `CatalogGroup` will now not show members until loaded
 - [The next improvement]
 
 #### 8.3.7 - 2023-10-26

--- a/lib/ReactViews/DataCatalog/CatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/CatalogGroup.jsx
@@ -138,7 +138,7 @@ function CatalogGroup(props) {
             </li>
           )}
 
-          {props.children}
+          {!props.loading ? props.children : null}
         </ul>
       )}
     </li>

--- a/test/ReactViews/DataCatalog/CatalogGroupSpec.tsx
+++ b/test/ReactViews/DataCatalog/CatalogGroupSpec.tsx
@@ -27,6 +27,32 @@ describe("CatalogGroup", () => {
         0
       );
     });
+    it("Doesn't show children when loading", () => {
+      const TestChild = () => <span>some child</span>;
+      act(() => {
+        testRenderer = create(
+          <ThemeProvider theme={terriaTheme}>
+            <CatalogGroup open={true} t={() => {}} loading={true}>
+              <TestChild />
+            </CatalogGroup>
+          </ThemeProvider>
+        );
+      });
+      expect(testRenderer.root.findAllByType(TestChild).length).toEqual(0);
+    });
+    it("Shows children when not loading", () => {
+      const TestChild = () => <span>some child</span>;
+      act(() => {
+        testRenderer = create(
+          <ThemeProvider theme={terriaTheme}>
+            <CatalogGroup open={true} t={() => {}} loading={false}>
+              <TestChild />
+            </CatalogGroup>
+          </ThemeProvider>
+        );
+      });
+      expect(testRenderer.root.findAllByType(TestChild).length).toEqual(1);
+    });
   });
   describe("Empty", () => {
     it("Shows empty message", () => {


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs/issues/6867

### Test me

- [Before link](http://ci.terria.io/main/#clean&start=%7B%22version%22%3A%20%228.0.0%22%2C%22initSources%22%3A%20%5B%7B%22homeCamera%22%3A%20%7B%22north%22%3A%20-8%2C%22east%22%3A%20158%2C%22south%22%3A%20-45%2C%22west%22%3A%20109%7D%2C%22catalog%22%3A%20%5B%7B%22type%22%3A%20%22wms-group%22%2C%22name%22%3A%20%22gsky%20ows%20geoglam%22%2C%22url%22%3A%20%22https%3A%2F%2Fgsky.nci.org.au%2Fows%2Fgeoglam%22%2C%22members%22%3A%20%5B%7B%22type%22%3A%20%22wms%22%2C%22name%22%3A%20%22Some%20manually%20defined%20member%22%2C%22url%22%3A%20%22https%3A%2F%2Fgsky.nci.org.au%2Fows%2Fgeoglam%22%7D%5D%7D%5D%2C%22viewerMode%22%3A%20%223dSmooth%22%2C%22baseMaps%22%3A%20%7B%22defaultBaseMapId%22%3A%20%22basemap-positron%22%2C%22previewBaseMapId%22%3A%20%22basemap-positron%22%7D%7D%5D%7D)
- [After link](http://ci.terria.io/catalog-group-hide-isloading/#clean&start=%7B%22version%22%3A%20%228.0.0%22%2C%22initSources%22%3A%20%5B%7B%22homeCamera%22%3A%20%7B%22north%22%3A%20-8%2C%22east%22%3A%20158%2C%22south%22%3A%20-45%2C%22west%22%3A%20109%7D%2C%22catalog%22%3A%20%5B%7B%22type%22%3A%20%22wms-group%22%2C%22name%22%3A%20%22gsky%20ows%20geoglam%22%2C%22url%22%3A%20%22https%3A%2F%2Fgsky.nci.org.au%2Fows%2Fgeoglam%22%2C%22members%22%3A%20%5B%7B%22type%22%3A%20%22wms%22%2C%22name%22%3A%20%22Some%20manually%20defined%20member%22%2C%22url%22%3A%20%22https%3A%2F%2Fgsky.nci.org.au%2Fows%2Fgeoglam%22%7D%5D%7D%5D%2C%22viewerMode%22%3A%20%223dSmooth%22%2C%22baseMaps%22%3A%20%7B%22defaultBaseMapId%22%3A%20%22basemap-positron%22%2C%22previewBaseMapId%22%3A%20%22basemap-positron%22%7D%7D%5D%7D)
- Notice that in before link - you will see an item before group has finished loading

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] ~I've updated relevant documentation in `doc/`.~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
