### PR TITLE
Always show all user add data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 - Fixed regression causing explorer window not to display instructions when first opened.
 - [The next improvement]
 - Enable eslint for typescript: plugin:@typescript-eslint/eslint-recommended
+- Prevent user adding empty web url
+- Fix bug where search results shown in `My Data` tab
 
 #### 8.4.1 - 2023-12-08
 

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -5,13 +5,12 @@ import classNames from "classnames";
 import Icon from "../../../../Styled/Icon";
 import Box from "../../../../Styled/Box";
 import PropTypes from "prop-types";
-
-import DataCatalog from "../../../DataCatalog/DataCatalog.jsx";
 import DataPreview from "../../../Preview/DataPreview.jsx";
 import AddData from "./AddData.jsx";
 import { withTranslation, Trans } from "react-i18next";
 
 import Styles from "./my-data-tab.scss";
+import DataCatalogMember from "../../../DataCatalog/DataCatalogMember";
 
 // My data tab include Add data section and preview section
 @observer
@@ -180,14 +179,18 @@ class MyDataTab extends React.Component {
               <div className={Styles.tabLeft}>{this.renderTabs()}</div>
 
               <ul className={Styles.dataCatalog}>
-                <DataCatalog
-                  items={
-                    this.props.terria.catalog.userAddedDataGroup.memberModels
-                  }
-                  removable
-                  viewState={this.props.viewState}
-                  terria={this.props.terria}
-                />
+                {this.props.terria.catalog.userAddedDataGroup.memberModels.map(
+                  (item) => (
+                    <DataCatalogMember
+                      viewState={this.props.viewState}
+                      member={item}
+                      key={item.uniqueId}
+                      removable
+                      terria={this.props.terria}
+                      isTopLevel
+                    />
+                  )
+                )}
               </ul>
             </Box>
           )}


### PR DESCRIPTION
### What this PR does

Fixes #6878

Remove search results from being displayed under MyData tab by just rendering out the members of `userAddedDataGroup` .

### Test me

Visit https://ci.terria.io/my-data-tab-search-results-of-ad
- Add any user data
- Perform a search 
- Go back to `My Data` tab
- It should show user data rather than search results

Share link with user data added: https://ci.terria.io/my-data-tab-search-results-of-ad/#share=s-7KysabR1RYvYctyH6ugWpYuaVJo

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
