### PR TITLE
Restrict mobx to <6.13.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Properly initialize react ref in functional components
 - Add NominatimSearchProvider.
 - Removed the basemaps - positron, darkmatter and black-marble - from the default settings. The Carto ones are no longer free and requires an [Enterprise or Grantee license](https://carto.com/basemaps). If you have the appropriate license you can add them via your [initialization file](https://docs.terria.io/guide/customizing/initialization-files/#basemaps). [Example configuration](https://gist.github.com/na9da/ef7871afee7cbe3d0a95e5b6351834c9).
+- Restrict mobx version to '< 6.13.0' to avoid tsc errors because mobx now uses iterator helper types introduced in TypeScript 5.6.
 - [The next improvement]
 
 #### 8.7.8 - 2024-11-01

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "math-expression-evaluator": "^1.3.7",
     "mini-css-extract-plugin": "^0.5.0",
     "minisearch": "^3.0.2",
-    "mobx": "^6.7.0",
+    "mobx": "<6.13.0",
     "mobx-react": "7.6.0",
     "mobx-utils": "^6.0.5",
     "moment": "^2.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8815,10 +8815,10 @@ mobx-utils@^6.0.5:
   resolved "https://registry.yarnpkg.com/mobx-utils/-/mobx-utils-6.0.6.tgz#99a2e0d54e958e4c9de4b35729e0c3768b6afc43"
   integrity sha512-lzJtxOWgj3Dp2HeXviInV3ZRY4YhThzRHXuy90oKXDH2g+ymJGIts4bdjb7NQuSi34V25cMZoQX7TkHJQuKLOQ==
 
-mobx@^6.7.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.9.0.tgz#8a894c26417c05bed2cf7499322e589ee9787397"
-  integrity sha512-HdKewQEREEJgsWnErClfbFoVebze6rGazxFLU/XUyrII8dORfVszN1V0BMRnQSzcgsNNtkX8DHj3nC6cdWE9YQ==
+mobx@<6.13.0:
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.12.5.tgz#ed2e4312bc9dbe3d9ecd063c70a5ba9e7c2b823b"
+  integrity sha512-xRq2tyY6unAec0ItlsrgoCuxrWXLoIkM5cGPuerm/0nX/CI9FxAO6ttfRYfFa+B5Yz51d59IfKy0mJwxOEwqzQ==
 
 moment@^2.17.1:
   version "2.29.1"


### PR DESCRIPTION

### What this PR does

Mobx 6.13 makes tsc error out with:

Error: node_modules/mobx/dist/types/observableset.d.ts(45,31): error TS2552: Cannot find name 'ReadonlySetLike'. Did you mean 'ReadonlySet'?

which is issue 3903 in the mobx repository.
Restrict mobx to <6.13 for now to avoid
the issue.

### Test me

I believe this is tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [X] I've updated relevant documentation in `doc/`.
- [X] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
