### PR TITLE
Remove Carto basemaps.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Properly initialize react ref in functional components
 - Add NominatimSearchProvider.
+- Removed the basemaps - positron, darkmatter and black-marble - from the default settings. The Carto ones are no longer free and requires an [Enterprise or Grantee license](https://carto.com/basemaps). If you have the appropriate license you can add them via your [initialization file](https://docs.terria.io/guide/customizing/initialization-files/#basemaps). [Example configuration](https://gist.github.com/na9da/ef7871afee7cbe3d0a95e5b6351834c9).
 - [The next improvement]
 
 #### 8.7.8 - 2024-11-01

--- a/lib/Models/BaseMaps/defaultBaseMaps.ts
+++ b/lib/Models/BaseMaps/defaultBaseMaps.ts
@@ -94,50 +94,5 @@ export function defaultBaseMaps(terria: Terria): BaseMapJson[] {
     contrastColor: "#000000"
   });
 
-  baseMaps.push({
-    item: {
-      id: "basemap-black-marble",
-      name: "NASA Black Marble",
-      type: "wms",
-      url: "http://geoserver.nationalmap.nicta.com.au/imagery/nasa-black-marble/wms",
-      attribution:
-        "<a href='https://earthobservatory.nasa.gov/Features/NightLights'>Black Marble</a> - From NASA's Earth Observatory. <a href='https://earthobservatory.nasa.gov/image-use-policy'>Use Policy</a>.",
-      layers: "nasa-black-marble:dnb_land_ocean_ice.2012.54000x27000_geo",
-      opacity: 1.0
-    },
-    image: "build/TerriaJS/images/black-marble.png",
-    contrastColor: "#ffffff"
-  });
-
-  baseMaps.push({
-    item: {
-      id: "basemap-positron",
-      name: "Positron (Light)",
-      type: "open-street-map",
-      url: "https://basemaps.cartocdn.com/light_all/",
-      attribution:
-        "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>, © <a href='https://carto.com/about-carto/'>CARTO</a>",
-      subdomains: ["a", "b", "c", "d"],
-      opacity: 1.0
-    },
-    image: "build/TerriaJS/images/positron.png",
-    contrastColor: "#000000"
-  });
-
-  baseMaps.push({
-    item: {
-      id: "basemap-darkmatter",
-      name: "Dark Matter",
-      type: "open-street-map",
-      url: "https://basemaps.cartocdn.com/dark_all/",
-      attribution:
-        "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>, © <a href='https://carto.com/about-carto/'>CARTO</a>",
-      subdomains: ["a", "b", "c", "d"],
-      opacity: 1.0
-    },
-    image: "build/TerriaJS/images/dark-matter.png",
-    contrastColor: "#ffffff"
-  });
-
   return baseMaps;
 }

--- a/lib/Traits/TraitsClasses/BaseMapTraits.ts
+++ b/lib/Traits/TraitsClasses/BaseMapTraits.ts
@@ -53,7 +53,7 @@ export class BaseMapsTraits extends ModelTraits {
     description:
       "The id of the baseMap to be used as the base map in data preview. "
   })
