### PR TITLE
Fix mouse capture bug that affects pedestrian mode.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.4.1)
 
+- Fix a bug where `DragPoints` was interfering with pedstrian mode mouse movements.
 - [The next improvement]
 
 #### 8.4.0 - 2023-12-01

--- a/lib/Map/DragPoints/DragPoints.js
+++ b/lib/Map/DragPoints/DragPoints.js
@@ -44,6 +44,13 @@ DragPoints.prototype.setUp = function () {
 };
 
 /**
+ * Destroy drag points helper. The instance becomes unusable after calling destroy.
+ */
+DragPoints.prototype.destroy = function () {
+  this._dragPointsHelper.destroy();
+};
+
+/**
  * The drag count is an indication of how long the user dragged for. If it's really small, perhaps the user clicked,
  * but a mousedown/mousemove/mouseup event trio was triggered anyway. It solves a problem where in leaflet the click
  * event triggers even if the point has been dragged because it lets us determine whether the point was really dragged.


### PR DESCRIPTION
### What this PR does

Fixes #6935 

[This PR](https://github.com/TerriaJS/terriajs/pull/6841) fixed the broken interaction for dragging points drawn on the map by making `DragPoints.js` work in v8. But the way `MeasureTool`, `UserDrawing` and `DragPoints` work, it always captures the mouse down and mouse up events even when the `MeasureTool` is not active.

This PR fixes the mouse capture problem by making sure `DragPoints` is activated only when a `UserDrawing` is activated.

### Test me

- Follow the steps in the [issue](https://github.com/TerriaJS/terriajs/issues/6935) to reproduce the error in [main](http://ci.terria.io/main/#share=s-dIDM45olteiauOppxXnsY9mTG7C&clean&https://gist.githubusercontent.com/na9da/737c818d6ca2ee0d22147181ae6eba0c/raw/9bd838001fd5820e65791a8e0892d29fa6005f92/melb-central-ion.json).
- The main thing you are looking for is the camera jumping around a bit instead of smoothly animating when you press down the mouse and drag it around.
- Make sure it is fixed in the [PR branch](http://ci.terria.io/fix-pedestrian/#share=s-dIDM45olteiauOppxXnsY9mTG7C&clean&https://gist.githubusercontent.com/na9da/737c818d6ca2ee0d22147181ae6eba0c/raw/9bd838001fd5820e65791a8e0892d29fa6005f92/melb-central-ion.json).

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
