### PR TITLE
Remove deprecated @types/json5

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@types/fs-extra": "^7.0.0",
     "@types/jasmine": "^2.8.8",
     "@types/jasmine-ajax": "^3.3.0",
-    "@types/json5": "^0.0.30",
     "@types/leaflet": "^1.7.10",
     "@types/linkify-it": "^3.0.5",
     "@types/lodash-es": "^4.17.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,11 +1807,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/json5@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.30.tgz#44cb52f32a809734ca562e685c6473b5754a7818"
-  integrity sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA==
-
 "@types/leaflet@^1.7.10":
   version "1.7.10"
   resolved "https://registry.yarnpkg.com/@types/leaflet/-/leaflet-1.7.10.tgz#092f97af29bb870b7d1ed72d516d4b3dde66a6c8"


### PR DESCRIPTION
### What this PR does

There are now types in json5,
so remove this package.

### Test me

I believe this is tested by CI?

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
