### PR TITLE
Add `usePreCachedTilesIfAvailable` to `ArcGisMapServerCatalogItemTraits`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.5.2)
 
+- Add `usePreCachedTilesIfAvailable` to `ArcGisMapServerCatalogItemTraits`.
 - [The next improvement]
 
 #### 8.5.1 - 2024-02-23

--- a/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
@@ -317,6 +317,22 @@ class MapServerStratum extends LoadableStratum(
 
     return [createStratumInstance(LegendTraits, { items })];
   }
+
+  /** Only used "pre-cached" tiles if we aren't requesting any specific layers
+   * If the `layersArray` property is specified, we request individual dynamic layers and ignore the fused map cache.
+   */
+  @computed get usePreCachedTilesIfAvailable() {
+    if (this._item.parameters) return false;
+
+    return (
+      this._item.layersArray.length === 0 ||
+      !this._item.layers ||
+      setsAreEqual(
+        this._item.layersArray.map((l) => l.id),
+        this.allLayers.map((l) => l.id)
+      )
+    );
+  }
 }
 
 StratumOrder.addLoadStratum(MapServerStratum.stratumName);
@@ -575,13 +591,7 @@ export default class ArcGisMapServerCatalogItem extends UrlMixin(
           /** Only used "pre-cached" tiles if we aren't requesting any specific layers
            * If the `layersArray` property is specified, we request individual dynamic layers and ignore the fused map cache.
            */
-          usePreCachedTilesIfAvailable:
-            this.layersArray.length === 0 ||
-            !this.layers ||
-            setsAreEqual(
-              this.layersArray.map((l) => l.id),
-              stratum.allLayers.map((l) => l.id)
-            ),
+          usePreCachedTilesIfAvailable: this.usePreCachedTilesIfAvailable,
           mapServerData: stratum.mapServer,
           token: stratum.token,
           credit: this.attribution

--- a/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
@@ -588,9 +588,6 @@ export default class ArcGisMapServerCatalogItem extends UrlMixin(
           tileWidth: this.tileWidth,
           parameters: params,
           enablePickFeatures: this.allowFeaturePicking,
-          /** Only used "pre-cached" tiles if we aren't requesting any specific layers
-           * If the `layersArray` property is specified, we request individual dynamic layers and ignore the fused map cache.
-           */
           usePreCachedTilesIfAvailable: this.usePreCachedTilesIfAvailable,
           mapServerData: stratum.mapServer,
           token: stratum.token,

--- a/lib/Traits/TraitsClasses/ArcGisMapServerCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/ArcGisMapServerCatalogItemTraits.ts
@@ -92,4 +92,12 @@ export default class ArcGisMapServerCatalogItemTraits extends mixTraits(
     type: "boolean"
   })
   isForwardTimeWindow: boolean = true;
+
+  @primitiveTrait({
+    name: "Is Forward Time Window",
+    description:
+      "If true, the server's pre-cached tiles are used if they are available. This will default to true if no specific layers are fetched (i.e. all layers are fetched). Otherwise, it will default to false. This will also default to false if parameters have been specified",
+    type: "boolean"
+  })
+  usePreCachedTilesIfAvailable?: boolean;
 }

