### PR TITLE
Update to interactjs 1.10.27

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.7.11)
 
+- Update to interactjs 1.10.27 to fix Safari issues.
 - [The next improvement]
 
 #### 8.7.10 - 2024-11-29

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "i18next-http-backend": "^1.4.1",
     "imports-loader": "^0.8.0",
     "inobounce": "^0.1.2",
-    "interactjs": "1.4.0-alpha.17",
+    "interactjs": "^1.10.27",
     "javascript-natural-sort": "^0.7.1",
     "json5": "^2.1.0",
     "leaflet": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,6 +1267,11 @@
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
   integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
 
+"@interactjs/types@1.10.27":
+  version "1.10.27"
+  resolved "https://registry.yarnpkg.com/@interactjs/types/-/types-1.10.27.tgz#10afd71cef2498e2b5192cf0d46f937d8ceb767f"
+  integrity sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==
+
 "@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
@@ -6955,10 +6960,12 @@ inobounce@^0.1.2:
   resolved "https://registry.yarnpkg.com/inobounce/-/inobounce-0.1.6.tgz#b3912e63cdb2eacbcbfcdce6a0681a105b49a8d2"
   integrity sha512-526BdpKOby/5Ft9AvihHC948w5VBzIkI76yBWclkj9zVEK9JRNcuybm4HztB7O9VkM4sp6E4WqnhtRRhgGNt+A==
 
-interactjs@1.4.0-alpha.17:
-  version "1.4.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/interactjs/-/interactjs-1.4.0-alpha.17.tgz#07181adbeed32c6267aa6e4e54cabb3140e967e3"
-  integrity sha512-EBTe0lL/Lpya18hBg9RlxcfcPYu7XUspP64fD0pUAhE2CSY8smYFGeIumMzO64ail9ifKEFebnXsVNN+NDc9Bw==
+interactjs@^1.10.27:
+  version "1.10.27"
+  resolved "https://registry.yarnpkg.com/interactjs/-/interactjs-1.10.27.tgz#16499aba4987a5ccfdaddca7d1ba7bb1118e14d0"
+  integrity sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==
+  dependencies:
+    "@interactjs/types" "1.10.27"
 
 internal-slot@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
### What this PR does

I don't have Safari, but TerriaMap
supposedly does "not work with
Safari".

The interactjs version that
is used has multiple bugs that
affect Safari, for example:

https://github.com/taye/interact.js/issues/682

so bump the version to the latest
interactjs in hope that it makes
things better for Safari.

### Test me

I believe this is tested by CI?

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
