### PR TITLE
Add to the doZoomTo function the case of an imagery layer with imageryProvider.rectangle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 #### next release (8.7.4)
 
-- [The next improvement]
+- Add to the "doZoomTo" function the case of an imagery layer with imageryProvider.rectangle
 
 #### 8.7.3 - 2024-05-28
 

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -928,6 +928,11 @@ export default class Cesium extends GlobeOrMap {
           duration: flightDurationSeconds,
           destination: target.rectangle
         });
+      } else if (defined(target.imageryProvider) && defined(target.imageryProvider.rectangle)) {
+        return flyToPromise(camera, {
+          duration: flightDurationSeconds,
+          destination: target.imageryProvider.rectangle
+        });
       } else {
         return Promise.resolve();
       }


### PR DESCRIPTION
### What this PR does

Adds the "doZoomTo" function for imagery layers that have defined the rectangle property, such as "ion-imagery" layers.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
