### PR TITLE
Fix legend and feature info for wms difference output.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   - getFeaturesFromPickResult now async to handle I3SNode.loadFields()
   - extract common style logic to new Cesium3dTilesStyleMixin.ts
 - Set default value for date and datetime WPS fields only when the field is marked as required.
+- Fix legend shown for WMS difference output item
+- Add `diffItemProperties` trait to override properties of WSM difference output item. Useful for customizing feature info template strings etc.
 - [The next improvement]
 
 #### 8.7.5 - 2024-06-26

--- a/lib/ModelMixins/DiffableMixin.ts
+++ b/lib/ModelMixins/DiffableMixin.ts
@@ -61,7 +61,8 @@ export class DiffStratum extends LoadableStratum(DiffableTraits) {
     // disable export if showing diff
     // currently there is no way to generate export for the difference layer as
     // it requires 2 time parameters which is not supported in standard WCS
-    return this.catalogItem.isShowingDiff ? true : false;
+    const disableExport = this.catalogItem.isShowingDiff;
+    return disableExport;
   }
 
   @computed
@@ -69,7 +70,8 @@ export class DiffStratum extends LoadableStratum(DiffableTraits) {
     // disable splitter if showing diff
     // currently there is no use splitting the difference layer because
     // most comparable features like style, datetime etc are disabled.
-    return this.catalogItem.isShowingDiff ? true : false;
+    const disableSplitter = this.catalogItem.isShowingDiff;
+    return disableSplitter;
   }
 }
 

--- a/lib/ModelMixins/DiffableMixin.ts
+++ b/lib/ModelMixins/DiffableMixin.ts
@@ -61,8 +61,7 @@ export class DiffStratum extends LoadableStratum(DiffableTraits) {
     // disable export if showing diff
     // currently there is no way to generate export for the difference layer as
     // it requires 2 time parameters which is not supported in standard WCS
-    const disableExport = this.catalogItem.isShowingDiff;
-    return disableExport;
+    return this.catalogItem.isShowingDiff;
   }
 
   @computed
@@ -70,8 +69,7 @@ export class DiffStratum extends LoadableStratum(DiffableTraits) {
     // disable splitter if showing diff
     // currently there is no use splitting the difference layer because
     // most comparable features like style, datetime etc are disabled.
-    const disableSplitter = this.catalogItem.isShowingDiff;
-    return disableSplitter;
+    return this.catalogItem.isShowingDiff;
   }
 }
 

--- a/lib/ModelMixins/DiffableMixin.ts
+++ b/lib/ModelMixins/DiffableMixin.ts
@@ -1,17 +1,16 @@
 import { computed, makeObservable, override } from "mobx";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import AbstractConstructor from "../Core/AbstractConstructor";
-import createStratumInstance from "../Models/Definition/createStratumInstance";
 import LoadableStratum from "../Models/Definition/LoadableStratum";
 import Model, { BaseModel } from "../Models/Definition/Model";
-import StratumOrder from "../Models/Definition/StratumOrder";
+import createStratumInstance from "../Models/Definition/createStratumInstance";
 import { SelectableDimensionEnum } from "../Models/SelectableDimensions/SelectableDimensions";
 import DiffableTraits from "../Traits/TraitsClasses/DiffableTraits";
 import LegendTraits from "../Traits/TraitsClasses/LegendTraits";
 import MappableMixin from "./MappableMixin";
 import TimeFilterMixin from "./TimeFilterMixin";
 
