### PR TITLE
Make lock icon black

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 #### next release (8.3.9)
 
-- Make all icons in `CatalogGroup` black by default and white when a catalog group is focused, selected or hovered over. Also adjust lock icon position in workbench.
+- Make all icons in `CatalogGroup` black by default and white when a catalog group is focused, selected or hovered over. Improve lock icon position in workbench.
 - [The next improvement]
 
 #### 8.3.8 - 2023-11-15

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.3.9)
 
+- Make all icons in `CatalogGroup` black by default and white when a catalog group is focused, selected or hovered over.
 - [The next improvement]
 
 #### 8.3.8 - 2023-11-15

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 #### next release (8.3.9)
 
-- Make all icons in `CatalogGroup` black by default and white when a catalog group is focused, selected or hovered over.
+- Make all icons in `CatalogGroup` black by default and white when a catalog group is focused, selected or hovered over. Also adjust lock icon position in workbench.
 - [The next improvement]
 
 #### 8.3.8 - 2023-11-15

--- a/lib/ModelMixins/AccessControlMixin.ts
+++ b/lib/ModelMixins/AccessControlMixin.ts
@@ -60,7 +60,7 @@ function AccessControlMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
       }
 
       // Default
-      return "public--";
+      return "public";
     }
 
     @action

--- a/lib/ModelMixins/AccessControlMixin.ts
+++ b/lib/ModelMixins/AccessControlMixin.ts
@@ -60,7 +60,7 @@ function AccessControlMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
       }
 
       // Default
-      return "public";
+      return "public--";
     }
 
     @action

--- a/lib/ReactViews/DataCatalog/CatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/CatalogGroup.jsx
@@ -17,12 +17,18 @@ const CatalogGroupButton = styled.button`
     &:focus {
       color: ${props.theme.textLight};
       background-color: ${props.theme.modalHighlight};
+      svg {
+        fill: white;
+      }
     }
     ${
       props.active &&
       `
         color: ${props.theme.textLight};
         background-color: ${props.theme.modalHighlight};
+        svg {
+          fill: white;
+        }
       `
     }
     `}

--- a/lib/ReactViews/PrivateIndicator/PrivateIndicator.jsx
+++ b/lib/ReactViews/PrivateIndicator/PrivateIndicator.jsx
@@ -25,7 +25,7 @@ export default function PrivateIndicator(props) {
           width: 15px;
           height: 15px;
           fill: ${(p) =>
-            p.inWorkbench ? p.theme.textLight : p.theme.colorPrimary};
+            p.inWorkbench ? p.theme.textLight : p.theme.charcoalGrey};
         }
       `}
     >

--- a/lib/ReactViews/PrivateIndicator/PrivateIndicator.jsx
+++ b/lib/ReactViews/PrivateIndicator/PrivateIndicator.jsx
@@ -19,14 +19,6 @@ export default function PrivateIndicator(props) {
       inWorkbench={props.inWorkbench}
       css={`
         margin-top: -1px;
-        ${(p) =>
-          p.inWorkbench &&
-          `
-          position: absolute;
-          margin-right: 2px;
-          right: 20px;
-        `}
-
         svg {
           width: 15px;
           height: 15px;

--- a/lib/ReactViews/PrivateIndicator/PrivateIndicator.jsx
+++ b/lib/ReactViews/PrivateIndicator/PrivateIndicator.jsx
@@ -19,7 +19,13 @@ export default function PrivateIndicator(props) {
       inWorkbench={props.inWorkbench}
       css={`
         margin-top: -1px;
-        ${(p) => p.inWorkbench && `margin-right: 2px;`}
+        ${(p) =>
+          p.inWorkbench &&
+          `
+          position: absolute;
+          margin-right: 2px;
+          right: 20px;
+        `}
 
         svg {
           width: 15px;

--- a/lib/ReactViews/Workbench/WorkbenchItem.tsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.tsx
@@ -149,12 +149,12 @@ class WorkbenchItemRaw extends React.Component<IProps> {
           </Box>
           {CatalogMemberMixin.isMixedInto(item) ? (
             <Box centered paddedHorizontally>
+              {item.isPrivate && (
+                <BoxSpan paddedHorizontally>
+                  <PrivateIndicator inWorkbench />
+                </BoxSpan>
+              )}
               <RawButton onClick={() => this.toggleDisplay()}>
-                {item.isPrivate && (
-                  <BoxSpan paddedHorizontally>
-                    <PrivateIndicator inWorkbench />
-                  </BoxSpan>
-                )}
                 <BoxSpan padded>
                   {this.isOpen ? (
                     <StyledIcon


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/eap-digital-twin/issues/44
See description in this [PR](https://github.com/TerriaJS/eap-digital-twin/pull/172) that will be replaced by this PR.

Two issues on `Add all group members` icon are unresolved.
- The icon always remains black.
- The icon overlaps with lock icon.

To see the problems, go to [here](http://ci.terria.io/make-lock-icon-black/#clean&https://gist.githubusercontent.com/mwu2018/bca0baa40885fec33a2d5c97300260c6/raw/b68a07e5d659fe58e132670e0cb6a66ec261b900/test-exclusions.json) then navigate to `natmap->National Datasets->Communications->NBN Technology Types`.

Need a new ticket.

### Test me
[Before](http://ci.terria.io/main/#clean&https://gist.githubusercontent.com/mwu2018/bca0baa40885fec33a2d5c97300260c6/raw/b68a07e5d659fe58e132670e0cb6a66ec261b900/test-exclusions.json).
[After](http://ci.terria.io/make-lock-icon-black/#clean&https://gist.githubusercontent.com/mwu2018/bca0baa40885fec33a2d5c97300260c6/raw/b68a07e5d659fe58e132670e0cb6a66ec261b900/test-exclusions.json).

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
