### PR TITLE
Update to webpack 4.47.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.4.1)
 
 - Fix a bug where `DragPoints` was interfering with pedstrian mode mouse movements.
+- Update `webpack` to `4.47.0` to support Node >= 18 without extra command line parameters.
 - [The next improvement]
 
 #### 8.4.0 - 2023-12-01

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Sites we're aware of that are using TerriaJS. These are not endorsements or test
 ### Technical
 
 - NodeJS v16, v18 and v20 are supported
-  - **Note** for v18+ you will need to set `NODE_OPTIONS=--openssl-legacy-provider` in your environment.
 - Built in TypeScript & ES2020+ JavaScript, compiled with Babel to ES5.
 - Supports modern browsers (recent versions of Microsoft Edge, Mozilla Firefox & Google Chrome).
 - [TerriaJS Server component](https://github.com/TerriajS/TerriaJS-Server) runs in NodeJS and provides proxying for web services that don't support CORS or require authentication. Instead of using TerriaJS-Sever proxy service, an alternative proxying service URL can be specified. See [Specify an alternative proxy server URL](/doc/connecting-to-data/cross-origin-resource-sharing.md)

--- a/doc/contributing/problems-and-solutions.md
+++ b/doc/contributing/problems-and-solutions.md
@@ -90,4 +90,4 @@ Error: error:0308010C:digital envelope routines::unsupported
 
 ### Solution
 
-For NodeJS versions 18 and above you will need to set `NODE_OPTIONS=--openssl-legacy-provider` in your environment.
+Update to TerriaJS 8.4.1.

--- a/doc/customizing/cloning-and-building.md
+++ b/doc/customizing/cloning-and-building.md
@@ -22,7 +22,6 @@ TerriaJS can be built and run on almost any macOS, Linux, or Windows system. The
 
 -   The Bash command shell. On macOS or Linux you almost certainly already have this. On Windows, you can easily get it by installing [Git for Windows](https://gitforwindows.org/). In the instructions below, we assume you're using a Bash command prompt.
 -   [Node.js](https://nodejs.org) v16.0. You can check your node version by running `node --version` on the command-line.
-    -   **Note** you can also use Node.js 18 and 20, but you will need to set `NODE_OPTIONS=--openssl-legacy-provider` in your environment.
 -   [npm](https://www.npmjs.com/) v8.0. npm is usually installed automatically alongside the above. You can check your npm version by running `npm --version`.
 -   [yarn](https://yarnpkg.com/) v1.19.0 or later. This can be installed using `npm install -g yarn@^1.19.0`
 

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "typescript": "^4.9.5",
     "urijs": "^1.18.12",
     "url-loader": "^1.1.2",
-    "webpack": "~4.46.0",
+    "webpack": "~4.47.0",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.1.14",
     "worker-loader": "^2.0.0"


### PR DESCRIPTION
### What this PR does

Update to webpack 4.47.0

This release supports md4 in Node >=18.

Refs #6998

### Test me

The CI tests show the webpack 4.47.0 version being used, but I don't know how to test this beyond that.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
