### PR TITLE
Add CatalogProvider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.5.1)
 
+- Added highly experimental CatalogProvider, intended to encapsulate functionality related to the entire catalog, or large subtrees of it, that doesn't fit into individual catalog member models.
 - `BingMapsCatalogItem` now supports Bing's `culture` parameter.
 - Update a prompt text in DataPreview.
 - [The next improvement]

--- a/lib/Models/Catalog/CatalogProvider.ts
+++ b/lib/Models/Catalog/CatalogProvider.ts
@@ -1,0 +1,18 @@
+import TerriaError from "../../Core/TerriaError";
+import ReferenceMixin from "../../ModelMixins/ReferenceMixin";
+
+/**
+ * @experimental This interface is not stable and likely to change without preserving backwards
+ * compatibility in following patch versions of TerriaJS.
+ *
+ * A CatalogProvider can provide extra functionality where many members in the catalog
+ * are backed by a service with additional capabilities other than producing Terria catalog JSON
+ *
+ * This may include: login, search, ability to track members when they are moved, loading cached dynamic strata
+ *
+ *
+ */
+export default interface CatalogProvider {
+  createLoadError(reference: ReferenceMixin.Instance): TerriaError;
+  isProviderFor(reference: ReferenceMixin.Instance): boolean;
+}

--- a/lib/Models/Catalog/CatalogReferences/MagdaReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/MagdaReference.ts
@@ -202,6 +202,15 @@ export default class MagdaReference extends AccessControlMixin(
         return target;
       }
 
