### PR TITLE
Render app before loading all datasets

### DIFF
--- a/lib/Models/InitSource.ts
+++ b/lib/Models/InitSource.ts
@@ -1,3 +1,4 @@
+import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import { JsonObject } from "../Core/Json";
 import Result from "../Core/Result";
 import { TerriaErrorSeverity } from "../Core/TerriaError";
@@ -143,6 +144,23 @@ export function isInitFromOptions(
   initSource: InitSource
 ): initSource is InitSourceFromOptions {
   return "options" in initSource;
+}
+
+/**
+ * Return the lat, lng, height in pickedFeatures settings as Cartesian3.
+ *
+ * @param pickedFeatures The pickedFeatures setting in init source
+ * @return The position as Cartesian3 or `undefined` if it could not be parsed.
+ */
+export function readPickedFeaturePosition(
+  pickedFeatures: InitSourcePickedFeatures
+): Cartesian3 | undefined {
+  const { lng, lat, height } = pickedFeatures.pickCoords ?? {};
+  return typeof lng === "number" &&
+    typeof lat === "number" &&
+    (typeof height === "number" || height === undefined)
+    ? Cartesian3.fromDegrees(lng, lat, height)
+    : undefined;
 }
 
 export default InitSource;

--- a/lib/Models/InitWorkbench.ts
+++ b/lib/Models/InitWorkbench.ts
@@ -1,0 +1,191 @@
+import { runInAction } from "mobx";
+import TerriaError from "../Core/TerriaError";
+import filterOutUndefined from "../Core/filterOutUndefined";
+import GroupMixin from "../ModelMixins/GroupMixin";
+import MappableMixin from "../ModelMixins/MappableMixin";
+import ReferenceMixin from "../ModelMixins/ReferenceMixin";
+import { BaseModel } from "./Definition/Model";
+import Terria from "./Terria";
+import Workbench from "./Workbench";
+
+interface LoadResult {
+  loadedItems: MappableMixin.Instance[];
+  loadErrors: TerriaError[];
+}
+
+/**
+ * Override workbench with the given items after loading each of them.
+ *
+ * Initially, all valid items given by `itemIds` are added to the workbench, but
+ * only items that were successfully loaded are retained once the promise resolves.
+
+ * If an item is a Group or a Reference, it will be loaded recursively and then
+ * replaced by the resolved members.
+ *
+ * @param terria The Terria instance
+ * @param workbench Workbench instance
+ * @param itemIds IDs of items to add to the workbench
+ * @return Promise that resolves when all the given items have been loaded and added to the workbench, returning the errors encountered while loading the items.
+ */
+export async function loadWorkbenchItems(
+  terria: Terria,
+  workbench: Workbench,
+  itemIds: string[]
+): Promise<TerriaError[]> {
+  const idErrors: TerriaError[] = [];
+  // Set the new contents of the workbench.
+  const items = filterOutUndefined(
+    itemIds.map((modelId) => {
+      if (typeof modelId !== "string") {
+        idErrors.push(
+          new TerriaError({
+            sender: terria,
+            title: "Invalid model ID in workbench",
+            message: "A model ID in the workbench list is not a string."
+          })
+        );
+      } else {
+        return terria.getModelByIdOrShareKey(BaseModel, modelId);
+      }
+    })
+  );
+
+  // Optimistically add all items to the workbench.
+  // Note that this could contain, not just Mappable items, but also Group and Reference items.
+  // Further below, we update the workbench again to keep only the Mappable items.
+  runInAction(() => {
+    workbench.items = items;
+  });
+
+  // Load the items
+  const results = await Promise.all(
+    items.map((item) =>
+      loadWorkbenchItem(item, 0).then((result) => ({
+        ...result,
+        sourceItem: item
+      }))
+    )
+  );
+
+  // Remove failed items from the workbench and accumulate load errors
+  const loadErrors: TerriaError[] = [];
+  runInAction(() => {
+    const updatedWorkbenchItems: BaseModel[] = [];
+    workbench.items.forEach((item) => {
+      const result = results.find(
+        (r) => r.sourceItem === item || r.sourceItem === item.sourceReference
+      );
+      if (result) {
+        updatedWorkbenchItems.push(...result.loadedItems);
+        loadErrors.push(...result.loadErrors);
+      } else {
+        updatedWorkbenchItems.push(item);
+      }
+    });
+    workbench.items = updatedWorkbenchItems;
+  });
+
+  const allErrors = [...idErrors, ...loadErrors];
+  return allErrors;
+}
+
+async function loadWorkbenchItem(
+  item: BaseModel,
+  depth: number
+): Promise<{
+  loadedItems: MappableMixin.Instance[];
+  loadErrors: TerriaError[];
+}> {
+  // Avoid expanding Group items to more than 1 level of nesting.
+  if (depth > 1) {
+    return { loadedItems: [], loadErrors: [] };
+  }
+
+  // Load the item based on its type.
+  // For share links, the item will most likely be a Mappable item - the simplest case.
+  // Directly adding References and Groups to workbench is currently rare and
+  // used when an external service like data.gov.au wants to preview a whole group.
+
+  if (ReferenceMixin.isMixedInto(item)) {
+    return loadReferenceItem(item, depth);
+  } else if (GroupMixin.isMixedInto(item)) {
+    // FIXME: Automatically loading all group members is pretty risky. What if the group has 100s of members?
+    // Should we avoid loading Groups altogether or should we limit the number of members loaded from the group?
+    return loadGroupMembers(item, depth);
+  } else if (MappableMixin.isMixedInto(item)) {
+    return loadMappableItem(item);
+  } else {
+    return {
+      loadedItems: [],
+      loadErrors: [
+        TerriaError.from(
+          "Can not load an un-mappable item to the map. Item Id: " +
+            item.uniqueId
+        )
+      ]
+    };
+  }
+}
+
+async function loadMappableItem(
+  item: MappableMixin.Instance
+): Promise<LoadResult> {
+  const result = await item.loadMapItems();
+  return result.error
+    ? { loadedItems: [], loadErrors: [result.error] }
+    : { loadedItems: [item], loadErrors: [] };
+}
+
+async function loadGroupMembers(
+  group: GroupMixin.Instance,
+  depth: number
+): Promise<LoadResult> {
+  const loadedItems: MappableMixin.Instance[] = [];
+  const loadErrors: TerriaError[] = [];
+  // load group
+  (await group.loadMembers()).pushErrorTo(loadErrors);
+
+  // load group members
+  const memberResults = await Promise.all(
+    group.memberModels.map((member) => loadWorkbenchItem(member, depth + 1))
+  );
+
+  // accumulate group member results
+  memberResults.forEach((result) => {
+    loadErrors.push(...result.loadErrors);
+    loadedItems.push(...result.loadedItems);
+  });
+
+  return {
+    loadedItems,
+    loadErrors
+  };
+}
+
+async function loadReferenceItem(
+  item: ReferenceMixin.Instance,
+  depth: number
+): Promise<LoadResult> {
+  const referenceErrors: TerriaError[] = [];
+  (await item.loadReference()).pushErrorTo(referenceErrors);
+  if (item.target) {
+    const { loadErrors, loadedItems } = await loadWorkbenchItem(
+      item.target,
+      depth
+    );
+    return {
+      loadErrors: [...referenceErrors, ...loadErrors],
+      loadedItems
+    };
+  } else {
+    referenceErrors.push(
+      TerriaError.from(
+        "Reference model has no target. Model Id: " + item.uniqueId
+      )
+    );
+  }
+  return {
+    loadErrors: referenceErrors,
+    loadedItems: []
+  };
+}

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -126,7 +126,6 @@ import TimelineStack from "./TimelineStack";
 import { isViewerMode, setViewerMode } from "./ViewerMode";
 import Workbench from "./Workbench";
 import SelectableDimensionWorkflow from "./Workflows/SelectableDimensionWorkflow";
