### PR TITLE
test: fix arguments to ViewState

### DIFF
--- a/test/ReactViews/DataCatalogSpec.jsx
+++ b/test/ReactViews/DataCatalogSpec.jsx
@@ -17,7 +17,8 @@ describe("DataCatalog", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria
+      terria: terria,
+      catalogSearchProvider: undefined
     });
   });
 

--- a/test/ReactViews/StandardUserInterfaceSpec.jsx
+++ b/test/ReactViews/StandardUserInterfaceSpec.jsx
@@ -20,7 +20,8 @@ describe("StandardUserInterface", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria
+      terria: terria,
+      catalogSearchProvider: undefined
     });
   });
 

--- a/test/ReactViews/Workbench/WorkbenchItemSpec.jsx
+++ b/test/ReactViews/Workbench/WorkbenchItemSpec.jsx
@@ -13,7 +13,7 @@ describe("WorkbenchItem", function () {
 
   beforeEach(function () {
     terria = new Terria({ baseUrl: "./" });
-    viewState = new ViewState({ terria });
+    viewState = new ViewState({ terria, catalogSearchProvider: undefined });
     item = new CatalogItem(terria);
   });
 


### PR DESCRIPTION
### What this PR does

There are two arguments required
for ViewStateOptions, so put in
a second argument with an undefined
value which is what is used
at other call sites.

### Test me

Test only changes.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
