### PR TITLE
Enable terrain splitter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   - extract common style logic to new Cesium3dTilesStyleMixin.ts
 - Set default value for date and datetime WPS fields only when the field is marked as required.
 - Add Proj4 definition for EPSG:8059
+- Upgrade to terriajs-cesium 8.0.1.
+- Re-enable terrain splitting.
 - [The next improvement]
 
 #### 8.7.5 - 2024-06-26

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -410,16 +410,15 @@ export default class Cesium extends GlobeOrMap {
     this._disposeWorkbenchMapItemsSubscription = this.observeModelLayer();
     this._disposeTerrainReaction = autorun(() => {
       this.scene.globe.terrainProvider = this.terrainProvider;
-      // TODO: bring over globe and atmosphere splitting support from terriajs-cesium
-      // this.scene.globe.splitDirection = this.terria.showSplitter
-      //   ? this.terria.terrainSplitDirection
-      //   : SplitDirection.NONE;
+      this.scene.globe.splitDirection = this.terria.showSplitter
+        ? this.terria.terrainSplitDirection
+        : SplitDirection.NONE;
       this.scene.globe.depthTestAgainstTerrain =
         this.terria.depthTestAgainstTerrainEnabled;
-      // if (this.scene.skyAtmosphere) {
-      //   this.scene.skyAtmosphere.splitDirection =
-      //     this.scene.globe.splitDirection;
-      // }
+      if (this.scene.skyAtmosphere) {
+        this.scene.skyAtmosphere.splitDirection =
+          this.scene.globe.splitDirection;
+      }
     });
     this._disposeSplitterReaction = this._reactToSplitterChanges();
 

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -1749,7 +1749,7 @@ export default class Cesium extends GlobeOrMap {
 
   _addVectorTileHighlight(
     imageryProvider: MapboxVectorTileImageryProvider | ProtomapsImageryProvider,
-    rectangle: Rectangle
+    _rectangle: Rectangle
   ): () => void {
     const result = new ImageryLayer(imageryProvider, {
       show: true,

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "style-loader": "^0.23.1",
     "styled-components": "^5.3.9",
     "svg-sprite-loader": "^6.0.11",
-    "terriajs-cesium": "8.0.0",
+    "terriajs-cesium": "8.0.1",
     "terriajs-cesium-widgets": "5.0.0",
     "terriajs-html2canvas": "1.0.0-alpha.12-terriajs-1",
     "thredds-catalog-crawler": "0.0.7",


### PR DESCRIPTION
### What this PR does

Fixes #7090 

Terrain splitter was not ported after the upgrade from terriajs-cesium 1.92. 
This PR re-enables the feature. The terriajs-cesium changes required was already merged in [this PR](https://github.com/TerriaJS/cesium/pull/87).

### Test me

- Open this share link for this PR branch - http://ci.terria.io/enable-terrain-splitter/#share=s-3ROX3XKNUda1ljIcORuYUXXqKg0
- Ensure that you can switch the terrain direction from the workbench controls
- Closing the compare tool should disable the terrain splitting
- Previously, this terrain splitting feature was broken - http://ci.terria.io/main/#share=s-3ROX3XKNUda1ljIcORuYUXXqKg0

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
