### PR TITLE
Fix missing add data instructions in explorer window

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Improve tsconfig files
 - Update `thredds-catalog-crawler` to `0.0.6`
 - `WebMapServiceCatalogItem` will drop problematic query parameters from `url` when calling `GetCapabilities` (eg `"styles","srs","crs","format"`)
+- Fixed regression causing explorer window not to display instructions when first opened.
 - [The next improvement]
 
 #### 8.4.1 - 2023-12-08

--- a/lib/ReactViews/Preview/DataPreview.jsx
+++ b/lib/ReactViews/Preview/DataPreview.jsx
@@ -68,20 +68,22 @@ class DataPreview extends React.Component {
         </div>
       );
     } else if (chartData) {
-      <div className={Styles.previewInner}>
-        <h3 className={Styles.h3}>{previewed.name}</h3>
-        <p>{t("preview.doesNotContainGeospatialData")}</p>
-        <div className={Styles.previewChart}>
-          {/* TODO: Show a preview chart
+      return (
+        <div className={Styles.previewInner}>
+          <h3 className={Styles.h3}>{previewed.name}</h3>
+          <p>{t("preview.doesNotContainGeospatialData")}</p>
+          <div className={Styles.previewChart}>
+            {/* TODO: Show a preview chart
                 <Chart
                    data={chartData}
                    axisLabel={{ x: previewed.xAxis.units, y: undefined }}
                    height={250 - 34}
                    />
             */}
+          </div>
+          <Description item={previewed} />
         </div>
-        <Description item={previewed} />
-      </div>;
+      );
     } else if (previewed && CatalogFunctionMixin.isMixedInto(previewed)) {
       return (
         <InvokeFunction
@@ -101,18 +103,20 @@ class DataPreview extends React.Component {
         </div>
       );
     } else {
-      <div className={Styles.placeholder}>
-        <Trans i18nKey="preview.selectToPreview">
-          <p>Select a dataset to see a preview</p>
-          <p>- OR -</p>
-          <button
-            className={Styles.btnBackToMap}
-            onClick={() => this.backToMap()}
-          >
-            Go to the map
-          </button>
-        </Trans>
-      </div>;
+      return (
+        <div className={Styles.placeholder}>
+          <Trans i18nKey="preview.selectToPreview">
+            <p>Select a dataset to see a preview</p>
+            <p>- OR -</p>
+            <button
+              className={Styles.btnBackToMap}
+              onClick={() => this.backToMap()}
+            >
+              Go to the map
+            </button>
+          </Trans>
+        </div>
+      );
     }
   }
 


### PR DESCRIPTION
### What this PR does

Fixes a regression where add data instructions aren't shown when first opening the explorer window.

### Test me

Open explorer window on http://ci.terria.io/main/ and http://ci.terria.io/regression-data-preview/

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
