### PR TITLE
Fix sass 1.79 deprecation warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 
 - Fix remaining lint warnings
 - Augment cesium types and start using import instead of require in ts files
+- Update to sass 1.79.1
 - [The next improvement]
 
 #### 8.7.6 - 2024-08-22

--- a/lib/ReactViews/Notification/notification-window.scss
+++ b/lib/ReactViews/Notification/notification-window.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 @import "~terriajs-variables";
 @import "../../Sass/common/mixins";
 
@@ -26,7 +28,7 @@
 
 .notification {
   border-radius: $radius-small;
-  border: 1px solid darken($dark, 3%);
+  border: 1px solid color.adjust($dark, $lightness: -3%);
   // background: $dark;
   z-index: 300;
   pre {

--- a/lib/ReactViews/Preview/metadata-table.scss
+++ b/lib/ReactViews/Preview/metadata-table.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 @import "~terriajs-variables";
 @import "../../Sass/common/mixins";
 
@@ -6,7 +8,7 @@
 }
 
 .root table tr:nth-child(odd) {
-  background-color: darken($faint-bg, 8%);
+  background-color: color.adjust($faint-bg, $lightness: -8%);
 }
 .root table tr:nth-child(even) {
   background-color: $faint-bg;

--- a/lib/Sass/common/_variables.scss
+++ b/lib/Sass/common/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 @import url("https://fonts.googleapis.com/css?family=Nunito:300,400,500,400italic,600,700&display=swap");
 
 $font-pop: "Nunito", sans-serif;
@@ -9,7 +11,7 @@ $font: $font-base;
 $color-primary: #519ac2;
 $color-primary-disabled: #595b60;
 @function get-hover-color($base-color) {
-  @return lighten($base-color, 10%);
+  @return color.adjust($base-color, $lightness: 10%);
 }
 $color-secondary: #ff6f00;
 
@@ -169,7 +171,7 @@ $chart-grid-color: rgba(#fff, 0.085);
 $chart-text-color: #fff;
 $chart-line-color: #ccc;
 $chart-preview-line-color: $chart-line-color;
-$chart-darker: darken($dark, 8%);
+$chart-darker: color.adjust($dark, $lightness: -8%);
 $chart-panel-background: $dark;
 $chart-panel-header: $chart-darker;
 

--- a/package.json
+++ b/package.json
@@ -231,7 +231,7 @@
     "react-shallow-testutils": "^3.0.0",
     "react-test-renderer": "^16.3.2",
     "regenerator-runtime": "^0.13.2",
-    "sass": "^1.66.1",
+    "sass": "^1.79.1",
     "terriajs-server": "^4.0.0",
     "utf-8-validate": "^6.0.3",
     "yaml": "^1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3622,21 +3622,6 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.4.2:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
 chokidar@^2.0.0, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -3656,6 +3641,21 @@ chokidar@^2.0.0, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
+chokidar@^3.4.1, chokidar@^3.4.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chokidar@^3.5.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
@@ -3670,6 +3670,13 @@ chokidar@^3.5.1:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+chokidar@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.0.tgz#4d603963e5dd762dc5c7bb1cb5664e53a3002225"
+  integrity sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==
+  dependencies:
+    readdirp "^4.0.1"
 
 chownr@^2.0.0:
   version "2.0.0"
@@ -10058,6 +10065,11 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+readdirp@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.0.1.tgz#b2fe35f8dca63183cd3b86883ecc8f720ea96ae6"
+  integrity sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -10497,12 +10509,12 @@ sass-loader@^10:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-sass@^1.66.1:
-  version "1.69.7"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.69.7.tgz#6e7e1c8f51e8162faec3e9619babc7da780af3b7"
-  integrity sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==
+sass@^1.79.1:
+  version "1.79.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.79.1.tgz#0c572e8f09cc4095c27077567f78dbb9b3dceeb2"
+  integrity sha512-+mA7svoNKeL0DiJqZGeR/ZGUu8he4I8o3jyUcOFyo4eBJrwNgIMmAEwCMo/N2Y3wdjOBcRzoNxZIOtrtMX8EXg==
   dependencies:
-    chokidar ">=3.0.0 <4.0.0"
+    chokidar "^4.0.0"
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 


### PR DESCRIPTION
### What this PR does

This bumps sass to version 1.79 and fixes
the deprecation warning:

DEPRECATION WARNING: lighten() is deprecated. Suggestions: color.scale($color, $lightness: 21.7021276596%)
color.adjust($color, $lightness: 10%)
More info: https://sass-lang.com/d/color-functions
   ╷
12 │   @return lighten($base-color, 10%);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    lib/Sass/common/_variables.scss 12:11  get-hover-color()
    lib/Sass/common/_buttons.scss 69:17    root stylesheet

and:

DEPRECATION WARNING: darken() is deprecated. Suggestions: color.scale($color, $lightness: -27.7551020408%)
color.adjust($color, $lightness: -8%)
More info: https://sass-lang.com/d/color-functions
    ╷
172 │ $chart-darker: darken($dark, 8%);
    │                ^^^^^^^^^^^^^^^^^
    ╵
    lib/Sass/common/_variables.scss 172:16  @import
    lib/Sass/common/_buttons.scss 1:9       root stylesheet

### Test me

Check that darkened and lightened colors appear as they should.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
