### PR TITLE
Remove spuriuos return

### DIFF
--- a/lib/ReactViews/Custom/Chart/MomentPointsChart.jsx
+++ b/lib/ReactViews/Custom/Chart/MomentPointsChart.jsx
@@ -138,7 +138,6 @@ function closestPointIndex(x, sortedPoints) {
       return i - 1;
     }
   }
-  return;
 }
 
 export default MomentPointsChart;


### PR DESCRIPTION
### What this PR does

Return as the last statement
of a function without return value
is not required, so remove it.

### Test me

Tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
