### PR TITLE
Remove `OneKeyFrom` type check to reduce compile time.

### DIFF
--- a/lib/Styled/Box.tsx
+++ b/lib/Styled/Box.tsx
@@ -1,6 +1,6 @@
 import { Ref } from "react";
 import styled from "styled-components";
-import { OneKeyFrom, Overflow, WhiteSpace, WordBreak } from "./Styled.types";
+import { Overflow, WhiteSpace, WordBreak } from "./Styled.types";
 
 interface Column {
   col1?: boolean;
@@ -68,7 +68,7 @@ export interface IBoxPropsBase {
   as?: React.ElementType | keyof JSX.IntrinsicElements;
 }
 
-export type IBoxProps = IBoxPropsBase & OneKeyFrom<Column>;
+export type IBoxProps = IBoxPropsBase & Column;
 
 export const Box = styled.div<IBoxProps>`
   display: flex;

--- a/lib/Styled/Styled.types.ts
+++ b/lib/Styled/Styled.types.ts
@@ -23,12 +23,6 @@ export type WhiteSpace =
   | "initial"
   | "inherit";
 
-export type OneKeyFrom<T, K extends keyof T = keyof T> = K extends any
-  ? Pick<T, K> & Partial<Record<Exclude<keyof T, K>, never>> extends infer O
-    ? { [P in keyof O]: O[P] }
-    : never
-  : never;
-
 /**
  * Types that can be used after upgrade to ts4.
  */

--- a/lib/Styled/Text.tsx
+++ b/lib/Styled/Text.tsx
@@ -1,6 +1,5 @@
 import { ComponentProps } from "react";
 import styled from "styled-components";
-import { OneKeyFrom } from "./Styled.types";
 
 interface ITextSize {
   noFontSize?: boolean;
@@ -52,9 +51,9 @@ export interface ITextPropsBase {
 }
 
 export type ITextProps = ITextPropsBase &
-  OneKeyFrom<ITextSize> &
-  OneKeyFrom<ITextColor> &
-  OneKeyFrom<ITextWeight> &
+  ITextSize &
+  ITextColor &
+  ITextWeight &
   ComponentProps<"div">;
 
 // should it be a span or inline-block-div? - leaning to div


### PR DESCRIPTION
### What this PR does

Save 16 seconds from typescript compile step. 

Running [typescript analyzer](https://github.com/microsoft/typescript-analyze-trace) reports a hotspot when compiling Terria code (see report below). Apparently the [OneKeyFrom](https://github.com/TerriaJS/terriajs/blob/92c0afe822e323804b38beff5479100936d7e532/lib/Styled/Styled.types.ts#L26-L30) type used for typing the [Text](https://github.com/TerriaJS/terriajs/blob/92c0afe822e323804b38beff5479100936d7e532/lib/Styled/Text.tsx#L54-L58) and [Box](https://github.com/TerriaJS/terriajs/blob/92c0afe822e323804b38beff5479100936d7e532/lib/Styled/Box.tsx#L71) component props is pretty expensive to type check. 

I am not sure if there is a better fix, but for now I have removed `OneKeyFrom` which loosens the type checking a bit, but I think this is a good compromise as it:
- saves more than 16 seconds off current compilation time
- avoids future use of `Text` component from further increasing the compile time

Typescript analyzer report:
```
$ npx @typescript/analyze-trace tstrace

Hot Spots
├─ Check file /home/san244/work/terriamap-editor/packages/terriajs/lib/Styled/Checkbox/Checkbox.tsx (6801ms)
│  └─ Check deferred node from (line 78, char 7) to (line 121, char 18) (6791ms)
├─ Check file /home/san244/work/terriamap-editor/packages/terriajs/lib/ReactViews/StandardUserInterface/TrainerBar/TrainerBar.tsx (1180ms)
│  └─ Check deferred node from (line 87, char 9) to (line 89, char 19) (790ms)
├─ Check file /home/san244/work/terriamap-editor/packages/terriajs/lib/Styled/Text.tsx (992ms)
│  └─ Check variable declaration from (line 227, char 4) to (line 233, char 1) (652ms)
│     └─ Check expression from (line 227, char 15) to (line 233, char 1) (652ms)
│        └─ Check expression from (line 227, char 15) to (line 233, char 1) (652ms)
│           └─ Check expression from (line 227, char 15) to (line 227, char 34) (650ms)
│              └─ Check expression from (line 227, char 15) to (line 227, char 28) (650ms)
├─ Check file /home/san244/work/terriamap-editor/packages/terriajs/lib/ReactViews/Workbench/Controls/OpacitySection.tsx (841ms)
│  └─ Check deferred node from (line 52, char 11) to (line 56, char 25) (835ms)
├─ Check file /home/san244/work/terriamap-editor/packages/terriajs/lib/ReactViews/Feedback/FeedbackForm.tsx (699ms)
│  └─ Check deferred node from (line 187, char 11) to (line 198, char 18) (547ms)
├─ Check file /home/san244/work/terriamap-editor/packages/terriajs/lib/ReactViews/SelectableDimensions/SelectableDimension.tsx (620ms)
│  └─ Check deferred node from (line 39, char 13) to (line 44, char 20) (609ms)
├─ Check file /home/san244/work/terriamap-editor/packages/terriajs/lib/ReactViews/Map/BottomBar/DistanceLegend.tsx (551ms)
│  └─ Check deferred node from (line 191, char 9) to (line 199, char 16) (542ms)
└─ Check file /home/san244/work/terriamap-editor/node_modules/@types/styled-components/index.d.ts (525ms)

Duplicate packages
└─ @types/d3-color
   ├─ Version 3.0.2 from /home/san244/work/terriamap-editor/node_modules/@types/d3-color
   └─ Version 1.4.2 from /home/san244/work/terriamap-editor/node_modules/@types/d3-interpolate/node_modules/@types/d3-color
```

### Test me

Before:
```
time tsc

real    0m29.036s
user    0m43.665s
sys     0m1.237s
```

After:
```
time tsc

real    0m12.047s
user    0m24.441s
sys     0m0.581s
```

### Checklist

- [ ] ~There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~ Only changes the types
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
