### PR TITLE
Remove `string-replace-webpack-plugin` to fix critical security warning.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.7.2)
 
 - Add NumberParameterEditor to enable WPS AllowedValues Ranges to be set and use DefaultValue
+- Show Cesium's original credit message instead of a custom Terria one when using the default Ion access token.
 
 #### 8.7.1 - 2024-04-16
 

--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
-const StringReplacePlugin = require("string-replace-webpack-plugin");
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const ForkTsCheckerNotifierWebpackPlugin = require("fork-ts-checker-notifier-webpack-plugin");
 const webpack = require("webpack");
@@ -50,66 +49,6 @@ function configureWebpack(
 
   config.module = config.module || {};
   config.module.rules = config.module.rules || [];
-
-  config.module.rules.push({
-    test: /\.js?$/,
-    include: path.dirname(require.resolve("terriajs-cesium/README.md")),
-    exclude: [
-      // require.resolve("terriajs-cesium/Source/ThirdParty/zip"),
-      // require.resolve("terriajs-cesium/Source/Core/buildModuleUrl"),
-      // require.resolve("terriajs-cesium/Source/Core/TaskProcessor")
-    ],
-    loader: StringReplacePlugin.replace({
-      replacements: [
-        // {
-        //   pattern: /buildModuleUrl\([\'|\"|\`](.*)[\'|\"|\`]\)/gi,
-        //   replacement: function (match, p1, offset, string) {
-        //     let p1_modified = p1.replace(/\\/g, "\\\\");
-        //     return (
-        //       "require(`" +
-        //       cesiumDir.replace(/\\/g, "\\\\") +
-        //       "/Source/" +
-        //       p1_modified +
-        //       "`)"
-        //     );
-        //   }
-        // },
-        {
-          pattern: /Please assign <i>Cesium.Ion.defaultAccessToken<\/i>/g,
-          replacement: function () {
-            return 'Please set "cesiumIonAccessToken" in config.json';
-          }
-        },
-        {
-          pattern: / before making any Cesium API calls/g,
-          replacement: function () {
-            return "";
-          }
-        }
-      ]
-    })
-  });
-
-  // The sprintf module included by Cesium includes a license comment with a big
-  // pile of links, some of which are apparently dodgy and cause Websense to flag
-  // web workers that include the comment as malicious.  So here we munge URLs in
-  // comments so broken security software doesn't consider them links that a user
-  // might actually visit.
-  config.module.rules.push({
-    test: /\.js?$/,
-    include: path.resolve(cesiumDir, "Source", "ThirdParty"),
-    loader: StringReplacePlugin.replace({
-      replacements: [
-        {
-          pattern: /\/\*[\S\s]*?\*\//g, // find multi-line comments
-          replacement: function (match) {
-            // replace http:// and https:// with a spelling-out of it.
-            return match.replace(/(https?):\/\//g, "$1-colon-slashslash ");
-          }
-        }
-      ]
-    })
-  });
 
   const zipJsDir = path.dirname(require.resolve("@zip.js/zip.js/package.json"));
 
@@ -316,7 +255,6 @@ function configureWebpack(
   };
 
   config.plugins = (config.plugins || []).concat([
-    new StringReplacePlugin(),
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
   ]);
 

--- a/package.json
+++ b/package.json
@@ -172,8 +172,6 @@
     "sass-loader": "^10",
     "shpjs": "^3.6.0",
     "simple-statistics": "^7.0.1",
-    "string-replace-loader": "^2.1.1",
-    "string-replace-webpack-plugin": "^0.1.3",
     "style-loader": "^0.23.1",
     "styled-components": "^5.3.9",
     "svg-sprite-loader": "^6.0.11",


### PR DESCRIPTION
### What this PR does

Removes [string-replace-webpack-plugin](https://www.npmjs.com/package/string-replace-webpack-plugin) which generates a [security warning](https://github.com/advisories/GHSA-76p3-8jx3-jpfq) due to one of its stale dependency.

The plugin was mainly used for replacing babel generated getters with `superGet` in mobx 4. But after mobx upgrade this is no longer required.

It is currently only used for [updating](https://github.com/TerriaJS/terriajs/blob/b21e457fcda8ff4ce0aa1c95eb3348b69f72513e/buildprocess/configureWebpack.js#L77-L88) the [credit string in Ion.js](https://github.com/CesiumGS/cesium/blob/c82102b8eda2f86e4e90acd023893296de57bd2e/packages/engine/Source/Core/Ion.js#L46-L50) that is shown when using the default Ion token.

It looks like this:
![image](https://github.com/TerriaJS/terriajs/assets/1430/3fde027f-3d1d-4dd2-8ef0-36ff6b021862)

I'm not sure if it is a very useful customization to have, so I have dropped it in favor of keeping the build script simpler. However if the consensus is to add it back, I can use a more updated webpack plugin like [string-replace-loader](https://www.npmjs.com/package/string-replace-loader) or see if we can customize it run time instead of build time.

### Test me

Shouldn't affect the app except it will now show Cesium's default credit line when a default access token is used.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
