### PR TITLE
Move strings from RelatedMaps to translation.json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Add NumberParameterEditor to enable WPS AllowedValues Ranges to be set and use DefaultValue
 - Feature info template has access to activeStyle of item having TableTraits.
+- Allow related maps UI strings to be translated. Translation support for related maps content is not included.
 
 #### 8.7.1 - 2024-04-16
 

--- a/lib/ReactViews/RelatedMaps/RelatedMaps.tsx
+++ b/lib/ReactViews/RelatedMaps/RelatedMaps.tsx
@@ -28,6 +28,7 @@ class RelatedMaps extends React.Component<PropTypes> {
   }
 
   render() {
+    const t = this.props.t;
     const dropdownTheme = {
       inner: Styles.dropdownInner,
       icon: "gallery"
@@ -38,15 +39,15 @@ class RelatedMaps extends React.Component<PropTypes> {
     return (
       <MenuPanel
         theme={dropdownTheme}
-        btnText="Related Maps"
+        btnText={t("relatedMaps.buttonText")}
         smallScreen={smallScreen}
         viewState={this.props.viewState}
-        btnTitle="See related maps"
+        btnTitle={t("relatedMaps.buttonTitle")}
         showDropdownInCenter
       >
-        <h2>Related Maps</h2>
+        <h2>{t("relatedMaps.panelHeading")}</h2>
 
-        <p>Clicking on a map below will open it in a separate window or tab.</p>
+        <p>{t("relatedMaps.panelText")}</p>
 
         {this.props.relatedMaps.map((map, i) => (
           <Box flex key={i}>

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -2154,5 +2154,11 @@
     "colorAdd": "Add",
     "colorRemove": "Remove",
     "invalid": "Invalid"
+  },
+  "relatedMaps": {
+    "buttonText": "Related Maps",
+    "buttonTitle": "See related maps",
+    "panelHeading": "Related Maps",
+    "panelText": "Clicking on a map below will open it in a separate window or tab."
   }
 }


### PR DESCRIPTION
### What this PR does

Move strings to translation.json. This doesn't add translation support for RelatedMaps content.

### Test me

View http://ci.terria.io/translate-related-maps and test button name, title and panel text

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
