### PR TITLE
Fixed a bug in ArcGisMapServerCatalogItem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - Prevent user adding empty web url
 - Fix bug where search results shown in `My Data` tab
 - Fix bug in function createDiscreteTimesFromIsoSegments where it might create duplicate timestamps.
+- Fix bug in ArcGisMapServerCatalogItem.
 - [The next improvement]
 
 #### 8.4.1 - 2023-12-08

--- a/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
@@ -102,15 +102,8 @@ class MapServerStratum extends LoadableStratum(
       token = await getToken(item.terria, item.tokenUrl, item.url);
     }
 
-    let layerId;
-    const lastSegment = item.uri.segment(-1);
-    if (lastSegment && lastSegment.match(/\d+/)) {
-      // URL is a single REST layer, like .../arcgis/rest/services/Society/Society_SCRC/MapServer/16
-      layerId = lastSegment;
-    }
-
     let serviceUri = getBaseURI(item);
-    let layersUri = getBaseURI(item).segment(layerId || "layers"); // either 'layers' or a number
+    let layersUri = getBaseURI(item).segment("layers");
     let legendUri = getBaseURI(item).segment("legend");
 
     if (isDefined(token)) {
@@ -154,16 +147,6 @@ class MapServerStratum extends LoadableStratum(
       if (isDefined(layersMetadataResponse?.layers)) {
         layers = layersMetadataResponse.layers;
       }
-      // The following conditional code is commented out becasue
-      // the test will be true when the requested url path ends with
-      // layer ID. Overwriting "layers" will make "stratum.allLayers"
-      // contain single layer instead of all layers that were set
-      // previously from the base URI, causing unexpected errors.
-      //
-      // If layersMetadata is only a single layer -> shove into an array
-      // else if (isDefined(layersMetadataResponse?.id)) {
-      // layers = [layersMetadataResponse];
-      // }
 
       if (!isDefined(layers) || layers.length === 0) {
         throw networkRequestError({

--- a/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
@@ -153,10 +153,17 @@ class MapServerStratum extends LoadableStratum(
 
       if (isDefined(layersMetadataResponse?.layers)) {
         layers = layersMetadataResponse.layers;
-        // If layersMetadata is only a single layer -> shove into an array
-      } else if (isDefined(layersMetadataResponse?.id)) {
-        layers = [layersMetadataResponse];
       }
+      // The following conditional code is commented out becasue
+      // the test will be true when the requested url path ends with
+      // layer ID. Overwriting "layers" will make "stratum.allLayers"
+      // contain single layer instead of all layers that were set
+      // previously from the base URI, causing unexpected errors.
+      //
+      // If layersMetadata is only a single layer -> shove into an array
+      // else if (isDefined(layersMetadataResponse?.id)) {
+      // layers = [layersMetadataResponse];
+      // }
 
       if (!isDefined(layers) || layers.length === 0) {
         throw networkRequestError({

--- a/test/Models/Catalog/esri/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/Catalog/esri/ArcGisMapServerCatalogItemSpec.ts
@@ -280,6 +280,20 @@ describe("ArcGisMapServerCatalogItem", function () {
           expect(imageryProvider.usingPrecachedTiles).toBe(false);
         });
 
+        it("usePreCachedTilesIfAvailable = false if requesting layer ID in url path", async function () {
+          runInAction(() => {
+            item = new ArcGisMapServerCatalogItem("test", new Terria());
+            item.setTrait(CommonStrata.definition, "url", singleLayerUrl);
+          });
+          await item.loadMapItems();
+
+          expect(item.layersArray.length).toBe(1);
+
+          imageryProvider = item.mapItems[0]
+            .imageryProvider as ArcGisMapServerImageryProvider;
+          expect(imageryProvider.usingPrecachedTiles).toBe(false);
+        });
+
         it("usePreCachedTilesIfAvailable = true if not requesting specific layers", async function () {
           runInAction(() => {
             item = new ArcGisMapServerCatalogItem("test", new Terria());


### PR DESCRIPTION
### What this PR does

Fixes #7041 

### Test me
Open [before](http://ci.terria.io/main) or [after](http://ci.terria.io/issue-7041) in browser and upload data from URL https://portal.spatial.nsw.gov.au/server/rest/services/NSW_Administrative_Boundaries_Theme/MapServer/8
then compare the results.
-  Before: Will not show boundaries in the map and will get many 404 errors in the dev tool panel.
-  After: Will show boundaries properly.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
