### PR TITLE
Fix ArcGisMapServerImageryProvider tileInfo bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fixed exception thrown from `objectArrayTrait` when a model has 0 strata and a `MergeStrategy` of `topStratum`.
 - Fix `generateCatalogIndex` after `searchProvider` changes
 - Fix bug with relative URLs being ignored in `generateCatalogIndex`
+- Fix bug with ArcGisMapServerImageryProvider not correctly identifying if the `tile` endpoint can be used
 - [The next improvement]
 
 #### 8.6.1 - 2024-03-14

--- a/lib/Models/Catalog/Esri/ArcGisInterfaces.ts
+++ b/lib/Models/Catalog/Esri/ArcGisInterfaces.ts
@@ -46,8 +46,8 @@ export interface MapServer {
    * So instead we create a single item in the group called "All layers" (models.arcGisMapServerCatalogGroup.singleFusedMapCacheLayerName)
    */
   singleFusedMapCache?: boolean;
-  //comma separated list of supported capabilities - e.g. "Map,Query,Data,TilesOnly,Tilemap"
   tileInfo?: unknown;
+  //comma separated list of supported capabilities - e.g. "Map,Query,Data,TilesOnly,Tilemap"
   capabilities?: string;
   mapName?: string;
   timeInfo?: TimeInfo;

--- a/lib/Models/Catalog/Esri/ArcGisInterfaces.ts
+++ b/lib/Models/Catalog/Esri/ArcGisInterfaces.ts
@@ -47,6 +47,7 @@ export interface MapServer {
    */
   singleFusedMapCache?: boolean;
   //comma separated list of supported capabilities - e.g. "Map,Query,Data,TilesOnly,Tilemap"
+  tileInfo?: unknown;
   capabilities?: string;
   mapName?: string;
   timeInfo?: TimeInfo;

--- a/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
@@ -322,6 +322,8 @@ class MapServerStratum extends LoadableStratum(
    * If the `layersArray` property is specified, we request individual dynamic layers and ignore the fused map cache.
    */
   @computed get usePreCachedTilesIfAvailable() {
+    if (!this.mapServer.tileInfo) return false;
+
     if (this._item.parameters) return false;
 
     return (

--- a/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
+++ b/lib/Models/Catalog/Esri/ArcGisMapServerCatalogItem.ts
@@ -322,6 +322,7 @@ class MapServerStratum extends LoadableStratum(
    * If the `layersArray` property is specified, we request individual dynamic layers and ignore the fused map cache.
    */
   @computed get usePreCachedTilesIfAvailable() {
+    // Checking tileInfo in MapServer metadata should be handled by cesium - but currently there is a bug in ArcGisMapServerImageryProvider
     if (!this.mapServer.tileInfo) return false;
 
     if (this._item.parameters) return false;

--- a/test/Models/Catalog/esri/ArcGisMapServerCatalogItemSpec.ts
+++ b/test/Models/Catalog/esri/ArcGisMapServerCatalogItemSpec.ts
@@ -59,6 +59,12 @@ describe("ArcGisMapServerCatalogItem", function () {
         return realLoadWithXhr(...args);
       } else if (url.match("/cadastre_history/MapServer")) {
         args[0] = "test/ArcGisMapServer/time-enabled.json";
+      } else if (url.match("/LayerWithTiles/MapServer")) {
+        url = url.replace(/^.*\/MapServer/, "MapServer");
+        url = url.replace(/MapServer\/?\?.*/i, "mapserver.json");
+        url = url.replace(/MapServer\/Legend\/?\?.*/i, "legend.json");
+        url = url.replace(/MapServer\/Layers\/?\?.*/i, "layers.json");
+        args[0] = "test/ArcGisMapServer/LayerWithTiles/" + url;
       }
 
       return realLoadWithXhr(...args);
@@ -268,12 +274,16 @@ describe("ArcGisMapServerCatalogItem", function () {
         it("usePreCachedTilesIfAvailable = false if requesting specific layers", async function () {
           runInAction(() => {
             item = new ArcGisMapServerCatalogItem("test", new Terria());
-            item.setTrait(CommonStrata.definition, "url", mapServerUrl);
-            item.setTrait(CommonStrata.definition, "layers", "31,32");
+            item.setTrait(
+              CommonStrata.definition,
+              "url",
+              "http://www.example.com/LayerWithTiles/MapServer"
+            );
+            item.setTrait(CommonStrata.definition, "layers", "0");
           });
           await item.loadMapItems();
 
-          expect(item.layersArray.length).toBe(2);
+          expect(item.layersArray.length).toBe(1);
 
           imageryProvider = item.mapItems[0]
             .imageryProvider as ArcGisMapServerImageryProvider;
@@ -284,7 +294,11 @@ describe("ArcGisMapServerCatalogItem", function () {
         it("usePreCachedTilesIfAvailable = false if requesting layer ID in url path", async function () {
           runInAction(() => {
             item = new ArcGisMapServerCatalogItem("test", new Terria());
-            item.setTrait(CommonStrata.definition, "url", singleLayerUrl);
+            item.setTrait(
+              CommonStrata.definition,
+              "url",
+              "http://www.example.com/LayerWithTiles/MapServer/1"
+            );
           });
           await item.loadMapItems();
 
@@ -299,7 +313,11 @@ describe("ArcGisMapServerCatalogItem", function () {
         it("usePreCachedTilesIfAvailable = false if parameters have been specified", async function () {
           runInAction(() => {
             item = new ArcGisMapServerCatalogItem("test", new Terria());
-            item.setTrait(CommonStrata.definition, "url", mapServerUrl);
+            item.setTrait(
+              CommonStrata.definition,
+              "url",
+              "http://www.example.com/LayerWithTiles/MapServer"
+            );
             item.setTrait(CommonStrata.definition, "layers", undefined);
             item.setTrait(CommonStrata.definition, "parameters", {
               test: "something"
@@ -318,11 +336,15 @@ describe("ArcGisMapServerCatalogItem", function () {
         it("usePreCachedTilesIfAvailable = true if not requesting specific layers", async function () {
           runInAction(() => {
             item = new ArcGisMapServerCatalogItem("test", new Terria());
-            item.setTrait(CommonStrata.definition, "url", mapServerUrl);
+            item.setTrait(
+              CommonStrata.definition,
+              "url",
+              "http://www.example.com/LayerWithTiles/MapServer"
+            );
             item.setTrait(CommonStrata.definition, "layers", undefined);
           });
           await item.loadMapItems();
-          expect(item.layersArray.length).toBe(74);
+          expect(item.layersArray.length).toBe(2);
 
           imageryProvider = item.mapItems[0]
             .imageryProvider as ArcGisMapServerImageryProvider;
@@ -333,18 +355,15 @@ describe("ArcGisMapServerCatalogItem", function () {
         it("usePreCachedTilesIfAvailable = true if requesting all layers", async function () {
           runInAction(() => {
             item = new ArcGisMapServerCatalogItem("test", new Terria());
-            item.setTrait(CommonStrata.definition, "url", mapServerUrl);
             item.setTrait(
               CommonStrata.definition,
-              "layers",
-              new Array(74)
-                .fill(0)
-                .map((_, i) => i)
-                .join(",")
+              "url",
+              "http://www.example.com/LayerWithTiles/MapServer"
             );
+            item.setTrait(CommonStrata.definition, "layers", "0,1");
           });
           await item.loadMapItems();
-          expect(item.layersArray.length).toBe(74);
+          expect(item.layersArray.length).toBe(2);
 
           imageryProvider = item.mapItems[0]
             .imageryProvider as ArcGisMapServerImageryProvider;

--- a/wwwroot/test/ArcGisMapServer/LayerWithTiles/layers.json
+++ b/wwwroot/test/ArcGisMapServer/LayerWithTiles/layers.json
@@ -1,0 +1,451 @@
+{
+  "layers": [
+    {
+      "currentVersion": 11.1,
+      "cimVersion": "3.1.0",
+      "id": 0,
+      "name": "CED",
+      "type": "Feature Layer",
+      "description": "",
+      "geometryType": "esriGeometryPolygon",
+      "sourceSpatialReference": {
+        "wkid": 102100,
+        "latestWkid": 3857,
+        "xyTolerance": 0.001,
+        "zTolerance": 0.001,
+        "mTolerance": 0.001,
+        "falseX": -20037700,
+        "falseY": -30241100,
+        "xyUnits": 10000,
+        "falseZ": -100000,
+        "zUnits": 10000,
+        "falseM": -100000,
+        "mUnits": 10000
+      },
+      "copyrightText": "",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 0,
+      "referenceScale": 0.0,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [0, 0, 0, 0],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [227, 26, 28, 255],
+              "width": 1
+            }
+          }
+        },
+        "scaleSymbols": true,
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": true,
+      "extent": {
+        "xmin": 1.0777612572299998e7,
+        "ymin": -5425372.930199999,
+        "xmax": 1.7711957239600003e7,
+        "ymax": -1022048.4739000015,
+        "spatialReference": {
+          "wkid": 102100,
+          "latestWkid": 3857,
+          "xyTolerance": 0.001,
+          "zTolerance": 0.001,
+          "mTolerance": 0.001,
+          "falseX": -20037700,
+          "falseY": -30241100,
+          "xyUnits": 10000,
+          "falseZ": -100000,
+          "zUnits": 10000,
+          "falseM": -100000,
+          "mUnits": 10000
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "CED_NAME",
+      "typeIdField": null,
+      "subtypeFieldName": null,
+      "subtypeField": null,
+      "defaultSubtypeCode": null,
+      "fields": [
+        {
+          "name": "objectid",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "shape",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "CED_CODE",
+          "type": "esriFieldTypeString",
+          "alias": "CED_CODE",
+          "length": 6,
+          "domain": null
+        },
+        {
+          "name": "CED_NAME",
+          "type": "esriFieldTypeString",
+          "alias": "CED_NAME",
+          "length": 40,
+          "domain": null
+        },
+        {
+          "name": "st_length(shape)",
+          "type": "esriFieldTypeDouble",
+          "alias": "Shape_Length",
+          "domain": null
+        },
+        {
+          "name": "st_area(shape)",
+          "type": "esriFieldTypeDouble",
+          "alias": "Shape_Area",
+          "domain": null
+        }
+      ],
+      "geometryField": {
+        "name": "shape",
+        "type": "esriFieldTypeGeometry",
+        "alias": "Shape"
+      },
+      "indexes": [
+        {
+          "name": "i257ced_code",
+          "fields": "CED_CODE",
+          "isAscending": true,
+          "isUnique": false,
+          "description": ""
+        },
+        {
+          "name": "i257ced_name",
+          "fields": "CED_NAME",
+          "isAscending": true,
+          "isUnique": false,
+          "description": ""
+        },
+        {
+          "name": "r533_sde_rowid_uk",
+          "fields": "objectid",
+          "isAscending": true,
+          "isUnique": true,
+          "description": ""
+        },
+        {
+          "name": "a522_ix1",
+          "fields": "shape",
+          "isAscending": true,
+          "isUnique": true,
+          "description": ""
+        }
+      ],
+      "subtypes": [],
+      "relationships": [],
+      "canModifyLayer": true,
+      "canScaleSymbols": false,
+      "hasLabels": false,
+      "capabilities": "Map,Query,Data",
+      "maxRecordCount": 2000,
+      "supportsStatistics": true,
+      "supportsExceedsLimitStatistics": true,
+      "supportsAdvancedQueries": true,
+      "hasZ": true,
+      "hasM": true,
+      "supportedQueryFormats": "JSON, geoJSON, PBF",
+      "isDataVersioned": false,
+      "ownershipBasedAccessControlForFeatures": { "allowOthersToQuery": true },
+      "useStandardizedQueries": true,
+      "supportedSpatialRelationships": [
+        "esriSpatialRelIntersects",
+        "esriSpatialRelContains",
+        "esriSpatialRelCrosses",
+        "esriSpatialRelEnvelopeIntersects",
+        "esriSpatialRelIndexIntersects",
+        "esriSpatialRelOverlaps",
+        "esriSpatialRelTouches",
+        "esriSpatialRelWithin",
+        "esriSpatialRelRelation"
+      ],
+      "advancedQueryCapabilities": {
+        "useStandardizedQueries": true,
+        "supportsStatistics": true,
+        "supportsPercentileStatistics": true,
+        "supportsHavingClause": true,
+        "supportsOrderBy": true,
+        "supportsDistinct": true,
+        "supportsCountDistinct": true,
+        "supportsPagination": true,
+        "supportsLod": false,
+        "supportsQueryWithLodSR": false,
+        "supportsTrueCurve": true,
+        "supportsQueryWithDatumTransformation": true,
+        "supportsReturningQueryExtent": true,
+        "supportsQueryWithDistance": true,
+        "supportsSqlExpression": true,
+        "supportsTimeRelation": true,
+        "supportsSqlFormat": false,
+        "supportsQueryAnalytic": true
+      },
+      "supportsDatumTransformation": true,
+      "advancedQueryAnalyticCapabilities": {
+        "supportsLinearRegression": true,
+        "supportsAsync": false,
+        "supportsPercentileAnalytic": false
+      },
+      "dateFieldsTimeReference": null,
+      "preferredTimeReference": null,
+      "datesInUnknownTimezone": false,
+      "hasGeometryProperties": true,
+      "geometryProperties": {
+        "shapeAreaFieldName": "st_area(shape)",
+        "shapeLengthFieldName": "st_length(shape)",
+        "units": "esriMeters",
+        "mapUnits": { "uwkid": 9001 }
+      },
+      "hasMetadata": true,
+      "isDataArchived": false,
+      "archivingInfo": {
+        "supportsQueryWithHistoricMoment": false,
+        "startArchivingMoment": -1
+      },
+      "supportsCoordinatesQuantization": true,
+      "supportsDynamicLegends": true,
+      "serviceItemId": "29715c4ca43543de88ec7ce6506b13bf"
+    },
+    {
+      "currentVersion": 11.1,
+      "cimVersion": "3.1.0",
+      "id": 1,
+      "name": "CED_GEN",
+      "type": "Feature Layer",
+      "description": "",
+      "geometryType": "esriGeometryPolygon",
+      "sourceSpatialReference": {
+        "wkid": 102100,
+        "latestWkid": 3857,
+        "xyTolerance": 0.001,
+        "zTolerance": 0.001,
+        "mTolerance": 0.001,
+        "falseX": -20037700,
+        "falseY": -30241100,
+        "xyUnits": 10000,
+        "falseZ": -100000,
+        "zUnits": 10000,
+        "falseM": -100000,
+        "mUnits": 10000
+      },
+      "copyrightText": "",
+      "parentLayer": null,
+      "subLayers": [],
+      "minScale": 0,
+      "maxScale": 0,
+      "referenceScale": 0.0,
+      "drawingInfo": {
+        "renderer": {
+          "type": "simple",
+          "symbol": {
+            "type": "esriSFS",
+            "style": "esriSFSSolid",
+            "color": [0, 0, 0, 0],
+            "outline": {
+              "type": "esriSLS",
+              "style": "esriSLSSolid",
+              "color": [227, 26, 28, 255],
+              "width": 1
+            }
+          }
+        },
+        "scaleSymbols": true,
+        "transparency": 0,
+        "labelingInfo": null
+      },
+      "defaultVisibility": false,
+      "extent": {
+        "xmin": 1.07776133515e7,
+        "ymin": -5410374.9551,
+        "xmax": 1.77119524529e7,
+        "ymax": -1022048.4739000015,
+        "spatialReference": {
+          "wkid": 102100,
+          "latestWkid": 3857,
+          "xyTolerance": 0.001,
+          "zTolerance": 0.001,
+          "mTolerance": 0.001,
+          "falseX": -20037700,
+          "falseY": -30241100,
+          "xyUnits": 10000,
+          "falseZ": -100000,
+          "zUnits": 10000,
+          "falseM": -100000,
+          "mUnits": 10000
+        }
+      },
+      "hasAttachments": false,
+      "htmlPopupType": "esriServerHTMLPopupTypeAsHTMLText",
+      "displayField": "CED_NAME",
+      "typeIdField": null,
+      "subtypeFieldName": null,
+      "subtypeField": null,
+      "defaultSubtypeCode": null,
+      "fields": [
+        {
+          "name": "objectid",
+          "type": "esriFieldTypeOID",
+          "alias": "OBJECTID",
+          "domain": null
+        },
+        {
+          "name": "shape",
+          "type": "esriFieldTypeGeometry",
+          "alias": "Shape",
+          "domain": null
+        },
+        {
+          "name": "CED_CODE",
+          "type": "esriFieldTypeString",
+          "alias": "CED_CODE",
+          "length": 6,
+          "domain": null
+        },
+        {
+          "name": "CED_NAME",
+          "type": "esriFieldTypeString",
+          "alias": "CED_NAME",
+          "length": 40,
+          "domain": null
+        },
+        {
+          "name": "st_length(shape)",
+          "type": "esriFieldTypeDouble",
+          "alias": "Shape_Length",
+          "domain": null
+        },
+        {
+          "name": "st_area(shape)",
+          "type": "esriFieldTypeDouble",
+          "alias": "Shape_Area",
+          "domain": null
+        }
+      ],
+      "geometryField": {
+        "name": "shape",
+        "type": "esriFieldTypeGeometry",
+        "alias": "Shape"
+      },
+      "indexes": [
+        {
+          "name": "i258ced_code",
+          "fields": "CED_CODE",
+          "isAscending": true,
+          "isUnique": false,
+          "description": ""
+        },
+        {
+          "name": "i258ced_name",
+          "fields": "CED_NAME",
+          "isAscending": true,
+          "isUnique": false,
+          "description": ""
+        },
+        {
+          "name": "r535_sde_rowid_uk",
+          "fields": "objectid",
+          "isAscending": true,
+          "isUnique": true,
+          "description": ""
+        },
+        {
+          "name": "a524_ix1",
+          "fields": "shape",
+          "isAscending": true,
+          "isUnique": true,
+          "description": ""
+        }
+      ],
+      "subtypes": [],
+      "relationships": [],
+      "canModifyLayer": true,
+      "canScaleSymbols": false,
+      "hasLabels": false,
+      "capabilities": "Map,Query,Data",
+      "maxRecordCount": 2000,
+      "supportsStatistics": true,
+      "supportsExceedsLimitStatistics": true,
+      "supportsAdvancedQueries": true,
+      "hasZ": true,
+      "hasM": true,
+      "supportedQueryFormats": "JSON, geoJSON, PBF",
+      "isDataVersioned": false,
+      "ownershipBasedAccessControlForFeatures": { "allowOthersToQuery": true },
+      "useStandardizedQueries": true,
+      "supportedSpatialRelationships": [
+        "esriSpatialRelIntersects",
+        "esriSpatialRelContains",
+        "esriSpatialRelCrosses",
+        "esriSpatialRelEnvelopeIntersects",
+        "esriSpatialRelIndexIntersects",
+        "esriSpatialRelOverlaps",
+        "esriSpatialRelTouches",
+        "esriSpatialRelWithin",
+        "esriSpatialRelRelation"
+      ],
+      "advancedQueryCapabilities": {
+        "useStandardizedQueries": true,
+        "supportsStatistics": true,
+        "supportsPercentileStatistics": true,
+        "supportsHavingClause": true,
+        "supportsOrderBy": true,
+        "supportsDistinct": true,
+        "supportsCountDistinct": true,
+        "supportsPagination": true,
+        "supportsLod": false,
+        "supportsQueryWithLodSR": false,
+        "supportsTrueCurve": true,
+        "supportsQueryWithDatumTransformation": true,
+        "supportsReturningQueryExtent": true,
+        "supportsQueryWithDistance": true,
+        "supportsSqlExpression": true,
+        "supportsTimeRelation": true,
+        "supportsSqlFormat": false,
+        "supportsQueryAnalytic": true
+      },
+      "supportsDatumTransformation": true,
+      "advancedQueryAnalyticCapabilities": {
+        "supportsLinearRegression": true,
+        "supportsAsync": false,
+        "supportsPercentileAnalytic": false
+      },
+      "dateFieldsTimeReference": null,
+      "preferredTimeReference": null,
+      "datesInUnknownTimezone": false,
+      "hasGeometryProperties": true,
+      "geometryProperties": {
+        "shapeAreaFieldName": "st_area(shape)",
+        "shapeLengthFieldName": "st_length(shape)",
+        "units": "esriMeters",
+        "mapUnits": { "uwkid": 9001 }
+      },
+      "hasMetadata": true,
+      "isDataArchived": false,
+      "archivingInfo": {
+        "supportsQueryWithHistoricMoment": false,
+        "startArchivingMoment": -1
+      },
+      "supportsCoordinatesQuantization": true,
+      "supportsDynamicLegends": true,
+      "serviceItemId": "29715c4ca43543de88ec7ce6506b13bf"
+    }
+  ],
+  "tables": []
+}

--- a/wwwroot/test/ArcGisMapServer/LayerWithTiles/legend.json
+++ b/wwwroot/test/ArcGisMapServer/LayerWithTiles/legend.json
@@ -1,0 +1,52 @@
+{
+  "layers": [
+    {
+      "layerId": 0,
+      "layerName": "CED",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 0,
+      "legend": [
+        {
+          "label": "",
+          "url": "13475f3a5a215091da89ba1f50364cdc",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAY0lEQVQ4je3UwQnAIBBE0UG2irDpxc4kndmL1mESsxLwPHvcf/H2EIWRdugNx2SdFxIqJQ1kAMXAhHr2ToFNdaILdEwCpBOe2AuQTxyMrQD57A0H8rdnTDaw/6eUOY709V7gAWeDEPvhQjLjAAAAAElFTkSuQmCC",
+          "contentType": "image/png",
+          "groupId": "0",
+          "height": 20,
+          "width": 20
+        }
+      ],
+      "legendGroups": [
+        {
+          "id": "0",
+          "heading": ""
+        }
+      ]
+    },
+    {
+      "layerId": 1,
+      "layerName": "CED_GEN",
+      "layerType": "Feature Layer",
+      "minScale": 0,
+      "maxScale": 0,
+      "legend": [
+        {
+          "label": "",
+          "url": "13475f3a5a215091da89ba1f50364cdc",
+          "imageData": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAY0lEQVQ4je3UwQnAIBBE0UG2irDpxc4kndmL1mESsxLwPHvcf/H2EIWRdugNx2SdFxIqJQ1kAMXAhHr2ToFNdaILdEwCpBOe2AuQTxyMrQD57A0H8rdnTDaw/6eUOY709V7gAWeDEPvhQjLjAAAAAElFTkSuQmCC",
+          "contentType": "image/png",
+          "groupId": "0",
+          "height": 20,
+          "width": 20
+        }
+      ],
+      "legendGroups": [
+        {
+          "id": "0",
+          "heading": ""
+        }
+      ]
+    }
+  ]
+}

--- a/wwwroot/test/ArcGisMapServer/LayerWithTiles/mapserver.json
+++ b/wwwroot/test/ArcGisMapServer/LayerWithTiles/mapserver.json
@@ -1,0 +1,224 @@
+{
+  "currentVersion": 11.1,
+  "cimVersion": "3.1.0",
+  "serviceDescription": "",
+  "mapName": "Layers",
+  "description": "",
+  "copyrightText": "",
+  "supportsDynamicLayers": true,
+  "layers": [
+    {
+      "id": 0,
+      "name": "CED",
+      "parentLayerId": -1,
+      "defaultVisibility": true,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 0,
+      "type": "Feature Layer",
+      "geometryType": "esriGeometryPolygon",
+      "supportsDynamicLegends": true
+    },
+    {
+      "id": 1,
+      "name": "CED_GEN",
+      "parentLayerId": -1,
+      "defaultVisibility": false,
+      "subLayerIds": null,
+      "minScale": 0,
+      "maxScale": 0,
+      "type": "Feature Layer",
+      "geometryType": "esriGeometryPolygon",
+      "supportsDynamicLegends": true
+    }
+  ],
+  "tables": [],
+  "spatialReference": {
+    "wkid": 102100,
+    "latestWkid": 3857,
+    "xyTolerance": 0.001,
+    "zTolerance": 0.001,
+    "mTolerance": 0.001,
+    "falseX": -20037700,
+    "falseY": -30241100,
+    "xyUnits": 10000,
+    "falseZ": -100000,
+    "zUnits": 10000,
+    "falseM": -100000,
+    "mUnits": 10000
+  },
+  "singleFusedMapCache": false,
+  "tileInfo": {
+    "rows": 256,
+    "cols": 256,
+    "dpi": 96,
+    "format": "PNG",
+    "compressionQuality": 0,
+    "origin": {
+      "x": -2.0037508342787e7,
+      "y": 2.0037508342787e7
+    },
+    "spatialReference": {
+      "wkid": 102100,
+      "latestWkid": 3857,
+      "xyTolerance": 0.001,
+      "zTolerance": 0.001,
+      "mTolerance": 0.001,
+      "falseX": -20037700,
+      "falseY": -30241100,
+      "xyUnits": 1.4892314192838538e8,
+      "falseZ": -100000,
+      "zUnits": 10000,
+      "falseM": -100000,
+      "mUnits": 10000
+    },
+    "lods": [
+      {
+        "level": 0,
+        "resolution": 156543.033928,
+        "scale": 5.91657527591555e8
+      },
+      {
+        "level": 1,
+        "resolution": 78271.5169639999,
+        "scale": 2.95828763795777e8
+      },
+      {
+        "level": 2,
+        "resolution": 39135.7584820001,
+        "scale": 1.47914381897889e8
+      },
+      {
+        "level": 3,
+        "resolution": 19567.8792409999,
+        "scale": 7.3957190948944e7
+      },
+      {
+        "level": 4,
+        "resolution": 9783.93962049996,
+        "scale": 3.6978595474472e7
+      },
+      {
+        "level": 5,
+        "resolution": 4891.96981024998,
+        "scale": 1.8489297737236e7
+      },
+      {
+        "level": 6,
+        "resolution": 2445.98490512499,
+        "scale": 9244648.868618
+      },
+      {
+        "level": 7,
+        "resolution": 1222.99245256249,
+        "scale": 4622324.434309
+      },
+      {
+        "level": 8,
+        "resolution": 611.49622628138,
+        "scale": 2311162.217155
+      },
+      {
+        "level": 9,
+        "resolution": 305.748113140558,
+        "scale": 1155581.108577
+      },
+      {
+        "level": 10,
+        "resolution": 152.874056570411,
+        "scale": 577790.554289
+      },
+      {
+        "level": 11,
+        "resolution": 76.4370282850732,
+        "scale": 288895.277144
+      },
+      {
+        "level": 12,
+        "resolution": 38.2185141425366,
+        "scale": 144447.638572
+      },
+      {
+        "level": 13,
+        "resolution": 19.1092570712683,
+        "scale": 72223.819286
+      }
+    ]
+  },
+  "storageInfo": {
+    "storageFormat": "esriMapCacheStorageModeCompactV2",
+    "packetSize": 128
+  },
+  "initialExtent": {
+    "xmin": 1.0686671116154265e7,
+    "ymin": -5916377.298219686,
+    "xmax": 1.8701674453269962e7,
+    "ymax": -598607.9389850269,
+    "spatialReference": {
+      "wkid": 102100,
+      "latestWkid": 3857,
+      "xyTolerance": 0.001,
+      "zTolerance": 0.001,
+      "mTolerance": 0.001,
+      "falseX": -20037700,
+      "falseY": -30241100,
+      "xyUnits": 10000,
+      "falseZ": -100000,
+      "zUnits": 10000,
+      "falseM": -100000,
+      "mUnits": 10000
+    }
+  },
+  "fullExtent": {
+    "xmin": 1.0777612572299998e7,
+    "ymin": -5425372.930199999,
+    "xmax": 1.7711957239600003e7,
+    "ymax": -1022048.4739000015,
+    "spatialReference": {
+      "wkid": 102100,
+      "latestWkid": 3857,
+      "xyTolerance": 0.001,
+      "zTolerance": 0.001,
+      "mTolerance": 0.001,
+      "falseX": -20037700,
+      "falseY": -30241100,
+      "xyUnits": 10000,
+      "falseZ": -100000,
+      "zUnits": 10000,
+      "falseM": -100000,
+      "mUnits": 10000
+    }
+  },
+  "datesInUnknownTimezone": false,
+  "minScale": 0,
+  "maxScale": 72223.819286,
+  "units": "esriMeters",
+  "supportedImageFormatTypes": "PNG32,PNG24,PNG,JPG,DIB,TIFF,EMF,PS,PDF,GIF,SVG,SVGZ,BMP",
+  "documentInfo": {
+    "Title": "Untitled.aprx",
+    "Author": "",
+    "Comments": "",
+    "Subject": "",
+    "Category": "",
+    "Version": "3.1.0",
+    "AntialiasingMode": "Fast",
+    "TextAntialiasingMode": "Force",
+    "Keywords": ""
+  },
+  "capabilities": "Map,Query,Data",
+  "supportedQueryFormats": "JSON, geoJSON, PBF",
+  "exportTilesAllowed": false,
+  "referenceScale": 0.0,
+  "supportsDatumTransformation": true,
+  "archivingInfo": { "supportsHistoricMoment": false },
+  "supportsClipping": true,
+  "supportsSpatialFilter": true,
+  "supportsTimeRelation": true,
+  "supportsQueryDataElements": true,
+  "mapUnits": { "uwkid": 9001 },
+  "maxRecordCount": 2000,
+  "maxImageHeight": 4096,
+  "maxImageWidth": 4096,
+  "supportedExtensions": "FeatureServer, KmlServer, OGCFeatureServer, WFSServer, WMSServer",
+  "serviceItemId": "29715c4ca43543de88ec7ce6506b13bf"
+}


### PR DESCRIPTION
### What this PR does

There is a bug in Ceisum's code here - there is an `await` missing

https://github.com/TerriaJS/cesium/blob/33d48c5987ff3b6176bff315a32c693550696c2c/packages/engine/Source/Scene/ArcGisMapServerImageryProvider.js#L767

which means that when `mapServerData` is provided, it doesn't parse metadata correctly.

For example here - `useTiles` is supposed to be set to false

https://github.com/TerriaJS/cesium/blob/33d48c5987ff3b6176bff315a32c693550696c2c/packages/engine/Source/Scene/ArcGisMapServerImageryProvider.js#L138-L141

But because of the missing `await` - the imagery provider is created before this value is changed.

To fix this in the short-term I have added our own check for `tileInfo`

### Test me

- Add the following web data
- `https://go-vicmap-age.shared.landusevictoria.systems/arcgis/rest/services/dtv_foi_poly_melb/MapServer`
- Before http://ci.terria.io/main/
- After http://ci.terria.io/arcgismapserver-tileinfo/
- Before you will not see the layer on the map (and also a bunch of 404 erros)
- After you will see the layer

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] ~I've updated relevant documentation in `doc/`.~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
