### PR TITLE
test: stop awaiting act()

### DIFF
--- a/test/ReactViews/ToolSpec.tsx
+++ b/test/ReactViews/ToolSpec.tsx
@@ -22,7 +22,7 @@ describe("Tool", function () {
   // 16.3.2, we can enable them after migrating to a newer version.
   xit("renders the item returned by getToolComponent", async function () {
     let rendered: any;
-    await act(async () => {
+    act(async () => {
       rendered = createWithContexts(
         viewState,
         <Tool

--- a/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
+++ b/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
@@ -86,6 +86,9 @@ describe("ItemSearchTool", function () {
   it("initializes an describes the parameters when mounted", async function () {
     spyOn(itemSearchProvider, "initialize").and.callThrough();
     spyOn(itemSearchProvider, "describeParameters").and.callThrough();
+    // FIXME: the await triggers the warning
+    //   "Do not await the result of calling act(...) with sync logic, it is not a Promise."
+    //   but removing the await makes the test for describeParameters fail.
     await act(() => {
       rendered = render({
         item,
@@ -188,6 +191,6 @@ function renderAndLoad(
 async function submitForm(root: ReactTestInstance): Promise<ReactTestInstance> {
   const searchForm = root.findByType("form");
   expect(searchForm).toBeDefined();
-  await act(() => searchForm.props.onSubmit({ preventDefault: () => {} }));
+  act(() => searchForm.props.onSubmit({ preventDefault: () => {} }));
   return searchForm;
 }

--- a/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
+++ b/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
@@ -86,16 +86,18 @@ describe("ItemSearchTool", function () {
   it("initializes an describes the parameters when mounted", async function () {
     spyOn(itemSearchProvider, "initialize").and.callThrough();
     spyOn(itemSearchProvider, "describeParameters").and.callThrough();
-    // FIXME: the await triggers the warning
-    //   "Do not await the result of calling act(...) with sync logic, it is not a Promise."
-    //   but removing the await makes the test for describeParameters fail.
-    await act(() => {
-      rendered = render({
-        item,
-        itemSearchProvider,
-        viewState
-      });
+    let renderPromise: Promise<void> | undefined;
+    act(() => {
+      renderPromise = new Promise((resolve) =>
+        render({
+          item,
+          itemSearchProvider,
+          viewState,
+          afterLoad: resolve
+        })
+      );
     });
+    await renderPromise;
     expect(itemSearchProvider.initialize).toHaveBeenCalledTimes(1);
     expect(itemSearchProvider.describeParameters).toHaveBeenCalledTimes(1);
   });

--- a/test/ReactViews/Tools/ItemSearchTool/SearchResultsSpec.tsx
+++ b/test/ReactViews/Tools/ItemSearchTool/SearchResultsSpec.tsx
@@ -27,7 +27,7 @@ async function render(
   props: Omit<SearchResultsProps, "i18n" | "t" | "tReady">
 ): Promise<ReactTestRenderer> {
   let rendered: ReactTestRenderer;
-  await act(() => {
+  act(() => {
     rendered = create(<SearchResults {...props} />);
   });
   // @ts-ignore

--- a/test/ReactViews/Workflows/WorkflowPanelSpec.tsx
+++ b/test/ReactViews/Workflows/WorkflowPanelSpec.tsx
@@ -23,7 +23,7 @@ describe("WorkflowPanel", function () {
 
   it("sets isWorkflowPanelActive when opened", async function () {
     expect(viewState.terria.isWorkflowPanelActive).toBe(false);
-    await act(() => {
+    act(() => {
       TestRenderer.create(
         <WorkflowPanel
           viewState={viewState}
@@ -38,7 +38,7 @@ describe("WorkflowPanel", function () {
   });
 
   it("unsets isWorkflowPanelActive sidepanel when closed", async function () {
-    await act(() => {
+    act(() => {
       testRenderer = TestRenderer.create(
         <WorkflowPanel
           viewState={viewState}


### PR DESCRIPTION
### What this PR does

This fixes the warning:

Do not await the result of calling act(...) with sync logic, it is not a Promise.

### Test me

Tests only update.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
