### PR TITLE
prettyPrintGtfsEntityField: fix types

### DIFF
--- a/lib/Models/Catalog/Gtfs/prettyPrintGtfsEntityField.ts
+++ b/lib/Models/Catalog/Gtfs/prettyPrintGtfsEntityField.ts
@@ -9,7 +9,7 @@ export default function prettyPrintGtfsEntityField(
     // TODO: Get sone of this data (eg. route short name) from static GTFS csv files instead
     // This probably only works for NSW
     case "route_short_name": {
-      const route: string = _get(entity, "vehicle.trip.route_id");
+      const route: string | undefined = _get(entity, "vehicle.trip.route_id");
       if (route !== undefined && route.indexOf("_") + 1 > 0) {
         return route.substr(route.indexOf("_") + 1);
       } else {
@@ -17,7 +17,7 @@ export default function prettyPrintGtfsEntityField(
       }
     }
     case "occupancy_status#str": {
-      const occupancy: OccupancyStatus = _get(
+      const occupancy: OccupancyStatus | undefined = _get(
         entity,
         "vehicle.occupancy_status"
       );


### PR DESCRIPTION
### What this PR does

Running yarn upgrade gives a type error
for something with loadash-es, so add
a default value and fix a type annotation
to include undefined.

### Test me

I believe this is tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