+      if (
+        this.recordId === undefined &&
+        this.terria.catalogProvider?.isProviderFor(this)
+      ) {
+        // Occurs if record is no longer found inside containing group
+        // (i.e moved, deleted or user no longer has access, including if not logged in)
+        throw this.terria.catalogProvider.createLoadError(this);
+      }
+
       const record = await this.loadMagdaRecord({
         id: this.recordId,
         optionalAspects: [

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -2,54 +2,45 @@ import i18next from "i18next";
 import {
   action,
   computed,
+  makeObservable,
   observable,
   runInAction,
   toJS,
-  when,
-  makeObservable
+  when
 } from "mobx";
 import { createTransformer } from "mobx-utils";
-import buildModuleUrl from "terriajs-cesium/Source/Core/buildModuleUrl";
 import Clock from "terriajs-cesium/Source/Core/Clock";
-import defaultValue from "terriajs-cesium/Source/Core/defaultValue";
-import defined from "terriajs-cesium/Source/Core/defined";
 import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import CesiumEvent from "terriajs-cesium/Source/Core/Event";
-import queryToObject from "terriajs-cesium/Source/Core/queryToObject";
 import RequestScheduler from "terriajs-cesium/Source/Core/RequestScheduler";
 import RuntimeError from "terriajs-cesium/Source/Core/RuntimeError";
 import TerrainProvider from "terriajs-cesium/Source/Core/TerrainProvider";
+import buildModuleUrl from "terriajs-cesium/Source/Core/buildModuleUrl";
+import defaultValue from "terriajs-cesium/Source/Core/defaultValue";
+import defined from "terriajs-cesium/Source/Core/defined";
+import queryToObject from "terriajs-cesium/Source/Core/queryToObject";
 import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
 import URI from "urijs";
 import {
   Category,
-  LaunchAction,
-  DataSourceAction
+  DataSourceAction,
+  LaunchAction
 } from "../Core/AnalyticEvents/analyticEvents";
 import AsyncLoader from "../Core/AsyncLoader";
 import Class from "../Core/Class";
 import ConsoleAnalytics from "../Core/ConsoleAnalytics";
 import CorsProxy from "../Core/CorsProxy";
-import ensureSuffix from "../Core/ensureSuffix";
-import filterOutUndefined from "../Core/filterOutUndefined";
-import getDereferencedIfExists from "../Core/getDereferencedIfExists";
-import getPath from "../Core/getPath";
 import GoogleAnalytics from "../Core/GoogleAnalytics";
-import hashEntity from "../Core/hashEntity";
-import instanceOf from "../Core/instanceOf";
-import isDefined from "../Core/isDefined";
 import {
+  JsonArray,
+  JsonObject,
   isJsonBoolean,
   isJsonNumber,
   isJsonObject,
-  isJsonString,
-  JsonArray,
-  JsonObject
+  isJsonString
 } from "../Core/Json";
 import { isLatLonHeight } from "../Core/LatLonHeight";
-import loadJson from "../Core/loadJson";
-import loadJson5 from "../Core/loadJson5";
 import Result from "../Core/Result";
 import ServerConfig from "../Core/ServerConfig";
 import TerriaError, {
@@ -57,6 +48,15 @@ import TerriaError, {
   TerriaErrorSeverity
 } from "../Core/TerriaError";
 import { Complete } from "../Core/TypeModifiers";
+import ensureSuffix from "../Core/ensureSuffix";
+import filterOutUndefined from "../Core/filterOutUndefined";
+import getDereferencedIfExists from "../Core/getDereferencedIfExists";
+import getPath from "../Core/getPath";
+import hashEntity from "../Core/hashEntity";
+import instanceOf from "../Core/instanceOf";
+import isDefined from "../Core/isDefined";
+import loadJson from "../Core/loadJson";
+import loadJson5 from "../Core/loadJson5";
 import { getUriWithoutPath } from "../Core/uriHelpers";
 import PickedFeatures, {
   featureBelongsToCatalogItem,
@@ -67,12 +67,14 @@ import GroupMixin from "../ModelMixins/GroupMixin";
 import MappableMixin, { isDataSource } from "../ModelMixins/MappableMixin";
 import ReferenceMixin from "../ModelMixins/ReferenceMixin";
 import TimeVarying from "../ModelMixins/TimeVarying";
-import { HelpContentItem } from "../ReactViewModels/defaultHelpContent";
-import { defaultTerms, Term } from "../ReactViewModels/defaultTerms";
 import NotificationState from "../ReactViewModels/NotificationState";
+import { HelpContentItem } from "../ReactViewModels/defaultHelpContent";
+import { Term, defaultTerms } from "../ReactViewModels/defaultTerms";
 import { ICredit } from "../ReactViews/Map/BottomBar/Credits";
 import { SHARE_VERSION } from "../ReactViews/Map/Panels/SharePanel/BuildShareLink";
 import { shareConvertNotification } from "../ReactViews/Notification/shareConvertNotification";
+import { SearchBarTraits } from "../Traits/SearchProviders/SearchBarTraits";
+import SearchProviderTraits from "../Traits/SearchProviders/SearchProviderTraits";
 import MappableTraits from "../Traits/TraitsClasses/MappableTraits";
 import MapNavigationModel from "../ViewModels/MapNavigation/MapNavigationModel";
 import TerriaViewer from "../ViewModels/TerriaViewer";
@@ -81,13 +83,15 @@ import CameraView from "./CameraView";
 import Catalog from "./Catalog/Catalog";
 import CatalogGroup from "./Catalog/CatalogGroup";
 import CatalogMemberFactory from "./Catalog/CatalogMemberFactory";
+import CatalogProvider from "./Catalog/CatalogProvider";
 import MagdaReference, {
   MagdaReferenceHeaders
 } from "./Catalog/CatalogReferences/MagdaReference";
 import SplitItemReference from "./Catalog/CatalogReferences/SplitItemReference";
 import CommonStrata from "./Definition/CommonStrata";
-import hasTraits from "./Definition/hasTraits";
 import { BaseModel } from "./Definition/Model";
+import ModelPropertiesFromTraits from "./Definition/ModelPropertiesFromTraits";
+import hasTraits from "./Definition/hasTraits";
 import updateModelFromJson from "./Definition/updateModelFromJson";
 import upsertModelFromJson from "./Definition/upsertModelFromJson";
 import {
@@ -102,12 +106,12 @@ import IElementConfig from "./IElementConfig";
 import InitSource, {
   InitSourceData,
   InitSourceFromData,
+  ShareInitSourceData,
+  StoryData,
   isInitFromData,
   isInitFromDataPromise,
   isInitFromOptions,
-  isInitFromUrl,
-  ShareInitSourceData,
-  StoryData
+  isInitFromUrl
 } from "./InitSource";
 import Internationalization, {
   I18nStartOptions,
@@ -115,7 +119,7 @@ import Internationalization, {
 } from "./Internationalization";
 import MapInteractionMode from "./MapInteractionMode";
 import NoViewer from "./NoViewer";
-import { defaultRelatedMaps, RelatedMap } from "./RelatedMaps";
+import { RelatedMap, defaultRelatedMaps } from "./RelatedMaps";
 import CatalogIndex from "./SearchProviders/CatalogIndex";
 import { SearchBarModel } from "./SearchProviders/SearchBarModel";
 import ShareDataService from "./ShareDataService";
@@ -124,9 +128,6 @@ import TimelineStack from "./TimelineStack";
 import { isViewerMode, setViewerMode } from "./ViewerMode";
 import Workbench from "./Workbench";
 import SelectableDimensionWorkflow from "./Workflows/SelectableDimensionWorkflow";
-import { SearchBarTraits } from "../Traits/SearchProviders/SearchBarTraits";
-import ModelPropertiesFromTraits from "./Definition/ModelPropertiesFromTraits";
-import SearchProviderTraits from "../Traits/SearchProviders/SearchProviderTraits";
 
 // import overrides from "../Overrides/defaults.jsx";
 
@@ -681,6 +682,11 @@ export default class Terria {
    * that the `terria.errorService` always exists.
    */
   errorService: ErrorServiceProvider = new StubErrorServiceProvider();
+
+  /**
+   * @experimental
+   */
+  catalogProvider?: CatalogProvider;
 
   constructor(options: TerriaOptions = {}) {
     makeObservable(this);


### PR DESCRIPTION
### What this PR does

Added experimental CatalogProvider interface. Useful for adding extended functionality spanning the entire catalog, or large subtrees of the catalog.

### Checklist

- [x] I've updated CHANGES.md with what I changed.
