### PR TITLE
Show feature info panel chart error inline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.7.2)
 
+- When feature info panel chart loading fails, show an inline error, instead of a popup.
 - Add NumberParameterEditor to enable WPS AllowedValues Ranges to be set and use DefaultValue
 
 #### 8.7.1 - 2024-04-16

--- a/lib/ReactViews/Custom/Chart/FeatureInfoPanelChart.jsx
+++ b/lib/ReactViews/Custom/Chart/FeatureInfoPanelChart.jsx
@@ -45,7 +45,7 @@ class FeatureInfoPanelChart extends React.Component {
   get chartItem() {
     const catalogItem = this.props.item;
     if (!ChartableMixin.isMixedInto(catalogItem)) {
-      return;
+      return undefined;
     }
     return catalogItem.chartItems.find(
       (chartItem) =>

--- a/lib/ReactViews/Custom/Chart/FeatureInfoPanelChart.jsx
+++ b/lib/ReactViews/Custom/Chart/FeatureInfoPanelChart.jsx
@@ -33,6 +33,9 @@ class FeatureInfoPanelChart extends React.Component {
     margin: { top: 5, left: 5, right: 5, bottom: 5 }
   };
 
+  /**
+   * Will be set to true if attempts to load the catalog item fails
+   */
   @observable
   loadingFailed = false;
 
@@ -53,17 +56,17 @@ class FeatureInfoPanelChart extends React.Component {
     );
   }
 
-  setError(result) {
-    this.loadingFailed = result.error !== undefined;
-    result.logError();
+  setLoadError(loadResult) {
+    this.loadingFailed = loadResult.error !== undefined;
+    loadResult.logError();
   }
 
   async componentDidUpdate() {
-    this.setError(await this.props.item.loadMapItems());
+    this.setLoadError(await this.props.item.loadMapItems());
   }
 
   async componentDidMount() {
-    this.setError(await this.props.item.loadMapItems());
+    this.setLoadError(await this.props.item.loadMapItems());
   }
 
   render() {

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -636,6 +636,7 @@
     "download": "Download",
     "showItemInChart": "Show {{value}} in chart",
     "loading": "Loading chart data...",
+    "loadingFailed": "Error loading chart.",
     "noData": "No chartable data found."
   },
   "viewModels": {


### PR DESCRIPTION
### What this PR does

When feature info panel chart loading fails, show an inline error, instead of a popup.

Current behaviour is to pop an error message to the user, but  the load function being connected to the react life-cycle methods,  can be called several times. This results in as many pop ups  to the user. Also if every feature has an error, then user will have to dismiss the errors for each one of them. I think a better solution might be to show the error inline instead of popping it to the user.

eg:
![image](https://github.com/TerriaJS/terriajs/assets/1430/ed9672ce-4f56-4b1a-8273-817afe879202)


### Test me

Compare behaviour in before and after links.

Before:
[Test link for main branch](http://ci.terria.io/main/#share=s-xXVKBF4Gg8Aei4HBsHqtT2pTgJk&clean&https://gist.githubusercontent.com/na9da/a3df09bf3bf08655dba9279e8efb0d67/raw/1ae28eed679a93aeb0380dc8460f18003d0cad40/gistfile1.json).
clicking anywhere on the dataset resulted in the error popup being shown 4-5 times

After:
[Test link for this branch](http://ci.terria.io/show-chart-error-inline/#share=s-xXVKBF4Gg8Aei4HBsHqtT2pTgJk&clean&https://gist.githubusercontent.com/na9da/a3df09bf3bf08655dba9279e8efb0d67/raw/1ae28eed679a93aeb0380dc8460f18003d0cad40/gistfile1.json).
no error popups are shown.


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
