### PR TITLE
Detect loadMapItems() error

### DIFF
--- a/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunctionJob.ts
+++ b/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunctionJob.ts
@@ -372,7 +372,7 @@ export default class WebProcessingServiceCatalogFunctionJob extends XmlRequestMi
           "Error ocurred while updating Input Features GeoJSON model JSON"
         );
       });
-      (await this.geoJsonItem!.loadMapItems()).throwIfError;
+      (await this.geoJsonItem!.loadMapItems()).throwIfError();
     }
 
     runInAction(() => {

--- a/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunctionJob.ts
+++ b/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunctionJob.ts
@@ -361,7 +361,7 @@ export default class WebProcessingServiceCatalogFunctionJob extends XmlRequestMi
         this.geoJsonItem = new GeoJsonCatalogItem(createGuid(), this.terria);
         updateModelFromJson(this.geoJsonItem, CommonStrata.user, {
           name: `${this.name} Input Features`,
-          // Use cesium primitives so we don't have to deal with feature picking/selection
+          // Use cesium primitives, so we don't have to deal with feature picking/selection
           forceCesiumPrimitives: true,
           geoJsonData: {
             type: "FeatureCollection",
@@ -369,7 +369,7 @@ export default class WebProcessingServiceCatalogFunctionJob extends XmlRequestMi
             totalFeatures: this.geojsonFeatures!.length
           }
         }).logError(
-          "Error ocurred while updating Input Features GeoJSON model JSON"
+          "Error occurred while updating Input Features GeoJSON model JSON"
         );
       });
       (await this.geoJsonItem!.loadMapItems()).throwIfError();


### PR DESCRIPTION
### What this PR does

Call the function throwIfError() when
loadMapItems() fails, don't just reference
it.

While fixing that I noticed a typo in the error message,
so fix that in the second commit in the PR.

### Test me

Not sure how to test.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
