### PR TITLE
Update contact for code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,12 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement. Please send these
-reports via email addressed to at least 2 of the following community leaders:
-
-- Ana Belgun: ana.belgun@data61.csiro.au
-- Stephen Davies: stephen.davies@data61.csiro.au
-- Nick Forbes-Smith: nick.forbes-smith@data61.csiro.au
-- Peter Hassall: peter.hassall@data61.csiro.au
+reports via email to conduct@terria.com.au.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement. Please send these
-reports via email to conduct@terria.com.au.
+reports via email to support@terria.io.
 
 All complaints will be reviewed and investigated promptly and fairly.
 


### PR DESCRIPTION
Updated to remove de-activated email accounts.

@ljowen I'm not sure if you want to put your new email addresses there, or create a forwarding address - I've assumed the latter. Originally I put 4 email addresses so people could choose who they wanted to report cases to (especially where perceived breaches involved one of the community leaders), but I think most other orgs and communities just have a forwarding address.

Tasks:

- [ ] Create a forwarding address conduct@terria.com.au (or similar) forwarding to community leaders