### PR TITLE
Fix `Workbench.collapseAll()` and `Workbench.expandAll()` for References

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.7.7)
 
+- Fix `Workbench.collapseAll()` and `Workbench.expandAll()` for References.
 - [The next improvement]
 
 #### 8.7.6 - 2024-08-22

--- a/lib/Models/Workbench.ts
+++ b/lib/Models/Workbench.ts
@@ -56,7 +56,7 @@ export default class Workbench {
    */
   @computed
   get shouldExpandAll(): boolean {
-    return this._items.every((item) => !(item as any).isOpenInWorkbench);
+    return this.items.every((item) => !(item as any).isOpenInWorkbench);
   }
 
   /**
@@ -97,7 +97,7 @@ export default class Workbench {
    */
   @action
   collapseAll() {
-    this._items.map((item) => {
+    this.items.map((item) => {
       item.setTrait(CommonStrata.user, "isOpenInWorkbench", false);
     });
   }
@@ -107,7 +107,7 @@ export default class Workbench {
    */
   @action
   expandAll() {
-    this._items.map((item) => {
+    this.items.map((item) => {
       item.setTrait(CommonStrata.user, "isOpenInWorkbench", true);
     });
   }

--- a/test/Models/WorkbenchSpec.ts
+++ b/test/Models/WorkbenchSpec.ts
@@ -6,11 +6,16 @@ import WebMapServiceCatalogItem from "../../lib/Models/Catalog/Ows/WebMapService
 import Workbench from "../../lib/Models/Workbench";
 import Result from "../../lib/Core/Result";
 import TerriaError, { TerriaErrorSeverity } from "../../lib/Core/TerriaError";
+import TerriaReference from "../../lib/Models/Catalog/CatalogReferences/TerriaReference";
 
 describe("Workbench", function () {
   let terria: Terria;
   let workbench: Workbench;
-  let item1: BaseModel, item2: BaseModel, item3: BaseModel, item4: BaseModel;
+  let item1: WebMapServiceCatalogItem,
+    item2: WebMapServiceCatalogItem,
+    item3: WebMapServiceCatalogItem,
+    item4: WebMapServiceCatalogItem,
+    ref: TerriaReference;
 
   beforeEach(function () {
     terria = new Terria();
@@ -20,6 +25,9 @@ describe("Workbench", function () {
     item2 = new WebMapServiceCatalogItem("B", terria);
     item3 = new WebMapServiceCatalogItem("C", terria);
     item4 = new WebMapServiceCatalogItem("D", terria);
+    ref = new TerriaReference("test", new Terria());
+    ref.setTrait(CommonStrata.user, "url", "test/init/wms-v8.json");
+    ref.setTrait(CommonStrata.user, "path", ["MLzS8W", "fCUx4Y"]);
 
     item1.setTrait("definition", "url", "test/WMS/single_metadata_url.xml");
     item2.setTrait("definition", "url", "test/WMS/single_metadata_url.xml");
@@ -29,6 +37,24 @@ describe("Workbench", function () {
     terria.addModel(item1);
     terria.addModel(item2);
     terria.addModel(item3);
+  });
+
+  it("can collapse/expand all catalog items", async function () {
+    // See if it is compatible with references as well as ordinary catalog items.
+    workbench.items = [item1, ref];
+    await ref.loadReference();
+    workbench.collapseAll();
+    expect(item1.isOpenInWorkbench).toBe(false);
+    expect((ref.target as WebMapServiceCatalogItem).isOpenInWorkbench).toBe(
+      false
+    );
+    expect(workbench.shouldExpandAll).toBe(true);
+    workbench.expandAll();
+    expect(item1.isOpenInWorkbench).toBe(true);
+    expect((ref.target as WebMapServiceCatalogItem).isOpenInWorkbench).toBe(
+      true
+    );
+    expect(workbench.shouldExpandAll).toBe(false);
   });
 
   it("re-orders items correctly", function () {

--- a/test/Models/WorkbenchSpec.ts
+++ b/test/Models/WorkbenchSpec.ts
@@ -1,6 +1,5 @@
 import CommonStrata from "../../lib/Models/Definition/CommonStrata";
 import MagdaReference from "../../lib/Models/Catalog/CatalogReferences/MagdaReference";
-import { BaseModel } from "../../lib/Models/Definition/Model";
 import Terria from "../../lib/Models/Terria";
 import WebMapServiceCatalogItem from "../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
 import Workbench from "../../lib/Models/Workbench";


### PR DESCRIPTION
### What this PR does

Fixes a bug where `Workbench.collapseAll()` and `Workbench.expandAll()` does not collapse/expand References in the workbench

### Test me

Build with TerriaMap and load [this init file](https://gist.github.com/ykiu/fe135b589899970752323af9b7963e66) like so:
http://localhost:3001/#clean&https%3A%2F%2Fgist.githubusercontent.com%2Fykiu%2Ffe135b589899970752323af9b7963e66%2Fraw%2Fbc22d2782df8d77e0fcaff23ad2a3e5de46865d3%2Fterria-reference.json

Then, add "foo" from the catalog to the map.

Before this PR the "Collapse all" button does not actually collapse the item in the workbench.
After this PR the button actually collapses the item.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
  - Not applicable.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
