### PR TITLE
CI: sync versions of dependencies

### DIFF
--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -19,7 +19,7 @@ gh api /repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA} -f state=pending -f co
 # Install some tools we need from npm
 npm install -g https://github.com/terriajs/sync-dependencies
 npm install -g yarn@^1.19.0
-yarn add -W request@2.83.0
+yarn add -W request@^2.88.2
 
 # Clone and build TerriaMap, using this version of TerriaJS
 TERRIAJS_COMMIT_HASH=$(git rev-parse HEAD)
@@ -34,7 +34,6 @@ git commit -a -m 'temporary commit' # so the version doesn't indicate local modi
 git tag -a "TerriaMap-$TERRIAMAP_COMMIT_HASH--TerriaJS-$TERRIAJS_COMMIT_HASH" -m 'temporary tag'
 rm yarn.lock # because TerriaMap's yarn.lock won't reflect terriajs dependencies
 yarn install
-yarn add -W moment@2.24.0
 yarn gulp build --baseHref="/${SAFE_BRANCH_NAME}/"
 
 pwd


### PR DESCRIPTION
### What this PR does

The ^ on the request version was lost
in #6986 (cc @ljowen), so put it back so
we get a slightly less ancient version that
is what terriajs-server also uses.

Also remove the addition of moment,
that is already installed because
of the dependencies of terriajs.

### Test me

Run the CI-flow that runs this script.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
