### PR TITLE
karma: stop listening on "::"

### DIFF
--- a/buildprocess/createKarmaBaseConfig.js
+++ b/buildprocess/createKarmaBaseConfig.js
@@ -13,7 +13,6 @@ module.exports = function (config) {
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ["jasmine"],
-    listenAddress: "::",
 
     // list of files / patterns to load in the browser
     files: [


### PR DESCRIPTION
### What this PR does

Karma-runner 6.3.20 and later defaults
to IPv4, so this removes the warning:

WARN [config]: ListenAddress was set to :: but hostname was left as the default: localhost. If your browsers fail to connect, consider changing the hostname option.

### Test me

I think this is for @ljowen who added the workaround earlier, but just checking that the CI tests still work and the message disappears should be sufficient.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
