### PR TITLE
Restore ci-deploy.sh to use main branch of TerriaMap when building

### DIFF
--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -23,7 +23,7 @@ npm install -g yarn@^1.19.0
 
 # Clone and build TerriaMap, using this version of TerriaJS
 TERRIAJS_COMMIT_HASH=$(git rev-parse HEAD)
-git clone -b use-cesium-ion-geocoder https://github.com/TerriaJS/TerriaMap.git
+git clone -b main https://github.com/TerriaJS/TerriaMap.git
 cd TerriaMap
 TERRIAMAP_COMMIT_HASH=$(git rev-parse HEAD)
 sed -i -e 's@"terriajs": ".*"@"terriajs": "'$GITHUB_REPOSITORY'#'${GITHUB_BRANCH}'"@g' package.json


### PR DESCRIPTION
/### What this PR does

Fixes TerriaMap deployed using different branch (this was changed to be able to deploy the cesiumIon geocoder branch)

### Test me
Deployment runs

### Checklist

- ~[ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
- ~[ ] I've updated relevant documentation in `doc/`.~
- ~[ ] I've updated CHANGES.md with what I changed.~
- [x] I've provided instructions in the PR description on how to test this PR.
