### PR TITLE
GeojsonMixin: fix case-insensitive comparison

### DIFF
--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -637,11 +637,13 @@ function GeoJsonMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
             ([styleKey, styleValue]) =>
               featurePropertiesEntires.find(([featKey, featValue]) => {
                 if (typeof styleValue === "string" && !style.caseSensitive) {
-                  featKey === styleKey &&
+                  return (
+                    featKey === styleKey &&
                     (typeof featValue === "string"
                       ? featValue
                       : featValue.toString()
-                    ).toLowerCase() === styleValue.toLowerCase();
+                    ).toLowerCase() === styleValue.toLowerCase()
+                  );
                 }
                 return featKey === styleKey && featValue === styleValue;
               }) !== undefined


### PR DESCRIPTION
### What this PR does

Add a return before the boolean expression
to make the behavior different for case-insensitive mode.

### Test me

Not sure where this is used.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
