### PR TITLE
Use useRef instead of createRef in functional component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Fix `Workbench.collapseAll()` and `Workbench.expandAll()` for References.
 - Add to the "doZoomTo" function the case of an imagery layer with imageryProvider.rectangle
 - Add "leafletMaxZoom" to configParameters so that the maxZoom of the Leaflet viewer can be changed.
+- Properly initialize react ref in functional components
 - [The next improvement]
 
 #### 8.7.7 - 2024-10-01

--- a/lib/ReactViews/Tools/ItemSearchTool/SearchResults.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import Mustache from "mustache";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useVirtual } from "react-virtual";
 import styled from "styled-components";
@@ -28,7 +28,7 @@ const SearchResults: React.FC<SearchResultsProps> = (props) => {
     currentMapEffect.is === "highlightSingleResult"
       ? currentMapEffect.result
       : undefined;
-  const parentRef = React.createRef<HTMLDivElement>();
+  const parentRef = useRef<HTMLDivElement>(null);
   const list = useVirtual({
     size: results.length,
     parentRef,

--- a/lib/ReactViews/Tools/PedestrianMode/MouseTooltip.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MouseTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Scene from "terriajs-cesium/Source/Scene/Scene";
@@ -11,7 +11,7 @@ type MouseTooltipProps = {
 
 const MouseTooltip: React.FC<MouseTooltipProps> = (props) => {
   const { scene, text } = props;
-  const tooltipText = createRef<typeof TooltipText>();
+  const tooltipText = useRef<typeof TooltipText>(null);
 
   useEffect(function tooltipFollowMouse() {
     const setTooltipPosition = (position: { x: number; y: number }) => {


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

`createRef` should only be used in class components while in functional components we should use `useRef`, https://react.dev/reference/react/createRef#migrating-from-a-class-with-createref-to-a-function-with-useref.
This is the change mentioned in https://github.com/TerriaJS/terriajs/pull/7213, 

### Test me

Example link from #7290 can be used for testing this

### Checklist

- ~[ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
- ~[ ] I've updated relevant documentation in `doc/`.~
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
