### PR TITLE
update readme node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Sites we're aware of that are using TerriaJS. These are not endorsements or test
 
 ### Technical
 
-- NodeJS v14 or v16 are supported
+- NodeJS v16, v18 and v20 are supported
+  - **Note** for v18+ you will need to set `NODE_OPTIONS=--openssl-legacy-provider` in your environment.
 - Built in TypeScript & ES2020+ JavaScript, compiled with Babel to ES5.
 - Supports modern browsers (recent versions of Microsoft Edge, Mozilla Firefox & Google Chrome).
 - [TerriaJS Server component](https://github.com/TerriajS/TerriaJS-Server) runs in NodeJS and provides proxying for web services that don't support CORS or require authentication. Instead of using TerriaJS-Sever proxy service, an alternative proxying service URL can be specified. See [Specify an alternative proxy server URL](/doc/connecting-to-data/cross-origin-resource-sharing.md)

--- a/doc/contributing/problems-and-solutions.md
+++ b/doc/contributing/problems-and-solutions.md
@@ -79,3 +79,15 @@ Then run the following to install NodeJS v16 and use it:
 nvm install 16
 nvm use 16
 ```
+
+### Problem
+
+When building TerriaMap/TerriaJS I see the following error
+
+```
+Error: error:0308010C:digital envelope routines::unsupported
+```
+
+### Solution
+
+For NodeJS versions 18 and above you will need to set `NODE_OPTIONS=--openssl-legacy-provider` in your environment.

--- a/doc/customizing/cloning-and-building.md
+++ b/doc/customizing/cloning-and-building.md
@@ -22,6 +22,7 @@ TerriaJS can be built and run on almost any macOS, Linux, or Windows system. The
 
 -   The Bash command shell. On macOS or Linux you almost certainly already have this. On Windows, you can easily get it by installing [Git for Windows](https://gitforwindows.org/). In the instructions below, we assume you're using a Bash command prompt.
 -   [Node.js](https://nodejs.org) v16.0. You can check your node version by running `node --version` on the command-line.
+    -   **Note** you can also use Node.js 18 and 20, but you will need to set `NODE_OPTIONS=--openssl-legacy-provider` in your environment.
 -   [npm](https://www.npmjs.com/) v8.0. npm is usually installed automatically alongside the above. You can check your npm version by running `npm --version`.
 -   [yarn](https://yarnpkg.com/) v1.19.0 or later. This can be installed using `npm install -g yarn@^1.19.0`
 


### PR DESCRIPTION
We now no longer support NodeJS 14 - and we have added support for 18 and 20.

I have updated docs to reflect this