--- a/lib/Traits/TraitsClasses/ArcGisMapServerCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/ArcGisMapServerCatalogItemTraits.ts
@@ -96,7 +96,7 @@ export default class ArcGisMapServerCatalogItemTraits extends mixTraits(
   @primitiveTrait({
     name: "Is Forward Time Window",
     description:
-      "If true, the server's pre-cached tiles are used if they are available. This will default to true if no specific layers are fetched (i.e. all layers are fetched). Otherwise, it will default to false. This will also default to false if parameters have been specified",
+      "If true, the server's pre-cached tiles are used if they are available. If false, then the MapServer export endpoint will be used. This will default to true if no specific layers are fetched (i.e. all layers are fetched). Otherwise, it will default to false. This will also default to false if parameters have been specified",
     type: "boolean"
   })
   usePreCachedTilesIfAvailable?: boolean;

--- a/test/Models/Catalog/esri/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/Catalog/esri/ArcGisMapServerCatalogItemSpec.ts
@@ -278,6 +278,7 @@ describe("ArcGisMapServerCatalogItem", function () {
           imageryProvider = item.mapItems[0]
             .imageryProvider as ArcGisMapServerImageryProvider;
           expect(imageryProvider.usingPrecachedTiles).toBe(false);
+          expect(item.usePreCachedTilesIfAvailable).toBe(false);
         });
 
         it("usePreCachedTilesIfAvailable = false if requesting layer ID in url path", async function () {
@@ -292,6 +293,26 @@ describe("ArcGisMapServerCatalogItem", function () {
           imageryProvider = item.mapItems[0]
             .imageryProvider as ArcGisMapServerImageryProvider;
           expect(imageryProvider.usingPrecachedTiles).toBe(false);
+          expect(item.usePreCachedTilesIfAvailable).toBe(false);
+        });
+
+        it("usePreCachedTilesIfAvailable = false if parameters have been specified", async function () {
+          runInAction(() => {
+            item = new ArcGisMapServerCatalogItem("test", new Terria());
+            item.setTrait(CommonStrata.definition, "url", mapServerUrl);
+            item.setTrait(CommonStrata.definition, "layers", undefined);
+            item.setTrait(CommonStrata.definition, "parameters", {
+              test: "something"
+            });
+          });
+          await item.loadMapItems();
+
+          expect(item.parameters).toEqual({ test: "something" });
+
+          imageryProvider = item.mapItems[0]
+            .imageryProvider as ArcGisMapServerImageryProvider;
+          expect(imageryProvider.usingPrecachedTiles).toBe(false);
+          expect(item.usePreCachedTilesIfAvailable).toBe(false);
         });
 
         it("usePreCachedTilesIfAvailable = true if not requesting specific layers", async function () {
@@ -306,6 +327,7 @@ describe("ArcGisMapServerCatalogItem", function () {
           imageryProvider = item.mapItems[0]
             .imageryProvider as ArcGisMapServerImageryProvider;
           expect(imageryProvider.usingPrecachedTiles).toBe(true);
+          expect(item.usePreCachedTilesIfAvailable).toBe(true);
         });
 
         it("usePreCachedTilesIfAvailable = true if requesting all layers", async function () {
@@ -327,6 +349,7 @@ describe("ArcGisMapServerCatalogItem", function () {
           imageryProvider = item.mapItems[0]
             .imageryProvider as ArcGisMapServerImageryProvider;
           expect(imageryProvider.usingPrecachedTiles).toBe(true);
+          expect(item.usePreCachedTilesIfAvailable).toBe(true);
         });
       });
     });


### PR DESCRIPTION
### Add `usePreCachedTilesIfAvailable` to `ArcGisMapServerCatalogItemTraits`

This uses existing defaults for `usePreCachedTilesIfAvailable` with one small modification - it will default to false if `parameters` is defined - this is so you can use URL parameters like `layerParameterValues` (which filters features by properties - similar to WMS dimensions).

- [Test URL](http://ci.terria.io/arcgis-tiles-trait/#clean&start=%7B%22initSources%22%3A%20%5B%7B%22homeCamera%22%3A%20%7B%22north%22%3A%20-8%2C%22east%22%3A%20158%2C%22south%22%3A%20-45%2C%22west%22%3A%20109%7D%2C%22catalog%22%3A%20%5B%7B%22type%22%3A%20%22esri-mapServer%22%2C%22name%22%3A%20%22Test%20(with%20parameter)%22%2C%22url%22%3A%20%22https%3A%2F%2Fgo-vicmap-age.shared.landusevictoria.systems%2Farcgis%2Frest%2Fservices%2Fdtv_foi_poly_melb%2FMapServer%22%2C%22parameters%22%3A%20%7B%22some%22%3A%20%22parameter%22%7D%7D%2C%7B%22type%22%3A%20%22esri-mapServer%22%2C%22name%22%3A%20%22Test%20(without%20parameter)%22%2C%22url%22%3A%20%22https%3A%2F%2Fgo-vicmap-age.shared.landusevictoria.systems%2Farcgis%2Frest%2Fservices%2Fdtv_foi_poly_melb%2FMapServer%22%7D%5D%2C%22viewerMode%22%3A%20%223dSmooth%22%2C%22baseMaps%22%3A%20%7B%22defaultBaseMapId%22%3A%20%22basemap-positron%22%2C%22previewBaseMapId%22%3A%20%22basemap-positron%22%7D%7D%5D%7D)
- Open "Test (with parameter)" and "Test (without parameter)"
- Look in network dev console
- You can see one layer is calling MapServer `export` with an extra parameter (`...&some=parameter...`)
- The other layer is calling the `tile` endpoint

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
