### PR TITLE
Fix SDMX `featureInfoTemplate` `<chart>` bug not showing correct `yColumn`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.6.1)
 
+- Fix SDMX `featureInfoTemplate` `<chart>` bug not showing correct `yColumn`
 - [The next improvement]
 
 #### 8.6.0 - 2024-03-12

--- a/lib/Models/Catalog/SdmxJson/SdmxJsonDataflowStratum.ts
+++ b/lib/Models/Catalog/SdmxJson/SdmxJsonDataflowStratum.ts
@@ -804,7 +804,7 @@ export class SdmxJsonDataflowStratum extends LoadableStratum(
       this.catalogItem.discreteTimes.length > 1
     ) {
       const chartName = `${this.catalogItem.name}: {{${regionType.nameProp}}}`;
-      template += `</table>{{#terria.timeSeries.data}}<chart title="${chartName}" x-column="{{terria.timeSeries.xName}}" y-column="${this.unitMeasure}" >{{terria.timeSeries.data}}</chart>{{/terria.timeSeries.data}}`;
+      template += `</table>{{#terria.timeSeries.data}}<chart title="${chartName}" x-column="{{terria.timeSeries.xName}}" y-column="${this.primaryMeasureColumn?.title}" >{{terria.timeSeries.data}}</chart>{{/terria.timeSeries.data}}`;
     }
 
     return createStratumInstance(FeatureInfoTemplateTraits, { template });

--- a/test/Models/Catalog/SdmxJson/SdmxJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/SdmxJson/SdmxJsonCatalogItemSpec.ts
@@ -264,6 +264,34 @@ describe("SdmxJsonCatalogItem", function () {
     );
   });
 
+  it("sets featureInfoTemplate with time-series chart", async function () {
+    runInAction(() => {
+      sdmxItem.setTrait("definition", "agencyId", "ABS");
+      sdmxItem.setTrait("definition", "dataflowId", "RT");
+      sdmxItem.setTrait("definition", "modelOverrides", [
+        createStratumInstance(ModelOverrideTraits, {
+          id: "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ABS:CL_STATE(1.0.0)",
+          type: "region",
+          regionType: "STE_2016"
+        })
+      ]);
+    });
+
+    await sdmxItem.regionProviderLists?.[0]
+      ?.getRegionProvider("STE_2016")
+      ?.loadRegionIDs();
+
+    await sdmxItem.loadMapItems();
+
+    expect(sdmxItem.mapItems.length).toBe(1);
+
+    expect(sdmxItem.featureInfoTemplate).toBeDefined();
+    expect(sdmxItem.featureInfoTemplate?.template).toContain("<chart");
+    expect(sdmxItem.featureInfoTemplate?.template).toContain(
+      `y-column="Observation Value"`
+    );
+  });
+
   it("handles single region gracefully", async function () {
     jasmine.Ajax.stubRequest(
       "http://www.example.com/data/RT/M1.20.10..M"


### PR DESCRIPTION
### Fix SDMX `featureInfoTemplate` `<chart>` bug not showing correct `yColumn`

After we merged in #6960 we fixed `<chart y-column="$COL" ...`, but SDMX had an incorrect `y-column`, so the charts have stopped working.

This is now fixed.

### Test me

- [Before](http://ci.terria.io/main/#configUrl=https://terria-catalogs-public.storage.googleapis.com/nationalmap/config/prod.json&share=s-qKMpWMZnYWpGXCLEakXP2s4B1TS)
- [After](http://ci.terria.io/fix-sdmx-chart-ycols/#configUrl=https://terria-catalogs-public.storage.googleapis.com/nationalmap/config/prod.json&share=s-qKMpWMZnYWpGXCLEakXP2s4B1TS)
- Notice time-series chart is now showing in FeatureInfoPanel

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] ~I've updated relevant documentation in `doc/`.~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
