### PR TITLE
Fix: draw marker on first load

### DIFF
--- a/lib/Models/LocationMarkerUtils.ts
+++ b/lib/Models/LocationMarkerUtils.ts
@@ -110,3 +110,7 @@ export function getMarkerLocation(terria: Terria): LatLonHeight | undefined {
   }
   return undefined;
 }
+
+export function getMarkerCatalogItem(terria: Terria) {
+  return terria.getModelById(CzmlCatalogItem, MARKER_UNIQUE_ID);
+}

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -39,6 +39,8 @@ import {
 import DisclaimerHandler from "./DisclaimerHandler";
 import SearchState from "./SearchState";
 import CatalogSearchProviderMixin from "../ModelMixins/SearchProviders/CatalogSearchProviderMixin";
+import { getMarkerCatalogItem } from "../Models/LocationMarkerUtils";
+import CzmlCatalogItem from "../Models/Catalog/CatalogItems/CzmlCatalogItem";
 
 export const DATA_CATALOG_NAME = "data-catalog";
 export const USER_DATA_NAME = "my-data";
@@ -368,6 +370,7 @@ export default class ViewState {
   private _mobileMenuSubscription: IReactionDisposer;
   private _storyPromptSubscription: IReactionDisposer;
   private _previewedItemIdSubscription: IReactionDisposer;
+  private _locationMarkerSubscription: IReactionDisposer;
   private _workbenchHasTimeWMSSubscription: IReactionDisposer;
   private _storyBeforeUnloadSubscription: IReactionDisposer;
   private _disclaimerHandler: DisclaimerHandler;
@@ -475,6 +478,17 @@ export default class ViewState {
       }
     );
 
+    this._locationMarkerSubscription = reaction(
+      () => getMarkerCatalogItem(this.terria),
+      (item: CzmlCatalogItem | undefined) => {
+        if (item) {
+          terria.overlays.add(item);
+          /* dispose subscription after init */
+          this._locationMarkerSubscription();
+        }
+      }
+    );
+
     this._previewedItemIdSubscription = reaction(
       () => this.terria.previewedItemId,
       async (previewedItemId: string | undefined) => {
@@ -525,6 +539,7 @@ export default class ViewState {
     this._storyPromptSubscription();
     this._previewedItemIdSubscription();
     this._workbenchHasTimeWMSSubscription();
+    this._locationMarkerSubscription();
     this._disclaimerHandler.dispose();
     this.searchState.dispose();
   }


### PR DESCRIPTION
### What this PR does

Fixes #6854 

When a location marker is stored in a share or start url, react to it's addition to the catalog once and draw the marker

### Test me

Visit http://ci.terria.io/bug-search-marker/#share=s-kzAOTeO49a1mrKMNum3v7zrVzO7 the map marker should be shown


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
