### PR TITLE
Remove deprecated default `relatedMaps`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   - Upgrade TypeScript to 5.2
   - Switch Babel configuration to new JSX transform
 - Improve tsconfig files
-- Remove deprecated default `relatedMaps` 
+- Remove deprecated default `relatedMaps`
 - [The next improvement]
 
 #### 8.4.1 - 2023-12-08

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   - Upgrade TypeScript to 5.2
   - Switch Babel configuration to new JSX transform
 - Improve tsconfig files
+- Remove deprecated default `relatedMaps` 
 - [The next improvement]
 
 #### 8.4.1 - 2023-12-08

--- a/lib/Models/RelatedMaps.ts
+++ b/lib/Models/RelatedMaps.ts
@@ -32,34 +32,10 @@ export const defaultRelatedMaps: RelatedMap[] = [
   },
   {
     imageUrl:
-      "https://terria-catalogs-public.storage.googleapis.com/misc/related-maps/qld-dt.png",
-    url: "https://qld.digitaltwin.terria.io/",
-    title: "QLD Spatial Digital Twin",
-    description:
-      "The QLD Spatial Digital Twin is an evolving 4D data platform that enables users to discover, visualise, analyse and share a rich range of datasets in a real world context, to enable better planning and decision making. It is an initiative of Advance Queensland and the Department of Resources in partnership with CSIRO-Data61."
-  },
-  {
-    imageUrl:
       "https://terria-catalogs-public.storage.googleapis.com/misc/related-maps/dea.png",
     url: "https://maps.dea.ga.gov.au/",
     title: "Digital Earth Australia",
     description:
       "Digital Earth Australia (DEA) Map is a website for map-based access to DEA’s products, developed by Data61 CSIRO for Geoscience Australia. DEA uses satellite data to detect physical changes across Australia in unprecedented detail. It identifies soil and coastal erosion, crop growth, water quality and changes to cities and regions."
-  },
-  {
-    imageUrl:
-      "https://terria-catalogs-public.storage.googleapis.com/misc/related-maps/droughtmap.jpg",
-    url: "https://map.drought.gov.au/",
-    title: "National Drought Map",
-    description:
-      "The DroughtMap is a platform built for the Australian Government to assist with planning and management of drought effects in Australia."
-  },
-  {
-    imageUrl:
-      "https://terria-catalogs-public.storage.googleapis.com/misc/related-maps/aurin-map.jpg",
-    url: "https://map.aurin.org.au/",
-    title: "AURIN Map",
-    description:
-      "AURIN Map provides access to datasets on urban infrastructure for urban researchers, policy and decision makers."
   }
 ];


### PR DESCRIPTION
### Remove deprecated default `relatedMaps`

- http://ci.terria.io/remove-deprecated-relatedmaps/
- Click "Related Maps"
- QLD DT, Drought Map and AURIN maps are now removed

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