-  previewBaseMapId?: string = "basemap-positron";
+  previewBaseMapId?: string = "basemap-natural-earth-II";
 
   @objectArrayTrait<BaseMapTraits>({
     type: BaseMapTraits,

--- a/test/Models/BaseMaps/BaseMapsModelSpec.ts
+++ b/test/Models/BaseMaps/BaseMapsModelSpec.ts
@@ -63,7 +63,7 @@ describe("BaseMapModel", () => {
   it("properly use enabledBaseMaps list", () => {
     const baseMaps: any = {
       items: [baseMapPositron],
-      enabledBaseMaps: ["basemap-positron"]
+      enabledBaseMaps: ["basemap-natural-earth-II"]
     };
     baseMapsModel.loadFromJson(CommonStrata.definition, baseMaps);
     expect(baseMapsModel.items.length).toBe(
@@ -73,12 +73,27 @@ describe("BaseMapModel", () => {
   });
 
   it("propperly override image", () => {
-    const _baseMapPositron = JSON.parse(JSON.stringify(baseMapPositron));
-    _baseMapPositron.item.id = "basemap-positron";
-    _baseMapPositron.image = "test";
+    const _baseMapNaturalEarth = JSON.parse(
+      JSON.stringify({
+        item: {
+          id: "basemap-natural-earth-II-test",
+          name: "Natural Earth II",
+          type: "url-template-imagery",
+          url: "https://storage.googleapis.com/terria-datasets-public/basemaps/natural-earth-tiles/{z}/{x}/{reverseY}.png",
+          attribution:
+            "<a href='https://www.naturalearthdata.com/downloads/10m-raster-data/10m-natural-earth-2/'>Natural Earth II</a> - From Natural Earth. <a href='https://www.naturalearthdata.com/about/terms-of-use/'>Public Domain</a>.",
+          maximumLevel: 7,
+          opacity: 1.0
+        },
+        image: "build/TerriaJS/images/natural-earth.png",
+        contrastColor: "#000000"
+      })
+    );
+    _baseMapNaturalEarth.item.id = "basemap-natural-earth-II";
+    _baseMapNaturalEarth.image = "test";
     const baseMaps: any = {
-      items: [_baseMapPositron],
-      enabledBaseMaps: ["basemap-positron"]
+      items: [_baseMapNaturalEarth],
+      enabledBaseMaps: ["basemap-natural-earth-II"]
     };
     baseMapsModel.loadFromJson(CommonStrata.definition, baseMaps);
     expect(baseMapsModel.items.length).toBe(defaultBaseMapsLength);

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -1615,7 +1615,7 @@ describe("Terria", function () {
       );
     });
 
-    it("propperly loads base maps", async function () {
+    it("correctly loads the base maps", async function () {
       await terria.start({ configUrl: "" });
       terria.applyInitData({
         initData: {
@@ -1623,16 +1623,17 @@ describe("Terria", function () {
             items: [
               {
                 item: {
-                  id: "basemap-positron",
-                  name: "Positron (Light)",
-                  type: "open-street-map",
-                  url: "https://basemaps.cartocdn.com/light_all/",
+                  id: "basemap-natural-earth-II",
+                  name: "Natural Earth II",
+                  type: "url-template-imagery",
+                  url: "https://storage.googleapis.com/terria-datasets-public/basemaps/natural-earth-tiles/{z}/{x}/{reverseY}.png",
                   attribution:
-                    "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>, © <a href='https://carto.com/about-carto/'>CARTO</a>",
-                  subdomains: ["a", "b", "c", "d"],
+                    "<a href='https://www.naturalearthdata.com/downloads/10m-raster-data/10m-natural-earth-2/'>Natural Earth II</a> - From Natural Earth. <a href='https://www.naturalearthdata.com/about/terms-of-use/'>Public Domain</a>.",
+                  maximumLevel: 7,
                   opacity: 1.0
                 },
-                image: "/images/positron.png"
+                image: "build/TerriaJS/images/natural-earth.png",
+                contrastColor: "#000000"
               },
               {
                 item: {


### PR DESCRIPTION
### What this PR does

Remove positron and darkmatter basemaps. 

The Carto ones are no longer free and requires an [Enterprise or Grantee license](https://carto.com/basemaps). If you have the appropriate license you can add them via your [initialization file](https://docs.terria.io/guide/customizing/initialization-files/#basemaps). 

Here's the [example configuration](https://gist.github.com/na9da/ef7871afee7cbe3d0a95e5b6351834c9) to add back Carto basemaps provided you have the necessary license.

Also removed the nasa-black-matter basemap which was decommissioned.

### Test me

- Open CI - http://ci.terria.io/remove-basemaps
- Ensure the map settings does not list positron and darkmatter maps
- Ensure the preview map doesn't show positron map

Note, this also requires a terriamap PR to update the[ default basemap settings](https://github.com/TerriaJS/TerriaMap/blob/195abe6d6fbd2dfb365fab387e8a8d89558ab418/wwwroot/init/simple.json#L764-L767) in simple.json.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
