### PR TITLE
feat[i18n]: add ide extension config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "inlang.vs-code-extension"
+  ]
+}

--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://inlang.com/schema/project-settings",
+    "sourceLanguageTag": "en",
+    "languageTags": [
+      "en", "ar", "ca", "cs", "de", "el"
+    ],
+    "modules": [
+      "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@4/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-empty-pattern@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-identical-pattern@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-missing-translation@latest/dist/index.js",
+      "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-without-source@latest/dist/index.js"
+    ],
+    "plugin.inlang.i18next": {
+      "pathPattern": {
+        "translation": "./wwwroot/languages/{languageTag}/translation.json"
+      }
+    }
+}
+


### PR DESCRIPTION
> let me know what needs to be changed in order to merge this

# Description: DX upgrade with little i18n tool.
- I added a [ide-extension](https://inlang.com/m/r7kp499g/app-inlang-ideExtension) config to `terriajs`. This enables developers and contributors to extract, access and update translations in code using the existing json files under the hood. 

- **Opt-in:** With the config in place you can also use the [fink editor](https://inlang.com/m/tdozzpar/app-inlang-editor) to update product copy/translation with a no code UI. Here u see an example from my fork: https://inlang.com/editor/github.com/NilsJacobsen/terriajs

# What I added (opt-in)
- A config file -> `settings.json`
- Vscode recommendation so the contributors can use the extension

## Screenshots:
IDE-Extension:
![image](https://github.com/TerriaJS/terriajs/assets/58360188/98ccd7a0-ced9-4610-bc37-7ac9b6b02219)
![image](https://github.com/TerriaJS/terriajs/assets/58360188/d79aa1ea-66c4-4809-9695-6a46bb6e9bcf)

Editor:
<img width="1512" alt="image" src="https://github.com/TerriaJS/terriajs/assets/58360188/19237679-1491-42ee-b9bb-75520c1efe86">


