### PR TITLE
ServerConfig.d.ts: add types for options

### DIFF
--- a/lib/Core/CorsProxy.ts
+++ b/lib/Core/CorsProxy.ts
@@ -1,4 +1,5 @@
 import defined from "terriajs-cesium/Source/Core/defined";
+import { type ServerConfigOptions } from "./ServerConfig";
 import URI from "urijs";
 
 /**
@@ -62,7 +63,7 @@ export default class CorsProxy {
    * @returns A promise that resolves when initialisation is complete.
    */
   init(
-    serverConfig: any,
+    serverConfig: ServerConfigOptions | undefined,
     baseProxyUrl: string = CorsProxy.DEFAULT_BASE_PROXY_PATH,
     proxyDomains: string[] = []
   ): void {

--- a/lib/Core/ServerConfig.d.ts
+++ b/lib/Core/ServerConfig.d.ts
@@ -1,6 +1,18 @@
+export declare interface ServerConfigOptions {
+  version: string;
+  proxyAllDomains: boolean;
+  allowProxyFor: string[];
+  maxConversionSize: number;
+  newShareUrlPrefix?: string;
+  shareUrlPrefixes: object;
+  additionalFeedbackParameters: object[];
+}
+
 declare class ServerConfig {
-  config: unknown;
-  init(serverConfigUrl: string): Promise<unknown>;
+  config: ServerConfigOptions;
+  init(
+    serverConfigUrl: string | undefined
+  ): Promise<ServerConfigOptions | undefined>;
 }
 
 export default ServerConfig;

--- a/lib/Core/ServerConfig.js
+++ b/lib/Core/ServerConfig.js
@@ -11,7 +11,7 @@ function ServerConfig() {
    * Contains configuration information retrieved from the server. The attributes are defined by TerriaJS-Server but include:
    *   version: current version of server
    *   proxyAllDomains: whether all domains can be proxied
-   *   allowProxyFrom: array of domains that can be proxied
+   *   allowProxyFor: array of domains that can be proxied
    *   maxConversionSize: maximum size, in bytes, of files that can be uploaded to conversion service
    *   newShareUrlPrefix: if defined, the share URL service is active
    *   shareUrlPrefixes: object defining share URL prefixes that can be resolved

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -42,7 +42,7 @@ import {
 } from "../Core/Json";
 import { isLatLonHeight } from "../Core/LatLonHeight";
 import Result from "../Core/Result";
-import ServerConfig from "../Core/ServerConfig";
+import ServerConfig, { type ServerConfigOptions } from "../Core/ServerConfig";
 import TerriaError, {
   TerriaErrorOverrides,
   TerriaErrorSeverity
@@ -650,7 +650,7 @@ export default class Terria {
     this.forceLoadInitSources.bind(this)
   );
 
-  @observable serverConfig: any; // TODO
+  @observable serverConfig?: ServerConfig; // TODO
   @observable shareDataService: ShareDataService | undefined;
 
   /* Splitter controls */
@@ -2135,7 +2135,7 @@ export default class Terria {
 
   async initCorsProxy(
     config: ConfigParameters,
-    serverConfig: any
+    serverConfig: ServerConfigOptions | undefined
   ): Promise<void> {
     if (config.proxyableDomainsUrl) {
       console.warn(i18next.t("models.terria.proxyableDomainsDeprecation"));

--- a/lib/Models/sendFeedback.ts
+++ b/lib/Models/sendFeedback.ts
@@ -47,6 +47,7 @@ export default function sendFeedback(options: {
       };
       if (
         options.additionalParameters &&
+        terria.serverConfig &&
         terria.serverConfig.config &&
         terria.serverConfig.config.additionalFeedbackParameters
       ) {


### PR DESCRIPTION
### What this PR does

Add some types for the options in
ServerConfig. This uncovered a missing
check in sendFeedback.

### Test me

Tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
