### PR TITLE
refactor the DateTimeParameterEditor to be a functional component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,9 @@
 - Update `thredds-catalog-crawler` to `0.0.6`
 - `WebMapServiceCatalogItem` will drop problematic query parameters from `url` when calling `GetCapabilities` (eg `"styles","srs","crs","format"`)
 - Fixed regression causing explorer window not to display instructions when first opened.
-- [The next improvement]
 - Enable eslint for typescript: plugin:@typescript-eslint/eslint-recommended
+- Fix WPS date parameter reset bug
+- [The next improvement]
 
 #### 8.4.1 - 2023-12-08
 

--- a/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
@@ -1,91 +1,57 @@
-import React from "react";
+import React, { useState } from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
-import createReactClass from "create-react-class";
-import PropTypes from "prop-types";
-
 import Styles from "./parameter-editors.scss";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 
-const DateTimeParameterEditor = createReactClass({
-  displayName: "DateTimeParameterEditor",
+const DateTimeParameterEditor = (props) => {
+  const [dateValue, setDateValue] = useState(
+    defined(props.parameter) && defined(props.parameter.value)
+      ? props.parameter.value
+      : ""
+  );
+  const [timeValue, setTimeValue] = useState("00:00");
 
-  propTypes: {
-    previewed: PropTypes.object,
-    parameter: PropTypes.object
-  },
+  const style =
+    defined(props.parameter) && defined(props.parameter.value)
+      ? Styles.field
+      : Styles.fieldDatePlaceholder;
 
-  getInitialState() {
-    return this.getDateTime();
-  },
-
-  getDateTime() {
-    const dateTimeBreakOut = {};
-    const timeDate = this.props.parameter.value;
-    if (timeDate !== undefined) {
-      const splits = timeDate.split("T");
-      dateTimeBreakOut.date = splits[0];
-      if (splits[1].length === 0) {
-        dateTimeBreakOut.time = "00:00";
-      } else {
-        dateTimeBreakOut.time = splits[1];
-      }
-    } else {
-      dateTimeBreakOut.date = "";
-      dateTimeBreakOut.time = "00:00";
-    }
-
-    this.setDateTime(dateTimeBreakOut);
-
-    return dateTimeBreakOut;
-  },
-
-  setDateTime(dateTime) {
-    let value;
-    if (dateTime.date && dateTime.time) {
-      value = dateTime.date + "T" + dateTime.time;
-    }
-    this.props.parameter.setValue(CommonStrata.user, value);
-  },
-
-  onChangeDate(e) {
-    const dateTimeBreakOut = this.getDateTime();
-    dateTimeBreakOut.date = e.target.value;
-    this.setDateTime(dateTimeBreakOut);
-    this.setState(dateTimeBreakOut);
-  },
-
-  onChangeTime(e) {
-    const dateTimeBreakOut = this.getDateTime();
-    dateTimeBreakOut.time = e.target.value;
-    this.setDateTime(dateTimeBreakOut);
-    this.setState(dateTimeBreakOut);
-  },
-
-  render() {
-    const style =
-      defined(this.props.parameter) && defined(this.props.parameter.value)
-        ? Styles.field
-        : Styles.fieldDatePlaceholder;
-
-    return (
+  return (
+    <div>
       <div>
         <input
           className={style}
           type="date"
           placeholder="YYYY-MM-DD"
-          onChange={this.onChangeDate}
-          value={this.state.date}
+          value={dateValue}
+          onChange={(e) => {
+            setDateValue(e.target.value);
+            if (defined(props.parameter)) {
+              props.parameter.setValue(
+                CommonStrata.user,
+                `${e.target.value}T${timeValue}`
+              );
+            }
+          }}
         />
         <input
           className={style}
           type="time"
           placeholder="HH:mm:ss.sss"
-          onChange={this.onChangeTime}
-          value={this.state.time}
+          value={timeValue}
+          onChange={(e) => {
+            setTimeValue(e.target.value);
+            if (defined(props.parameter)) {
+              props.parameter.setValue(
+                CommonStrata.user,
+                `${dateValue}T${e.target.value}`
+              );
+            }
+          }}
         />
       </div>
-    );
-  }
-});
+    </div>
+  );
+};
 
