### PR TITLE
Geojson and  Table style changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Add support for multiple `urls` for `GeoJsonCatalogItem`.
 - Automatically explode GeoJSON `MultiPoint` features to `Point` features.
 - Add new table styling traits - `scaleByDistance` and `disableDepthTestDistance`.
+- Add support for `LineString` and `MultiLineString` when using `GeoJsonCatalogItem` in `CZML` mode.
 - [The next improvement]
 
 #### 8.4.0 - 2023-12-01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 #### next release (8.4.1)
 
+- Temporary UX fixes for clipping box:
+  - An option to zoom to clipping box
+  - An option to re-position the clipping box
+  - Trigger repositioning of clipping box when the user enables clipping box for the first time
+  - Cursor and scale point handle changes (makes it much easier to grasp)
+  - More robust interaction with the box
 - Fix a bug where `DragPoints` was interfering with pedstrian mode mouse movements.
 - Update `webpack` to `4.47.0` to support Node >= 18 without extra command line parameters.
 - Add support for multiple `urls` for `GeoJsonCatalogItem`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 - Fix a bug where `DragPoints` was interfering with pedstrian mode mouse movements.
 - Update `webpack` to `4.47.0` to support Node >= 18 without extra command line parameters.
+- Add support for multiple `urls` for `GeoJsonCatalogItem`.
+- Automatically explode GeoJSON `MultiPoint` features to `Point` features. 
+- Add new table styling traits - `scaleByDistance` and `disableDepthTestDistance`.
 - [The next improvement]
 
 #### 8.4.0 - 2023-12-01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - Fix a bug where `DragPoints` was interfering with pedstrian mode mouse movements.
 - Update `webpack` to `4.47.0` to support Node >= 18 without extra command line parameters.
 - Add support for multiple `urls` for `GeoJsonCatalogItem`.
-- Automatically explode GeoJSON `MultiPoint` features to `Point` features. 
+- Automatically explode GeoJSON `MultiPoint` features to `Point` features.
 - Add new table styling traits - `scaleByDistance` and `disableDepthTestDistance`.
 - [The next improvement]
 

--- a/lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem.ts
@@ -131,7 +131,12 @@ class GeoJsonCatalogItem
       const featureCollections = filterOutUndefined(
         await Promise.all(promises)
       );
-      jsonData = mergeFeatureCollections(featureCollections);
+
+      // Forced type casting required as TS not happy with assigning
+      // FeatureCollection to JsonValue
+      jsonData = mergeFeatureCollections(
+        featureCollections
+      ) as any as JsonValue;
     }
     // GeojsonTraits.url
     else if (this.url) {
@@ -188,12 +193,16 @@ class GeoJsonCatalogItem
   }
 }
 
