### PR TITLE
Improve default formats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.7.7)
 
+- Improve default supported formats for ArcGisPortalItemReference.
 - [The next improvement]
 
 #### 8.7.6 - 2024-08-22

--- a/lib/Models/Catalog/Esri/ArcGisPortalItemReference.ts
+++ b/lib/Models/Catalog/Esri/ArcGisPortalItemReference.ts
@@ -166,15 +166,15 @@ export default class ArcGisPortalItemReference extends AccessControlMixin(
       createStratumInstance(ArcGisPortalItemFormatTraits, {
         id: "WMS",
         formatRegex: "WMS",
-        urlRegex: "WMSServer",
+        urlRegex: "WMSServer|wms$",
         definition: {
-          type: "wms"
+          type: "wms-group"
         }
       }),
       createStratumInstance(ArcGisPortalItemFormatTraits, {
         id: "ArcGIS MapServer Group",
         formatRegex: "Map Service",
-        urlRegex: "MapServer$|MapServer/$",
+        urlRegex: /MapServer$|MapServer\/$|MapServer\?f=pjson$|MapServer\?f=json$/,
         definition: {
           type: "esri-mapServer-group"
         }
@@ -185,6 +185,14 @@ export default class ArcGisPortalItemReference extends AccessControlMixin(
         urlRegex: /MapServer\/\d/,
         definition: {
           type: "esri-mapServer"
+        }
+      }),
+      createStratumInstance(ArcGisPortalItemFormatTraits, {
+        id: "ArcGIS ImageServer",
+        formatRegex: "Map Service",
+        urlRegex: /ImageServer/,
+        definition: {
+          type: "esri-imageServer"
         }
       }),
       createStratumInstance(ArcGisPortalItemFormatTraits, {

--- a/lib/Models/Catalog/Esri/ArcGisPortalItemReference.ts
+++ b/lib/Models/Catalog/Esri/ArcGisPortalItemReference.ts
@@ -174,7 +174,8 @@ export default class ArcGisPortalItemReference extends AccessControlMixin(
       createStratumInstance(ArcGisPortalItemFormatTraits, {
         id: "ArcGIS MapServer Group",
         formatRegex: "Map Service",
-        urlRegex: /MapServer$|MapServer\/$|MapServer\?f=pjson$|MapServer\?f=json$/,
+        urlRegex:
+          /MapServer$|MapServer\/$|MapServer\?f=pjson$|MapServer\?f=json$/,
         definition: {
           type: "esri-mapServer-group"
         }


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/nsw-digital-twin/issues/674

### How to test
[before](http://ci.terria.io/main/#clean&https://gist.githubusercontent.com/mwu2018/0bb12e8f5b4c892c8f6001f11abcb619/raw/3a4352bbd53050c6c098d50a74bb7858a179e510/test-arcgis-portal-group.json)
[after](http://ci.terria.io/improve-default-formats/#clean&https://gist.githubusercontent.com/mwu2018/0bb12e8f5b4c892c8f6001f11abcb619/raw/3a4352bbd53050c6c098d50a74bb7858a179e510/test-arcgis-portal-group.json)

  After expanding the group, search keyword "instrument" in the catalog. Then go to
  - `Digital Earth Australia Hotspots`, testing item with type `WMS` and URL ending with `wms`.
  - `Environmental Planning Instrument - Acid Sulfate Soils`, testing item with type `Map Service` and URL ending with `MapServer?f=pjson`.
  - `Environmental Planning Instrument - Acid Sulfate Soils/Protection`, testing item with type `Map Service` and URL ending with `MapServer/1?f=pjson`.
  - `Transitional - Excluded Land`, testing item with type `ImageServer` and URL ending with `ImageServer`.

All of the above tests will fail in [before](http://ci.terria.io/main/#clean&https://gist.githubusercontent.com/mwu2018/0bb12e8f5b4c892c8f6001f11abcb619/raw/3a4352bbd53050c6c098d50a74bb7858a179e510/test-arcgis-portal-group.json).

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