-module.exports = DateTimeParameterEditor;
+export default DateTimeParameterEditor;

--- a/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
@@ -4,53 +4,48 @@ import Styles from "./parameter-editors.scss";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import PropTypes from "prop-types";
 
-const DateTimeParameterEditor = (props) => {
+const DateTimeParameterEditor = ({ parameter, previewed }) => {
   const [dateValue, setDateValue] = useState(
-    defined(props.parameter) && defined(props.parameter.value)
-      ? props.parameter.value
-      : ""
+    defined(parameter) && defined(parameter.value) ? parameter.value : ""
   );
   const [timeValue, setTimeValue] = useState("00:00");
 
   const style =
-    defined(props.parameter) && defined(props.parameter.value)
+    defined(parameter) && defined(parameter.value)
       ? Styles.field
       : Styles.fieldDatePlaceholder;
-
   return (
     <div>
-      <div>
-        <input
-          className={style}
-          type="date"
-          placeholder="YYYY-MM-DD"
-          value={dateValue}
-          onChange={(e) => {
-            setDateValue(e.target.value);
-            if (defined(props.parameter)) {
-              props.parameter.setValue(
-                CommonStrata.user,
-                `${e.target.value}T${timeValue}`
-              );
-            }
-          }}
-        />
-        <input
-          className={style}
-          type="time"
-          placeholder="HH:mm:ss.sss"
-          value={timeValue}
-          onChange={(e) => {
-            setTimeValue(e.target.value);
-            if (defined(props.parameter)) {
-              props.parameter.setValue(
-                CommonStrata.user,
-                `${dateValue}T${e.target.value}`
-              );
-            }
-          }}
-        />
-      </div>
+      <input
+        className={style}
+        type="date"
+        placeholder="YYYY-MM-DD"
+        value={dateValue}
+        onChange={(e) => {
+          setDateValue(e.target.value);
+          if (defined(parameter)) {
+            parameter.setValue(
+              CommonStrata.user,
+              `${e.target.value}T${timeValue}`
+            );
+          }
+        }}
+      />
+      <input
+        className={style}
+        type="time"
+        placeholder="HH:mm:ss.sss"
+        value={timeValue}
+        onChange={(e) => {
+          setTimeValue(e.target.value);
+          if (defined(parameter)) {
+            parameter.setValue(
+              CommonStrata.user,
+              `${dateValue}T${e.target.value}`
+            );
+          }
+        }}
+      />
     </div>
   );
 };

--- a/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/DateTimeParameterEditor.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
 import Styles from "./parameter-editors.scss";
 import CommonStrata from "../../Models/Definition/CommonStrata";
+import PropTypes from "prop-types";
 
 const DateTimeParameterEditor = (props) => {
   const [dateValue, setDateValue] = useState(
@@ -52,6 +53,11 @@ const DateTimeParameterEditor = (props) => {
       </div>
     </div>
   );
+};
+
+DateTimeParameterEditor.propTypes = {
+  parameter: PropTypes.object,
+  previewed: PropTypes.object
 };
 
 export default DateTimeParameterEditor;


### PR DESCRIPTION
### What this PR does

Fixes #6896

This is a description of what I've done in this PR, especially explaining choices made to make the reviewer's job easier. If I don't replace this paragraph with an actual description, my PR will probably be ignored.

### Test me

Browse to 
http://ci.terria.io/wps-time-reset/#share=s-bRTdoGD1E1hSA95nLCVwIEjNXa9

From the My Data tab select the AWAVEA WPS service and then the Wave: Annual Bivariate Probability Distribution service

Select a point location,  manually edit the start and end times.  Update the times manually several times to test that the other unedited values do not change.

![image](https://github.com/TerriaJS/terriajs/assets/1597830/1fe17e7e-c66f-4419-a623-bbddb6fbab0e)

Ensure the debugging console is open on the Network tab, hit Run Analysis

confirm the Payload of the request has the Date Time correctly formatted  as YYYY-MM-DDThh:mm

![image](https://github.com/TerriaJS/terriajs/assets/1597830/8ad0b20c-be77-4056-b279-9a49d4c5999d)

### Checklist

- [x] There are unit tests to verify my changes are correct
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