-class DiffStratum extends LoadableStratum(DiffableTraits) {
+export class DiffStratum extends LoadableStratum(DiffableTraits) {
   static stratumName = "diffStratum";
   constructor(readonly catalogItem: DiffableMixin.Instance) {
     super();
@@ -55,6 +54,22 @@ class DiffStratum extends LoadableStratum(DiffableTraits) {
   @computed
   get disableDateTimeSelector() {
     return this.catalogItem.isShowingDiff;
+  }
+
+  @computed
+  get disableExport() {
+    // disable export if showing diff
+    // currently there is no way to generate export for the difference layer as
+    // it requires 2 time parameters which is not supported in standard WCS
+    return this.catalogItem.isShowingDiff ? true : false;
+  }
+
+  @computed
+  get disableSplitter() {
+    // disable splitter if showing diff
+    // currently there is no use splitting the difference layer because
+    // most comparable features like style, datetime etc are disabled.
+    return this.catalogItem.isShowingDiff ? true : false;
   }
 }
 
@@ -113,8 +128,6 @@ namespace DiffableMixin {
   export function isMixedInto(model: any): model is Instance {
     return model?.hasDiffableMixin;
   }
-
-  StratumOrder.addLoadStratum(DiffStratum.stratumName);
 }
 
 export default DiffableMixin;

--- a/lib/Models/Catalog/Ows/WebMapServiceCapabilitiesStratum.ts
+++ b/lib/Models/Catalog/Ows/WebMapServiceCapabilitiesStratum.ts
@@ -825,7 +825,7 @@ export default class WebMapServiceCapabilitiesStratum extends LoadableStratum(
   @computed get currentTime() {
     // Get default times for all layers
     const defaultTimes = filterOutUndefined(
-      Array.from(this.capabilitiesLayers).map(([layerName, layer]) => {
+      Array.from(this.capabilitiesLayers).map(([_layerName, layer]) => {
         if (!layer) return;
         const dimensions = this.capabilities.getInheritedValues(
           layer,

--- a/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
+++ b/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
@@ -52,6 +52,7 @@ import Loader from "../../Loader";
 import DatePicker from "./DatePicker";
 import LocationPicker from "./LocationPicker";
 import { CLOSE_TOOL_ID } from "../../Map/MapNavigation/registerMapNavigations";
+import updateModelFromJson from "../../../Models/Definition/updateModelFromJson";
 
 const dateFormat = require("dateformat");
 
@@ -404,6 +405,7 @@ class Main extends React.Component<MainPropsType> {
     const terria = this.props.terria;
     terria.overlays.remove(this.props.leftItem);
     terria.overlays.remove(this.props.rightItem);
+
     terria.workbench.add(this.diffItem);
 
     this.diffItem.setTrait(CommonStrata.user, "name", this.diffItemName);
@@ -992,6 +994,13 @@ async function createSplitItem(
       // we simply set the opacity of the item to 0.
       newItem.setTrait(CommonStrata.user, "opacity", 0);
     }
+
+    // Override feature info template as the parent featureInfoTemplate might
+    // not be relevant for the difference item. This has to be done in the user
+    // stratum to override template set in definition stratum.
+    updateModelFromJson(newItem, CommonStrata.user, {
+      featureInfoTemplate: { template: "" }
+    });
 
     setDefaultDiffStyle(newItem);
 

--- a/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
+++ b/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
@@ -356,7 +356,7 @@ class Main extends React.Component<MainPropsType> {
   }
 
   @action.bound
-  onUserPickingLocation(pickingLocation: LatLonHeight) {
+  onUserPickingLocation(_pickingLocation: LatLonHeight) {
     this._isPickingNewLocation = true;
   }
 
@@ -365,7 +365,7 @@ class Main extends React.Component<MainPropsType> {
     pickedFeatures: PickedFeatures,
     pickedLocation: LatLonHeight
   ) {
-    const { leftItem, rightItem, t } = this.props;
+    const { leftItem, rightItem } = this.props;
     const feature = pickedFeatures.features.find(
       (f) =>
         doesFeatureBelongToItem(f, leftItem) ||
@@ -961,10 +961,8 @@ const LegendImage = function (props: any) {
       {...props}
       // Show the legend only if it loads successfully, so we start out hidden
       style={{ display: "none", marginTop: "4px" }}
-      // @ts-expect-error
-      onLoad={(e) => (e.target.style.display = "block")}
-      // @ts-expect-error
-      onError={(e) => (e.target.style.display = "none")}
+      onLoad={(e) => (e.currentTarget.style.display = "block")}
+      onError={(e) => (e.currentTarget.style.display = "none")}
     />
   );
 };

--- a/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
+++ b/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
@@ -410,6 +410,12 @@ class Main extends React.Component<MainPropsType> {
 
     this.diffItem.setTrait(CommonStrata.user, "name", this.diffItemName);
     this.diffItem.showDiffImage(this.leftDate, this.rightDate, this.diffStyle);
+
+    // If given, appply additional properties for the diff item
+    const diffItemProperties = this.diffItem.diffItemProperties;
+    if (diffItemProperties) {
+      updateModelFromJson(this.diffItem, CommonStrata.user, diffItemProperties);
+    }
     terria.showSplitter = false;
   }
 

--- a/lib/Traits/TraitsClasses/DiffableTraits.ts
+++ b/lib/Traits/TraitsClasses/DiffableTraits.ts
@@ -1,3 +1,5 @@
+import { JsonObject } from "../../Core/Json";
+import anyTrait from "../Decorators/anyTrait";
 import primitiveArrayTrait from "../Decorators/primitiveArrayTrait";
 import primitiveTrait from "../Decorators/primitiveTrait";
 import mixTraits from "../mixTraits";
@@ -39,4 +41,10 @@ export default class DiffableTraits extends mixTraits(TimeFilterTraits) {
     description: "The ID of the style used to compute the difference image"
   })
   diffStyleId?: string;
+
+  @anyTrait({
+    name: "Difference item properties",
+    description: "Additional properties to set on the difference output item."
+  })
+  diffItemProperties?: JsonObject;
 }

--- a/test/ModelMixins/DiffableMixinSpec.ts
+++ b/test/ModelMixins/DiffableMixinSpec.ts
@@ -62,17 +62,17 @@ class TestDiffableItem extends DiffableMixin(
   }
 
   showDiffImage(
-    firstDate: JulianDate,
-    secondDate: JulianDate,
-    diffStyleId: string
+    _firstDate: JulianDate,
+    _secondDate: JulianDate,
+    _diffStyleId: string
   ) {}
 
   clearDiffImage() {}
 
   getLegendUrlForStyle(
-    diffStyleId: string,
-    firstDate: JulianDate,
-    secondDate: JulianDate
+    _diffStyleId: string,
+    _firstDate: JulianDate,
+    _secondDate: JulianDate
   ) {
     return "test-legend-url";
   }


### PR DESCRIPTION
### What this PR does

Makes following changes to WMS difference output:
 - Fixes legend URL for WMS difference outputs - #7237
 - Allow overriding properties of difference output item - https://github.com/TerriaJS/terriajs/issues/7238

### Test me

1. Open [this test link](http://ci.terria.io/wms-diff-fixes/#share=s-2Xp6mjzhyYokbChYJNIbRHM0RsY&https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/terria/terria-cube-v8.json&clean) which has a difference output
2. Ensure the legend shown is for the difference output
![image](https://github.com/user-attachments/assets/a2778499-5b39-487c-a7b6-15afd03d9796)

3. Ensure the feature info for the difference item shows the raw data by default.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
