### PR TITLE
ViewState: add reaction to dispose

### DIFF
--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -536,6 +536,7 @@ export default class ViewState {
     this._previewedItemIdSubscription();
     this._workbenchHasTimeWMSSubscription();
     this._locationMarkerSubscription();
+    this._storyBeforeUnloadSubscription();
     this.searchState.dispose();
   }
 


### PR DESCRIPTION
### What this PR does

The _storyBeforeUnloadSubscription is
not referenced from the dispose method
unlike the other reactions, so add
it there.

### Test me

I don't know how to test this.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