+/**
+ * Reduce an array of FeatureCollection into a single FeatureCollection.
+ *
+ * Note that this only accumulates the features and ignores any properties set
+ * on the individual FeatureCollection.
+ */
 function mergeFeatureCollections(
   featureCollections: Array<FeatureCollection>
-): JsonValue {
-  return featureCollection(
-    featureCollections.map((fc) => fc.features).flat()
-  ) as any as JsonValue;
+): FeatureCollection {
+  return featureCollection(featureCollections.map((fc) => fc.features).flat());
 }
 
 export function fileApiNotSupportedError(terria: Terria) {

--- a/lib/Table/createLongitudeLatitudeFeaturePerId.ts
+++ b/lib/Table/createLongitudeLatitudeFeaturePerId.ts
@@ -3,6 +3,7 @@ import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Color from "terriajs-cesium/Source/Core/Color";
 import Iso8601 from "terriajs-cesium/Source/Core/Iso8601";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import NearFarScalar from "terriajs-cesium/Source/Core/NearFarScalar";
 import Packable from "terriajs-cesium/Source/Core/Packable";
 import TimeInterval from "terriajs-cesium/Source/Core/TimeInterval";
 import TimeIntervalCollection from "terriajs-cesium/Source/Core/TimeIntervalCollection";
@@ -191,7 +192,9 @@ function createFeature(
         color: createProperty(Color, interpolate),
         outlineColor: createProperty(Color, interpolate),
         pixelSize: createProperty(Number, interpolate),
-        outlineWidth: createProperty(Number, interpolate)
+        outlineWidth: createProperty(Number, interpolate),
+        scaleByDistance: new TimeIntervalCollectionProperty(),
+        disableDepthTestDistance: new TimeIntervalCollectionProperty()
       }
     : undefined;
 
@@ -204,7 +207,9 @@ function createFeature(
         width: createProperty(Number, interpolate),
         color: createProperty(Color, interpolate),
         rotation: createProperty(Number, interpolate),
-        pixelOffset: createProperty(Cartesian2, interpolate)
+        pixelOffset: createProperty(Cartesian2, interpolate),
+        scaleByDistance: new TimeIntervalCollectionProperty(),
+        disableDepthTestDistance: new TimeIntervalCollectionProperty()
       }
     : undefined;
 
@@ -254,7 +259,9 @@ function createFeature(
         outlineWidth: createProperty(Number, interpolate),
         pixelOffset: createProperty(Cartesian2, interpolate),
         verticalOrigin: new TimeIntervalCollectionProperty(),
-        horizontalOrigin: new TimeIntervalCollectionProperty()
+        horizontalOrigin: new TimeIntervalCollectionProperty(),
+        scaleByDistance: new TimeIntervalCollectionProperty(),
+        disableDepthTestDistance: new TimeIntervalCollectionProperty()
       }
     : undefined;
 

--- a/lib/Traits/TraitsClasses/GeoJsonCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/GeoJsonCatalogItemTraits.ts
@@ -1,5 +1,6 @@
 import { JsonObject } from "../../Core/Json";
 import anyTrait from "../Decorators/anyTrait";
+import objectArrayTrait from "../Decorators/objectArrayTrait";
 import primitiveTrait from "../Decorators/primitiveTrait";
 import mixTraits from "../mixTraits";
 import ApiRequestTraits from "./ApiRequestTraits";
@@ -9,6 +10,15 @@ export default class GeoJsonCatalogItemTraits extends mixTraits(
   GeoJsonTraits,
   ApiRequestTraits
 ) {
+  @objectArrayTrait({
+    type: ApiRequestTraits,
+    name: "URLs",
+    idProperty: "url",
+    description:
+      "Array of GeoJSON URLs to fetch. The GeoJSON features from the URL responses will be merged into one single FeatureCollection. When this trait is specified, the `url` trait is ignored."
+  })
+  urls?: ApiRequestTraits[];
+
   @anyTrait({
     name: "geoJsonData",
     description: "A geojson data object"

--- a/lib/Traits/TraitsClasses/GeoJsonTraits.ts
+++ b/lib/Traits/TraitsClasses/GeoJsonTraits.ts
@@ -155,4 +155,12 @@ export class GeoJsonTraits extends mixTraits(
     - \`heightOffset: number\` to offset height values (in m)`
   })
   czmlTemplate?: JsonObject;
+
+  @primitiveTrait({
+    type: "boolean",
+    name: "Explode MultiPoints",
+    description:
+      "Replaces `MultiPoint` features with its equivalent `Point` features when `true`. This is useful for example when using Table mode which does not support `MultiPoint` features currently."
+  })
+  explodeMultiPoints = true;
 }

--- a/lib/Traits/TraitsClasses/Table/LabelStyleTraits.ts
+++ b/lib/Traits/TraitsClasses/Table/LabelStyleTraits.ts
@@ -4,6 +4,7 @@ import objectTrait from "../../Decorators/objectTrait";
 import primitiveArrayTrait from "../../Decorators/primitiveArrayTrait";
 import primitiveTrait from "../../Decorators/primitiveTrait";
 import mixTraits from "../../mixTraits";
+import ScaleByDistanceTraits from "../ScaleByDistanceTraits";
 import {
   BinStyleTraits,
   EnumStyleTraits,
@@ -59,6 +60,23 @@ export class LabelSymbolTraits extends mixTraits(TableStyleMapSymbolTraits) {
     type: "number"
   })
   scale = 1;
+
+  @objectTrait({
+    name: "Scale by distance",
+    description:
+      "Scales a point, billboard or label feature by its distance from the camera.",
+    type: ScaleByDistanceTraits,
+    isNullable: true
+  })
+  scaleByDistance?: ScaleByDistanceTraits;
+
+  @primitiveTrait({
+    name: "Disable depth test distance",
+    description:
+      "The distance from camera at which to disable depth testing, for example to prevent clipping of features againts terrain. Set to a very large value like 99999999 to disable depth testing altogether. When not defined or set to 0, depth testing is always applied.",
+    type: "number"
+  })
+  disableDepthTestDistance?: number;
 
   @primitiveTrait({
     name: "Fill color",

--- a/lib/Traits/TraitsClasses/Table/PointStyleTraits.ts
+++ b/lib/Traits/TraitsClasses/Table/PointStyleTraits.ts
@@ -4,6 +4,7 @@ import objectTrait from "../../Decorators/objectTrait";
 import primitiveArrayTrait from "../../Decorators/primitiveArrayTrait";
 import primitiveTrait from "../../Decorators/primitiveTrait";
 import mixTraits from "../../mixTraits";
+import ScaleByDistanceTraits from "../ScaleByDistanceTraits";
 import {
   BinStyleTraits,
   EnumStyleTraits,
@@ -47,6 +48,23 @@ export class PointSymbolTraits extends mixTraits(TableStyleMapSymbolTraits) {
     type: "number"
   })
   width?: number = 16;
+
+  @objectTrait({
+    name: "Scale by distance",
+    description:
+      "Scales a point, billboard or label feature by its distance from the camera.",
+    type: ScaleByDistanceTraits,
+    isNullable: true
+  })
+  scaleByDistance?: ScaleByDistanceTraits;
+
+  @primitiveTrait({
+    name: "Disable depth test distance",
+    description:
+      "The distance from camera at which to disable depth testing, for example to prevent clipping of features againts terrain. Set to a very large value like 99999999 to disable depth testing altogether. When not defined or set to 0, depth testing is always applied.",
+    type: "number"
+  })
+  disableDepthTestDistance?: number;
 }
 
 export class EnumPointSymbolTraits extends mixTraits(

--- a/test/ModelMixins/TableMixinSpec.ts
+++ b/test/ModelMixins/TableMixinSpec.ts
@@ -34,6 +34,7 @@ import TableTrailStyleTraits, {
 
 import HorizontalOrigin from "terriajs-cesium/Source/Scene/HorizontalOrigin";
 import VerticalOrigin from "terriajs-cesium/Source/Scene/VerticalOrigin";
+import ScaleByDistanceTraits from "../../lib/Traits/TraitsClasses/ScaleByDistanceTraits";
 
 const LatLonValCsv = require("raw-loader!../../wwwroot/test/csv/lat_lon_val.csv");
 const LatLonEnumCsv = require("raw-loader!../../wwwroot/test/csv/lat_lon_enum.csv");
@@ -2022,6 +2023,64 @@ describe("TableMixin", function () {
           }
         });
       });
+    });
+
+    it("correctly applies disableDepthTestDistance trait", async function () {
+      item.setTrait(CommonStrata.user, "csvString", LatLonValCsv);
+      item.setTrait(CommonStrata.user, "styles", [
+        createStratumInstance(TableStyleTraits, {
+          id: "test-style",
+          point: createStratumInstance(TablePointStyleTraits, {
+            null: createStratumInstance(PointSymbolTraits, {
+              disableDepthTestDistance: 42
+            })
+          })
+        })
+      ]);
+      item.setTrait(CommonStrata.user, "activeStyle", "test-style");
+      await item.loadMapItems();
+
+      const mapItem = item.mapItems[0] as CustomDataSource;
+      mapItem.entities.values.forEach((entity) =>
+        expect(
+          entity.point?.disableDepthTestDistance?.getValue(JulianDate.now())
+        ).toBe(42)
+      );
+    });
+
+    it("correctly applies scaleByDistance traits", async function () {
+      item.setTrait(CommonStrata.user, "csvString", LatLonValCsv);
+      item.setTrait(CommonStrata.user, "styles", [
+        createStratumInstance(TableStyleTraits, {
+          id: "test-style",
+          point: createStratumInstance(TablePointStyleTraits, {
+            null: createStratumInstance(PointSymbolTraits, {
+              scaleByDistance: createStratumInstance(ScaleByDistanceTraits, {
+                near: 0,
+                nearValue: 4,
+                far: 50000,
+                farValue: 10
+              })
+            })
+          })
+        })
+      ]);
+      item.setTrait(CommonStrata.user, "activeStyle", "test-style");
+      await item.loadMapItems();
+
+      const mapItem = item.mapItems[0] as CustomDataSource;
+      mapItem.entities.values.forEach((entity) =>
+        expect(
+          entity.point?.scaleByDistance?.getValue(JulianDate.now())
+        ).toEqual(
+          jasmine.objectContaining({
+            near: 0,
+            nearValue: 4,
+            far: 50000,
+            farValue: 10
+          })
+        )
+      );
     });
 
     it("doesn't pick hidden style as default activeStyle", async function () {

--- a/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
@@ -1120,6 +1120,61 @@ describe("GeoJsonCatalogItemSpec", () => {
     });
   });
 
