### PR TITLE
Cog support cesium only 2 warn reprojection

### DIFF
--- a/lib/Models/Catalog/CatalogItems/CogCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/CogCatalogItem.ts
@@ -35,7 +35,6 @@ export default class CogCatalogItem extends MappableMixin(
   }
 
   @override
-  @computed
   get shortReport(): string | undefined {
     let content = "";
     // Warn for 2D mode

--- a/lib/Models/Catalog/CatalogItems/CogCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/CogCatalogItem.ts
@@ -1,5 +1,5 @@
 import i18next from "i18next";
-import { computed, override } from "mobx";
+import { computed, override, runInAction } from "mobx";
 import proj4 from "proj4-fully-loaded";
 import TextureMagnificationFilter from "terriajs-cesium/Source/Renderer/TextureMagnificationFilter";
 import TextureMinificationFilter from "terriajs-cesium/Source/Renderer/TextureMinificationFilter";
@@ -12,6 +12,9 @@ import MappableMixin, { MapItem } from "../../../ModelMixins/MappableMixin";
 import CogCatalogItemTraits from "../../../Traits/TraitsClasses/CogCatalogItemTraits";
 import CreateModel from "../../Definition/CreateModel";
 import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
+import WebMercatorTilingScheme from "terriajs-cesium/Source/Core/WebMercatorTilingScheme";
+import GeographicTilingScheme from "terriajs-cesium/Source/Core/GeographicTilingScheme";
+import CommonStrata from "../../Definition/CommonStrata";
 
 export default class CogCatalogItem extends MappableMixin(
   CatalogMemberMixin(CreateModel(CogCatalogItemTraits))
@@ -32,10 +35,32 @@ export default class CogCatalogItem extends MappableMixin(
   }
 
   @override
+  @computed
   get shortReport(): string | undefined {
+    let content = "";
+    // Warn for 2D mode
     if (this.terria.currentViewer.type === "Leaflet") {
-      return i18next.t("models.commonModelErrors.3dTypeIn2dMode", this);
+      content = i18next.t("models.commonModelErrors.3dTypeIn2dMode", this);
     }
+
+    // Check if tilingScheme is neither WebMercatorTilingScheme nor GeographicTilingScheme
+    else if (
+      this.imageryProvider?.tilingScheme &&
+      !(
+        this.imageryProvider?.tilingScheme instanceof WebMercatorTilingScheme
+      ) &&
+      !(this.imageryProvider?.tilingScheme instanceof GeographicTilingScheme)
+    ) {
+      // Warning message about experimental reprojection
+      content = i18next.t(
+        "models.cogCatalogItem.experimentalReprojectionWarning",
+        this
+      );
+    } else {
+      content = "";
+    }
+
+    return "";
   }
 
   @computed get mapItems(): MapItem[] {

--- a/wwwroot/languages/en/translation.json
+++ b/wwwroot/languages/en/translation.json
@@ -2029,6 +2029,9 @@
           }
         }
       }
+    },
+    "cogCatalogItem": {
+      "experimentalReprojectionWarning": "This COG is not in a native projection (EPSG:4326 or EPSG:3857). Reprojecting is experimental and may not work as expected. If you have control of the source data we recommend reprojecting to EPSG:4326 or EPSG:3857 using GDAL or similar."
     }
   },
   "searchProvider": {


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

This is an incomplete PR to add a shortReport warning when adding a COG in a non-native projection.
Not currently working.

### Problem Explanation
The main problem we are trying to solve is ensuring that the shortReport computed property can access imageryProvider.tilingScheme correctly. Here are the key points:

- imageryProvider is defined as a computed property.
- imageryProvider is an asynchronous object that updates its internal state after it is fully loaded. Specifically, imageryProvider.ready becomes true once it is ready.
- The shortReport computed property depends on imageryProvider.tilingScheme, which is only accessible when imageryProvider is ready.
- We need to set up a reaction to imageryProvider.ready so that the shortReport property is recomputed whenever imageryProvider becomes ready.

### Solution Approach
To solve this problem, we could:
Set up a reaction to imageryProvider.ready to update tilingScheme and trigger recomputation of shortReport.

### Implementation Challenge
One potential solution involves extending the constructor of MappableMixin to set up the reaction. However, this approach is tricky because calling super() requires several arguments that are not easily accessible in the context of CogCatalogItem.

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
