### PR TITLE
drawTimer: fix type of parameter

### DIFF
--- a/lib/ReactViews/Generic/Timer/drawTimer.js
+++ b/lib/ReactViews/Generic/Timer/drawTimer.js
@@ -155,7 +155,7 @@ export function createTimer(
  * @param {string} containerId The id of the element to insert the timer into.
  * @param {string} elapsedTimeClass A class for styling the animation that fills the timer as it runs.
  * @param {string} backgroundClass A class for styling the timer's background circle.
- * @param {string} [elapsed=0] How much time (in seconds) has already passed.
+ * @param {number} [elapsed=0] How much time (in seconds) has already passed.
  */
 export function startTimer(
   radius,


### PR DESCRIPTION
### What this PR does

The elapsed is passed to something
that expects a number, so use that
type for the parameter itself.

### Test me

I believe this is tested by CI?

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
