### PR TITLE
Fix Deprecation warnings caused by declarations after nested blocks.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   - getFeaturesFromPickResult now async to handle I3SNode.loadFields()
   - extract common style logic to new Cesium3dTilesStyleMixin.ts
 - Set default value for date and datetime WPS fields only when the field is marked as required.
+- Fix Sass deprecation warnings (declarations after nested blocks)
 - [The next improvement]
 
 #### 8.7.5 - 2024-06-26

--- a/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
+++ b/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
@@ -40,14 +40,14 @@
 .ui-root {
   // This is a workaround for a bug in IE11 on Windows 7.
   // https://connect.microsoft.com/IE/feedback/details/796745/mouse-events-are-not-delivered-at-all-anymore-when-inside-an-svg-a-use-is-removed-from-the-dom
-  svg use {
-    pointer-events: none;
-  }
   position: relative;
   flex-basis: 100%;
   height: 100vh;
   @media (max-width: $sm) {
     position: unset;
+  }
+  svg use {
+    pointer-events: none;
   }
 }
 
@@ -153,8 +153,6 @@
 }
 
 @media (min-width: $sm) {
-  .ui {
-  }
   .uiInner {
     display: flex;
     overflow: hidden;

--- a/lib/ReactViews/Story/story-editor.scss
+++ b/lib/ReactViews/Story/story-editor.scss
@@ -2,10 +2,6 @@
 @import "../../Sass/common/mixins";
 
 .popupEditor {
-  &.is-mounted {
-    opacity: 1;
-    @include transform(none);
-  }
   @include transform(translateY(20%));
   opacity: 0;
   @include transition(all 0.3s);
@@ -19,6 +15,10 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  &.is-mounted {
+    opacity: 1;
+    @include transform(none);
+  }
   .inner {
     max-width: 800px;
     width: 80vw;

--- a/lib/ReactViews/Story/story-panel.scss
+++ b/lib/ReactViews/Story/story-panel.scss
@@ -2,10 +2,6 @@
 @import "../../Sass/common/mixins";
 
 .story-container {
-  &.is-mounted {
-    opacity: 1;
-    @include transform(none);
-  }
   @include transform(translateY(20%));
   opacity: 0;
   @include transition(all 0.3s);
@@ -19,6 +15,11 @@
   text-align: left;
   box-sizing: border-box;
   box-shadow: 0 0 15px 6px rgba(100, 100, 100, 0.3);
+
+  &.is-mounted {
+    opacity: 1;
+    @include transform(none);
+  }
 
   .left {
     border-right: 1px solid $field-border;

--- a/lib/ReactViews/Workbench/Controls/legend.scss
+++ b/lib/ReactViews/Workbench/Controls/legend.scss
@@ -3,8 +3,7 @@
 .legend {
   composes: clearfix from "../../../Sass/common/_base.scss";
   composes: list-reset from "../../../Sass/common/_base.scss";
-  font-family: $font-mono;
-  font-size: $font-size-small;
+  font-family: $font-mono;  
   // Small font size prevents the font from dictating the table row height.
   font-size: 5px;
 

--- a/lib/ReactViews/Workbench/Controls/legend.scss
+++ b/lib/ReactViews/Workbench/Controls/legend.scss
@@ -5,13 +5,12 @@
   composes: list-reset from "../../../Sass/common/_base.scss";
   font-family: $font-mono;
   font-size: $font-size-small;
+  // Small font size prevents the font from dictating the table row height.
+  font-size: 5px;
 
   li {
     display: block;
   }
-
-  // Small font size prevents the font from dictating the table row height.
-  font-size: 5px;
 
   .legendOpenExternally {
     font-size: $font-size-small;
@@ -25,11 +24,11 @@
 }
 
 .legend__inner {
+  padding: $padding 0 0 0;
   a {
     // Only the actual legend should be clickable rather than the whole area
     display: inline-block;
   }
-  padding: $padding 0 0 0;
 }
 
 .legend__legendBoxImg {

--- a/lib/ReactViews/Workbench/Controls/legend.scss
+++ b/lib/ReactViews/Workbench/Controls/legend.scss
@@ -3,7 +3,7 @@
 .legend {
   composes: clearfix from "../../../Sass/common/_base.scss";
   composes: list-reset from "../../../Sass/common/_base.scss";
-  font-family: $font-mono;  
+  font-family: $font-mono;
   // Small font size prevents the font from dictating the table row height.
   font-size: 5px;
 

--- a/lib/Sass/common/_base.scss
+++ b/lib/Sass/common/_base.scss
@@ -429,6 +429,16 @@
 // This is what happens when we mess up with CSS Modules so make it SUPER SUPER OBVIOUS
 // TODO: Remove in build
 .undefined {
+  position: relative;
+  background: #f00 !important;
+  color: magenta !important;
+  border: 3px orange dashed !important;
+
+  animation-name: flash;
+  animation-duration: 1s;
+  animation-timing-function: step-start;
+  animation-iteration-count: infinite;
+
   &:before {
     position: fixed !important;
     top: 0 !important;
@@ -439,16 +449,6 @@
     opacity: 1 !important;
     z-index: 100000 !important;
   }
-
-  position: relative;
-  background: #f00 !important;
-  color: magenta !important;
-  border: 3px orange dashed !important;
-
-  animation-name: flash;
-  animation-duration: 1s;
-  animation-timing-function: step-start;
-  animation-iteration-count: infinite;
 }
 
 @keyframes flash {

--- a/lib/Sass/common/_buttons.scss
+++ b/lib/Sass/common/_buttons.scss
@@ -153,23 +153,22 @@ $btn-setting-size: 35px;
 
 .btn--catalog {
   padding: $padding 30px + $padding;
-  @media (min-width: $sm) {
-    padding: $padding-small 30px + $padding;
-  }
-
   position: relative;
   width: 100%;
   font-weight: bold;
+  @media (min-width: $sm) {
+    padding: $padding-small 30px + $padding;
+  }
   .btn--group-indicator {
     position: absolute;
     left: 0;
     padding: $padding $padding * 2.2 $padding $padding * 1.5;
-    @media (min-width: $sm) {
-      padding: $padding-small $padding * 2.2 $padding-small $padding * 1.5;
-    }
     top: 0;
     font-size: $font-size-mid-large;
     opacity: 0.5;
+    @media (min-width: $sm) {
+      padding: $padding-small $padding * 2.2 $padding-small $padding * 1.5;
+    }
   }
   &:before {
     position: absolute;


### PR DESCRIPTION
See: https://sass-lang.com/documentation/breaking-changes/mixed-decls/

### What this PR does

Reorder declarations to appear above any nested blocks

### Test me

Sass compiles without deprecation warnings

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
