### PR TITLE
Reduce log noise in MagdaReference.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Fix `PointStyleTraits.marker` bug where URLs were not being used.
 - Fixed a bug with passing a relative baseUrl to Cesium >= 1.113.0 when `document.baseURI` is different to its `location`.
 - Fix node v18 compatibility by forcing `webpack-terser-plugin` version resolution and fixing new type errors
+- Reduce log noise in `MagdaReference`.
 - [The next improvement]
 
 #### 8.7.0 - 2024-03-22

--- a/lib/Models/Catalog/CatalogReferences/MagdaReference.ts
+++ b/lib/Models/Catalog/CatalogReferences/MagdaReference.ts
@@ -522,7 +522,7 @@ export default class MagdaReference extends AccessControlMixin(
         group.setTrait(magdaRecordStratum, "name", record.name);
       }
       group.setTrait(magdaRecordStratum, "members", filterOutUndefined(ids));
-      if (GroupMixin.isMixedInto(group)) {
+      if (GroupMixin.isMixedInto(group) && group.uniqueId) {
         console.log(`Refreshing ids for ${group.uniqueId}`);
         group.refreshKnownContainerUniqueIds(group.uniqueId);
       }


### PR DESCRIPTION
### What this PR does

Fixes #7101 

No need to log `Refreshing ids for ${group.uniqueId}` if `${group.uniqueId}` is undefined because `group.refreshKnownContainerUniqueIds(group.uniqueId)` will do nothing. 

Otherwise there will be too much noise in the log.

### Test me


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