-import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 
 // import overrides from "../Overrides/defaults.jsx";
 
@@ -1685,7 +1684,6 @@ export default class Terria {
       } catch (error) {
         // Not a CameraView but does it specify focusWorkbenchItems?
         if (typeof initData.initialCamera.focusWorkbenchItems === "boolean") {
-          debugger;
           this.focusWorkbenchItemsAfterLoadingInitSources =
             initData.initialCamera.focusWorkbenchItems;
         } else {
@@ -1921,7 +1919,7 @@ export default class Terria {
 
     const initObj = aspects["terria-init"];
     if (isJsonObject(initObj)) {
-      const { catalog, ...initObjWithoutCatalog } = initObj;
+      const { catalog: _, ...initObjWithoutCatalog } = initObj;
       /** Load the init data without the catalog yet, as we'll push the catalog
        * source up as an init source later */
       try {

--- a/lib/Models/Workbench.ts
+++ b/lib/Models/Workbench.ts
@@ -117,9 +117,11 @@ export default class Workbench {
    * Note that the model's dereferenced equivalent may appear in the {@link Workbench#items} list
    * rather than the model itself.
    * @param item The model to add.
+   *
+   * @private
    */
   @action
-  private insertItem(item: BaseModel, index: number = 0) {
+  _insertItem(item: BaseModel, index: number = 0) {
     if (this.contains(item)) {
       return;
     }
@@ -189,7 +191,7 @@ export default class Workbench {
       });
     }
 
-    this.insertItem(item);
+    this._insertItem(item);
 
     let error: TerriaError | undefined;
 
@@ -267,7 +269,7 @@ export default class Workbench {
       return;
     }
     this.remove(item);
-    this.insertItem(item, newIndex);
+    this._insertItem(item, newIndex);
   }
 }
 


### PR DESCRIPTION
This is useful for rendering the app before we fully finish loading all the workbench items from a share link.

### What this PR does

Currently when loading a share URL with several items in the workbench, the app does not render until all workbench items have been loaded. If the data custodian server is slow, this could be perceived as Terria being slow to load. This PR contains changes for testing a different behaviour where we render the app before all workbench datasets have been loaded.

Some implications:
- User can view and interact with the app before all datasets have been loaded. This creates more complexity as we need to be careful not to override the changes user might have made while the datasets were loading.
- Data loading errors will be raised to the user later when we have finished all datasets - this could be surprising
- User needs to be aware from various spinners in the workbench/feature info panel that the datasets haven't been fully loaded. Other UX changes might be required to make this more obvious.

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
