### PR TITLE
CI: fix yarn warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn prettier-check
 
       - name: Build TerriaJS tests
-        run: yarn gulp lint release -- --continue
+        run: yarn gulp lint release --continue
         env:
           NODE_OPTIONS: --max_old_space_size=4096
 


### PR DESCRIPTION
### What this PR does

The double dashes are not required
according to yarn.

### Test me

Check CI output that warning no longer appears.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
