### PR TITLE
Update to thredds-catalog-crawler 0.0.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,11 @@
 
 #### next release (8.5.0)
 
-- Update `thredds-catalog-crawler` to `0.0.6`
 - **Breaking changes:**
   - Upgrade TypeScript to 5.2
   - Switch Babel configuration to new JSX transform
 - Improve tsconfig files
+- Update `thredds-catalog-crawler` to `0.0.6`
 - [The next improvement]
 
 #### 8.4.1 - 2023-12-08

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.4.2)
 
+- Update `thredds-catalog-crawler` to `0.0.6`
 - [The next improvement]
 
 #### 8.4.1 - 2023-12-08

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "svg-sprite-loader": "4.1.3",
     "terriajs-cesium": "1.92.0-tile-error-provider-fix-2",
     "terriajs-html2canvas": "1.0.0-alpha.12-terriajs-1",
-    "thredds-catalog-crawler": "0.0.5",
+    "thredds-catalog-crawler": "0.0.6",
     "ts-essentials": "^5.0.0",
     "ts-loader": "^5.3.3",
     "ts-node": "^5.0.1",


### PR DESCRIPTION
### What this PR does

Update to thredds-catalog-crawler 0.0.6

This fixes CVE-2021-21366.

### Test me

Don't think documentation needs to be updated, but I'm not sure how to test the change.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
