### PR TITLE
Fix FilterSection bug, add unit test

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.7.4)
 
 - Fix position of draggable point after moving.
+- Fix bug in FilterSection
 
 #### 8.7.3 - 2024-05-28
 

--- a/lib/ReactViews/Workbench/Controls/FilterSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/FilterSection.jsx
@@ -27,7 +27,7 @@ class FilterSection extends React.Component {
     }
     return (
       <div className={Styles.filters}>
-        {item.filters.map(this.renderFilter)}
+        {item.filters.map(this.renderFilter, this)}
       </div>
     );
   }

--- a/test/ReactViews/Workbench/Controls/FilterSectionSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/FilterSectionSpec.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { act } from "react-dom/test-utils";
+import TestRenderer, { ReactTestRenderer } from "react-test-renderer";
+import FilterSection from "../../../../lib/ReactViews/Workbench/Controls/FilterSection";
+import { Range } from "rc-slider";
+import Terria from "../../../../lib/Models/Terria";
+import CommonStrata from "../../../../lib/Models/Definition/CommonStrata";
+import CreateModel from "../../../../lib/Models/Definition/CreateModel";
+import { FilterTraits } from "../../../../lib/Traits/TraitsClasses/Cesium3dTilesTraits";
+import objectArrayTrait from "../../../../lib/Traits/Decorators/objectArrayTrait";
+import ModelTraits from "../../../../lib/Traits/ModelTraits";
+import { runInAction } from "mobx";
+
+class TestTraits extends ModelTraits {
+  @objectArrayTrait({
+    type: FilterTraits,
+    idProperty: "name",
+    name: "filters",
+    description: "The filters to apply to this catalog item."
+  })
+  filters?: FilterTraits[];
+}
+
+class TestModel extends CreateModel(TestTraits) {}
+
+describe("FilterSectionSpec", function () {
+  let testRenderer: ReactTestRenderer;
+  let terria: Terria;
+  let item: TestModel;
+
+  beforeAll(() => {
+    terria = new Terria({
+      baseUrl: "./"
+    });
+    item = new TestModel("test", terria);
+  });
+
+  it("Renders nothing if no filters", function () {
+    testRenderer = TestRenderer.create(<FilterSection item={item} />);
+    expect(testRenderer.root.children.length).toBe(0);
+  });
+
+  it("Renders a range input for each filter", function () {
+    runInAction(() => {
+      const filter = item.addObject(
+        CommonStrata.user,
+        "filters",
+        "level-filter"
+      );
+      filter?.setTrait(CommonStrata.user, "property", "level");
+      filter?.setTrait(CommonStrata.user, "minimumValue", 0);
+      filter?.setTrait(CommonStrata.user, "maximumValue", 42);
+      filter?.setTrait(CommonStrata.user, "minimumShown", 10);
+      filter?.setTrait(CommonStrata.user, "maximumShown", 20);
+    });
+
+    act(() => {
+      testRenderer = TestRenderer.create(<FilterSection item={item} />);
+      const rangeInputs = testRenderer.root.findAllByType(Range);
+      expect(rangeInputs.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
### What this PR does

Fixes #7181

Supply `this` parameter to map in `FilterSection` fixing issue where items with filters defined cause a crash.

### Test me

Before: 
App crashes
http://ci.terria.io/main/#clean&https://gist.githubusercontent.com/ljowen/71dde00d88828f93acb575456ebb439f/raw/5eb93a98ff0563d43f7174b414acd7dd2cbf15e0/strata-title.json

After:
No crash
http://ci.terria.io/filter-section-bug/#clean&https://gist.githubusercontent.com/ljowen/71dde00d88828f93acb575456ebb439f/raw/5eb93a98ff0563d43f7174b414acd7dd2cbf15e0/strata-title.json

To view actual data you will need to test locally to be able to auth with NSW DTV

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