+  describe("When given multiple URLs", function () {
+    let terria: Terria;
+    let geojson: GeoJsonCatalogItem;
+
+    beforeEach(async function () {
+      terria = new Terria({
+        baseUrl: "./"
+      });
+      geojson = new GeoJsonCatalogItem("test-geojson", terria);
+      geojson.setTrait(CommonStrata.user, "forceCesiumPrimitives", true);
+    });
+
+    it("fetches and merges the responses as a single geojson feature collection", async function () {
+      updateModelFromJson(geojson, CommonStrata.user, {
+        urls: [
+          { url: "test/GeoJSON/api.geojson", responseDataPath: "nested.data" },
+          {
+            url: "test/GeoJSON/points.geojson"
+          }
+        ]
+      });
+      await geojson.loadMapItems();
+      expect(geojson.mapItems.length).toEqual(1);
+      const mapItem = geojson.mapItems[0] as CustomDataSource;
+
+      expect(isDataSource(mapItem)).toBeTruthy();
+      expect(mapItem.entities.values.length).toBe(7);
+    });
+  });
+
+  describe("handling MultiPoint features", function () {
+    let terria: Terria;
+    let geojson: GeoJsonCatalogItem;
+
+    beforeEach(function () {
+      terria = new Terria({
+        baseUrl: "./"
+      });
+      geojson = new GeoJsonCatalogItem("test-geojson", terria);
+      geojson.setTrait(
+        CommonStrata.user,
+        "url",
+        "test/GeoJSON/multipoint.geojson"
+      );
+    });
+
+    it("explodes multipoints as points", async function () {
+      await geojson.loadMapItems();
+      const points = geojson.mapItems[0] as CustomDataSource;
+      expect(points).toBeDefined();
+      expect(isDataSource(points)).toBeTruthy();
+      expect(points.entities.values.length).toEqual(5);
+    });
+  });
+
   describe("geojson can be split", function () {
     let terria: Terria;
     let geojson: GeoJsonCatalogItem;

--- a/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
@@ -3,6 +3,7 @@ import { GeomType, LineSymbolizer, PolygonSymbolizer } from "protomaps";
 import { CustomDataSource } from "terriajs-cesium";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import Color from "terriajs-cesium/Source/Core/Color";
 import Iso8601 from "terriajs-cesium/Source/Core/Iso8601";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import createGuid from "terriajs-cesium/Source/Core/createGuid";
@@ -10,6 +11,7 @@ import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
 import HeightReference from "terriajs-cesium/Source/Scene/HeightReference";
 import { JsonObject } from "../../../../lib/Core/Json";
+import StandardCssColors from "../../../../lib/Core/StandardCssColors";
 import loadJson from "../../../../lib/Core/loadJson";
 import loadText from "../../../../lib/Core/loadText";
 import ContinuousColorMap from "../../../../lib/Map/ColorMap/ContinuousColorMap";
@@ -883,9 +885,18 @@ describe("GeoJsonCatalogItemSpec", () => {
 
         expect(geojson.legends.length).toBe(1);
         expect(geojson.legends[0].items.length).toBe(1);
-        expect(geojson.legends[0].items.map((i) => i.color)).toEqual([
-          "rgb(102,194,165)"
-        ]);
+
+        expect(
+          geojson.legends[0].items.map(
+            (i) =>
+              // Look through default colors for disabled styles
+              // This can change, as `createColorForIdTransformer` will use the least used color (to avoid clashes)
+              !!StandardCssColors.modifiedBrewer8ClassSet2.find(
+                (c) =>
+                  Color.fromCssColorString(c).toCssColorString() === i.color
+              )
+          )
+        ).toEqual([true]);
 
         updateModelFromJson(geojson, CommonStrata.definition, {
           legends: [

--- a/test/Models/Catalog/esri/ArcGisFeatureServerCatalogItemSpec.ts
+++ b/test/Models/Catalog/esri/ArcGisFeatureServerCatalogItemSpec.ts
@@ -311,7 +311,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
         pixelOffset: [0, 0],
         width: 6,
         height: 16,
-        rotation: 0
+        rotation: 0,
+        scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
       });
 
       expect(tableStyle.pointStyleMap.traitValues.enum).toEqual([
@@ -322,7 +323,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "1",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "2",
@@ -331,7 +333,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "2",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "3",
@@ -340,7 +343,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "3",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "4",
@@ -349,7 +353,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "4",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "5",
@@ -358,7 +363,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "5",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "6",
@@ -367,7 +373,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "6",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "7",
@@ -376,7 +383,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "7",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "8",
@@ -385,7 +393,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "8",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "9",
@@ -394,7 +403,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "9",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "10",
@@ -403,7 +413,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "10",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "11",
@@ -412,7 +423,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "11",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         },
         {
           legendTitle: "12",
@@ -421,7 +433,8 @@ describe("ArcGisFeatureServerCatalogItem", function () {
           width: 2,
           height: 16,
           value: "12",
-          rotation: 0
+          rotation: 0,
+          scaleByDistance: { near: 0, nearValue: 1, far: 1, farValue: 1 }
         }
       ]);
 

--- a/wwwroot/test/GeoJSON/multipoint.geojson
+++ b/wwwroot/test/GeoJSON/multipoint.geojson
@@ -1,0 +1,18 @@
+{
+  "type": "Feature",
+  "bbox": [-10.0, -10.0, 10.0, 10.0],
+  "properties": {
+    "foo": "hi",
+    "bar": "bye"
+  },
+  "geometry": {
+    "type": "MultiPoint",
+    "coordinates": [
+      [100.0, 0.0],
+      [101.0, 0.0],
+      [101.0, 1.0],
+      [100.0, 1.0],
+      [100.0, 0.0]
+    ]
+  }
+}


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/terriajs/issues/6956 https://github.com/TerriaJS/terriajs/issues/6374

This PR makes the following changes:
- Add support for multiple `urls` for `GeoJsonCatalogItem` ([commit](https://github.com/TerriaJS/terriajs/pull/7002/commits/a5c7269f62741392b35922b081eea720e372d171))
- Automatically explode GeoJSON `MultiPoint` features to `Point` features ([commit](https://github.com/TerriaJS/terriajs/pull/7002/commits/0a121eabc3fca080334642e7951a4241a2fabd00))
- Add new table styling traits - `scaleByDistance` and `disableDepthTestDistance` ([commit](https://github.com/TerriaJS/terriajs/pull/7002/commits/4ee5b43e49822e9666898656407b9f3c0308ef6e))
- Add support for `LineString` and `MultiLineString` when using `GeoJsonCatalogItem` in `CZML` mode. ([commit](https://github.com/TerriaJS/terriajs/pull/7002/commits/230e489486fc740820d7953226e711232bbf4ac1))

### Test me

This [test link](http://ci.terria.io/geojson-table-changes/#share=s-cVNATqHXLcE5E14CWgwYBSg87QE&https://gist.githubusercontent.com/na9da/c0bdef76799379795036ea2bb5336950/raw/bd5394c8131522c4246596d2e4cee1c35b4658d0/scale-by-distance.json) demonstrates all the above changes (except the LineString one). The catalog definition for the test link defines [multiple URLs](https://gist.github.com/na9da/c0bdef76799379795036ea2bb5336950#file-scale-by-distance-json-L6-L13), and the new traits [scaleByDistance and disableDepthTestDistance](https://gist.github.com/na9da/c0bdef76799379795036ea2bb5336950#file-scale-by-distance-json-L21-L27). The URL endpoints also return `MultiPoint` GeoJSON features which can now be correctly styled using table styling.

Notice how:
- Responses from 2 different endpoints are merged together as a single GeoJSON catalog item
- MultiPoint features are correctly styled using table styling properties
- the points are rendered small when zoomed out and scale up when zooming in. This reduces visual noise.
- add the Label and Marker items from the catalog, to see a similar effect.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
