### PR TITLE
Use `encoding: false` when copying files using gulp.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Remove unused class-list dependency.
 - TSify `ConsoleAnalytics` module.
 - Update to gulp 5.0 to fix security vulnerabilities.
+  - Gulp 5 defaults to encoding copied files as utf-8, had turn off encoding by setting `encoding: false` to correctly copy binary assets from dependencies.
 - Update to dompurify 2.5.7 to fix security vulnerabilities.
 - Remove unused simple-statistics dependency.
 - Update to pretty-quick 4.0.0 to fix security vulnerabilities.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,8 @@ gulp.task("copy-cesium-workers", function () {
 
   return gulp
     .src([path.join(cesiumWorkersRoot, "**")], {
-      base: cesiumWorkersRoot
+      base: cesiumWorkersRoot,
+      encoding: false
     })
     .pipe(gulp.dest("wwwroot/build/Cesium/build/Workers"));
 });
@@ -95,7 +96,8 @@ gulp.task("copy-cesium-thirdparty", function () {
 
   return gulp
     .src([path.join(cesiumThirdPartyRoot, "**")], {
-      base: cesiumThirdPartyRoot
+      base: cesiumThirdPartyRoot,
+      encoding: false
     })
     .pipe(gulp.dest("wwwroot/build/Cesium/build/ThirdParty"));
 });
@@ -109,7 +111,8 @@ gulp.task("copy-cesium-source-assets", function () {
 
   return gulp
     .src([path.join(cesiumAssetsRoot, "**")], {
-      base: cesiumAssetsRoot
+      base: cesiumAssetsRoot,
+      encoding: false
     })
     .pipe(gulp.dest("wwwroot/build/Cesium/build/Assets"));
 });


### PR DESCRIPTION
### What this PR does

Assets we copy from third party libs include binary files like images, wasm builds etc. [Gulp5](https://medium.com/gulpjs/announcing-gulp-v5-c67d077dbdb7#:~:text=Most%20usage%20of%20gulp%20won%E2%80%99t%20need%20to%20change%20anything%2C%20but%20certain%20plugins%20may%20produce%20non%2DUTF%2D8%20output%20and%20you%E2%80%99ll%20need%20to%20set%20%60%7B%20encoding%3A%20false%20%7D%60%20on%20your%20gulp%20streams.) by default re-encodes files as utf-8 which breaks copying of binary files. By, setting `encoding: false` gulp treats all copied files as binary, reverting to the previous behaviour.

Requires terriamap PR - https://github.com/TerriaJS/TerriaMap/pull/713

### Test me

- Open [main](http://ci.terria.io/main). 
- You'll see that thumbnails in map settings and the cesium icon in the bottom bar are broken (so are some wasm files used for draco decoding etc.)
- Now open CI for [this branch](http://ci.terria.io/gulp5-fix-bin-copy).
- Observe that these thumbnails are now fixed.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
