### PR TITLE
update react imports to easy react upgrade

### DIFF
--- a/lib/Models/MapInteractionMode.ts
+++ b/lib/Models/MapInteractionMode.ts
@@ -1,8 +1,8 @@
+import { makeObservable, observable } from "mobx";
+import { ReactNode } from "react";
 import defaultValue from "terriajs-cesium/Source/Core/defaultValue";
 import PickedFeatures from "../Map/PickedFeatures/PickedFeatures";
-import { observable, makeObservable } from "mobx";
 import ViewState from "../ReactViewModels/ViewState";
-import React from "react";
 
 export enum UIMode {
   Difference
@@ -11,7 +11,7 @@ export enum UIMode {
 interface Options {
   onCancel?: () => void;
   message: string;
-  messageAsNode?: React.ReactNode;
+  messageAsNode?: ReactNode;
   customUi?: () => unknown;
   buttonText?: string;
   uiMode?: UIMode; // diff tool hack for now
@@ -37,7 +37,7 @@ export default class MapInteractionMode {
   message: () => string;
 
   @observable
-  messageAsNode: () => React.ReactNode;
+  messageAsNode: () => ReactNode;
 
   @observable
   pickedFeatures?: PickedFeatures;

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -7,7 +7,7 @@ import {
   runInAction,
   makeObservable
 } from "mobx";
-import React, { Ref } from "react";
+import { ReactNode, MouseEvent, ComponentType, Ref } from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
 import addedByUser from "../Core/addedByUser";
 import {
@@ -371,7 +371,7 @@ export default class ViewState {
    */
   @observable currentTool?: Tool;
 
-  @observable panel: React.ReactNode;
+  @observable panel: ReactNode;
 
   private _pickedFeaturesSubscription: IReactionDisposer;
   private _disclaimerVisibleSubscription: IReactionDisposer;
@@ -711,7 +711,7 @@ export default class ViewState {
 
   @action
   openHelpPanelItemFromSharePanel(
-    evt: React.MouseEvent<HTMLDivElement>,
+    evt: MouseEvent<HTMLDivElement>,
     itemName: string
   ) {
     evt.preventDefault();
@@ -882,9 +882,7 @@ export default class ViewState {
 
 interface Tool {
   toolName: string;
-  getToolComponent: () =>
-    | React.ComponentType<any>
-    | Promise<React.ComponentType<any>>;
+  getToolComponent: () => ComponentType<any> | Promise<ComponentType<any>>;
 
   showCloseButton: boolean;
   params?: any;

--- a/lib/ReactViews/ActionBar/ActionBar.tsx
+++ b/lib/ReactViews/ActionBar/ActionBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { FC, useEffect } from "react";
 import styled from "styled-components";
 import Box from "../../Styled/Box";
 import { PortalChild } from "../StandardUserInterface/Portal";
@@ -11,7 +11,7 @@ import { ActionBarPortalId } from "./ActionBarPortal";
  * {@link ActionButton} can be used as a themed button for the action bar
  * {@link ActionButtonGroup} can be used for grouping elements inside an action bar
  */
-export const ActionBar: React.FC<object> = (props) => {
+export const ActionBar: FC<object> = (props) => {
   const viewState = useViewState();
 
   useEffect(function setVisibility() {

--- a/lib/ReactViews/ActionBar/ActionBarPortal.tsx
+++ b/lib/ReactViews/ActionBar/ActionBarPortal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import styled from "styled-components";
 import { Portal } from "../StandardUserInterface/Portal";
 
@@ -16,7 +16,7 @@ interface PropsType {
 /**
  * A Portal to show ActionBar UI.
  */
-const ActionBarPortal: React.FC<PropsType> = ({ show }) => {
+const ActionBarPortal: FC<PropsType> = ({ show }) => {
   return <StyledPortal id={ActionBarPortalId} show={show} />;
 };
 

--- a/lib/ReactViews/ActionBar/ActionButton.tsx
+++ b/lib/ReactViews/ActionBar/ActionButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { HTMLProps, FC } from "react";
 import { useTheme } from "styled-components";
 import AnimatedSpinnerIcon from "../../Styled/AnimatedSpinnerIcon";
 import { ButtonProps } from "../../Styled/Button";
@@ -7,7 +7,7 @@ import StyledButton from "./StyledButton";
 
 export interface ActionButtonProps
   extends Omit<
-    ButtonProps & React.HTMLProps<HTMLButtonElement>,
+    ButtonProps & HTMLProps<HTMLButtonElement>,
     "iconProps" | "renderIcon"
   > {
   className?: string;
@@ -18,7 +18,7 @@ export interface ActionButtonProps
 /**
  * A themed button to use inside {@link ActionBar}
  */
-export const ActionButton: React.FC<ActionButtonProps> = ({
+export const ActionButton: FC<ActionButtonProps> = ({
   className,
   icon,
   showProcessingIcon,

--- a/lib/ReactViews/Analytics/BooleanParameterGroupEditor.jsx
+++ b/lib/ReactViews/Analytics/BooleanParameterGroupEditor.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import MoreOrLess from "../Generic/MoreOrLess.jsx";

--- a/lib/ReactViews/Analytics/DateParameterEditor.tsx
+++ b/lib/ReactViews/Analytics/DateParameterEditor.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { useCallback } from "react";
+import { FC, useCallback } from "react";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import DateParameter from "../../Models/FunctionParameters/DateParameter";
 import Styles from "./parameter-editors.scss";
@@ -8,7 +8,7 @@ interface DateParameterEditorProps {
   parameter: DateParameter;
 }
 
-const DateParameterEditor: React.FC<DateParameterEditorProps> = observer(
+const DateParameterEditor: FC<DateParameterEditorProps> = observer(
   ({ parameter }) => {
     const style =
       parameter?.value !== undefined

--- a/lib/ReactViews/Analytics/DateTimeParameterEditor.tsx
+++ b/lib/ReactViews/Analytics/DateTimeParameterEditor.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { useCallback } from "react";
+import { FC, ChangeEvent, useCallback } from "react";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import DateTimeParameter from "../../Models/FunctionParameters/DateTimeParameter";
 import Styles from "./parameter-editors.scss";
@@ -8,15 +8,15 @@ interface DateTimeParameterEditorProps {
   parameter: DateTimeParameter;
 }
 
-const DateTimeParameterEditor: React.FC<DateTimeParameterEditorProps> =
-  observer(({ parameter }) => {
+const DateTimeParameterEditor: FC<DateTimeParameterEditorProps> = observer(
+  ({ parameter }) => {
     const style =
       parameter?.value !== undefined
         ? Styles.field
         : Styles.fieldDatePlaceholder;
 
     const onDateTimeChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) =>
+      (e: ChangeEvent<HTMLInputElement>) =>
         parameter.setValue(CommonStrata.user, e.target.value),
       [parameter]
     );
@@ -31,6 +31,7 @@ const DateTimeParameterEditor: React.FC<DateTimeParameterEditorProps> =
         />
       </div>
     );
-  });
+  }
+);
 
 export default DateTimeParameterEditor;

--- a/lib/ReactViews/Analytics/GeoJsonParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/GeoJsonParameterEditor.jsx
@@ -1,6 +1,6 @@
 "use strict";
 
-import React from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import defined from "terriajs-cesium/Source/Core/defined";
 import Styles from "./parameter-editors.scss";
@@ -24,7 +24,7 @@ import { runInAction } from "mobx";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 
 @observer
-class GeoJsonParameterEditor extends React.Component {
+class GeoJsonParameterEditor extends Component {
   static propTypes = {
     previewed: PropTypes.object,
     parameter: PropTypes.object,

--- a/lib/ReactViews/Analytics/InvokeFunction.jsx
+++ b/lib/ReactViews/Analytics/InvokeFunction.jsx
@@ -1,7 +1,7 @@
 import { makeObservable, observable, runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
 import parseCustomMarkdownToReact from "../Custom/parseCustomMarkdownToReact";
@@ -44,7 +44,7 @@ class ParameterViewModel {
 }
 
 @observer
-class InvokeFunction extends React.Component {
+class InvokeFunction extends Component {
   static propTypes = {
     terria: PropTypes.object,
     previewed: PropTypes.object,

--- a/lib/ReactViews/Analytics/LineParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/LineParameterEditor.jsx
@@ -1,6 +1,5 @@
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
-import React from "react";
 import { withTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";

--- a/lib/ReactViews/Analytics/NumberParameterEditor.tsx
+++ b/lib/ReactViews/Analytics/NumberParameterEditor.tsx
@@ -1,11 +1,11 @@
-import React, { ChangeEvent, useEffect, useState } from "react";
+import { FC, ChangeEvent, useEffect, useState } from "react";
 import { observer } from "mobx-react";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import NumberParameter from "../../Models/FunctionParameters/NumberParameter";
 
 import Styles from "./parameter-editors.scss";
 
-const NumberParameterEditor: React.FC<{ parameter: NumberParameter }> = ({
+const NumberParameterEditor: FC<{ parameter: NumberParameter }> = ({
   parameter
 }) => {
   const [value, setValue] = useState<number | undefined>(0);

--- a/lib/ReactViews/Analytics/ParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/ParameterEditor.jsx
@@ -1,7 +1,5 @@
 "use strict";
 
-import React from "react";
-
 import createReactClass from "create-react-class";
 
 import PropTypes from "prop-types";

--- a/lib/ReactViews/Analytics/PointParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PointParameterEditor.jsx
@@ -1,7 +1,5 @@
 "use strict";
 
-import React from "react";
-
 import createReactClass from "create-react-class";
 
 import PropTypes from "prop-types";

--- a/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/PolygonParameterEditor.jsx
@@ -1,6 +1,6 @@
 "use strict";
 
-import React from "react";
+import { Component } from "react";
 
 import PropTypes from "prop-types";
 
@@ -17,7 +17,7 @@ import { runInAction } from "mobx";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 
 @observer
-class PolygonParameterEditor extends React.Component {
+class PolygonParameterEditor extends Component {
   static propTypes = {
     previewed: PropTypes.object,
     parameter: PropTypes.object,

--- a/lib/ReactViews/Analytics/RectangleParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RectangleParameterEditor.jsx
@@ -1,6 +1,6 @@
 "use strict";
 
-import React from "react";
+import { Component } from "react";
 
 import PropTypes from "prop-types";
 
@@ -18,7 +18,7 @@ import { runInAction } from "mobx";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 
 @observer
-class RectangleParameterEditor extends React.Component {
+class RectangleParameterEditor extends Component {
   static propTypes = {
     previewed: PropTypes.object,
     parameter: PropTypes.object,

--- a/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionDataParameterEditor.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import createReactClass from "create-react-class";
 
 import PropTypes from "prop-types";

--- a/lib/ReactViews/Analytics/RegionParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionParameterEditor.jsx
@@ -1,7 +1,5 @@
 "use strict";
 
-import React from "react";
-
 import createReactClass from "create-react-class";
 
 import PropTypes from "prop-types";

--- a/lib/ReactViews/Analytics/RegionPicker.jsx
+++ b/lib/ReactViews/Analytics/RegionPicker.jsx
@@ -1,7 +1,6 @@
 "use strict";
 
 import classNames from "classnames";
-import React from "react";
 
 import createReactClass from "create-react-class";
 

--- a/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
+++ b/lib/ReactViews/Analytics/RegionTypeParameterEditor.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-import React from "react";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import defined from "terriajs-cesium/Source/Core/defined";

--- a/lib/ReactViews/BadgeBar.tsx
+++ b/lib/ReactViews/BadgeBar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactNode, FC } from "react";
 import { useTheme } from "styled-components";
 import { TextSpan } from "../Styled/Text";
 const Box = require("../Styled/Box").default;
@@ -6,9 +6,9 @@ const Box = require("../Styled/Box").default;
 interface IProps {
   label: string;
   badge?: number;
-  children: React.ReactNode;
+  children: ReactNode;
 }
-const BadgeBar: React.FC<IProps> = (props: IProps) => {
+const BadgeBar: FC<IProps> = (props: IProps) => {
   const theme = useTheme();
   return (
     <Box

--- a/lib/ReactViews/BottomDock/BottomDock.tsx
+++ b/lib/ReactViews/BottomDock/BottomDock.tsx
@@ -1,6 +1,6 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import Terria from "../../Models/Terria";
 import ViewState from "../../ReactViewModels/ViewState";
 import ChartPanel from "../Custom/Chart/ChartPanel";
@@ -16,7 +16,7 @@ interface PropsType {
 }
 
 @observer
-class BottomDock extends React.Component<PropsType & MeasureElementProps> {
+class BottomDock extends Component<PropsType & MeasureElementProps> {
   refToMeasure: HTMLDivElement | null = null;
 
   handleClick() {

--- a/lib/ReactViews/BottomDock/ChartDisclaimer.tsx
+++ b/lib/ReactViews/BottomDock/ChartDisclaimer.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React from "react";
+import { FC, Fragment } from "react";
 import ChartView from "../../Charts/ChartView";
 import filterOutUndefined from "../../Core/filterOutUndefined";
 import hasTraits from "../../Models/Definition/hasTraits";
@@ -16,7 +16,7 @@ interface ChartDisclaimerProps {
   viewState: ViewState;
 }
 
-const ChartDisclaimer: React.FC<ChartDisclaimerProps> = ({ terria }) => {
+const ChartDisclaimer: FC<ChartDisclaimerProps> = ({ terria }) => {
   const chartView = new ChartView(terria);
 
   const uniqueChartDisclaimers: string[] = [
@@ -52,10 +52,10 @@ const ChartDisclaimer: React.FC<ChartDisclaimerProps> = ({ terria }) => {
     >
       <Spacing bottom={2} />
       {uniqueChartDisclaimers.map((chartDisclaimer) => (
-        <React.Fragment key={chartDisclaimer}>
+        <Fragment key={chartDisclaimer}>
           <Text textLight>{parseCustomHtmlToReact(chartDisclaimer!)}</Text>
           <Spacing bottom={2} />
-        </React.Fragment>
+        </Fragment>
       ))}
     </Box>
   );

--- a/lib/ReactViews/BottomDock/MapDataCount.tsx
+++ b/lib/ReactViews/BottomDock/MapDataCount.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { observer } from "mobx-react";
 
 import Icon, { StyledIcon } from "../../Styled/Icon";

--- a/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/CesiumTimeline.jsx
@@ -5,7 +5,6 @@ import createReactClass from "create-react-class";
 import dateFormat from "dateformat";
 import { autorun, runInAction } from "mobx";
 import PropTypes from "prop-types";
-import React from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import WrappedTimeline from "terriajs-cesium-widgets/Source/Timeline/Timeline";

--- a/lib/ReactViews/BottomDock/Timeline/DateTimePicker.tsx
+++ b/lib/ReactViews/BottomDock/Timeline/DateTimePicker.tsx
@@ -8,7 +8,7 @@ import {
 } from "mobx";
 import { observer } from "mobx-react";
 import moment from "moment";
-import React from "react";
+import { Component } from "react";
 import { withTranslation, WithTranslation } from "react-i18next";
 import styled from "styled-components";
 import isDefined from "../../../Core/isDefined";
@@ -155,7 +155,7 @@ interface PropsType extends WithTranslation {
 type Granularity = "century" | "year" | "month" | "day" | "time" | "hour";
 
 @observer
-class DateTimePicker extends React.Component<PropsType> {
+class DateTimePicker extends Component<PropsType> {
   public static defaultProps = {
     openDirection: "down"
   };

--- a/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/Timeline.jsx
@@ -1,7 +1,7 @@
 import dateFormat from "dateformat";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
@@ -14,7 +14,7 @@ import Styles from "./timeline.scss";
 import TimelineControls from "./TimelineControls";
 
 @observer
-class Timeline extends React.Component {
+class Timeline extends Component {
   static propTypes = {
     terria: PropTypes.object.isRequired,
     locale: PropTypes.object,

--- a/lib/ReactViews/BottomDock/Timeline/TimelineControls.jsx
+++ b/lib/ReactViews/BottomDock/Timeline/TimelineControls.jsx
@@ -1,7 +1,5 @@
 "use strict";
 
-import React from "react";
-
 import PropTypes from "prop-types";
 import createReactClass from "create-react-class";
 

--- a/lib/ReactViews/CleanDropdownPanel/CleanDropdownPanel.jsx
+++ b/lib/ReactViews/CleanDropdownPanel/CleanDropdownPanel.jsx
@@ -1,12 +1,5 @@
 "use strict";
 
-// Ref now needs to be passed in via refForCaret as there is no longer a button
-// in CleanDropdownPanel
-
-// proptypes are in mixin
-/* eslint react/prop-types:0*/
-
-import React from "react";
 import createReactClass from "create-react-class";
 // import Icon from "../../Icon";
 import InnerPanel from "../Map/Panels/InnerPanel";

--- a/lib/ReactViews/CleanDropdownPanel/CleanDropdownPanel.jsx
+++ b/lib/ReactViews/CleanDropdownPanel/CleanDropdownPanel.jsx
@@ -1,4 +1,9 @@
 "use strict";
+// Ref now needs to be passed in via refForCaret as there is no longer a button
+// in CleanDropdownPanel
+
+// proptypes are in mixin
+/* eslint react/prop-types:0*/
 
 import createReactClass from "create-react-class";
 // import Icon from "../../Icon";

--- a/lib/ReactViews/Clipboard.tsx
+++ b/lib/ReactViews/Clipboard.tsx
@@ -1,5 +1,5 @@
 import clipboard from "clipboard";
-import React, { useEffect, useState } from "react";
+import { ReactElement, FC, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import Box from "../Styled/Box";
@@ -16,14 +16,14 @@ enum CopyStatus {
 
 interface ClipboardProps {
   id: string;
-  source: React.ReactElement;
+  source: ReactElement;
   theme: "dark" | "light";
   rounded?: boolean;
   text?: string;
   onCopy?: (contents: string) => void;
 }
 
-const Clipboard: React.FC<ClipboardProps> = (props) => {
+const Clipboard: FC<ClipboardProps> = (props) => {
   const { id, source, theme, rounded } = props;
   const { t } = useTranslation();
   const [status, setStatus] = useState<CopyStatus>(

--- a/lib/ReactViews/Context/ContextProviders.tsx
+++ b/lib/ReactViews/Context/ContextProviders.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactNode } from "react";
 import { DefaultTheme, ThemeProvider } from "styled-components";
 import ViewState from "../../ReactViewModels/ViewState";
 import { ViewStateProvider } from "./ViewStateContext";
@@ -6,7 +6,7 @@ import { ViewStateProvider } from "./ViewStateContext";
 export const ContextProviders = (props: {
   viewState: ViewState;
   theme: DefaultTheme | ((theme: DefaultTheme) => DefaultTheme);
-  children: React.ReactNode[];
+  children: ReactNode[];
 }) => (
   <ViewStateProvider viewState={props.viewState}>
     <ThemeProvider theme={props.theme}>{props.children}</ThemeProvider>

--- a/lib/ReactViews/Context/ViewStateContext.tsx
+++ b/lib/ReactViews/Context/ViewStateContext.tsx
@@ -1,10 +1,10 @@
-import React, { createContext, useContext } from "react";
+import { FC, ComponentType, createContext, useContext } from "react";
 import ViewState from "../../ReactViewModels/ViewState";
 import TerriaError from "../../Core/TerriaError";
 
 export const ViewStateContext = createContext<ViewState | undefined>(undefined);
 
-export const ViewStateProvider: React.FC<{ viewState: ViewState }> = ({
+export const ViewStateProvider: FC<{ viewState: ViewState }> = ({
   viewState,
   children
 }) => (
@@ -21,8 +21,8 @@ export const useViewState = () => {
 };
 
 export const withViewState = <P extends WithViewState>(
-  Component: React.ComponentType<P>
-): React.FC<Omit<P, "viewState">> =>
+  Component: ComponentType<P>
+): FC<Omit<P, "viewState">> =>
   function withViewState(props) {
     return (
       <ViewStateContext.Consumer>

--- a/lib/ReactViews/Custom/Chart/BottomDockChart.jsx
+++ b/lib/ReactViews/Custom/Chart/BottomDockChart.jsx
@@ -9,7 +9,7 @@ import { withParentSize } from "@visx/responsive";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { Line } from "@visx/shape";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component, createRef, PureComponent } from "react";
 import groupBy from "lodash-es/groupBy";
 import minBy from "lodash-es/minBy";
 import Legends from "./Legends";
@@ -27,7 +27,7 @@ const defaultGridColor = "#efefef";
 const labelColor = "#efefef";
 
 @observer
-class BottomDockChart extends React.Component {
+class BottomDockChart extends Component {
   static propTypes = {
     terria: PropTypes.object.isRequired,
     parentWidth: PropTypes.number,
@@ -58,7 +58,7 @@ class BottomDockChart extends React.Component {
 export default withParentSize(BottomDockChart);
 
 @observer
-class Chart extends React.Component {
+class Chart extends Component {
   static propTypes = {
     terria: PropTypes.object.isRequired,
     width: PropTypes.number,
@@ -330,7 +330,7 @@ class Chart extends React.Component {
 }
 
 @observer
-class Plot extends React.Component {
+class Plot extends Component {
   static propTypes = {
     chartItems: PropTypes.array.isRequired,
     initialScales: PropTypes.array.isRequired,
@@ -344,7 +344,7 @@ class Plot extends React.Component {
 
   @computed
   get chartRefs() {
-    return this.props.chartItems.map((_) => React.createRef());
+    return this.props.chartItems.map((_) => createRef());
   }
 
   componentDidUpdate() {
@@ -418,7 +418,7 @@ class Plot extends React.Component {
   }
 }
 
-class XAxis extends React.PureComponent {
+class XAxis extends PureComponent {
   static propTypes = {
     top: PropTypes.number.isRequired,
     scale: PropTypes.func.isRequired,
@@ -453,7 +453,7 @@ class XAxis extends React.PureComponent {
   }
 }
 
-class YAxis extends React.PureComponent {
+class YAxis extends PureComponent {
   static propTypes = {
     scale: PropTypes.func.isRequired,
     color: PropTypes.string.isRequired,
@@ -490,7 +490,7 @@ class YAxis extends React.PureComponent {
   }
 }
 
-class Cursor extends React.PureComponent {
+class Cursor extends PureComponent {
   static propTypes = {
     x: PropTypes.number.isRequired
   };

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.tsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import { TFunction } from "i18next";
 import { action, makeObservable, observable, runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import styled, { useTheme } from "styled-components";
 import filterOutUndefined from "../../../Core/filterOutUndefined";
@@ -27,7 +27,7 @@ interface PropsType extends WithTranslation {
 }
 
 @observer
-class ChartExpandAndDownloadButtons extends React.Component<PropsType> {
+class ChartExpandAndDownloadButtons extends Component<PropsType> {
   @observable sourceItems: ChartableMixin.Instance[] = [];
 
   constructor(props: PropsType) {

--- a/lib/ReactViews/Custom/Chart/ChartPanel.jsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanel.jsx
@@ -3,7 +3,7 @@
 import { computed, makeObservable } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
 import ChartView from "../../../Charts/ChartView.ts";
@@ -18,7 +18,7 @@ import { ChartPanelDownloadButton } from "./ChartPanelDownloadButton";
 const height = 300;
 
 @observer
-class ChartPanel extends React.Component {
+class ChartPanel extends Component {
   static displayName = "ChartPanel";
 
   static propTypes = {

--- a/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.tsx
+++ b/lib/ReactViews/Custom/Chart/ChartPanelDownloadButton.tsx
@@ -2,7 +2,6 @@
 import FileSaver from "file-saver";
 import { runInAction, toJS } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
 import FeatureDetection from "terriajs-cesium/Source/Core/FeatureDetection";
 import isDefined from "../../../Core/isDefined";
 import Result from "../../../Core/Result";

--- a/lib/ReactViews/Custom/Chart/FeatureInfoPanelChart.tsx
+++ b/lib/ReactViews/Custom/Chart/FeatureInfoPanelChart.tsx
@@ -4,7 +4,7 @@ import { useParentSize } from "@visx/responsive";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { computed, makeObservable } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect, useState } from "react";
+import { FC, Component, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import ChartableMixin, { ChartItem } from "../../../ModelMixins/ChartableMixin";
@@ -36,8 +36,8 @@ const defaultMargin: Margin = { top: 5, left: 5, right: 5, bottom: 5 };
 /**
  * Chart component for feature info panel popup
  */
-const FeatureInfoPanelChart: React.FC<FeatureInfoPanelChartPropTypes> =
-  observer((props) => {
+const FeatureInfoPanelChart: FC<FeatureInfoPanelChartPropTypes> = observer(
+  (props) => {
     const [loadingFailed, setLoadingFailed] = useState(false);
     const { t } = useTranslation();
 
@@ -106,7 +106,8 @@ const FeatureInfoPanelChart: React.FC<FeatureInfoPanelChartPropTypes> =
         )}
       </div>
     );
-  });
+  }
+);
 
 const isLineType = (chartItem: ChartItem) =>
   chartItem.type === "line" || chartItem.type === "lineAndPoint";
@@ -124,7 +125,7 @@ interface ChartPropsType {
  * Private Chart component that renders the SVG chart
  */
 @observer
-class Chart extends React.Component<ChartPropsType> {
+class Chart extends Component<ChartPropsType> {
   xAxisHeight = 30;
   yAxisWidth = 10;
 

--- a/lib/ReactViews/Custom/Chart/Legends.jsx
+++ b/lib/ReactViews/Custom/Chart/Legends.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import { PureComponent } from "react";
 import { scaleOrdinal } from "@visx/scale";
 import { LegendOrdinal } from "@visx/legend";
 import Glyphs from "./Glyphs";
@@ -9,7 +9,7 @@ import styled from "styled-components";
 import { observer } from "mobx-react";
 
 @observer
-class Legends extends React.PureComponent {
+class Legends extends PureComponent {
   static propTypes = {
     chartItems: PropTypes.array.isRequired,
     width: PropTypes.number.isRequired
@@ -44,7 +44,7 @@ class Legends extends React.PureComponent {
 
 export default Legends;
 
-class Legend extends React.PureComponent {
+class Legend extends PureComponent {
   static propTypes = {
     label: PropTypes.object.isRequired,
     glyph: PropTypes.string

--- a/lib/ReactViews/Custom/Chart/LineAndPointChart.jsx
+++ b/lib/ReactViews/Custom/Chart/LineAndPointChart.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import { createRef, PureComponent } from "react";
 import LineChart from "./LineChart";
 import MomentPointsChart from "./MomentPointsChart";
 
@@ -7,7 +7,7 @@ import MomentPointsChart from "./MomentPointsChart";
  * A line chart, where each data point is represented by a circle, and a line is
  * drawn between each point.
  */
-export default class LineAndPointChart extends React.PureComponent {
+export default class LineAndPointChart extends PureComponent {
   static propTypes = {
     id: PropTypes.string.isRequired,
     chartItem: PropTypes.object.isRequired,
@@ -18,8 +18,8 @@ export default class LineAndPointChart extends React.PureComponent {
 
   constructor() {
     super();
-    this.lineRef = React.createRef();
-    this.pointRef = React.createRef();
+    this.lineRef = createRef();
+    this.pointRef = createRef();
   }
 
   doZoom(scales) {

--- a/lib/ReactViews/Custom/Chart/LineChart.jsx
+++ b/lib/ReactViews/Custom/Chart/LineChart.jsx
@@ -1,11 +1,11 @@
 import { LinePath } from "@visx/shape";
 import { line } from "d3-shape";
 import PropTypes from "prop-types";
-import React from "react";
+import { PureComponent } from "react";
 import { observer } from "mobx-react";
 
 @observer
-class LineChart extends React.PureComponent {
+class LineChart extends PureComponent {
   static propTypes = {
     id: PropTypes.string.isRequired,
     chartItem: PropTypes.object.isRequired,

--- a/lib/ReactViews/Custom/Chart/MomentLinesChart.jsx
+++ b/lib/ReactViews/Custom/Chart/MomentLinesChart.jsx
@@ -1,10 +1,10 @@
 import { observer } from "mobx-react";
 import { Line } from "@visx/shape";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 
 @observer
-class MomentLines extends React.Component {
+class MomentLines extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     chartItem: PropTypes.object.isRequired,

--- a/lib/ReactViews/Custom/Chart/MomentPointsChart.jsx
+++ b/lib/ReactViews/Custom/Chart/MomentPointsChart.jsx
@@ -3,12 +3,12 @@ import { interpolateNumber as d3InterpolateNumber } from "d3-interpolate";
 import { computed, makeObservable } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import Glyphs from "./Glyphs";
 import { GlyphCircle } from "@visx/glyph";
 
 @observer
-class MomentPointsChart extends React.Component {
+class MomentPointsChart extends Component {
   static propTypes = {
     id: PropTypes.string.isRequired,
     chartItem: PropTypes.object.isRequired,

--- a/lib/ReactViews/Custom/Chart/Tooltip.jsx
+++ b/lib/ReactViews/Custom/Chart/Tooltip.jsx
@@ -3,13 +3,13 @@ import { computed, makeObservable } from "mobx";
 import { Tooltip as VisxTooltip } from "@visx/tooltip";
 import { CSSTransition } from "react-transition-group";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component, PureComponent } from "react";
 import dateformat from "dateformat";
 import groupBy from "lodash-es/groupBy";
 import Styles from "./tooltip.scss";
 
 @observer
-class Tooltip extends React.Component {
+class Tooltip extends Component {
   static propTypes = {
     items: PropTypes.array.isRequired,
     left: PropTypes.number,
@@ -108,7 +108,7 @@ class Tooltip extends React.Component {
   }
 }
 
-class TooltipGroup extends React.PureComponent {
+class TooltipGroup extends PureComponent {
   static propTypes = {
     name: PropTypes.string,
     items: PropTypes.array.isRequired
@@ -128,7 +128,7 @@ class TooltipGroup extends React.PureComponent {
 }
 
 @observer
-class TooltipItem extends React.Component {
+class TooltipItem extends Component {
   static propTypes = {
     item: PropTypes.object.isRequired
   };

--- a/lib/ReactViews/Custom/Chart/ZoomX.jsx
+++ b/lib/ReactViews/Custom/Chart/ZoomX.jsx
@@ -2,10 +2,10 @@ import { observer } from "mobx-react";
 import { zoom as d3Zoom } from "d3-zoom";
 import { select as d3Select } from "d3-selection";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 
 @observer
-class ZoomX extends React.Component {
+class ZoomX extends Component {
   static propTypes = {
     initialScale: PropTypes.func.isRequired,
     scaleExtent: PropTypes.array.isRequired,

--- a/lib/ReactViews/Custom/ChartCustomComponent.ts
+++ b/lib/ReactViews/Custom/ChartCustomComponent.ts
@@ -1,5 +1,5 @@
 import { action, runInAction } from "mobx";
-import React, { ReactElement } from "react";
+import { createElement, ReactElement } from "react";
 import createGuid from "terriajs-cesium/Source/Core/createGuid";
 import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
@@ -300,7 +300,7 @@ export default abstract class ChartCustomComponent<
       );
 
       chartElements.push(
-        React.createElement(ChartExpandAndDownloadButtons, {
+        createElement(ChartExpandAndDownloadButtons, {
           key: "button",
           terria: context.terria,
           sourceItems: sourceItems,
@@ -328,7 +328,7 @@ export default abstract class ChartCustomComponent<
       });
 
       chartElements.push(
-        React.createElement(Chart, {
+        createElement(Chart, {
           key: "chart",
           item: chartItem,
           xAxisLabel: attrs.previewXLabel,
@@ -343,7 +343,7 @@ export default abstract class ChartCustomComponent<
       );
     }
 
-    return React.createElement(
+    return createElement(
       "div",
       {
         key: "chart-wrapper",
@@ -450,7 +450,7 @@ export default abstract class ChartCustomComponent<
   ): ReactElement | undefined {
     const title = node.parent!.children![0].children![0].data;
     const revisedChildren: ReactElement[] = [
-      React.createElement(
+      createElement(
         "div",
         {
           key: "title",
@@ -459,7 +459,7 @@ export default abstract class ChartCustomComponent<
         title
       ) as ReactElement
     ].concat(children);
-    return React.createElement(
+    return createElement(
       "td",
       { key: "chart", colSpan: 2, className: ChartPreviewStyles.chartTd },
       node.data,

--- a/lib/ReactViews/Custom/Collapsible/Collapsible.tsx
+++ b/lib/ReactViews/Custom/Collapsible/Collapsible.tsx
@@ -1,7 +1,7 @@
 "use strict";
 
 import { observer } from "mobx-react";
-import React, { useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import Box, { IBoxProps } from "../../../Styled/Box";
 import { RawButton } from "../../../Styled/Button";
 import { GLYPHS, StyledIcon } from "../../../Styled/Icon";
@@ -35,7 +35,7 @@ interface CollapsibleProps extends CollapsibleIconProps {
   bodyTextProps?: any;
 }
 
-export const CollapseIcon: React.FC<CollapsibleIconProps> = (props) => {
+export const CollapseIcon: FC<CollapsibleIconProps> = (props) => {
   let glyph = GLYPHS.opened;
   let glyphWidth = 8;
   let glyphRotation = 0;
@@ -64,7 +64,7 @@ export const CollapseIcon: React.FC<CollapsibleIconProps> = (props) => {
   );
 };
 
-const Collapsible: React.FC<CollapsibleProps> = observer((props) => {
+const Collapsible: FC<CollapsibleProps> = observer((props) => {
   const [isOpen, setIsOpen] = useState<boolean | undefined>();
 
   useEffect(() => setIsOpen(props.isOpen), [props.isOpen]);

--- a/lib/ReactViews/Custom/CollapsibleCustomComponent.ts
+++ b/lib/ReactViews/Custom/CollapsibleCustomComponent.ts
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import { createElement, ReactElement } from "react";
 import Collapsible from "./Collapsible/Collapsible";
 import CustomComponent, {
   DomElement,
@@ -32,7 +32,7 @@ export default class CollapsibleCustomComponent extends CustomComponent {
     const btnRight = Boolean(node.attribs?.rightbtn);
     const btnStyle = node.attribs?.btnstyle;
 
-    return React.createElement(
+    return createElement(
       Collapsible,
       {
         key: title,

--- a/lib/ReactViews/Custom/ExternalLink.tsx
+++ b/lib/ReactViews/Custom/ExternalLink.tsx
@@ -1,4 +1,10 @@
-import { AnchorHTMLAttributes, default as React } from "react";
+import {
+  ReactNode,
+  FC,
+  MouseEvent,
+  AnchorHTMLAttributes,
+  default as React
+} from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { useViewState } from "../Context";
@@ -8,17 +14,17 @@ const { StyledIcon } = require("../../Styled/Icon");
 
 interface Props {
   attributes: AnchorHTMLAttributes<HTMLAnchorElement>;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-export const ExternalLinkWithWarning: React.FC<Props> = (props: {
+export const ExternalLinkWithWarning: FC<Props> = (props: {
   attributes: AnchorHTMLAttributes<HTMLAnchorElement>;
-  children: React.ReactNode;
+  children: ReactNode;
 }) => {
   const viewState = useViewState();
   const { t } = useTranslation();
 
-  const onClick = (evt: React.MouseEvent) => {
+  const onClick = (evt: MouseEvent) => {
     evt.stopPropagation();
     evt.preventDefault();
     viewState.terria.notificationState.addNotificationToQueue({

--- a/lib/ReactViews/Custom/FeedbackLinkCustomComponent.tsx
+++ b/lib/ReactViews/Custom/FeedbackLinkCustomComponent.tsx
@@ -1,6 +1,6 @@
 import i18next from "i18next";
 import { runInAction } from "mobx";
-import React, { ReactElement } from "react";
+import { ReactElement } from "react";
 import ViewState from "../../ReactViewModels/ViewState";
 import { RawButton } from "../../Styled/Button";
 import Text from "../../Styled/Text";

--- a/lib/ReactViews/Custom/TerriaTooltip.tsx
+++ b/lib/ReactViews/Custom/TerriaTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import { createElement, ReactElement } from "react";
 import { TooltipWithButtonLauncher } from "../Generic/TooltipWrapper";
 import CustomComponent, {
   DomElement,
@@ -26,7 +26,7 @@ export default class TerriaTooltipCustomComponent extends CustomComponent {
     children: ReactElement[]
   ): ReactElement {
     /* eslint-disable-next-line react/no-children-prop */
-    return React.createElement(TooltipWithButtonLauncher, {
+    return createElement(TooltipWithButtonLauncher, {
       dismissOnLeave: true,
       launcherComponent: () => node.attribs?.title,
       children: () => children

--- a/lib/ReactViews/Custom/parseCustomHtmlToReact.ts
+++ b/lib/ReactViews/Custom/parseCustomHtmlToReact.ts
@@ -1,10 +1,11 @@
 import DOMPurify from "dompurify";
-import React, {
+import {
   AnchorHTMLAttributes,
   createElement,
   DetailedReactHTMLElement,
   ReactElement
 } from "react";
+import * as React from "react";
 import combine from "terriajs-cesium/Source/Core/combine";
 import defined from "terriajs-cesium/Source/Core/defined";
 import CustomComponent, {

--- a/lib/ReactViews/DataCatalog/CatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/CatalogGroup.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { useTranslation } from "react-i18next";

--- a/lib/ReactViews/DataCatalog/CatalogItem.tsx
+++ b/lib/ReactViews/DataCatalog/CatalogItem.tsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import { ReactElement, MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import defaultValue from "terriajs-cesium/Source/Core/defaultValue";
@@ -18,7 +18,7 @@ export enum ButtonState {
   Preview
 }
 
-const STATE_TO_ICONS: Record<ButtonState, React.ReactElement> = {
+const STATE_TO_ICONS: Record<ButtonState, ReactElement> = {
   [ButtonState.Loading]: <Icon glyph={Icon.GLYPHS.loader} />,
   [ButtonState.Remove]: <Icon glyph={Icon.GLYPHS.remove} />,
   [ButtonState.Add]: <Icon glyph={Icon.GLYPHS.add} />,
@@ -35,9 +35,9 @@ interface Props {
   trashable?: boolean;
 
   btnState: ButtonState;
-  onBtnClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  onTextClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  onTrashClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onBtnClick: (event: MouseEvent<HTMLButtonElement>) => void;
+  onTextClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  onTrashClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   titleOverrides?: Partial<Record<ButtonState, string>>;
 }
 

--- a/lib/ReactViews/DataCatalog/DataCatalog.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalog.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
 import { withTranslation } from "react-i18next";
@@ -9,7 +9,7 @@ import DataCatalogMember from "./DataCatalogMember";
 
 // Displays the data catalog.
 @observer
-class DataCatalog extends React.Component {
+class DataCatalog extends Component {
   static propTypes = {
     terria: PropTypes.object,
     viewState: PropTypes.object,

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.jsx
@@ -1,7 +1,7 @@
 import { comparer, reaction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import addedByUser from "../../Core/addedByUser";
 import getPath from "../../Core/getPath";
@@ -14,7 +14,7 @@ import {
 } from "./DisplayGroupHelper";
 
 @observer
-class DataCatalogGroup extends React.Component {
+class DataCatalogGroup extends Component {
   static propTypes = {
     group: PropTypes.object.isRequired,
     viewState: PropTypes.object.isRequired,

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.tsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.tsx
@@ -1,6 +1,6 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
 import addedByUser from "../../Core/addedByUser";
@@ -50,14 +50,14 @@ export default observer(function DataCatalogItem({
       .viewCatalogMember(item)
       .then((result) => result.raiseError(viewState.terria));
 
-  const toggleEnable = async (event: React.MouseEvent<HTMLButtonElement>) => {
+  const toggleEnable = async (event: MouseEvent<HTMLButtonElement>) => {
     const keepCatalogOpen = event.shiftKey || event.ctrlKey;
     await toggleItemOnMapFromCatalog(viewState, item, keepCatalogOpen, {
       [ToggleOnMapOp.Add]: DataSourceAction.addFromCatalogue,
       [ToggleOnMapOp.Remove]: DataSourceAction.removeFromCatalogue
     });
   };
-  const onBtnClicked = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const onBtnClicked = (event: MouseEvent<HTMLButtonElement>) => {
     runInAction(() => {
       if (onActionButtonClicked) {
         onActionButtonClicked(item);

--- a/lib/ReactViews/DataCatalog/DataCatalogMember.jsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogMember.jsx
@@ -2,7 +2,7 @@
 
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import GroupMixin from "../../ModelMixins/GroupMixin";
 import ReferenceMixin from "../../ModelMixins/ReferenceMixin";
 import DataCatalogGroup from "./DataCatalogGroup";
@@ -13,7 +13,7 @@ import DataCatalogReference from "./DataCatalogReference";
  * Component that is either a {@link CatalogItem} or a {@link DataCatalogMember} and encapsulated this choosing logic.
  */
 @observer
-class DataCatalogMember extends React.Component {
+class DataCatalogMember extends Component {
   static propTypes = {
     member: PropTypes.object.isRequired,
     viewState: PropTypes.object.isRequired,

--- a/lib/ReactViews/DataCatalog/DataCatalogReference.tsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogReference.tsx
@@ -1,6 +1,6 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { MouseEvent } from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
 import addedByUser from "../../Core/addedByUser";
 import { DataSourceAction } from "../../Core/AnalyticEvents/analyticEvents";
@@ -38,7 +38,7 @@ export default observer(function DataCatalogReference({
       .viewCatalogMember(reference)
       .then((result) => result.raiseError(viewState.terria));
 
-  const add = async (event: React.MouseEvent<HTMLButtonElement>) => {
+  const add = async (event: MouseEvent<HTMLButtonElement>) => {
     const keepCatalogOpen = event.shiftKey || event.ctrlKey;
 
     if (onActionButtonClicked) {

--- a/lib/ReactViews/Disclaimer.jsx
+++ b/lib/ReactViews/Disclaimer.jsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 // if we must use a placeholder image,
 // do not bundle in the full res `wwwroot/images/bing-aerial-labels-wide.png`
@@ -42,7 +42,7 @@ const DisclaimerButton = styled(Button).attrs({
 `;
 
 @observer
-class Disclaimer extends React.Component {
+class Disclaimer extends Component {
   static displayName = "Disclaimer";
 
   static propTypes = {

--- a/lib/ReactViews/DragDropFile.tsx
+++ b/lib/ReactViews/DragDropFile.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import { action, runInAction, makeObservable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { DragEvent, MouseEvent, Component } from "react";
 import { Trans, withTranslation, WithTranslation } from "react-i18next";
 import {
   Category,
@@ -20,7 +20,7 @@ import { raiseFileDragDropEvent } from "../ViewModels/FileDragDropListener";
 interface PropsType extends WithTranslation, WithViewState {}
 
 @observer
-class DragDropFile extends React.Component<PropsType> {
+class DragDropFile extends Component<PropsType> {
   target: EventTarget | undefined;
 
   constructor(props: PropsType) {
@@ -28,7 +28,7 @@ class DragDropFile extends React.Component<PropsType> {
     makeObservable(this);
   }
 
-  async handleDrop(e: React.DragEvent) {
+  async handleDrop(e: DragEvent) {
     e.persist();
     e.preventDefault();
     e.stopPropagation();
@@ -108,19 +108,19 @@ class DragDropFile extends React.Component<PropsType> {
   }
 
   @action
-  handleDragEnter(e: React.DragEvent) {
+  handleDragEnter(e: DragEvent) {
     e.preventDefault();
     e.stopPropagation();
     e.dataTransfer.dropEffect = "copy";
     this.target = e.target;
   }
 
-  handleDragOver(e: React.DragEvent) {
+  handleDragOver(e: DragEvent) {
     e.preventDefault();
   }
 
   @action
-  handleDragLeave(e: React.MouseEvent) {
+  handleDragLeave(e: MouseEvent) {
     e.preventDefault();
     if (e.screenX === 0 && e.screenY === 0) {
       this.props.viewState.isDraggingDroppingFile = false;

--- a/lib/ReactViews/DragDropNotification.jsx
+++ b/lib/ReactViews/DragDropNotification.jsx
@@ -2,13 +2,13 @@ import classNames from "classnames";
 import { reaction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import Icon from "../Styled/Icon";
 import Styles from "./drag-drop-notification.scss";
 import { withViewState } from "./Context";
 
 @observer
-class DragDropNotification extends React.Component {
+class DragDropNotification extends Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/lib/ReactViews/DragWrapper.jsx
+++ b/lib/ReactViews/DragWrapper.jsx
@@ -1,8 +1,8 @@
-import React from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import interact from "interactjs";
 
-class DragWrapper extends React.Component {
+class DragWrapper extends Component {
   constructor(props) {
     super(props);
     this.resizeListener = null;

--- a/lib/ReactViews/Errors/RaiseToUserErrorBoundary.tsx
+++ b/lib/ReactViews/Errors/RaiseToUserErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { ErrorInfo } from "react";
+import { ReactNode, Component, ErrorInfo } from "react";
 import { TerriaErrorOverrides } from "../../Core/TerriaError";
 import ViewState from "../../ReactViewModels/ViewState";
 
@@ -6,13 +6,13 @@ type PropsType = {
   viewState: ViewState;
   // Pass in options to customize the title and other presentation aspects of the error
   terriaErrorOptions?: TerriaErrorOverrides;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 /**
  * An error boundary that raises the error to the user.
  */
-export default class RaiseToUserErrorBoundary extends React.Component<PropsType> {
+export default class RaiseToUserErrorBoundary extends Component<PropsType> {
   state = { hasError: false };
 
   static getDerivedStateFromError(_error: Error) {

--- a/lib/ReactViews/ExplorerWindow/ExplorerWindow.tsx
+++ b/lib/ReactViews/ExplorerWindow/ExplorerWindow.tsx
@@ -1,6 +1,5 @@
 import { action } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
 import { useViewState } from "../Context";
 import ModalPopup from "./ModalPopup";
 import Tabs from "./Tabs";

--- a/lib/ReactViews/ExplorerWindow/ModalPopup.tsx
+++ b/lib/ReactViews/ExplorerWindow/ModalPopup.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useEffect, useRef, useState } from "react";
+import { ReactNode, FC, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ViewState from "../../ReactViewModels/ViewState";
 import Styles from "./explorer-window.scss";
@@ -12,11 +12,11 @@ interface IProps {
   viewState: ViewState;
   onStartAnimatingIn?: () => void;
   onDoneAnimatingIn?: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
   isTopElement?: boolean;
 }
 
-const ModalPopup: React.FC<IProps> = (props) => {
+const ModalPopup: FC<IProps> = (props) => {
   const { t } = useTranslation();
   const [inTransition, setInTransition] = useState(false);
   const animationTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/lib/ReactViews/ExplorerWindow/Tabs.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs.jsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import styled from "styled-components";
 import defined from "terriajs-cesium/Source/Core/defined";
@@ -12,7 +12,7 @@ import DataCatalogTab from "./Tabs/DataCatalogTab";
 import MyDataTab from "./Tabs/MyDataTab/MyDataTab";
 
 @observer
-class Tabs extends React.Component {
+class Tabs extends Component {
   static propTypes = {
     terria: PropTypes.object.isRequired,
     viewState: PropTypes.object.isRequired,

--- a/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.jsx
@@ -1,7 +1,7 @@
 import { computed, runInAction, makeObservable } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import { withTheme } from "styled-components";
 import DataCatalog from "../../DataCatalog/DataCatalog";
@@ -13,7 +13,7 @@ import Box from "../../../Styled/Box";
 
 // The DataCatalog Tab
 @observer
-class DataCatalogTab extends React.Component {
+class DataCatalogTab extends Component {
   static propTypes = {
     terria: PropTypes.object,
     viewState: PropTypes.object,

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/AddData.jsx
@@ -1,7 +1,7 @@
 import { observer } from "mobx-react";
 import { runInAction } from "mobx";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { Trans, withTranslation } from "react-i18next";
 import {
   Category,
@@ -28,7 +28,7 @@ import TerriaError from "../../../../Core/TerriaError";
  * Add data panel in modal window -> My data tab
  */
 @observer
-class AddData extends React.Component {
+class AddData extends Component {
   static propTypes = {
     terria: PropTypes.object,
     viewState: PropTypes.object,

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/CesiumIonConnector.tsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/CesiumIonConnector.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { MouseEvent, useState, useEffect } from "react";
 import { observer } from "mobx-react";
 import URI from "urijs";
 import { string } from "prop-types";
@@ -149,27 +149,27 @@ function CesiumIonConnector() {
       viewState.terria.configParameters.cesiumIonLoginTokenPersistence ?? ""
     ] ?? loginTokenPersistenceTypes.page;
 
-  const [codeChallenge, setCodeChallenge] = React.useState({
+  const [codeChallenge, setCodeChallenge] = useState({
     value: "",
     hash: ""
   });
 
-  const [tokens, setTokens] = React.useState<CesiumIonToken[]>([]);
-  const [isLoadingTokens, setIsLoadingTokens] = React.useState<boolean>(false);
-  const [assets, setAssets] = React.useState<CesiumIonAsset[]>([]);
-  const [isLoadingAssets, setIsLoadingAssets] = React.useState<boolean>(false);
+  const [tokens, setTokens] = useState<CesiumIonToken[]>([]);
+  const [isLoadingTokens, setIsLoadingTokens] = useState<boolean>(false);
+  const [assets, setAssets] = useState<CesiumIonAsset[]>([]);
+  const [isLoadingAssets, setIsLoadingAssets] = useState<boolean>(false);
 
   // This is the Cesium ion token representing the currently logged-in user, as obtained via
   // an OAuth2 Authorization Code Grant flow with Cesium ion.
-  const [loginToken, setLoginToken] = React.useState(
+  const [loginToken, setLoginToken] = useState(
     loginTokenPersistence.get() ?? ""
   );
 
-  const [userProfile, setUserProfile] = React.useState(defaultUserProfile);
+  const [userProfile, setUserProfile] = useState(defaultUserProfile);
   const [isLoadingUserProfile, setIsLoadingUserProfile] =
-    React.useState<boolean>(false);
+    useState<boolean>(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!crypto || !crypto.subtle) return;
 
     const codeChallenge = [...crypto.getRandomValues(new Uint8Array(32))]
@@ -189,7 +189,7 @@ function CesiumIonConnector() {
       });
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loginToken.length === 0) return;
 
     setIsLoadingUserProfile(true);
@@ -212,7 +212,7 @@ function CesiumIonConnector() {
       });
   }, [loginToken]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (loginToken.length === 0) return;
 
     setIsLoadingAssets(true);
@@ -235,7 +235,7 @@ function CesiumIonConnector() {
       });
   }, [loginToken]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       !viewState.terria.configParameters.cesiumIonAllowSharingAddedAssets ||
       loginToken.length === 0
@@ -570,7 +570,7 @@ function CesiumIonConnector() {
   function addToMap(
     terria: Terria,
     asset: CesiumIonAsset,
-    event: React.MouseEvent<HTMLButtonElement>
+    event: MouseEvent<HTMLButtonElement>
   ) {
     // If the asset may be shared, the user must choose a suitable token.
     // If not, we can access the asset using the login token.

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/FileInput.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/FileInput.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import createReactClass from "create-react-class";
 import classNames from "classnames";

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/MyDataTab.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import { observer } from "mobx-react";
 
 import classNames from "classnames";
@@ -14,7 +14,7 @@ import DataCatalogMember from "../../../DataCatalog/DataCatalogMember";
 
 // My data tab include Add data section and preview section
 @observer
-class MyDataTab extends React.Component {
+class MyDataTab extends Component {
   static propTypes = {
     terria: PropTypes.object,
     viewState: PropTypes.object,

--- a/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoCatalogItem.tsx
@@ -1,5 +1,4 @@
 import { observer } from "mobx-react";
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { getName } from "../../ModelMixins/CatalogMemberMixin";
 import MappableMixin from "../../ModelMixins/MappableMixin";

--- a/lib/ReactViews/FeatureInfo/FeatureInfoDownload.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoDownload.tsx
@@ -1,5 +1,5 @@
 import { TFunction } from "i18next";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import DataUri from "../../Core/DataUri";
 import filterOutUndefined from "../../Core/filterOutUndefined";
@@ -10,7 +10,7 @@ import { withViewState } from "../Context";
 import Styles from "./feature-info-download.scss";
 import Dropdown from "../Generic/Dropdown";
 
-class FeatureInfoDownload extends React.Component<{
+class FeatureInfoDownload extends Component<{
   data: JsonObject;
   name: string;
   viewState: ViewState;

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import { TFunction } from "i18next";
 import { action, reaction, runInAction, makeObservable } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
@@ -40,7 +40,7 @@ interface Props {
 }
 
 @observer
-class FeatureInfoPanel extends React.Component<Props> {
+class FeatureInfoPanel extends Component<Props> {
   constructor(props: Props) {
     super(props);
     makeObservable(this);
@@ -368,13 +368,11 @@ class FeatureInfoPanel extends React.Component<Props> {
               viewState.featureInfoPanelIsVisible ? (
                 // Are picked features loading -> show Loader
                 isDefined(terria.pickedFeatures) &&
-                terria.pickedFeatures.isLoading ? (
+                terria.pickedFeatures.isLoading ? ( // Do we have no features/catalog items to show?
                   <li>
                     <Loader light />
                   </li>
-                ) : // Do we have no features/catalog items to show?
-
-                featureInfoCatalogItems.length === 0 ? (
+                ) : featureInfoCatalogItems.length === 0 ? (
                   <li className={Styles.noResults}>
                     {this.getMessageForNoResults()}
                   </li>

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanelButton.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanelButton.tsx
@@ -1,13 +1,11 @@
-import React from "react";
+import { FC } from "react";
 import styled from "styled-components";
 import Button from "../../Styled/Button";
 import { StyledIcon } from "../../Styled/Icon";
 import Text from "../../Styled/Text";
 import { FeatureInfoPanelButton as FeatureInfoPanelButtonModel } from "../../ViewModels/FeatureInfoPanel";
 
-const FeatureInfoPanelButton: React.FC<FeatureInfoPanelButtonModel> = (
-  props
-) => {
+const FeatureInfoPanelButton: FC<FeatureInfoPanelButtonModel> = (props) => {
   const { text, icon } = props;
   if (!text) {
     return null;

--- a/lib/ReactViews/Feedback/FeedbackForm.tsx
+++ b/lib/ReactViews/Feedback/FeedbackForm.tsx
@@ -1,6 +1,17 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect, useRef } from "react";
+import {
+  ChangeEvent,
+  FormEvent,
+  FC,
+  ReactNode,
+  Component,
+  Children,
+  isValidElement,
+  cloneElement,
+  useEffect,
+  useRef
+} from "react";
 import { withTranslation, WithTranslation } from "react-i18next";
 import { useUID } from "react-uid";
 import styled, { DefaultTheme, withTheme } from "styled-components";
@@ -33,7 +44,7 @@ interface IState {
 }
 
 @observer
-class FeedbackForm extends React.Component<IProps, IState> {
+class FeedbackForm extends Component<IProps, IState> {
   static displayName = "FeedbackForm";
 
   state: IState = {
@@ -94,19 +105,19 @@ class FeedbackForm extends React.Component<IProps, IState> {
     this.resetState();
   }
 
-  updateName(e: React.ChangeEvent<HTMLInputElement>) {
+  updateName(e: ChangeEvent<HTMLInputElement>) {
     this.setState({
       name: e.target.value
     });
   }
 
-  updateEmail(e: React.ChangeEvent<HTMLInputElement>) {
+  updateEmail(e: ChangeEvent<HTMLInputElement>) {
     this.setState({
       email: e.target.value
     });
   }
 
-  updateComment(e: React.ChangeEvent<HTMLTextAreaElement>) {
+  updateComment(e: ChangeEvent<HTMLTextAreaElement>) {
     this.setState({
       comment: e.target.value
     });
@@ -124,13 +135,13 @@ class FeedbackForm extends React.Component<IProps, IState> {
     }
   }
 
-  changeSendShareUrl(_e: React.ChangeEvent<HTMLInputElement>) {
+  changeSendShareUrl(_e: ChangeEvent<HTMLInputElement>) {
     this.setState((prevState: IState) => ({
       sendShareURL: !prevState.sendShareURL
     }));
   }
 
-  onSubmit(e: React.FormEvent<HTMLFormElement | HTMLDivElement>) {
+  onSubmit(e: FormEvent<HTMLFormElement | HTMLDivElement>) {
     e.preventDefault();
 
     if (
@@ -329,13 +340,13 @@ const WarningText = styled(Text)`
 interface TextAreaProps {
   value: string;
   valueIsValid: boolean;
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
   styledMinHeight: string;
   styledMaxHeight?: string;
   [spread: string]: any;
 }
 
-const TextArea: React.FC<TextAreaProps> = (props: TextAreaProps) => {
+const TextArea: FC<TextAreaProps> = (props: TextAreaProps) => {
   const {
     value,
     onChange,
@@ -377,17 +388,17 @@ interface StyledLabelProps {
   viewState: ViewState;
   label: string;
   textProps?: any;
-  children: React.ReactNode;
+  children: ReactNode;
   spacingBottom?: boolean;
 }
 
-const StyledLabel: React.FC<StyledLabelProps> = (props: StyledLabelProps) => {
+const StyledLabel: FC<StyledLabelProps> = (props: StyledLabelProps) => {
   const { viewState, label, textProps } = props;
   const id = useUID();
-  const childrenWithId = React.Children.map(props.children, (child) => {
+  const childrenWithId = Children.map(props.children, (child) => {
     // checking isValidElement is the safe way and avoids a typescript error too
-    if (React.isValidElement(child)) {
-      return React.cloneElement(child, { id: id } as any);
+    if (isValidElement(child)) {
+      return cloneElement(child, { id: id } as any);
     }
     return child;
   });

--- a/lib/ReactViews/Generic/CloseButton.jsx
+++ b/lib/ReactViews/Generic/CloseButton.jsx
@@ -1,5 +1,4 @@
 // for all the panels and modals we will eventually normalise
-import React from "react";
 import styled from "styled-components";
 // import Box  from "../../Styled/Box";
 import Icon from "../../Styled/Icon";

--- a/lib/ReactViews/Generic/CloseButton.tsx
+++ b/lib/ReactViews/Generic/CloseButton.tsx
@@ -1,5 +1,4 @@
 // for all the panels and modals we will eventually normalise
-import React from "react";
 import styled from "styled-components";
 // import Box  from "../../Styled/Box";
 import Icon from "../../Styled/Icon";

--- a/lib/ReactViews/Generic/Dropdown.jsx
+++ b/lib/ReactViews/Generic/Dropdown.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-import React from "react";
 import PropTypes from "prop-types";
 import createReactClass from "create-react-class";
 import defined from "terriajs-cesium/Source/Core/defined";

--- a/lib/ReactViews/Generic/Editor.jsx
+++ b/lib/ReactViews/Generic/Editor.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React, { useRef } from "react";
+import { useRef } from "react";
 import { Editor } from "@tinymce/tinymce-react";
 import PropTypes from "prop-types";
 // eslint-disable-next-line no-unused-vars

--- a/lib/ReactViews/Generic/MoreOrLess.jsx
+++ b/lib/ReactViews/Generic/MoreOrLess.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import Icon from "../../Styled/Icon";

--- a/lib/ReactViews/Generic/Prompt.jsx
+++ b/lib/ReactViews/Generic/Prompt.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { PureComponent } from "react";
 import PropTypes from "prop-types";
 import FadeIn from "../Transitions/FadeIn/FadeIn";
 import Box from "../../Styled/Box";
@@ -8,7 +8,7 @@ import { RawButton } from "../../Styled/Button";
 import { withTheme } from "styled-components";
 import Caret from "../Generic/Caret";
 
-class Prompt extends React.PureComponent {
+class Prompt extends PureComponent {
   // Tried to keep/make use of the original story prompt css properties
   render() {
     return (

--- a/lib/ReactViews/Generic/Responsive.tsx
+++ b/lib/ReactViews/Generic/Responsive.tsx
@@ -1,5 +1,4 @@
 import PropTypes, { InferProps } from "prop-types";
-import React from "react";
 const MediaQuery = require("react-responsive").default;
 
 // This should come from some config some where

--- a/lib/ReactViews/Generic/Timer/Timer.jsx
+++ b/lib/ReactViews/Generic/Timer/Timer.jsx
@@ -1,6 +1,6 @@
 "use strict";
 
-import React from "react";
+import { PureComponent } from "react";
 import PropTypes from "prop-types";
 
 import createGuid from "terriajs-cesium/Source/Core/createGuid";
@@ -24,7 +24,7 @@ if (typeof document.hidden !== "undefined") {
   visibilityChange = "webkitvisibilitychange";
 }
 
-class Timer extends React.PureComponent {
+class Timer extends PureComponent {
   constructor(props) {
     super();
 

--- a/lib/ReactViews/Generic/TooltipWrapper.tsx
+++ b/lib/ReactViews/Generic/TooltipWrapper.tsx
@@ -1,7 +1,7 @@
 /**
  * base tooltipwrapperraw repurposed from magda, with some a11y modifications
  */
-import React from "react";
+import { ReactNode, SFC, createRef, Component } from "react";
 import ReactDOM from "react-dom";
 import { withTheme, DefaultTheme } from "styled-components";
 import { useUID } from "react-uid";
@@ -30,11 +30,11 @@ type Props = {
     state: State;
     launch: () => void;
     forceSetState: (bool?: boolean) => void;
-  }) => React.ReactNode;
+  }) => ReactNode;
   /** Styles to apply to the  actual tooltip */
   innerElementStyles?: object;
   /** The tooltip content itself, as higher-order function that provides a function to dismiss the tooltip */
-  children: (applyAriaId: boolean, dismiss: () => void) => React.ReactNode;
+  children: (applyAriaId: boolean, dismiss: () => void) => ReactNode;
 };
 
 type State = {
@@ -45,9 +45,9 @@ type State = {
 /**
  * @description Return a information tooltip, on hover show calculation method.
  */
-class TooltipWrapperRaw extends React.Component<Props, State> {
-  rootRef = React.createRef<HTMLDivElement>();
-  tooltipTextElementRef = React.createRef<HTMLSpanElement>();
+class TooltipWrapperRaw extends Component<Props, State> {
+  rootRef = createRef<HTMLDivElement>();
+  tooltipTextElementRef = createRef<HTMLSpanElement>();
   state = {
     offset: 0,
     open: !!this.props.startOpen
@@ -229,16 +229,14 @@ class TooltipWrapperRaw extends React.Component<Props, State> {
 export const TooltipWrapper = withTheme(TooltipWrapperRaw);
 
 type ButtonLauncherProps = {
-  launcherComponent: () => React.ReactNode;
-  children: (idForAria: string) => React.ReactNode;
+  launcherComponent: () => ReactNode;
+  children: (idForAria: string) => ReactNode;
   dismissOnLeave?: boolean;
   orientation?: "below" | "above";
   [spread: string]: any;
 };
 
-export const TooltipWithButtonLauncher: React.SFC<ButtonLauncherProps> = (
-  props
-) => {
+export const TooltipWithButtonLauncher: SFC<ButtonLauncherProps> = (props) => {
   const { launcherComponent, children, dismissOnLeave, orientation, ...rest } =
     props;
 

--- a/lib/ReactViews/Guidance/Guidance.jsx
+++ b/lib/ReactViews/Guidance/Guidance.jsx
@@ -2,7 +2,7 @@
  * <Guidance /> is the (currently unused) "in app tour" where we have the dots,
  * whereas <Guide /> is the generic "slider/static tour"
  */
-import React, { useState } from "react";
+import { useState } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import { useTranslation } from "react-i18next";

--- a/lib/ReactViews/Guidance/GuidanceDot.jsx
+++ b/lib/ReactViews/Guidance/GuidanceDot.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import Styles from "./guidance-dot.scss";
 

--- a/lib/ReactViews/Guide/Guide.jsx
+++ b/lib/ReactViews/Guide/Guide.jsx
@@ -24,7 +24,7 @@
 
  *
  */
-import React, { useState } from "react";
+import { useState } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import Styles from "./guide.scss";

--- a/lib/ReactViews/Guide/SatelliteGuide.jsx
+++ b/lib/ReactViews/Guide/SatelliteGuide.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { withTranslation } from "react-i18next";
 import Guide from "./Guide.jsx";
@@ -9,7 +9,7 @@ import { observer } from "mobx-react";
 export const SATELLITE_GUIDE_KEY = "satelliteGuidance";
 
 @observer
-class SatelliteGuide extends React.Component {
+class SatelliteGuide extends Component {
   static propTypes = {
     terria: PropTypes.object.isRequired,
     viewState: PropTypes.object.isRequired,

--- a/lib/ReactViews/HOCs/measureElement.tsx
+++ b/lib/ReactViews/HOCs/measureElement.tsx
@@ -1,8 +1,14 @@
-import React from "react";
+import {
+  ComponentClass,
+  ComponentProps,
+  Component,
+  RefObject,
+  createRef
+} from "react";
 import debounce from "lodash-es/debounce";
 
-const getDisplayName = <P extends React.ComponentProps<any>>(
-  WrappedComponent: React.ComponentClass<P>
+const getDisplayName = <P extends ComponentProps<any>>(
+  WrappedComponent: ComponentClass<P>
 ) => {
   return WrappedComponent.displayName || WrappedComponent.name || "Component";
 };
@@ -13,8 +19,8 @@ export interface MeasureElementProps {
 }
 
 interface MeasureElementComponent<P>
-  extends React.Component<P & MeasureElementProps> {
-  refToMeasure: React.RefObject<HTMLElement> | HTMLElement | null;
+  extends Component<P & MeasureElementProps> {
+  refToMeasure: RefObject<HTMLElement> | HTMLElement | null;
 }
 
 interface MeasureElementClass<P> {
@@ -48,12 +54,12 @@ interface IState {
     ref={this.refToMeasure}>
     ```
 */
-const measureElement = <P extends React.ComponentProps<any>>(
+const measureElement = <P extends ComponentProps<any>>(
   WrappedComponent: MeasureElementClass<P>,
   verbose = true
 ) => {
-  class MeasureElement extends React.Component<P, IState> {
-    wrappedComponent = React.createRef<InstanceType<typeof WrappedComponent>>();
+  class MeasureElement extends Component<P, IState> {
+    wrappedComponent = createRef<InstanceType<typeof WrappedComponent>>();
     checkAndUpdateSizingWithDebounce: () => void;
     static displayName = `MeasureElement(${getDisplayName(WrappedComponent)})`;
     constructor(props: P) {

--- a/lib/ReactViews/HOCs/withControlledVisibility.tsx
+++ b/lib/ReactViews/HOCs/withControlledVisibility.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ComponentType } from "react";
 import PropTypes from "prop-types";
 
 import IElementConfig from "../../Models/IElementConfig";
@@ -12,7 +12,7 @@ interface WithControlledVisibilityProps {
  * element is available inside either "hidden" or "shown" lists passed
  * as prop
  */
-export default <P extends object>(WrappedComponent: React.ComponentType<P>) => {
+export default <P extends object>(WrappedComponent: ComponentType<P>) => {
   // eslint-disable-next-line require-jsdoc
   function WithControlledVisibility({
     elementConfig,

--- a/lib/ReactViews/HOCs/withFallback.tsx
+++ b/lib/ReactViews/HOCs/withFallback.tsx
@@ -1,4 +1,9 @@
-import React, { Suspense } from "react";
+import {
+  ComponentClass,
+  FunctionComponent,
+  ComponentProps,
+  Suspense
+} from "react";
 import PropTypes from "prop-types";
 
 import ViewState from "../../ReactViewModels/ViewState";
@@ -18,8 +23,8 @@ interface WithFallbackProps {
  * HOC for a basic fallback UI incase any dependencies end up using suspense
  * features
  */
-export const withFallback = <P extends React.ComponentProps<any>>(
-  WrappedComponent: React.ComponentClass<P> | React.FunctionComponent<P>
+export const withFallback = <P extends ComponentProps<any>>(
+  WrappedComponent: ComponentClass<P> | FunctionComponent<P>
 ) => {
   const WithFallback = (props: P & WithFallbackProps) => {
     return (

--- a/lib/ReactViews/HOCs/withTerriaRef.tsx
+++ b/lib/ReactViews/HOCs/withTerriaRef.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ComponentClass, FunctionComponent, ComponentProps } from "react";
 import PropTypes from "prop-types";
 
 import ViewState from "../../ReactViewModels/ViewState";
@@ -11,8 +11,8 @@ interface WithTerriaRefProps {
 /*
     HOC to set a ref and store it in viewState
 */
-export const withTerriaRef = <P extends React.ComponentProps<any>>(
-  WrappedComponent: React.ComponentClass<P> | React.FunctionComponent<P>,
+export const withTerriaRef = <P extends ComponentProps<any>>(
+  WrappedComponent: ComponentClass<P> | FunctionComponent<P>,
   refName: string
 ) => {
   const WithTerriaRef = (props: P & WithTerriaRefProps) => {

--- a/lib/ReactViews/HelpScreens/HelpPrompt.tsx
+++ b/lib/ReactViews/HelpScreens/HelpPrompt.tsx
@@ -1,7 +1,7 @@
 /**
  * Prompt.tsx - don't use without guarding on useSmallScreenInterface - it won't look pretty!
  */
-import React, { useState } from "react";
+import { FC, useState } from "react";
 import { useTheme } from "styled-components";
 
 import FadeIn from "../Transitions/FadeIn/FadeIn";
@@ -28,7 +28,7 @@ interface PromptProps {
   isVisible: boolean;
 }
 
-export const HelpPrompt: React.FC<PromptProps> = ({
+export const HelpPrompt: FC<PromptProps> = ({
   title,
   content,
   dismissLabel,

--- a/lib/ReactViews/HelpScreens/SatelliteHelpPrompt.tsx
+++ b/lib/ReactViews/HelpScreens/SatelliteHelpPrompt.tsx
@@ -1,5 +1,4 @@
 import { observer } from "mobx-react";
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { useViewState } from "../Context";
 import HelpPrompt from "./HelpPrompt";

--- a/lib/ReactViews/Loader.tsx
+++ b/lib/ReactViews/Loader.tsx
@@ -1,5 +1,5 @@
 import { TFunction } from "i18next";
-import React from "react";
+import { FC } from "react";
 import { withTranslation, WithTranslation } from "react-i18next";
 import Box from "../Styled/Box";
 import { TextSpan } from "../Styled/Text";
@@ -13,7 +13,7 @@ interface PropsType extends WithTranslation {
   t: TFunction;
   [spread: string]: any;
 }
-const Loader: React.FC<PropsType> = (props: PropsType) => {
+const Loader: FC<PropsType> = (props: PropsType) => {
   const { message, t, boxProps, textProps, hideMessage, ...rest }: PropsType =
     props;
   return (

--- a/lib/ReactViews/LocationItem.jsx
+++ b/lib/ReactViews/LocationItem.jsx
@@ -1,7 +1,6 @@
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
 import prettifyCoordinates from "../Map/Vector/prettifyCoordinates";
-import React from "react";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import Styles from "./location-item.scss";

--- a/lib/ReactViews/Map/BottomBar/BottomBar.tsx
+++ b/lib/ReactViews/Map/BottomBar/BottomBar.tsx
@@ -4,7 +4,6 @@ import { useViewState } from "../../Context";
 import { MapCredits } from "./Credits";
 import { DistanceLegend } from "./DistanceLegend";
 import { LocationBar } from "./LocationBar";
-import React from "react";
 
 export const BottomBar: VFC = () => {
   const viewState = useViewState();

--- a/lib/ReactViews/Map/BottomBar/Credits/Credit.tsx
+++ b/lib/ReactViews/Map/BottomBar/Credits/Credit.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { ExternalLinkIcon } from "../../../Custom/ExternalLink";
 import { ICredit } from "./Credit.type";

--- a/lib/ReactViews/Map/BottomBar/Credits/Credits.tsx
+++ b/lib/ReactViews/Map/BottomBar/Credits/Credits.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Credit } from "./Credit";
 import { ICredit } from "./Credit.type";
 

--- a/lib/ReactViews/Map/BottomBar/Credits/DataAttribution/DataAttributionModal.tsx
+++ b/lib/ReactViews/Map/BottomBar/Credits/DataAttribution/DataAttributionModal.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { FC } from "react";
+import { FC } from "react";
 import ReactDOM from "react-dom";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";

--- a/lib/ReactViews/Map/BottomBar/Credits/MapCreditLogo.tsx
+++ b/lib/ReactViews/Map/BottomBar/Credits/MapCreditLogo.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import CreditDisplay from "terriajs-cesium/Source/Scene/CreditDisplay";
 import GlobeOrMap from "../../../../Models/GlobeOrMap";
 import Leaflet from "../../../../Models/Leaflet";

--- a/lib/ReactViews/Map/BottomBar/Credits/MapCredits.tsx
+++ b/lib/ReactViews/Map/BottomBar/Credits/MapCredits.tsx
@@ -1,6 +1,6 @@
 import { reaction } from "mobx";
 import { observer } from "mobx-react";
-import React, { FC, useCallback, useEffect, useState } from "react";
+import { FC, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import GlobeOrMap from "../../../../Models/GlobeOrMap";
 import { ICredit } from "./Credit.type";

--- a/lib/ReactViews/Map/BottomBar/Credits/Spacer.tsx
+++ b/lib/ReactViews/Map/BottomBar/Credits/Spacer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTheme } from "styled-components";
 
 export const Spacer = () => {

--- a/lib/ReactViews/Map/BottomBar/Credits/TerriaLogo.tsx
+++ b/lib/ReactViews/Map/BottomBar/Credits/TerriaLogo.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import Box from "../../../../Styled/Box";
 
 const logo = require("../../../../../wwwroot/images/terria-watermark.svg");

--- a/lib/ReactViews/Map/BottomBar/DistanceLegend.tsx
+++ b/lib/ReactViews/Map/BottomBar/DistanceLegend.tsx
@@ -2,7 +2,7 @@
 import L from "leaflet";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React, { FC, useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { useTheme } from "styled-components";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import EllipsoidGeodesic from "terriajs-cesium/Source/Core/EllipsoidGeodesic";

--- a/lib/ReactViews/Map/BottomBar/LocationBar.tsx
+++ b/lib/ReactViews/Map/BottomBar/LocationBar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { observer } from "mobx-react";
 import { FC, RefObject, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";

--- a/lib/ReactViews/Map/BottomLeftBar/BottomLeftBar.tsx
+++ b/lib/ReactViews/Map/BottomLeftBar/BottomLeftBar.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { FC } from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import styled, { useTheme } from "styled-components";
 import defined from "terriajs-cesium/Source/Core/defined";

--- a/lib/ReactViews/Map/MapColumn.tsx
+++ b/lib/ReactViews/Map/MapColumn.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { FC } from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import Box from "../../Styled/Box";
 import ActionBarPortal from "../ActionBar/ActionBarPortal";

--- a/lib/ReactViews/Map/MapNavigation/CollapsedNavigation.tsx
+++ b/lib/ReactViews/Map/MapNavigation/CollapsedNavigation.tsx
@@ -1,6 +1,6 @@
 import { autorun } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect } from "react";
+import { FC, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import styled, { useTheme } from "styled-components";
 import { applyTranslationIfExists } from "../../../Language/languageHelpers";
@@ -80,55 +80,49 @@ const NavigationButton = styled(BoxSpan).attrs({
   `}
 `;
 
-const CollapsedNavigationPanel: React.FC<PropTypes> = observer(
-  (props: PropTypes) => {
-    const viewState = useViewState();
-    const theme = useTheme();
-    const { t, i18n } = useTranslation();
-    const items = props.items;
-    return (
-      <CollapsedNavigationBox column>
-        <CloseButton
-          color={theme.darkWithOverlay}
-          topRight
-          onClick={() => viewState.closeCollapsedNavigation()}
-        />
-        <Text extraExtraLarge bold textDarker>
-          {t("mapNavigation.additionalTools")}
-        </Text>
-        <Spacing bottom={5} />
-        <ButtonsBox>
-          {items.map((item) => (
-            <NavigationButton
-              key={item.id}
-              title={applyTranslationIfExists(item.name, i18n)}
-              onClick={() => {
-                if (!item.controller.disabled) {
-                  viewState.closeCollapsedNavigation();
-                  item.controller.handleClick();
-                }
-              }}
-              css={`
-                ${item.controller.active &&
-                `border: 2px solid ${theme.colorPrimary};`}
-              `}
-              disabled={item.controller.disabled}
-            >
-              <StyledIcon
-                glyph={item.controller.glyph}
-                styledWidth="22px"
-                dark
-              />
-            </NavigationButton>
-          ))}
-        </ButtonsBox>
-      </CollapsedNavigationBox>
-    );
-  }
-);
+const CollapsedNavigationPanel: FC<PropTypes> = observer((props: PropTypes) => {
+  const viewState = useViewState();
+  const theme = useTheme();
+  const { t, i18n } = useTranslation();
+  const items = props.items;
+  return (
+    <CollapsedNavigationBox column>
+      <CloseButton
+        color={theme.darkWithOverlay}
+        topRight
+        onClick={() => viewState.closeCollapsedNavigation()}
+      />
+      <Text extraExtraLarge bold textDarker>
+        {t("mapNavigation.additionalTools")}
+      </Text>
+      <Spacing bottom={5} />
+      <ButtonsBox>
+        {items.map((item) => (
+          <NavigationButton
+            key={item.id}
+            title={applyTranslationIfExists(item.name, i18n)}
+            onClick={() => {
+              if (!item.controller.disabled) {
+                viewState.closeCollapsedNavigation();
+                item.controller.handleClick();
+              }
+            }}
+            css={`
+              ${item.controller.active &&
+              `border: 2px solid ${theme.colorPrimary};`}
+            `}
+            disabled={item.controller.disabled}
+          >
+            <StyledIcon glyph={item.controller.glyph} styledWidth="22px" dark />
+          </NavigationButton>
+        ))}
+      </ButtonsBox>
+    </CollapsedNavigationBox>
+  );
+});
 
 const CollapsedNavigationDisplayName = "CollapsedNavigation";
-export const CollapsedNavigation: React.FC = observer(() => {
+export const CollapsedNavigation: FC = observer(() => {
   const viewState = useViewState();
   useEffect(() =>
     autorun(() => {

--- a/lib/ReactViews/Map/MapNavigation/Items/AugmentedVirtualityTool.tsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/AugmentedVirtualityTool.tsx
@@ -1,7 +1,7 @@
 import i18next from "i18next";
 import { action, computed, observable, makeObservable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import AugmentedVirtuality from "../../../../Models/AugmentedVirtuality";
@@ -174,7 +174,7 @@ export class AugmentedVirtualityRealignController extends MapNavigationItemContr
   }
 }
 
-export const AugmentedVirtualityRealign: React.FC<{
+export const AugmentedVirtualityRealign: FC<{
   arRealignController: AugmentedVirtualityRealignController;
 }> = observer(
   (props: { arRealignController: AugmentedVirtualityRealignController }) => {

--- a/lib/ReactViews/Map/MapNavigation/Items/CatalogShortcut.jsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/CatalogShortcut.jsx
@@ -2,7 +2,6 @@
 
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
-import React from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
 import Icon from "../../../Styled/Icon";
 import Styles from "./tool_button.scss";

--- a/lib/ReactViews/Map/MapNavigation/Items/CloseToolButton.tsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/CloseToolButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import Icon from "../../../../Styled/Icon";
 import { useViewState } from "../../../Context";

--- a/lib/ReactViews/Map/MapNavigation/Items/Compass/Compass.tsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/Compass/Compass.tsx
@@ -12,7 +12,7 @@
 import { TFunction } from "i18next";
 import { computed, runInAction, when } from "mobx";
 import debounce from "lodash-es/debounce";
-import React from "react";
+import { Ref, PureComponent } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
@@ -138,7 +138,7 @@ const StyledCompassRotationMarker = styled.div`
 type PropTypes = WithTranslation & {
   terria: Terria;
   viewState: ViewState;
-  refFromHOC?: React.Ref<HTMLDivElement>;
+  refFromHOC?: Ref<HTMLDivElement>;
   theme: DefaultTheme;
   t: TFunction;
 };
@@ -152,7 +152,7 @@ type IStateTypes = {
 };
 
 // the compass on map
-class Compass extends React.PureComponent<PropTypes, IStateTypes> {
+class Compass extends PureComponent<PropTypes, IStateTypes> {
   _unsubscribeFromPostRender: any;
   _unsubscribeFromAnimationFrame: any;
   private _unsubscribeFromViewerChange?: CesiumEvent.RemoveCallback;

--- a/lib/ReactViews/Map/MapNavigation/Items/Compass/GyroscopeGuidance.jsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/Compass/GyroscopeGuidance.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import { useState, useRef } from "react";
 import styled, { css } from "styled-components";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";

--- a/lib/ReactViews/Map/MapNavigation/Items/MapNavigationItem.tsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/MapNavigationItem.tsx
@@ -1,6 +1,6 @@
 import { i18n } from "i18next";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import styled from "styled-components";
 import { applyTranslationIfExists } from "../../../../Language/languageHelpers";
@@ -19,7 +19,7 @@ interface PropTypes {
 }
 
 @observer
-class MapNavigationItemBase extends React.Component<PropTypes> {
+class MapNavigationItemBase extends Component<PropTypes> {
   render() {
     const { closeTool = true, item, expandInPlace, i18n } = this.props;
     if (item.render)

--- a/lib/ReactViews/Map/MapNavigation/Items/MeasureTool.ts
+++ b/lib/ReactViews/Map/MapNavigation/Items/MeasureTool.ts
@@ -1,6 +1,6 @@
 "use strict";
 import i18next from "i18next";
-import React from "react";
+import { RefObject, createRef } from "react";
 import ArcType from "terriajs-cesium/Source/Core/ArcType";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
@@ -32,7 +32,7 @@ export class MeasureTool extends MapNavigationItemController {
   private userDrawing: UserDrawing;
 
   onClose: () => void;
-  itemRef: React.RefObject<HTMLDivElement> = React.createRef();
+  itemRef: RefObject<HTMLDivElement> = createRef();
 
   constructor(props: MeasureToolOptions) {
     super();

--- a/lib/ReactViews/Map/MapNavigation/Items/MyLocation.ts
+++ b/lib/ReactViews/Map/MapNavigation/Items/MyLocation.ts
@@ -1,6 +1,6 @@
 import i18next from "i18next";
 import { action, observable, runInAction, makeObservable } from "mobx";
-import React from "react";
+import { RefObject, createRef } from "react";
 import CesiumCartographic from "terriajs-cesium/Source/Core/Cartographic";
 import createGuid from "terriajs-cesium/Source/Core/createGuid";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
@@ -23,7 +23,7 @@ export class MyLocation extends MapNavigationItemController {
   static id = "my-location";
   static displayName = "MyLocation";
   readonly terria: Terria;
-  itemRef: React.RefObject<HTMLDivElement> = React.createRef();
+  itemRef: RefObject<HTMLDivElement> = createRef();
   private readonly _marker: GeoJsonCatalogItem;
   @observable private watchId: number | undefined;
   @observable private flown: boolean | undefined;

--- a/lib/ReactViews/Map/MapNavigation/Items/ToolButton.tsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/ToolButton.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import Box from "../../../../Styled/Box";
 import Icon from "../../../../Styled/Icon";
 import MapIconButton from "../../../MapIconButton/MapIconButton";
@@ -9,25 +9,23 @@ interface ToolButtonProps {
   controller: ToolButtonController;
 }
 
-const ToolButton: React.FC<ToolButtonProps> = observer(
-  (props: ToolButtonProps) => {
-    const { controller } = props;
+const ToolButton: FC<ToolButtonProps> = observer((props: ToolButtonProps) => {
+  const { controller } = props;
 
-    return (
-      <Box displayInlineBlock>
-        <MapIconButton
-          primary={controller.active}
-          expandInPlace
-          title={controller.title}
-          onClick={() => controller.handleClick()}
-          iconElement={() => <Icon glyph={controller.glyph} />}
-          closeIconElement={() => <Icon glyph={Icon.GLYPHS.closeTool} />}
-        >
-          {controller.title}
-        </MapIconButton>
-      </Box>
-    );
-  }
-);
+  return (
+    <Box displayInlineBlock>
+      <MapIconButton
+        primary={controller.active}
+        expandInPlace
+        title={controller.title}
+        onClick={() => controller.handleClick()}
+        iconElement={() => <Icon glyph={controller.glyph} />}
+        closeIconElement={() => <Icon glyph={Icon.GLYPHS.closeTool} />}
+      >
+        {controller.title}
+      </MapIconButton>
+    </Box>
+  );
+});
 
 export default ToolButton;

--- a/lib/ReactViews/Map/MapNavigation/Items/ZoomControl.tsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/ZoomControl.tsx
@@ -1,5 +1,5 @@
 import { TFunction } from "i18next";
-import React from "react";
+import { Component } from "react";
 import { withTranslation, WithTranslation } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
@@ -28,7 +28,7 @@ interface PropTypes extends WithTranslation {
 
 export const ZOOM_CONTROL_ID = "zoom";
 
-class ZoomControlBase extends React.Component<PropTypes> {
+class ZoomControlBase extends Component<PropTypes> {
   static displayName = "ZoomControl";
 
   flyToPosition(

--- a/lib/ReactViews/Map/MapNavigation/MapNavigation.tsx
+++ b/lib/ReactViews/Map/MapNavigation/MapNavigation.tsx
@@ -10,7 +10,7 @@ import {
   makeObservable
 } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { createRef, Component } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import ViewState from "../../../ReactViewModels/ViewState";
@@ -87,9 +87,9 @@ enum Orientation {
 }
 
 @observer
-class MapNavigationBase extends React.Component<PropTypes> {
+class MapNavigationBase extends Component<PropTypes> {
   static displayName = "MapNavigation";
-  private navigationRef = React.createRef<HTMLDivElement>();
+  private navigationRef = createRef<HTMLDivElement>();
   private readonly resizeListener: () => any;
   private readonly viewState: ViewState;
   private itemSizeInBar: Map<string, number>;

--- a/lib/ReactViews/Map/MapNavigation/registerMapNavigations.tsx
+++ b/lib/ReactViews/Map/MapNavigation/registerMapNavigations.tsx
@@ -1,5 +1,4 @@
 import { runInAction } from "mobx";
-import React from "react";
 import AugmentedVirtuality from "../../../Models/AugmentedVirtuality";
 import ViewerMode from "../../../Models/ViewerMode";
 import ViewState from "../../../ReactViewModels/ViewState";

--- a/lib/ReactViews/Map/MenuBar/HelpButton/HelpButton.tsx
+++ b/lib/ReactViews/Map/MenuBar/HelpButton/HelpButton.tsx
@@ -1,5 +1,4 @@
 import { observer } from "mobx-react";
-import React from "react";
 import { useTranslation } from "react-i18next";
 import Icon from "../../../../Styled/Icon";
 import Text from "../../../../Styled/Text";

--- a/lib/ReactViews/Map/MenuBar/MenuBar.jsx
+++ b/lib/ReactViews/Map/MenuBar/MenuBar.jsx
@@ -2,7 +2,6 @@ import classNames from "classnames";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
 import styled from "styled-components";
 import withControlledVisibility from "../../HOCs/withControlledVisibility";
 import { useViewState } from "../../Context";

--- a/lib/ReactViews/Map/MenuBar/StoryButton/StoryButton.tsx
+++ b/lib/ReactViews/Map/MenuBar/StoryButton/StoryButton.tsx
@@ -1,4 +1,4 @@
-import React, { Ref } from "react";
+import { Ref } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { DefaultTheme } from "styled-components";
 

--- a/lib/ReactViews/Map/Panels/DropdownPanel.jsx
+++ b/lib/ReactViews/Map/Panels/DropdownPanel.jsx
@@ -1,9 +1,5 @@
 "use strict";
 
-// proptypes are in mixin
-/* eslint react/prop-types:0*/
-
-import React from "react";
 import createReactClass from "create-react-class";
 import classNames from "classnames";
 import Icon from "../../../Styled/Icon";

--- a/lib/ReactViews/Map/Panels/DropdownPanel.jsx
+++ b/lib/ReactViews/Map/Panels/DropdownPanel.jsx
@@ -1,5 +1,6 @@
 "use strict";
 
+/* eslint react/prop-types:0*/
 import createReactClass from "create-react-class";
 import classNames from "classnames";
 import Icon from "../../../Styled/Icon";

--- a/lib/ReactViews/Map/Panels/HelpPanel/HelpPanel.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/HelpPanel.jsx
@@ -1,7 +1,7 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import { withTheme } from "styled-components";
 import {
@@ -20,7 +20,7 @@ import HelpPanelItem from "./HelpPanelItem";
 export const HELP_PANEL_ID = "help";
 
 @observer
-class HelpPanel extends React.Component {
+class HelpPanel extends Component {
   static displayName = "HelpPanel";
 
   static propTypes = {

--- a/lib/ReactViews/Map/Panels/HelpPanel/HelpPanelItem.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/HelpPanelItem.jsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import styled, { withTheme } from "styled-components";
 import {
@@ -14,7 +14,7 @@ import { applyTranslationIfExists } from "../../../../Language/languageHelpers";
 import HelpVideoPanel from "./HelpVideoPanel";
 
 @observer
-class HelpPanelItem extends React.Component {
+class HelpPanelItem extends Component {
   static displayName = "HelpPanelItem";
 
   static propTypes = {

--- a/lib/ReactViews/Map/Panels/HelpPanel/HelpVideoPanel.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/HelpVideoPanel.jsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import { withTheme } from "styled-components";
 import Icon from "../../../../Styled/Icon";
@@ -16,7 +16,7 @@ import SatelliteGuide from "../../../Guide/SatelliteGuide";
 const HELP_VIDEO_NAME = "helpVideo";
 
 @observer
-class HelpVideoPanel extends React.Component {
+class HelpVideoPanel extends Component {
   static displayName = "HelpVideoPanel";
 
   static propTypes = {

--- a/lib/ReactViews/Map/Panels/HelpPanel/StyledHtml.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/StyledHtml.jsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import { withTheme } from "styled-components";
 import Spacing from "../../../../Styled/Spacing";
@@ -35,7 +35,7 @@ const renderOrderedList = function (contents) {
   ));
 };
 
-export class StyledHtmlRaw extends React.Component {
+export class StyledHtmlRaw extends Component {
   static displayName = "StyledHtml";
 
   static propTypes = {

--- a/lib/ReactViews/Map/Panels/HelpPanel/TrainerPane.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/TrainerPane.jsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import { withTheme } from "styled-components";
 import styled from "styled-components";
@@ -23,7 +23,7 @@ const UlTrainerItems = styled(Box).attrs({
 const TrainerButton = styled(Button)``;
 
 @observer
-class TrainerPane extends React.Component {
+class TrainerPane extends Component {
   static displayName = "TrainerPane";
 
   static propTypes = {

--- a/lib/ReactViews/Map/Panels/HelpPanel/VideoGuide.jsx
+++ b/lib/ReactViews/Map/Panels/HelpPanel/VideoGuide.jsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import { withTheme } from "styled-components";
 import Box from "../../../../Styled/Box";
@@ -55,7 +55,7 @@ VideoWrapperBox.propTypes = {
 };
 
 @observer
-class VideoGuide extends React.Component {
+class VideoGuide extends Component {
   static displayName = "VideoGuide";
 
   static propTypes = {

--- a/lib/ReactViews/Map/Panels/InnerPanel.jsx
+++ b/lib/ReactViews/Map/Panels/InnerPanel.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 import createReactClass from "create-react-class";
 import classNames from "classnames";

--- a/lib/ReactViews/Map/Panels/LangPanel/LangPanel.tsx
+++ b/lib/ReactViews/Map/Panels/LangPanel/LangPanel.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import Terria from "../../../../Models/Terria";
 import Box from "../../../../Styled/Box";

--- a/lib/ReactViews/Map/Panels/MobilePanel.jsx
+++ b/lib/ReactViews/Map/Panels/MobilePanel.jsx
@@ -1,8 +1,6 @@
 // proptypes are in mixin.
 /* eslint react/prop-types:0*/
 
-import React from "react";
-
 import createReactClass from "create-react-class";
 
 import MobileMenuItem from "../../Mobile/MobileMenuItem";

--- a/lib/ReactViews/Map/Panels/SettingPanel.tsx
+++ b/lib/ReactViews/Map/Panels/SettingPanel.tsx
@@ -8,7 +8,7 @@ import {
 } from "mobx";
 import { observer } from "mobx-react";
 import Slider from "rc-slider";
-import React, { ChangeEvent, ComponentProps, MouseEvent } from "react";
+import { Ref, Component, ChangeEvent, ComponentProps, MouseEvent } from "react";
 import { withTranslation, WithTranslation } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
@@ -40,13 +40,13 @@ const sides = {
 type PropTypes = WithTranslation & {
   terria: Terria;
   viewState: ViewState;
-  refFromHOC?: React.Ref<HTMLDivElement>;
+  refFromHOC?: Ref<HTMLDivElement>;
   theme: DefaultTheme;
   t: TFunction;
 };
 
 @observer
-class SettingPanel extends React.Component<PropTypes> {
+class SettingPanel extends Component<PropTypes> {
   /**
    * @param {Props} props
    */

--- a/lib/ReactViews/Map/Panels/SharePanel/AdvancedOptions/AdvancedOptions.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/AdvancedOptions/AdvancedOptions.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, MutableRefObject } from "react";
+import { FC, useState, MutableRefObject } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 

--- a/lib/ReactViews/Map/Panels/SharePanel/AdvancedOptions/EmbedSection.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/AdvancedOptions/EmbedSection.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 

--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintDatasets.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintDatasets.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { getName } from "../../../../../ModelMixins/CatalogMemberMixin";
 import { BaseModel } from "../../../../../Models/Definition/Model";
 import Description from "../../../../Preview/Description";

--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintSection.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintSection.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import styled from "styled-components";

--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintSource.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintSource.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import dateFormat from "dateformat";
 
 interface Props {

--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintView.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintView.tsx
@@ -1,5 +1,5 @@
 import DOMPurify from "dompurify";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import { StyleSheetManager, ThemeProvider } from "styled-components";
 import { terriaTheme } from "../../../../StandardUserInterface";

--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintViewButtons.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintViewButtons.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import Button from "../../../../../Styled/Button";
 import { downloadImg } from "./PrintView";

--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintViewMap.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintViewMap.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 
 interface Props {
   screenshot: Promise<string>;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const PrintViewMap = (props: Props) => {

--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintWorkbench.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintWorkbench.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import CatalogMemberMixin, {
   getName
 } from "../../../../../ModelMixins/CatalogMemberMixin";

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import { TFunction } from "i18next";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import Terria from "../../../../Models/Terria";
 import ViewState from "../../../../ReactViewModels/ViewState";
@@ -34,7 +34,7 @@ interface SharePanelState {
 }
 
 @observer
-class SharePanel extends React.Component<PropTypes, SharePanelState> {
+class SharePanel extends Component<PropTypes, SharePanelState> {
   static displayName = "SharePanel";
 
   constructor(props: PropTypes) {

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanelContent.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanelContent.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo, useState } from "react";
+import { FC, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Terria from "../../../../Models/Terria";
 import ViewState from "../../../../ReactViewModels/ViewState";

--- a/lib/ReactViews/Map/Panels/SharePanel/ShareUrl/ShareUrl.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/ShareUrl/ShareUrl.tsx
@@ -1,8 +1,9 @@
-import React, {
+import {
   useEffect,
   useImperativeHandle,
   useState,
-  PropsWithChildren
+  PropsWithChildren,
+  forwardRef
 } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
@@ -38,7 +39,7 @@ export interface IShareUrlRef {
   shorteningInProgress: boolean;
 }
 
-export const ShareUrl = React.forwardRef<
+export const ShareUrl = forwardRef<
   IShareUrlRef,
   PropsWithChildren<IShareUrlProps>
 >(function ShareUrl(

--- a/lib/ReactViews/Map/Panels/SharePanel/ShareUrl/ShareUrl.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/ShareUrl/ShareUrl.tsx
@@ -126,6 +126,7 @@ export const ShareUrl = forwardRef<
         id="share-url"
         rounded={rounded}
         onCopy={(text) =>
+          // eslint-disable-next-line react/prop-types
           terria.analytics?.logEvent(
             Category.share,
             ShareAction.storyCopy,

--- a/lib/ReactViews/Map/Panels/SharePanel/ShareUrl/ShareUrlBookmark.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/ShareUrl/ShareUrlBookmark.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 
 import ViewState from "../../../../../ReactViewModels/ViewState";

--- a/lib/ReactViews/Map/Panels/SharePanel/ShareUrl/ShareUrlWarning.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/ShareUrl/ShareUrlWarning.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { observer } from "mobx-react";

--- a/lib/ReactViews/Map/Panels/SharePanel/StorySharePanel.jsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/StorySharePanel.jsx
@@ -4,7 +4,6 @@
 /* eslint react/prop-types:0*/
 
 import createReactClass from "create-react-class";
-import React from "react";
 import Button from "../../../../Styled/Button";
 import Icon from "../../../../Styled/Icon";
 import BaseOuterPanel from "../BaseOuterPanel";

--- a/lib/ReactViews/Map/Panels/ToolsPanel/CountDatasets.tsx
+++ b/lib/ReactViews/Map/Panels/ToolsPanel/CountDatasets.tsx
@@ -1,7 +1,7 @@
 "use strict";
 
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   applyTranslationIfExists,
@@ -30,7 +30,7 @@ interface CountDatasetsProps {
   updateResults: (resultsHtml: string) => void;
 }
 
-const CountDatasets: React.FC<CountDatasetsProps> = observer((props) => {
+const CountDatasets: FC<CountDatasetsProps> = observer((props) => {
   const [btnStringOrComponent, setBtnStringOrComponent] = useState<
     string | JSX.Element
   >(`${TRANSLATE_KEY_PREFIX}countDatasets.btnText`);

--- a/lib/ReactViews/Map/Panels/ToolsPanel/ToolsPanel.jsx
+++ b/lib/ReactViews/Map/Panels/ToolsPanel/ToolsPanel.jsx
@@ -1,7 +1,7 @@
 "use strict";
 
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import MenuPanel from "../../../StandardUserInterface/customizable/MenuPanel";
 import { useViewState } from "../../../Context";

--- a/lib/ReactViews/Map/ProgressBar.tsx
+++ b/lib/ReactViews/Map/ProgressBar.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { VFC, useCallback, useEffect, useState } from "react";
+import { VFC, useCallback, useEffect, useState } from "react";
 import styled, { css, keyframes, useTheme } from "styled-components";
 import EventHelper from "terriajs-cesium/Source/Core/EventHelper";
 import { useViewState } from "../Context";

--- a/lib/ReactViews/Map/TerriaViewerWrapper/Splitter/Splitter.tsx
+++ b/lib/ReactViews/Map/TerriaViewerWrapper/Splitter/Splitter.tsx
@@ -1,6 +1,6 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React, { FC, useCallback, useEffect } from "react";
+import { FC, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 import Terria from "../../../../Models/Terria";

--- a/lib/ReactViews/Map/TerriaViewerWrapper/TerriaViewerWrapper.tsx
+++ b/lib/ReactViews/Map/TerriaViewerWrapper/TerriaViewerWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef } from "react";
+import { FC, useEffect, useRef } from "react";
 
 import { Splitter } from "./Splitter/Splitter";
 import { useViewState } from "../../Context";

--- a/lib/ReactViews/Map/Toast.tsx
+++ b/lib/ReactViews/Map/Toast.tsx
@@ -1,14 +1,14 @@
-import React from "react";
+import { ReactNode, FC } from "react";
 import styled from "styled-components";
 
 export type ToastProps = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 /**
  * A toast component that positions its children bottom center of the map
  */
-const Toast: React.FC<ToastProps> = ({ children }) => {
+const Toast: FC<ToastProps> = ({ children }) => {
   return <Container>{children}</Container>;
 };
 

--- a/lib/ReactViews/MapIconButton/MapIconButton.tsx
+++ b/lib/ReactViews/MapIconButton/MapIconButton.tsx
@@ -1,5 +1,5 @@
 "use strict";
-import React, { useRef, useState } from "react";
+import { ReactNode, RefObject, useRef, useState } from "react";
 import styled, { useTheme } from "styled-components";
 import Box from "../../Styled/Box";
 import { RawButton } from "../../Styled/Button";
@@ -96,9 +96,9 @@ interface IMapIconButtonProps extends IStyledMapIconButtonProps {
   iconElement: () => JSX.Element;
   closeIconElement?: () => JSX.Element;
   onClick?: () => void;
-  children?: React.ReactNode;
+  children?: ReactNode;
   className?: string;
-  buttonRef?: React.RefObject<any>;
+  buttonRef?: RefObject<any>;
   noExpand?: boolean;
 }
 

--- a/lib/ReactViews/Mobile/MobileHeader.jsx
+++ b/lib/ReactViews/Mobile/MobileHeader.jsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import styled, { withTheme } from "styled-components";
 import { applyTranslationIfExists } from "../../Language/languageHelpers";
@@ -18,7 +18,7 @@ import MobileMenu from "./MobileMenu";
 import MobileModalWindow from "./MobileModalWindow";
 
 @observer
-class MobileHeader extends React.Component {
+class MobileHeader extends Component {
   static displayName = "MobileHeader";
 
   showSearch() {

--- a/lib/ReactViews/Mobile/MobileMenu.jsx
+++ b/lib/ReactViews/Mobile/MobileMenu.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
 import { observer } from "mobx-react";
 
@@ -17,7 +17,7 @@ import { applyTranslationIfExists } from "../../Language/languageHelpers";
 import { Category, HelpAction } from "../../Core/AnalyticEvents/analyticEvents";
 
 @observer
-class MobileMenu extends React.Component {
+class MobileMenu extends Component {
   static propTypes = {
     menuItems: PropTypes.arrayOf(PropTypes.element),
     menuLeftItems: PropTypes.arrayOf(PropTypes.element),

--- a/lib/ReactViews/Mobile/MobileMenuItem.tsx
+++ b/lib/ReactViews/Mobile/MobileMenuItem.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import { MouseEventHandler } from "react";
 import Icon, { GLYPHS } from "../../Styled/Icon";
 
 import Styles from "./mobile-menu-item.scss";
 
 type Props = {
   href?: string;
-  onClick: React.MouseEventHandler<HTMLElement>;
+  onClick: MouseEventHandler<HTMLElement>;
   caption: string;
   icon: { id: keyof typeof GLYPHS };
 };

--- a/lib/ReactViews/Mobile/MobileModalWindow.jsx
+++ b/lib/ReactViews/Mobile/MobileModalWindow.jsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import Box from "../../Styled/Box";
 import Icon from "../../Styled/Icon";
@@ -13,7 +13,7 @@ import Styles from "./mobile-modal-window.scss";
 import MobileSearch from "./MobileSearch";
 
 @observer
-class MobileModalWindow extends React.Component {
+class MobileModalWindow extends Component {
   static propTypes = {
     terria: PropTypes.object,
     viewState: PropTypes.object.isRequired,

--- a/lib/ReactViews/Mobile/MobileSearch.jsx
+++ b/lib/ReactViews/Mobile/MobileSearch.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 
@@ -12,7 +12,7 @@ import Styles from "./mobile-search.scss";
 
 // A Location item when doing Bing map searvh or Gazetter search
 @observer
-class MobileSearch extends React.Component {
+class MobileSearch extends Component {
   static propTypes = {
     viewState: PropTypes.object,
     terria: PropTypes.object,

--- a/lib/ReactViews/Notification/MapInteractionWindow.tsx
+++ b/lib/ReactViews/Notification/MapInteractionWindow.tsx
@@ -3,7 +3,7 @@
 import classNames from "classnames";
 import { Lambda, observable, reaction, makeObservable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import styled from "styled-components";
 import isDefined from "../../Core/isDefined";
 import MapInteractionMode, { UIMode } from "../../Models/MapInteractionMode";
@@ -30,7 +30,7 @@ const MapInteractionWindowWrapper = styled.div<{ isDiffTool: boolean }>`
 `;
 
 @observer
-class MapInteractionWindow extends React.Component<{
+class MapInteractionWindow extends Component<{
   viewState: ViewState;
 }> {
   displayName = "MapInteractionWindow";

--- a/lib/ReactViews/Notification/Notification.tsx
+++ b/lib/ReactViews/Notification/Notification.tsx
@@ -1,5 +1,4 @@
 import { observer } from "mobx-react";
-import React from "react";
 import triggerResize from "../../Core/triggerResize";
 import { useViewState } from "../Context";
 

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -3,7 +3,6 @@
 import classNames from "classnames";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
-import React from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
 import parseCustomMarkdownToReact from "../Custom/parseCustomMarkdownToReact";
 import Styles from "./notification-window.scss";

--- a/lib/ReactViews/Notification/shareConvertNotification.tsx
+++ b/lib/ReactViews/Notification/shareConvertNotification.tsx
@@ -1,6 +1,5 @@
 import i18next from "i18next";
 import { runInAction } from "mobx";
-import React from "react";
 import isDefined from "../../Core/isDefined";
 import ViewState from "../../ReactViewModels/ViewState";
 import Collapsible from "../Custom/Collapsible/Collapsible";

--- a/lib/ReactViews/Notification/terriaErrorNotification.tsx
+++ b/lib/ReactViews/Notification/terriaErrorNotification.tsx
@@ -1,6 +1,5 @@
 import i18next from "i18next";
 import { runInAction } from "mobx";
-import React from "react";
 import TerriaError from "../../Core/TerriaError";
 import ViewState from "../../ReactViewModels/ViewState";
 import Box from "../../Styled/Box";

--- a/lib/ReactViews/Preview/DataPreview.jsx
+++ b/lib/ReactViews/Preview/DataPreview.jsx
@@ -3,7 +3,7 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { Trans, withTranslation } from "react-i18next";
 import CatalogFunctionMixin from "../../ModelMixins/CatalogFunctionMixin";
 import ReferenceMixin from "../../ModelMixins/ReferenceMixin";
@@ -20,7 +20,7 @@ import Styles from "./data-preview.scss";
  * Data preview section, for the preview map see DataPreviewMap
  */
 @observer
-class DataPreview extends React.Component {
+class DataPreview extends Component {
   static propTypes = {
     terria: PropTypes.object.isRequired,
     viewState: PropTypes.object,

--- a/lib/ReactViews/Preview/DataPreviewMap.jsx
+++ b/lib/ReactViews/Preview/DataPreviewMap.jsx
@@ -10,7 +10,7 @@ import {
 } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import filterOutUndefined from "../../Core/filterOutUndefined";
@@ -68,7 +68,7 @@ class AdaptForPreviewMap extends MappableMixin(CreateModel(MappableTraits)) {
  * @extends {React.Component<Props>}
  */
 @observer
-class DataPreviewMap extends React.Component {
+class DataPreviewMap extends Component {
   @observable
   isZoomedToExtent = false;
 

--- a/lib/ReactViews/Preview/DataPreviewSections.jsx
+++ b/lib/ReactViews/Preview/DataPreviewSections.jsx
@@ -3,7 +3,7 @@ import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import Mustache from "mustache";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import isDefined from "../../Core/isDefined";
 import CommonStrata from "../../Models/Definition/CommonStrata";
@@ -23,7 +23,7 @@ Mustache.escape = function (string) {
  * order if available.
  */
 @observer
-class DataPreviewSections extends React.Component {
+class DataPreviewSections extends Component {
   static propTypes = {
     metadataItem: PropTypes.object.isRequired,
     t: PropTypes.func.isRequired

--- a/lib/ReactViews/Preview/DataPreviewUrl.jsx
+++ b/lib/ReactViews/Preview/DataPreviewUrl.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import createReactClass from "create-react-class";
 
 import PropTypes from "prop-types";

--- a/lib/ReactViews/Preview/Description.jsx
+++ b/lib/ReactViews/Preview/Description.jsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { Trans, withTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
 import Box from "../../Styled/Box";
@@ -17,7 +17,7 @@ import WarningBox from "./WarningBox";
  * CatalogItem description.
  */
 @observer
-class Description extends React.Component {
+class Description extends Component {
   static propTypes = {
     item: PropTypes.object.isRequired,
     printView: PropTypes.bool,

--- a/lib/ReactViews/Preview/ExportData.tsx
+++ b/lib/ReactViews/Preview/ExportData.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 
 import { withTranslation, WithTranslation } from "react-i18next";
 
@@ -29,7 +29,7 @@ export async function exportData(item: ExportableMixin.Instance) {
  * CatalogItem ExportData.
  */
 @observer
-class ExportData extends React.Component<PropsType> {
+class ExportData extends Component<PropsType> {
   exportDataClicked(item: ExportableMixin.Instance) {
     exportData(item).catch((e) => {
       this.props.item.terria.raiseErrorToUser(e);

--- a/lib/ReactViews/Preview/GroupPreview.jsx
+++ b/lib/ReactViews/Preview/GroupPreview.jsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import parseCustomMarkdownToReact from "../Custom/parseCustomMarkdownToReact";
 import {
@@ -18,7 +18,7 @@ import WarningBox from "./WarningBox";
  * A "preview" for CatalogGroup.
  */
 @observer
-class GroupPreview extends React.Component {
+class GroupPreview extends Component {
   static propTypes = {
     previewed: PropTypes.object.isRequired,
     terria: PropTypes.object.isRequired,

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -1,7 +1,7 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
 import { DataSourceAction } from "../../Core/AnalyticEvents/analyticEvents";
@@ -30,7 +30,7 @@ import WarningBox from "./WarningBox";
  * @extends {React.Component<Props>}
  */
 @observer
-class MappablePreview extends React.Component {
+class MappablePreview extends Component {
   static propTypes = {
     previewed: PropTypes.object.isRequired,
     terria: PropTypes.object.isRequired,

--- a/lib/ReactViews/Preview/MetadataTable.jsx
+++ b/lib/ReactViews/Preview/MetadataTable.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import createReactClass from "create-react-class";
 import { isObservableArray } from "mobx";
 import PropTypes from "prop-types";

--- a/lib/ReactViews/Preview/WarningBox.tsx
+++ b/lib/ReactViews/Preview/WarningBox.tsx
@@ -1,5 +1,5 @@
 import { runInAction } from "mobx";
-import React from "react";
+import { FC } from "react";
 import TerriaError from "../../Core/TerriaError";
 import ViewState from "../../ReactViewModels/ViewState";
 import Box from "../../Styled/Box";
@@ -21,7 +21,7 @@ const showErrorNotification = (viewState: ViewState, error: TerriaError) => {
   viewState.terria.raiseErrorToUser(error, undefined, true);
 };
 
-const WarningBox: React.FC<{
+const WarningBox: FC<{
   error?: TerriaError;
   viewState?: ViewState;
 }> = (props) => {

--- a/lib/ReactViews/PrivateIndicator/PrivateIndicator.tsx
+++ b/lib/ReactViews/PrivateIndicator/PrivateIndicator.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import Icon from "../../Styled/Icon";
 import IconWrapper from "../../Styled/IconWrapper";

--- a/lib/ReactViews/ReactViewHelpers/highlightKeyword.jsx
+++ b/lib/ReactViews/ReactViewHelpers/highlightKeyword.jsx
@@ -1,8 +1,3 @@
-import React from "react";
-
-// Really really lightweight highlight without pulling in react-highlight-words
-// pros: lightweight
-// cons: ???
 export default function highlightKeyword(searchResult, keywordToHighlight) {
   if (!keywordToHighlight) return searchResult;
   const parts = searchResult.split(new RegExp(`(${keywordToHighlight})`, "gi"));

--- a/lib/ReactViews/RelatedMaps/RelatedMaps.tsx
+++ b/lib/ReactViews/RelatedMaps/RelatedMaps.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import { DefaultTheme, withTheme } from "styled-components";
 import { RelatedMap } from "../../Models/RelatedMaps";
@@ -19,7 +19,7 @@ type PropTypes = WithViewState &
   };
 
 @observer
-class RelatedMaps extends React.Component<PropTypes> {
+class RelatedMaps extends Component<PropTypes> {
   render() {
     const t = this.props.t;
     const dropdownTheme = {

--- a/lib/ReactViews/Search/Breadcrumbs.jsx
+++ b/lib/ReactViews/Search/Breadcrumbs.jsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { Component, Fragment } from "react";
 import { withTranslation } from "react-i18next";
 import { withTheme } from "styled-components";
 import Box from "../../Styled/Box";
@@ -23,7 +23,7 @@ const RawButtonAndUnderline = styled(RawButton)`
 `;
 
 @observer
-class Breadcrumbs extends React.Component {
+class Breadcrumbs extends Component {
   static propTypes = {
     terria: PropTypes.object,
     viewState: PropTypes.object,
@@ -105,7 +105,7 @@ class Breadcrumbs extends React.Component {
         <Box flexWrap>
           {parentGroups &&
             parentGroups.map((parent, i) => (
-              <React.Fragment key={i}>
+              <Fragment key={i}>
                 {this.renderCrumb(parent, i, parentGroups)}
                 {i !== parentGroups.length - 1 && (
                   <Box paddedHorizontally={1}>
@@ -114,7 +114,7 @@ class Breadcrumbs extends React.Component {
                     </Text>
                   </Box>
                 )}
-              </React.Fragment>
+              </Fragment>
             ))}
         </Box>
       </Box>

--- a/lib/ReactViews/Search/LocationSearchResults.tsx
+++ b/lib/ReactViews/Search/LocationSearchResults.tsx
@@ -7,7 +7,7 @@
 
 import { action, computed, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { FC, Component } from "react";
 import {
   useTranslation,
   withTranslation,
@@ -51,7 +51,7 @@ interface PropsType extends WithTranslation {
 }
 
 @observer
-class LocationSearchResults extends React.Component<PropsType> {
+class LocationSearchResults extends Component<PropsType> {
   @observable isExpanded = false;
 
   constructor(props: PropsType) {
@@ -185,7 +185,7 @@ interface SearchResultsFooterProps {
   name: string;
 }
 
-const SearchResultsFooter: React.FC<SearchResultsFooterProps> = (
+const SearchResultsFooter: FC<SearchResultsFooterProps> = (
   props: SearchResultsFooterProps
 ) => {
   const { t, i18n } = useTranslation();
@@ -207,7 +207,7 @@ interface NameWithLoaderProps {
   isWaitingForSearchToStart: boolean;
 }
 
-const NameWithLoader: React.FC<NameWithLoaderProps> = observer(
+const NameWithLoader: FC<NameWithLoaderProps> = observer(
   (props: NameWithLoaderProps) => {
     const { i18n } = useTranslation();
     return (

--- a/lib/ReactViews/Search/SearchBox.jsx
+++ b/lib/ReactViews/Search/SearchBox.jsx
@@ -1,7 +1,7 @@
 import createReactClass from "create-react-class";
 import debounce from "lodash-es/debounce";
 import PropTypes from "prop-types";
-import React from "react";
+import { forwardRef } from "react";
 import styled, { withTheme } from "styled-components";
 import Box, { BoxSpan } from "../../Styled/Box";
 import { RawButton } from "../../Styled/Button";
@@ -200,4 +200,4 @@ const SearchBoxWithRef = (props, ref) => (
   <SearchBox {...props} inputBoxRef={ref} />
 );
 
-export default withTheme(React.forwardRef(SearchBoxWithRef));
+export default withTheme(forwardRef(SearchBoxWithRef));

--- a/lib/ReactViews/Search/SearchBoxAndResults.jsx
+++ b/lib/ReactViews/Search/SearchBoxAndResults.jsx
@@ -1,7 +1,7 @@
 import { reaction, runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React from "react";
+import { createRef, Component } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { addMarker, removeMarker } from "../../Models/LocationMarkerUtils";
@@ -65,10 +65,10 @@ const PresentationBox = styled(Box).attrs({
 
 export const LOCATION_SEARCH_INPUT_NAME = "LocationSearchInput";
 
-export class SearchBoxAndResultsRaw extends React.Component {
+export class SearchBoxAndResultsRaw extends Component {
   constructor(props) {
     super(props);
-    this.locationSearchRef = React.createRef();
+    this.locationSearchRef = createRef();
   }
 
   componentDidMount() {

--- a/lib/ReactViews/Search/SearchHeader.tsx
+++ b/lib/ReactViews/Search/SearchHeader.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { applyTranslationIfExists } from "../../Language/languageHelpers";
 import SearchProviderResults from "../../Models/SearchProviders/SearchProviderResults";
@@ -12,7 +12,7 @@ interface SearchHeaderProps {
   isWaitingForSearchToStart: boolean;
 }
 
-const SearchHeader: React.FC<SearchHeaderProps> = observer(
+const SearchHeader: FC<SearchHeaderProps> = observer(
   (props: SearchHeaderProps) => {
     const { i18n } = useTranslation();
 

--- a/lib/ReactViews/Search/SearchResult.tsx
+++ b/lib/ReactViews/Search/SearchResult.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import styled, { useTheme } from "styled-components";
 import { Li } from "../../Styled/List";
 import Icon, { StyledIcon } from "../../Styled/Icon";
@@ -31,9 +31,7 @@ interface SearchResultProps {
   icon: keyof typeof Icon.GLYPHS;
 }
 
-const SearchResult: React.FC<SearchResultProps> = (
-  props: SearchResultProps
-) => {
+const SearchResult: FC<SearchResultProps> = (props: SearchResultProps) => {
   const theme = useTheme();
   const highlightedResultName = highlightKeyword(
     props.name,

--- a/lib/ReactViews/SelectableDimensions/Button.tsx
+++ b/lib/ReactViews/SelectableDimensions/Button.tsx
@@ -1,5 +1,5 @@
 import { runInAction } from "mobx";
-import React from "react";
+import { FC } from "react";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import { SelectableDimensionButton as SelectableDimensionButtonModel } from "../../Models/SelectableDimensions/SelectableDimensions";
 import { StyledIcon } from "../../Styled/Icon";
@@ -8,7 +8,7 @@ import { parseCustomMarkdownToReactWithOptions } from "../Custom/parseCustomMark
 import Button from "../../Styled/Button";
 import AnimatedSpinnerIcon from "../../Styled/AnimatedSpinnerIcon";
 
-export const SelectableDimensionButton: React.FC<{
+export const SelectableDimensionButton: FC<{
   id: string;
   dim: SelectableDimensionButtonModel;
 }> = ({ dim }) => {

--- a/lib/ReactViews/SelectableDimensions/Checkbox.tsx
+++ b/lib/ReactViews/SelectableDimensions/Checkbox.tsx
@@ -1,12 +1,12 @@
 import { runInAction } from "mobx";
-import React from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import { SelectableDimensionCheckbox as SelectableDimensionCheckboxModel } from "../../Models/SelectableDimensions/SelectableDimensions";
 import Checkbox from "../../Styled/Checkbox";
 import Text from "../../Styled/Text";
 
-export const SelectableDimensionCheckbox: React.FC<{
+export const SelectableDimensionCheckbox: FC<{
   id: string;
   dim: SelectableDimensionCheckboxModel;
 }> = ({ id, dim }) => {

--- a/lib/ReactViews/SelectableDimensions/Color.tsx
+++ b/lib/ReactViews/SelectableDimensions/Color.tsx
@@ -1,7 +1,7 @@
 import { debounce } from "lodash-es";
 import { action, runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { FC, useState } from "react";
 import { ChromePicker } from "react-color";
 import { useTranslation } from "react-i18next";
 import isDefined from "../../Core/isDefined";
@@ -20,7 +20,7 @@ const debounceSetColorDimensionValue = debounce(
   100
 );
 
-export const SelectableDimensionColor: React.FC<{
+export const SelectableDimensionColor: FC<{
   id: string;
   dim: SelectableDimensionColorModel;
 }> = observer(({ dim }) => {

--- a/lib/ReactViews/SelectableDimensions/ColorSchemeOptionRenderer.tsx
+++ b/lib/ReactViews/SelectableDimensions/ColorSchemeOptionRenderer.tsx
@@ -1,11 +1,11 @@
 import { useTranslation } from "react-i18next";
 import { rgb } from "d3-color";
 import * as d3Scale from "d3-scale-chromatic";
-import React from "react";
+import { VFC, ReactChild } from "react";
 import StandardCssColors from "../../Core/StandardCssColors";
 import { OptionRenderer } from "../../Models/SelectableDimensions/SelectableDimensions";
 
-const Invalid: React.VFC<object> = () => {
+const Invalid: VFC<object> = () => {
   const { t } = useTranslation();
   return <span>{t("selectableDimensions.invalid")}</span>;
 };
@@ -30,10 +30,7 @@ const Invalid: React.VFC<object> = () => {
 const interpolateWidth = 300;
 const height = 20;
 
-function ramp(
-  name: string | undefined,
-  n: number | undefined
-): React.ReactChild {
+function ramp(name: string | undefined, n: number | undefined): ReactChild {
   if (!name) return <Invalid />;
   let colors: string[];
 

--- a/lib/ReactViews/SelectableDimensions/Group.tsx
+++ b/lib/ReactViews/SelectableDimensions/Group.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import CommonStrata from "../../Models/Definition/CommonStrata";
@@ -17,7 +17,7 @@ import SelectableDimension from "./SelectableDimension";
 /**
  * Component to render a SelectableDimensionGroup or DimensionSelectorCheckboxGroup.
  */
-export const SelectableDimensionGroup: React.FC<{
+export const SelectableDimensionGroup: FC<{
   id: string;
   dim: SelectableDimensionGroupModel | SelectableDimensionCheckboxGroupModel;
 }> = ({ id, dim }) => {

--- a/lib/ReactViews/SelectableDimensions/MarkerOptionRenderer.tsx
+++ b/lib/ReactViews/SelectableDimensions/MarkerOptionRenderer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { getMakiIcon } from "../../Map/Icons/Maki/MakiIcons";
 import { OptionRenderer } from "../../Models/SelectableDimensions/SelectableDimensions";
 

--- a/lib/ReactViews/SelectableDimensions/Numeric.tsx
+++ b/lib/ReactViews/SelectableDimensions/Numeric.tsx
@@ -1,11 +1,11 @@
 import { runInAction } from "mobx";
-import React, { useState } from "react";
+import { FC, useState } from "react";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import { SelectableDimensionNumeric as SelectableDimensionNumericModel } from "../../Models/SelectableDimensions/SelectableDimensions";
 import Input from "../../Styled/Input";
 import { observer } from "mobx-react";
 
-export const SelectableDimensionNumeric: React.FC<{
+export const SelectableDimensionNumeric: FC<{
   id: string;
   dim: SelectableDimensionNumericModel;
 }> = observer(({ id, dim }) => {

--- a/lib/ReactViews/SelectableDimensions/Select.tsx
+++ b/lib/ReactViews/SelectableDimensions/Select.tsx
@@ -1,7 +1,7 @@
 import i18next from "i18next";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import ReactSelect from "react-select";
 import ReactSelectCreatable from "react-select/creatable";
 import { useTheme } from "styled-components";
@@ -12,7 +12,7 @@ import {
   SelectableDimensionMultiEnum as SelectableDimensionEnumMultiModel
 } from "../../Models/SelectableDimensions/SelectableDimensions";
 
-export const SelectableDimensionEnum: React.FC<{
+export const SelectableDimensionEnum: FC<{
   id: string;
   dim: SelectableDimensionEnumModel;
 }> = observer(({ dim }) => {
@@ -93,7 +93,7 @@ export const SelectableDimensionEnum: React.FC<{
 });
 
 /** Similar to SelectableDimensionEnum, but allows multiple values to be selected */
-export const SelectableDimensionEnumMulti: React.FC<{
+export const SelectableDimensionEnumMulti: FC<{
   id: string;
   dim: SelectableDimensionEnumMultiModel;
 }> = observer(({ dim }) => {

--- a/lib/ReactViews/SelectableDimensions/SelectableDimension.tsx
+++ b/lib/ReactViews/SelectableDimensions/SelectableDimension.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import {
   isButton,
   isCheckbox,
@@ -26,7 +26,7 @@ import {
 } from "./Select";
 import { SelectableDimensionText } from "./Text";
 
-const SelectableDimension: React.FC<{
+const SelectableDimension: FC<{
   id: string;
   dim: SelectableDimensionModel;
 }> = ({ id, dim }) => {

--- a/lib/ReactViews/SelectableDimensions/Text.tsx
+++ b/lib/ReactViews/SelectableDimensions/Text.tsx
@@ -1,10 +1,10 @@
 import { runInAction } from "mobx";
-import React from "react";
+import { FC } from "react";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import { SelectableDimensionText as SelectableDimensionTextModel } from "../../Models/SelectableDimensions/SelectableDimensions";
 import Input from "../../Styled/Input";
 
-export const SelectableDimensionText: React.FC<{
+export const SelectableDimensionText: FC<{
   id: string;
   dim: SelectableDimensionTextModel;
 }> = ({ id, dim }) => {

--- a/lib/ReactViews/SidePanel/Branding.tsx
+++ b/lib/ReactViews/SidePanel/Branding.tsx
@@ -1,6 +1,6 @@
 "use strict";
 import { observer } from "mobx-react";
-import React from "react";
+import { Fragment } from "react";
 import isDefined from "../../Core/isDefined";
 import ViewState from "../../ReactViewModels/ViewState";
 import parseCustomHtmlToReact from "../Custom/parseCustomHtmlToReact";
@@ -81,12 +81,12 @@ export default withViewState(
         `}
       >
         {brandingHtmlElements.map((element, idx) => (
-          <React.Fragment key={idx}>
+          <Fragment key={idx}>
             {parseCustomHtmlToReact(
               element.replace(/\{\{\s*version\s*\}\}/g, version),
               { disableExternalLinkIcon: true }
             )}
-          </React.Fragment>
+          </Fragment>
         ))}
       </div>
     );

--- a/lib/ReactViews/SidePanel/SidePanel.tsx
+++ b/lib/ReactViews/SidePanel/SidePanel.tsx
@@ -1,5 +1,11 @@
 import { observer } from "mobx-react";
-import React from "react";
+import {
+  FC,
+  ComponentPropsWithoutRef,
+  Ref,
+  MouseEventHandler,
+  forwardRef
+} from "react";
 import { useTranslation, withTranslation } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import ViewState from "../../ReactViewModels/ViewState";
@@ -47,7 +53,7 @@ interface EmptyWorkbenchProps {
   theme: DefaultTheme;
 }
 
-const EmptyWorkbench: React.FC<EmptyWorkbenchProps> = (props) => {
+const EmptyWorkbench: FC<EmptyWorkbenchProps> = (props) => {
   const { t } = useTranslation();
   return (
     <Text large textLight>
@@ -98,35 +104,34 @@ const EmptyWorkbench: React.FC<EmptyWorkbenchProps> = (props) => {
 
 type SidePanelButtonProps = {
   btnText?: string;
-} & React.ComponentPropsWithoutRef<typeof Button>;
+} & ComponentPropsWithoutRef<typeof Button>;
 
-const SidePanelButton = React.forwardRef<
-  HTMLButtonElement,
-  SidePanelButtonProps
->(function SidePanelButton(props, ref) {
-  const { btnText, ...rest } = props;
-  return (
-    <Button
-      primary
-      ref={ref}
-      renderIcon={props.children && (() => props.children)}
-      textProps={{
-        large: true
-      }}
-      {...rest}
-    >
-      {btnText ? btnText : ""}
-    </Button>
-  );
-});
+const SidePanelButton = forwardRef<HTMLButtonElement, SidePanelButtonProps>(
+  function SidePanelButton(props, ref) {
+    const { btnText, ...rest } = props;
+    return (
+      <Button
+        primary
+        ref={ref}
+        renderIcon={props.children && (() => props.children)}
+        textProps={{
+          large: true
+        }}
+        {...rest}
+      >
+        {btnText ? btnText : ""}
+      </Button>
+    );
+  }
+);
 
 export const EXPLORE_MAP_DATA_NAME = "ExploreMapDataButton";
 export const SIDE_PANEL_UPLOAD_BUTTON_NAME = "SidePanelUploadButton";
 
 interface SidePanelProps {
   viewState: ViewState;
-  refForExploreMapData: React.Ref<HTMLButtonElement>;
-  refForUploadData: React.Ref<HTMLButtonElement>;
+  refForExploreMapData: Ref<HTMLButtonElement>;
+  refForUploadData: Ref<HTMLButtonElement>;
   theme: DefaultTheme;
 }
 
@@ -134,17 +139,13 @@ const SidePanel = observer<React.FC<SidePanelProps>>(
   ({ viewState, theme, refForExploreMapData, refForUploadData }) => {
     const terria = viewState.terria;
     const { t, i18n } = useTranslation();
-    const onAddDataClicked: React.MouseEventHandler<HTMLButtonElement> = (
-      e
-    ) => {
+    const onAddDataClicked: MouseEventHandler<HTMLButtonElement> = (e) => {
       e.stopPropagation();
       viewState.setTopElement(ExplorerWindowElementName);
       viewState.openAddData();
     };
 
-    const onAddLocalDataClicked: React.MouseEventHandler<HTMLButtonElement> = (
-      e
-    ) => {
+    const onAddLocalDataClicked: MouseEventHandler<HTMLButtonElement> = (e) => {
       e.stopPropagation();
       viewState.setTopElement(ExplorerWindowElementName);
       viewState.openUserData();
@@ -215,7 +216,7 @@ const SidePanel = observer<React.FC<SidePanelProps>>(
 
 // Used to create two refs for <SidePanel /> to consume, rather than
 // using the withTerriaRef() HOC twice, designed for a single ref
-const SidePanelWithRefs: React.FC<
+const SidePanelWithRefs: FC<
   Omit<SidePanelProps, "refForExploreMapData" | "refForUploadData">
 > = (props) => {
   const refForExploreMapData = useRefForTerria(
@@ -229,10 +230,8 @@ const SidePanelWithRefs: React.FC<
   return (
     <SidePanel
       {...props}
-      refForExploreMapData={
-        refForExploreMapData as React.Ref<HTMLButtonElement>
-      }
-      refForUploadData={refForUploadData as React.Ref<HTMLButtonElement>}
+      refForExploreMapData={refForExploreMapData as Ref<HTMLButtonElement>}
+      refForUploadData={refForUploadData as Ref<HTMLButtonElement>}
     />
   );
 };

--- a/lib/ReactViews/SidePanel/SidePanel.tsx
+++ b/lib/ReactViews/SidePanel/SidePanel.tsx
@@ -113,6 +113,7 @@ const SidePanelButton = forwardRef<HTMLButtonElement, SidePanelButtonProps>(
       <Button
         primary
         ref={ref}
+        // eslint-disable-next-line react/prop-types
         renderIcon={props.children && (() => props.children)}
         textProps={{
           large: true

--- a/lib/ReactViews/SplitPoint.jsx
+++ b/lib/ReactViews/SplitPoint.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-import React from "react";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 

--- a/lib/ReactViews/StandardUserInterface/ExperimentalFeatures.tsx
+++ b/lib/ReactViews/StandardUserInterface/ExperimentalFeatures.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import { ReactNode, FC } from "react";
 import styled from "styled-components";
 import ViewState from "../../ReactViewModels/ViewState";
 import { withViewState } from "../Context";
 
 interface IProps {
   viewState: ViewState;
-  experimentalItems?: React.ReactNode[];
+  experimentalItems?: ReactNode[];
 }
 
 const ControlsWrapper = styled.div`
@@ -25,7 +25,7 @@ const Control = styled.div`
     margin-bottom: 0;
   }
 `;
-const ExperimentalFeatures: React.FC<IProps> = (props) => {
+const ExperimentalFeatures: FC<IProps> = (props) => {
   return (
     <ControlsWrapper>
       {(props.experimentalItems || []).map((item, i) => (

--- a/lib/ReactViews/StandardUserInterface/Portal.tsx
+++ b/lib/ReactViews/StandardUserInterface/Portal.tsx
@@ -1,6 +1,6 @@
 import { action } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect } from "react";
+import { FC, useEffect } from "react";
 import ReactDOM from "react-dom";
 import ViewState from "../../ReactViewModels/ViewState";
 import { useViewState } from "../Context";
@@ -20,7 +20,7 @@ type PortalProps = {
 /**
  * Defines a portal with given id that can be attached by calling <PortalChild portalId={id} />
  */
-export const Portal: React.FC<PortalProps> = ({ id, className }) => {
+export const Portal: FC<PortalProps> = ({ id, className }) => {
   const viewState = useViewState();
   /* eslint-disable-next-line react-hooks/exhaustive-deps */
   useEffect(
@@ -43,7 +43,7 @@ export type PortalChildProps = {
 /**
  * Attach children to the <Portal> identified by portalId
  */
-export const PortalChild: React.FC<PortalChildProps> = observer(
+export const PortalChild: FC<PortalChildProps> = observer(
   ({ viewState, portalId, children }) => {
     const container = viewState.portals.get(portalId);
     return container ? ReactDOM.createPortal(children, container) : null;

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import "inobounce";
 import { action } from "mobx";
 import { observer } from "mobx-react";
-import React, { ReactNode, useEffect } from "react";
+import { FC, DragEvent, ReactNode, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { DefaultTheme } from "styled-components";
 import combine from "terriajs-cesium/Source/Core/combine";
@@ -54,8 +54,8 @@ interface StandardUserInterfaceProps {
   children?: ReactNode;
 }
 
-const StandardUserInterfaceBase: React.FC<StandardUserInterfaceProps> =
-  observer((props) => {
+const StandardUserInterfaceBase: FC<StandardUserInterfaceProps> = observer(
+  (props) => {
     const { t } = useTranslation();
 
     const acceptDragDropFile = action(() => {
@@ -66,7 +66,7 @@ const StandardUserInterfaceBase: React.FC<StandardUserInterfaceProps> =
       }
     });
 
-    const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
       if (!e.dataTransfer.types || !e.dataTransfer.types.includes("Files")) {
         return;
       }
@@ -300,7 +300,8 @@ const StandardUserInterfaceBase: React.FC<StandardUserInterfaceProps> =
         <ClippingBoxToolLauncher viewState={props.viewState} />
       </ContextProviders>
     );
-  });
+  }
+);
 
 export const StandardUserInterface = withFallback(StandardUserInterfaceBase);
 export default withFallback(StandardUserInterfaceBase);

--- a/lib/ReactViews/StandardUserInterface/TrainerBar/TrainerBar.tsx
+++ b/lib/ReactViews/StandardUserInterface/TrainerBar/TrainerBar.tsx
@@ -1,6 +1,6 @@
 import { TFunction } from "i18next";
 import { observer } from "mobx-react";
-import React from "react";
+import { ChangeEvent, Component, Fragment } from "react";
 import { Translation, WithTranslation, withTranslation } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import {
@@ -121,10 +121,10 @@ const renderOrderedStepList = function (
   viewState: ViewState
 ) {
   return steps.map((step: StepItem, index: number) => (
-    <React.Fragment key={index}>
+    <Fragment key={index}>
       {renderStep(step, index + 1, viewState)}
       {index + 1 !== steps.length && <Spacing bottom={3} />}
-    </React.Fragment>
+    </Fragment>
   ));
 };
 
@@ -143,7 +143,7 @@ interface StepAccordionState {
 }
 
 // Originally written as a SFC but measureElement only supports class components at the moment
-class StepAccordionRaw extends React.Component<
+class StepAccordionRaw extends Component<
   StepAccordionProps & MeasureElementProps & WithTranslation & WithViewState,
   StepAccordionState
 > {
@@ -380,7 +380,7 @@ export const TrainerBar = observer((props: TrainerBarProps) => {
                 glyph={GLYPHS.oneTwoThree}
               />
             )}
-            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
               viewState.setCurrentTrainerItemIndex(Number(e.target.value))
             }
             value={viewState.currentTrainerItemIndex}

--- a/lib/ReactViews/StandardUserInterface/customizable/MenuButton.jsx
+++ b/lib/ReactViews/StandardUserInterface/customizable/MenuButton.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import classNames from "classnames";
 import Icon from "../../../Styled/Icon";
 import PropTypes from "prop-types";

--- a/lib/ReactViews/StandardUserInterface/customizable/ResponsiveSwitch.jsx
+++ b/lib/ReactViews/StandardUserInterface/customizable/ResponsiveSwitch.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import PropTypes from "prop-types";
 
 /**

--- a/lib/ReactViews/StandardUserInterface/processCustomElements.jsx
+++ b/lib/ReactViews/StandardUserInterface/processCustomElements.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Children, cloneElement } from "react";
 import {
   Nav,
   Menu,
@@ -29,7 +29,7 @@ const groupElementKeys = Object.keys(GROUP_ELEMENT_TO_KEY_MAPPING);
  *      for "menu", an array for "nav" etc.
  */
 export default function processCustomElements(isSmallScreen, customUI) {
-  const groupElements = React.Children.toArray(customUI);
+  const groupElements = Children.toArray(customUI);
 
   return groupElements.reduce((soFar, groupElement) => {
     const key = findKeyForGroupElement(groupElement);
@@ -65,7 +65,7 @@ function findKeyForGroupElement(groupElement) {
  * @returns {Array<Element>} a collection of processed children.
  */
 function getGroupChildren(isSmallScreen, groupElement) {
-  return React.Children.map(groupElement.props.children, (child) => {
+  return Children.map(groupElement.props.children, (child) => {
     if (typeof child === "string") {
       return <span>{child}</span>;
     } else if (
@@ -73,7 +73,7 @@ function getGroupChildren(isSmallScreen, groupElement) {
       child.type.propTypes &&
       child.type.propTypes.smallScreen
     ) {
-      return React.cloneElement(child, {
+      return cloneElement(child, {
         smallScreen: isSmallScreen
       });
     } else {

--- a/lib/ReactViews/Story/Story.tsx
+++ b/lib/ReactViews/Story/Story.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames";
-import React, {
+import {
+  RefObject,
   MouseEventHandler,
   useEffect,
   useLayoutEffect,
@@ -43,7 +44,7 @@ interface Props {
 }
 
 interface MenuProps extends Props {
-  storyRef: React.RefObject<HTMLElement>;
+  storyRef: RefObject<HTMLElement>;
 }
 
 const findTextContent = (content: any): string => {

--- a/lib/ReactViews/Story/StoryBuilder.tsx
+++ b/lib/ReactViews/Story/StoryBuilder.tsx
@@ -1,6 +1,14 @@
 import { action, toJS, makeObservable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import {
+  RefObject,
+  ComponentPropsWithoutRef,
+  FC,
+  ReactNode,
+  ReactElement,
+  createRef,
+  Component
+} from "react";
 import Sortable from "react-anything-sortable";
 import {
   Trans,
@@ -57,11 +65,11 @@ interface IState {
 }
 
 @observer
-class StoryBuilder extends React.Component<
+class StoryBuilder extends Component<
   IProps & MeasureElementProps & WithTranslation & WithViewState,
   IState
 > {
-  storiesWrapperRef = React.createRef<HTMLElement>();
+  storiesWrapperRef = createRef<HTMLElement>();
 
   refToMeasure: any;
 
@@ -393,7 +401,7 @@ class StoryBuilder extends React.Component<
               scroll
               overflowY={"auto"}
               styledMaxHeight="100%"
-              ref={this.storiesWrapperRef as React.RefObject<HTMLDivElement>}
+              ref={this.storiesWrapperRef as RefObject<HTMLDivElement>}
               css={`
                 margin-right: -10px;
               `}
@@ -509,7 +517,7 @@ class StoryBuilder extends React.Component<
   }
 }
 
-type PanelProps = React.ComponentPropsWithoutRef<typeof Box> & {
+type PanelProps = ComponentPropsWithoutRef<typeof Box> & {
   isVisible?: boolean;
   isHidden?: boolean;
 };
@@ -539,7 +547,7 @@ interface CaptureSceneProps {
   disabled?: boolean;
 }
 
-const CaptureScene: React.FC<CaptureSceneProps> = (props) => {
+const CaptureScene: FC<CaptureSceneProps> = (props) => {
   const { t } = useTranslation();
   return (
     <StoryButton
@@ -554,12 +562,12 @@ const CaptureScene: React.FC<CaptureSceneProps> = (props) => {
   );
 };
 
-type StoryButtonProps = React.ComponentPropsWithoutRef<typeof Button> & {
+type StoryButtonProps = ComponentPropsWithoutRef<typeof Button> & {
   btnText: string;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
-export const StoryButton: React.FC<StoryButtonProps> = (props) => {
+export const StoryButton: FC<StoryButtonProps> = (props) => {
   const { btnText, ...rest } = props;
   return (
     <Button
@@ -577,12 +585,12 @@ export const StoryButton: React.FC<StoryButtonProps> = (props) => {
 
 interface RemoveDialogProps {
   theme: DefaultTheme;
-  text: React.ReactElement;
+  text: ReactElement;
   onConfirm: () => void;
   closeDialog: () => void;
 }
 
-const RemoveDialog: React.FC<RemoveDialogProps> = (props) => {
+const RemoveDialog: FC<RemoveDialogProps> = (props) => {
   const { t } = useTranslation();
   return (
     <Box

--- a/lib/ReactViews/Story/StoryEditor.jsx
+++ b/lib/ReactViews/Story/StoryEditor.jsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import { lazy, Component, Suspense } from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
 import Styles from "./story-editor.scss";
@@ -6,8 +6,8 @@ import { withTranslation } from "react-i18next";
 import tinymce from "tinymce";
 
 // Lazy load the Editor component as the tinyMCE library is large
-const Editor = React.lazy(() => import("../Generic/Editor.jsx"));
-class StoryEditor extends React.Component {
+const Editor = lazy(() => import("../Generic/Editor.jsx"));
+class StoryEditor extends Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryBody.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Story } from "../Story";
 import parseCustomHtmlToReact from "../../Custom/parseCustomHtmlToReact";
 import styled from "styled-components";

--- a/lib/ReactViews/Story/StoryPanel/StoryButtons.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryButtons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import styled, { useTheme } from "styled-components";
 import { RawButton } from "../../../Styled/Button";

--- a/lib/ReactViews/Story/StoryPanel/StoryFooterBar.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryFooterBar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import styled, { useTheme } from "styled-components";
 import { constVoid } from "../../../Core/types";

--- a/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { RefObject, createRef, Component } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import { Swipeable } from "react-swipeable";
 import { DefaultTheme, withTheme } from "styled-components";
@@ -83,9 +83,9 @@ interface State {
 }
 
 @observer
-class StoryPanel extends React.Component<Props, State> {
+class StoryPanel extends Component<Props, State> {
   keydownListener: EventListener | undefined;
-  slideRef: React.RefObject<HTMLElement>;
+  slideRef: RefObject<HTMLElement>;
 
   constructor(props: Props) {
     super(props);
@@ -93,7 +93,7 @@ class StoryPanel extends React.Component<Props, State> {
       isCollapsed: false,
       inView: false
     };
-    this.slideRef = React.createRef();
+    this.slideRef = createRef();
   }
 
   componentDidMount() {
@@ -249,7 +249,7 @@ class StoryPanel extends React.Component<Props, State> {
               [Styles.isMounted]: this.state.inView
             })}
             key={story.id}
-            ref={this.slideRef as React.RefObject<HTMLDivElement>}
+            ref={this.slideRef as RefObject<HTMLDivElement>}
             css={`
               @media (min-width: 992px) {
                 max-width: 60vw;

--- a/lib/ReactViews/Story/StoryPanel/TitleBar.tsx
+++ b/lib/ReactViews/Story/StoryPanel/TitleBar.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import Box from "../../../Styled/Box";

--- a/lib/ReactViews/Tools/ClippingBox/ClippingBoxToolLauncher.tsx
+++ b/lib/ReactViews/Tools/ClippingBox/ClippingBoxToolLauncher.tsx
@@ -1,6 +1,6 @@
 import { action } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect } from "react";
+import { FC, useEffect } from "react";
 import ClippingMixin from "../../../ModelMixins/ClippingMixin";
 import BoxDrawing from "../../../Models/BoxDrawing";
 import Workbench from "../../../Models/Workbench";
@@ -17,42 +17,40 @@ const TOOL_NAME = "reposition-clipping-box";
  * A component that launches the clipping box repositioning tool when it gets
  *  triggerred by the user.
  */
-const ClippingBoxToolLauncher: React.FC<PropsType> = observer(
-  ({ viewState }) => {
-    const item = findItemRequiringRepositioning(viewState.terria.workbench);
-    const cesium = viewState.terria.cesium;
-    useEffect(
-      function init() {
-        if (!item || !cesium) {
-          return;
+const ClippingBoxToolLauncher: FC<PropsType> = observer(({ viewState }) => {
+  const item = findItemRequiringRepositioning(viewState.terria.workbench);
+  const cesium = viewState.terria.cesium;
+  useEffect(
+    function init() {
+      if (!item || !cesium) {
+        return;
+      }
+
+      viewState.openTool({
+        toolName: TOOL_NAME,
+        getToolComponent: () => RepositionClippingBox,
+        params: { viewState, item, cesium },
+        showCloseButton: false
+      });
+
+      return action(function cleanup() {
+        const currentTool = viewState.currentTool;
+        if (
+          currentTool &&
+          currentTool.toolName === TOOL_NAME &&
+          currentTool.params?.item === item
+        ) {
+          item.repositionClippingBoxTrigger = false;
+          viewState.closeTool();
         }
+      });
+    },
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    [item, cesium]
+  );
 
-        viewState.openTool({
-          toolName: TOOL_NAME,
-          getToolComponent: () => RepositionClippingBox,
-          params: { viewState, item, cesium },
-          showCloseButton: false
-        });
-
-        return action(function cleanup() {
-          const currentTool = viewState.currentTool;
-          if (
-            currentTool &&
-            currentTool.toolName === TOOL_NAME &&
-            currentTool.params?.item === item
-          ) {
-            item.repositionClippingBoxTrigger = false;
-            viewState.closeTool();
-          }
-        });
-      },
-      /* eslint-disable-next-line react-hooks/exhaustive-deps */
-      [item, cesium]
-    );
-
-    return null;
-  }
-);
+  return null;
+});
 
 /**
  * Find a workbench item that requires clipping box respositioning

--- a/lib/ReactViews/Tools/DiffTool/DatePicker.tsx
+++ b/lib/ReactViews/Tools/DiffTool/DatePicker.tsx
@@ -1,19 +1,19 @@
-import { action, computed, observable, makeObservable } from "mobx";
+import dateFormat from "dateformat";
+import { action, computed, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import styled from "styled-components";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import DiffableMixin from "../../../ModelMixins/DiffableMixin";
 import CommonStrata from "../../../Models/Definition/CommonStrata";
-import { formatDateTime } from "../../BottomDock/Timeline/DateFormats";
-import Icon, { StyledIcon } from "../../../Styled/Icon";
-import DateTimePicker from "../../BottomDock/Timeline/DateTimePicker";
-import Text, { TextSpan } from "../../../Styled/Text";
 import Box from "../../../Styled/Box";
 import Button from "../../../Styled/Button";
+import Icon, { StyledIcon } from "../../../Styled/Icon";
 import Spacing from "../../../Styled/Spacing";
-import dateFormat from "dateformat";
+import Text, { TextSpan } from "../../../Styled/Text";
+import { formatDateTime } from "../../BottomDock/Timeline/DateFormats";
+import DateTimePicker from "../../BottomDock/Timeline/DateTimePicker";
 
 interface PropsType extends WithTranslation {
   heading: string;
@@ -23,7 +23,7 @@ interface PropsType extends WithTranslation {
 }
 
 @observer
-class DatePicker extends React.Component<PropsType> {
+class DatePicker extends Component<PropsType> {
   @observable private isOpen = false;
 
   constructor(props: PropsType) {

--- a/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
+++ b/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
@@ -10,7 +10,14 @@ import {
 } from "mobx";
 import { observer } from "mobx-react";
 import { IDisposer } from "mobx-utils";
-import React, { useState } from "react";
+import {
+  RefObject,
+  ChangeEvent,
+  FC,
+  Component,
+  createRef,
+  useState
+} from "react";
 import ReactDOM from "react-dom";
 import { WithTranslation, withTranslation } from "react-i18next";
 import styled, { DefaultTheme, useTheme, withTheme } from "styled-components";
@@ -64,7 +71,7 @@ interface PropsType extends WithTranslation {
 }
 
 @observer
-class DiffTool extends React.Component<PropsType> {
+class DiffTool extends Component<PropsType> {
   static readonly toolName = "Image Difference";
 
   @observable private leftItem?: DiffableItem;
@@ -191,15 +198,13 @@ interface MainPropsType extends PropsType {
 }
 
 @observer
-class Main extends React.Component<MainPropsType> {
+class Main extends Component<MainPropsType> {
   @observable private location?: LatLonHeight;
   @observable private _locationPickError = false;
   @observable private _isPickingNewLocation = false;
 
-  private openLeftDatePickerButton: React.RefObject<HTMLButtonElement> =
-    React.createRef();
-  private openRightDatePickerButton: React.RefObject<HTMLButtonElement> =
-    React.createRef();
+  private openLeftDatePickerButton: RefObject<HTMLButtonElement> = createRef();
+  private openRightDatePickerButton: RefObject<HTMLButtonElement> = createRef();
 
   constructor(props: MainPropsType) {
     super(props);
@@ -329,7 +334,7 @@ class Main extends React.Component<MainPropsType> {
   }
 
   @action.bound
-  changeSourceItem(e: React.ChangeEvent<HTMLSelectElement>) {
+  changeSourceItem(e: ChangeEvent<HTMLSelectElement>) {
     const newSourceItem = this.diffableItemsInWorkbench.find(
       (item) => item.uniqueId === e.target.value
     );
@@ -337,7 +342,7 @@ class Main extends React.Component<MainPropsType> {
   }
 
   @action.bound
-  changePreviewStyle(e: React.ChangeEvent<HTMLSelectElement>) {
+  changePreviewStyle(e: ChangeEvent<HTMLSelectElement>) {
     const styleId = e.target.value;
     this.props.leftItem.styleSelectableDimensions?.[0]?.setDimensionValue(
       CommonStrata.user,
@@ -350,7 +355,7 @@ class Main extends React.Component<MainPropsType> {
   }
 
   @action.bound
-  changeDiffStyle(e: React.ChangeEvent<HTMLSelectElement>) {
+  changeDiffStyle(e: ChangeEvent<HTMLSelectElement>) {
     this.diffItem.setTrait(CommonStrata.user, "diffStyleId", e.target.value);
   }
 
@@ -774,7 +779,7 @@ const DiffAccordionToggle = styled(Box)`
   ${({ theme }) => theme.borderRadiusTop(theme.radius40Button)}
 `;
 
-const DiffAccordion: React.FC<DiffAccordionProps> = (props) => {
+const DiffAccordion: FC<DiffAccordionProps> = (props) => {
   const [showChildren, setShowChildren] = useState(true);
   const { t, viewState } = props;
   const theme = useTheme();

--- a/lib/ReactViews/Tools/ItemSearchTool/BackButton.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/BackButton.tsx
@@ -1,14 +1,11 @@
-import React from "react";
+import { FC } from "react";
 import { useTheme } from "styled-components";
 import { BoxSpan } from "../../../Styled/Box";
 import Button from "../../../Styled/Button";
 import { TextSpan } from "../../../Styled/Text";
 import { GLYPHS, StyledIcon } from "../../../Styled/Icon";
 
-const BackButton: React.FC<{ onClick: () => void }> = ({
-  children,
-  onClick
-}) => {
+const BackButton: FC<{ onClick: () => void }> = ({ children, onClick }) => {
   const theme = useTheme();
   return (
     <Button

--- a/lib/ReactViews/Tools/ItemSearchTool/ErrorComponent.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/ErrorComponent.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import { FC } from "react";
 
 import Text from "../../../Styled/Text";
 
-const ErrorComponent: React.FC = ({ children }) => {
+const ErrorComponent: FC = ({ children }) => {
   return (
     <Text large textLight>
       {children}

--- a/lib/ReactViews/Tools/ItemSearchTool/ItemSearchTool.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/ItemSearchTool.tsx
@@ -1,6 +1,6 @@
 import { autorun } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import CatalogMemberMixin from "../../../ModelMixins/CatalogMemberMixin";
 import SearchableItemMixin from "../../../ModelMixins/SearchableItemMixin";
@@ -38,7 +38,7 @@ export type ItemSearchQuery = Record<
 export type ItemSearchResults = ItemSearchResult[];
 export type ActiveSelectionDisposer = () => void | undefined;
 
-const ItemSearchTool: React.FC<PropsType> = observer((props) => {
+const ItemSearchTool: FC<PropsType> = observer((props) => {
   const { viewState, item, itemSearchProvider, t } = props;
   const itemName = CatalogMemberMixin.isMixedInto(item) ? item.name : "Item";
 

--- a/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/LazyItemSearchTool.tsx
@@ -1,5 +1,5 @@
 import i18next from "i18next";
-import React, { Suspense } from "react";
+import { FC, lazy, Suspense } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import CatalogMemberMixin from "../../../ModelMixins/CatalogMemberMixin";
@@ -8,12 +8,12 @@ import RaiseToUserErrorBoundary from "../../Errors/RaiseToUserErrorBoundary";
 import { Frame, Main } from "../ToolModal";
 import { PropsType } from "./ItemSearchTool";
 
-const ItemSearchTool = React.lazy(() => import("./ItemSearchTool"));
+const ItemSearchTool = lazy(() => import("./ItemSearchTool"));
 
 /**
  * Lazily loads the item search tool while showing a the search window and an animated spinner.
  */
-const LazyItemSearchTool: React.FC<PropsType> = (props) => {
+const LazyItemSearchTool: FC<PropsType> = (props) => {
   const { viewState, item } = props;
   const itemName = CatalogMemberMixin.isMixedInto(item) ? item.name : "Item";
   const [t] = useTranslation();

--- a/lib/ReactViews/Tools/ItemSearchTool/MapEffects.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/MapEffects.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { FC, useEffect } from "react";
 import SearchableItemMixin from "../../../ModelMixins/SearchableItemMixin";
 import { ItemSearchResult } from "../../../Models/ItemSearchProviders/ItemSearchProvider";
 
@@ -18,7 +18,7 @@ export type MapEffectsProps = {
  * A component that applies some effect on the map.
  *
  */
-const MapEffects: React.FC<MapEffectsProps> = ({ item, results, effect }) => {
+const MapEffects: FC<MapEffectsProps> = ({ item, results, effect }) => {
   switch (effect.is) {
     case "highlightAll":
       return <HighlightResults item={item} results={results} />;
@@ -38,7 +38,7 @@ export type HideAllResultsProps = {
   results: ItemSearchResult[];
 };
 
-export const HideAllResults: React.FC<HideAllResultsProps> = (props) => {
+export const HideAllResults: FC<HideAllResultsProps> = (props) => {
   const { item, results } = props;
   useEffect(() => {
     const disposer = item.hideFeaturesNotInItemSearchResults(results);
@@ -52,7 +52,7 @@ export type HighlightResultsProps = {
   results: ItemSearchResult | ItemSearchResult[];
 };
 
-export const HighlightResults: React.FC<HighlightResultsProps> = (props) => {
+export const HighlightResults: FC<HighlightResultsProps> = (props) => {
   useEffect(() => {
     const item = props.item;
     const results = Array.isArray(props.results)

--- a/lib/ReactViews/Tools/ItemSearchTool/SearchForm.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/SearchForm.tsx
@@ -1,6 +1,6 @@
 import { WithT } from "i18next";
 import isEmpty from "lodash-es/isEmpty";
-import React, { useEffect, useState } from "react";
+import { FC, FormEvent, ChangeEvent, useEffect, useState } from "react";
 import {
   useTranslation,
   WithTranslation,
@@ -42,7 +42,7 @@ type State =
   | { is: "error"; error: Error }
   | { is: "results"; results: ItemSearchResult[] };
 
-const SearchForm: React.FC<SearchFormProps> = (props) => {
+const SearchForm: FC<SearchFormProps> = (props) => {
   const { parameters, itemSearchProvider } = props;
   const [t] = useTranslation();
   const [state, setState] = useState<State>({ is: "initial" });
@@ -84,7 +84,7 @@ const SearchForm: React.FC<SearchFormProps> = (props) => {
       });
   }
 
-  const onSubmit = (e: React.FormEvent) => {
+  const onSubmit = (e: FormEvent) => {
     try {
       search();
     } finally {
@@ -136,7 +136,7 @@ interface ParameterProps extends WithT {
   disabled: boolean;
 }
 
-const Parameter: React.FC<ParameterProps> = (props) => {
+const Parameter: FC<ParameterProps> = (props) => {
   const { parameter } = props;
   switch (parameter.type) {
     case "numeric":
@@ -154,12 +154,12 @@ interface NumericParameterProps extends WithT {
   value?: { start: number; end: number };
 }
 
-export const NumericParameter: React.FC<NumericParameterProps> = (props) => {
+export const NumericParameter: FC<NumericParameterProps> = (props) => {
   const { parameter, value, t } = props;
   const { min, max } = parameter.range;
 
   const onChange =
-    (tag: "start" | "end") => (e: React.ChangeEvent<HTMLInputElement>) => {
+    (tag: "start" | "end") => (e: ChangeEvent<HTMLInputElement>) => {
       const parsed = parseFloat(e.target.value);
       const newValue: any = { ...props.value };
       if (isNaN(parsed)) delete newValue[tag];
@@ -225,7 +225,7 @@ type SelectOnChangeHandler<
   actionMeta: ActionMeta<OptionType>
 ) => void;
 
-const EnumParameter: React.FC<EnumParameterProps> = (props) => {
+const EnumParameter: FC<EnumParameterProps> = (props) => {
   const { parameter, disabled } = props;
   const options = parameter.values.map(({ id }) => ({
     value: id,
@@ -266,7 +266,7 @@ interface TextParameterProps {
   onChange: (value: string | undefined) => void;
 }
 
-const TextParameter: React.FC<TextParameterProps> = (props) => {
+const TextParameter: FC<TextParameterProps> = (props) => {
   const { parameter, value, onChange } = props;
   return (
     <Box column>

--- a/lib/ReactViews/Tools/ItemSearchTool/SearchResults.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { observer } from "mobx-react";
 import Mustache from "mustache";
-import React, { useRef, useState } from "react";
+import { FC, MouseEventHandler, useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useVirtual } from "react-virtual";
 import styled from "styled-components";
@@ -19,7 +19,7 @@ export interface SearchResultsProps {
 
 type ResultClickHandler = (result: ItemSearchResult) => void;
 
-const SearchResults: React.FC<SearchResultsProps> = (props) => {
+const SearchResults: FC<SearchResultsProps> = (props) => {
   const { item, results } = props;
   const [currentMapEffect, setCurrentMapEffect] = useState<MapEffect>({
     is: "highlightAll"
@@ -32,7 +32,7 @@ const SearchResults: React.FC<SearchResultsProps> = (props) => {
   const list = useVirtual({
     size: results.length,
     parentRef,
-    estimateSize: React.useCallback(() => 50, [])
+    estimateSize: useCallback(() => 50, [])
   });
   const [t] = useTranslation();
 
@@ -101,12 +101,12 @@ type ResultProps = {
   style: any;
 };
 
-export const Result: React.FC<ResultProps> = observer((props) => {
+export const Result: FC<ResultProps> = observer((props) => {
   const { result, template, isEven, isSelected, style } = props;
   const content = template
     ? parseCustomMarkdownToReact(Mustache.render(template, result.properties))
     : result.id;
-  const onClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
+  const onClick: MouseEventHandler<HTMLAnchorElement> = (e) => {
     try {
       props.onClick(result);
     } finally {
@@ -161,7 +161,7 @@ const Wrapper = styled(Box).attrs({ column: true, flex: 1 })`
   }
 `;
 
-export const ResultsCount: React.FC<{ count: number }> = ({ count }) => {
+export const ResultsCount: FC<{ count: number }> = ({ count }) => {
   const [t] = useTranslation();
   return (
     <Box

--- a/lib/ReactViews/Tools/PedestrianMode/DropPedestrianToGround.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/DropPedestrianToGround.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
@@ -19,9 +19,7 @@ type DropPedestrianToGroundProps = {
   afterDrop: () => void;
 };
 
-const DropPedestrianToGround: React.FC<DropPedestrianToGroundProps> = (
-  props
-) => {
+const DropPedestrianToGround: FC<DropPedestrianToGroundProps> = (props) => {
   const cesium = props.cesium;
   const scene = cesium.scene;
   const eventHandler = new ScreenSpaceEventHandler(scene.canvas);

--- a/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
@@ -1,5 +1,5 @@
 import { action, autorun, computed } from "mobx";
-import React, { useEffect, useRef, useState } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
@@ -27,7 +27,7 @@ export type MiniMapView = {
   rotation: number;
 };
 
-const MiniMap: React.FC<MiniMapProps> = (props) => {
+const MiniMap: FC<MiniMapProps> = (props) => {
   const { terria, baseMap, view } = props;
   const container = useRef<HTMLDivElement>(null);
   const [miniMapViewer, setMiniMapViewer] = useState<

--- a/lib/ReactViews/Tools/PedestrianMode/MouseTooltip.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MouseTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import { FC, useEffect, useRef } from "react";
 import styled from "styled-components";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Scene from "terriajs-cesium/Source/Scene/Scene";
@@ -9,7 +9,7 @@ type MouseTooltipProps = {
   text: string;
 };
 
-const MouseTooltip: React.FC<MouseTooltipProps> = (props) => {
+const MouseTooltip: FC<MouseTooltipProps> = (props) => {
   const { scene, text } = props;
   const tooltipText = useRef<typeof TooltipText>(null);
 

--- a/lib/ReactViews/Tools/PedestrianMode/MovementControls.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MovementControls.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import Cesium from "../../../Models/Cesium";
@@ -20,7 +20,7 @@ type MovementControlsProps = {
   maxVerticalLookAngle: number;
 };
 
-const MovementControls: React.FC<MovementControlsProps> = (props) => {
+const MovementControls: FC<MovementControlsProps> = (props) => {
   const [isMaximized, setIsMaximized] = useState(true);
   const [t] = useTranslation();
 

--- a/lib/ReactViews/Tools/PedestrianMode/PedestrianMode.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/PedestrianMode.tsx
@@ -1,6 +1,6 @@
 import { reaction } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import styled from "styled-components";
 import Cesium from "../../../Models/Cesium";
 import ViewState from "../../../ReactViewModels/ViewState";
@@ -21,7 +21,7 @@ type PedestrianModeProps = {
 };
 export const PEDESTRIAN_MODE_ID = "pedestrian-mode";
 
-const PedestrianMode: React.FC<PedestrianModeProps> = observer((props) => {
+const PedestrianMode: FC<PedestrianModeProps> = observer((props) => {
   const { viewState } = props;
 
   const cesium = viewState.terria.currentViewer;

--- a/lib/ReactViews/Tools/Tool.tsx
+++ b/lib/ReactViews/Tools/Tool.tsx
@@ -1,6 +1,14 @@
 import i18next, { WithT } from "i18next";
 import { computed, makeObservable } from "mobx";
-import React, { Suspense, useEffect, useState } from "react";
+import {
+  ComponentType,
+  FC,
+  lazy,
+  Component,
+  Suspense,
+  useEffect,
+  useState
+} from "react";
 import { useTranslation } from "react-i18next";
 import TerriaError from "../../Core/TerriaError";
 import {
@@ -15,7 +23,7 @@ import { useViewState } from "../Context";
 
 interface ToolProps {
   toolName: string;
-  getToolComponent: () => React.ComponentType | Promise<React.ComponentType>;
+  getToolComponent: () => ComponentType | Promise<ComponentType>;
   params?: any;
 }
 
@@ -27,7 +35,7 @@ interface ToolProps {
  * module that exports a default React Component. The promise is useful for
  * lazy-loading the tool.
  */
-const Tool: React.FC<ToolProps> = (props) => {
+const Tool: FC<ToolProps> = (props) => {
   const { getToolComponent, params, toolName } = props;
   const viewState = useViewState();
   const [t] = useTranslation();
@@ -37,7 +45,7 @@ const Tool: React.FC<ToolProps> = (props) => {
   const [toolAndProps, setToolAndProps] = useState<any>(undefined);
   useEffect(() => {
     setToolAndProps([
-      React.lazy(() =>
+      lazy(() =>
         Promise.resolve(getToolComponent()).then((c) => ({ default: c }))
       ),
       params
@@ -125,7 +133,7 @@ interface ToolErrorBoundaryProps extends WithT {
   children: any;
 }
 
-class ToolErrorBoundary extends React.Component<
+class ToolErrorBoundary extends Component<
   ToolErrorBoundaryProps,
   { hasError: boolean }
 > {

--- a/lib/ReactViews/Tools/ToolModal.tsx
+++ b/lib/ReactViews/Tools/ToolModal.tsx
@@ -1,6 +1,6 @@
 import { TFunction } from "i18next";
 import { observer } from "mobx-react";
-import React, { useState } from "react";
+import { FC, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled, { useTheme } from "styled-components";
 import ViewState from "../../ReactViewModels/ViewState";
@@ -15,7 +15,7 @@ export interface FrameProps {
   viewState: ViewState;
 }
 
-export const Frame: React.FC<FrameProps> = observer((props) => {
+export const Frame: FC<FrameProps> = observer((props) => {
   const theme = useTheme();
   const [t] = useTranslation();
   const [showChildren, setShowChildren] = useState(true);
@@ -92,7 +92,7 @@ interface ToolCloseButtonProps {
   t: TFunction;
 }
 
-const ToolCloseButton: React.FC<ToolCloseButtonProps> = (props) => {
+const ToolCloseButton: FC<ToolCloseButtonProps> = (props) => {
   return (
     <RawButton onClick={() => props.viewState.closeTool()}>
       <Text textLight small semiBold uppercase>
@@ -107,7 +107,7 @@ interface TitleProps {
   icon?: { id: string };
 }
 
-const Title: React.FC<TitleProps> = (props) => {
+const Title: FC<TitleProps> = (props) => {
   return (
     <Box centered>
       <Box>

--- a/lib/ReactViews/Tour/TourOverlay.jsx
+++ b/lib/ReactViews/Tour/TourOverlay.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-import React from "react";
 import PropTypes from "prop-types";
 import Styles from "../HelpScreens/obscure-overlay.scss";
 import classNames from "classnames";

--- a/lib/ReactViews/Tour/TourPortal.jsx
+++ b/lib/ReactViews/Tour/TourPortal.jsx
@@ -12,7 +12,7 @@
 import { autorun } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useTheme, withTheme } from "styled-components";
 import Box from "../../Styled/Box";

--- a/lib/ReactViews/Transitions/FadeIn/FadeIn.jsx
+++ b/lib/ReactViews/Transitions/FadeIn/FadeIn.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 
 import { CSSTransition } from "react-transition-group";

--- a/lib/ReactViews/Transitions/SlideUpFadeIn/SlideUpFadeIn.jsx
+++ b/lib/ReactViews/Transitions/SlideUpFadeIn/SlideUpFadeIn.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 
 import { CSSTransition } from "react-transition-group";

--- a/lib/ReactViews/WelcomeMessage/WelcomeMessage.jsx
+++ b/lib/ReactViews/WelcomeMessage/WelcomeMessage.jsx
@@ -1,7 +1,7 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
-import React, { useState } from "react";
+import { Component, useState } from "react";
 import { Trans, useTranslation, withTranslation } from "react-i18next";
 import styled, { withTheme } from "styled-components";
 import Box from "../../Styled/Box";
@@ -51,7 +51,7 @@ WelcomeMessageButton.propTypes = {
 };
 
 @observer
-class WelcomeMessage extends React.Component {
+class WelcomeMessage extends Component {
   static displayName = "WelcomeMessage";
 
   static propTypes = {

--- a/lib/ReactViews/Workbench/Controls/ChartItemSelector.tsx
+++ b/lib/ReactViews/Workbench/Controls/ChartItemSelector.tsx
@@ -1,6 +1,6 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 import ChartView from "../../../Charts/ChartView";
@@ -21,7 +21,7 @@ interface IChartItemSelector {
   item: BaseModel;
 }
 
-export const ChartItem: React.FC<IChartItem> = observer(
+export const ChartItem: FC<IChartItem> = observer(
   ({ chartItem }: IChartItem) => {
     const { t } = useTranslation();
     const lineColor = chartItem.isSelectedInWorkbench
@@ -58,7 +58,7 @@ export const ChartItem: React.FC<IChartItem> = observer(
   }
 );
 
-const ChartItemSelector: React.FC<IChartItemSelector> = observer(
+const ChartItemSelector: FC<IChartItemSelector> = observer(
   ({ item }: IChartItemSelector) => {
     const theme = useTheme();
     const chartView = new ChartView(item.terria);

--- a/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import createReactClass from "create-react-class";
 import PropTypes from "prop-types";
 import isDefined from "../../../Core/isDefined";

--- a/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.tsx
@@ -2,7 +2,7 @@ import dateFormat from "dateformat";
 import { TFunction } from "i18next";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import styled from "styled-components";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
@@ -27,7 +27,7 @@ interface IProps extends WithTranslation {
 }
 
 @observer
-class DateTimeSelectorSection extends React.Component<IProps, IState> {
+class DateTimeSelectorSection extends Component<IProps, IState> {
   state: IState = {
     isOpen: false
   };

--- a/lib/ReactViews/Workbench/Controls/DisplayAsPercentSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/DisplayAsPercentSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import Checkbox from "./../../../Styled/Checkbox/Checkbox";
 import { useTheme } from "styled-components";
@@ -9,7 +9,7 @@ interface IDisplayAsPercentSection {
   item: any;
 }
 
-const DisplayAsPercentSection: React.FC<IDisplayAsPercentSection> = (
+const DisplayAsPercentSection: FC<IDisplayAsPercentSection> = (
   props: IDisplayAsPercentSection
 ) => {
   const { t } = useTranslation();

--- a/lib/ReactViews/Workbench/Controls/FilterSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/FilterSection.jsx
@@ -2,12 +2,12 @@ import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import PropTypes from "prop-types";
 import { Range } from "rc-slider";
-import React from "react";
+import { Component } from "react";
 import CommonStrata from "../../../Models/Definition/CommonStrata";
 import Styles from "./filter-section.scss";
 
 @observer
-class FilterSection extends React.Component {
+class FilterSection extends Component {
   static propTypes = {
     item: PropTypes.object.isRequired
   };

--- a/lib/ReactViews/Workbench/Controls/GeneratedControlSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/GeneratedControlSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import { BaseModel } from "../../../Models/Definition/Model";
 import {
   filterSelectableDimensions,
@@ -14,7 +14,7 @@ export interface GeneratedControlSectionProps {
   placement: Placement;
 }
 
-const GeneratedControlSection: React.FC<GeneratedControlSectionProps> = ({
+const GeneratedControlSection: FC<GeneratedControlSectionProps> = ({
   item,
   controls,
   placement

--- a/lib/ReactViews/Workbench/Controls/LeftRightSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/LeftRightSection.tsx
@@ -1,6 +1,6 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import { useTranslation, withTranslation } from "react-i18next";
 import styled from "styled-components";
 import defined from "terriajs-cesium/Source/Core/defined";
@@ -39,7 +39,7 @@ interface ILeftRightSection {
   item: Model<SplitterTraits>;
 }
 
-const LeftRightSection: React.FC<ILeftRightSection> = observer(
+const LeftRightSection: FC<ILeftRightSection> = observer(
   ({ item }: ILeftRightSection) => {
     const goLeft = () => {
       runInAction(() => {

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.tsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.tsx
@@ -4,7 +4,7 @@ import { TFunction } from "i18next";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import Slider from "rc-slider";
-import React from "react";
+import { Component } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import styled from "styled-components";
 import CommonStrata from "../../../Models/Definition/CommonStrata";
@@ -21,7 +21,7 @@ interface OpacitySectionProps extends WithTranslation {
 }
 
 @observer
-class OpacitySection extends React.Component<OpacitySectionProps> {
+class OpacitySection extends Component<OpacitySectionProps> {
   constructor(props: OpacitySectionProps) {
     super(props);
     this.changeOpacity = this.changeOpacity.bind(this);

--- a/lib/ReactViews/Workbench/Controls/SatelliteImageryTimeFilterSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/SatelliteImageryTimeFilterSection.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import { Component } from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
@@ -13,7 +13,7 @@ import { runInAction, reaction } from "mobx";
 import Styles from "./satellite-imagery-time-filter-section.scss";
 
 @observer
-class SatelliteImageryTimeFilterSection extends React.Component {
+class SatelliteImageryTimeFilterSection extends Component {
   static propTypes = {
     item: PropTypes.object,
     t: PropTypes.func.isRequired

--- a/lib/ReactViews/Workbench/Controls/ScaleWorkbenchInfo.tsx
+++ b/lib/ReactViews/Workbench/Controls/ScaleWorkbenchInfo.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import { BaseModel } from "../../../Models/Definition/Model";
 import Text from "../../../Styled/Text";
 import { applyTranslationIfExists } from "../../../Language/languageHelpers";
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 interface IScaleWorkbenchInfoProps {
   item: BaseModel;
 }
-export const ScaleWorkbenchInfo: React.FC<IScaleWorkbenchInfoProps> = observer(
+export const ScaleWorkbenchInfo: FC<IScaleWorkbenchInfoProps> = observer(
   ({ item }: IScaleWorkbenchInfoProps) => {
     const { i18n } = useTranslation();
     if (!MinMaxLevelMixin.isMixedInto(item) || !item.scaleWorkbenchInfo) {

--- a/lib/ReactViews/Workbench/Controls/SelectableDimensionSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/SelectableDimensionSection.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
 import isDefined from "../../../Core/isDefined";
 import { BaseModel } from "../../../Models/Definition/Model";
@@ -17,7 +17,7 @@ interface PropsType extends WithTranslation {
 }
 
 @observer
-class SelectableDimensionSection extends React.Component<PropsType> {
+class SelectableDimensionSection extends Component<PropsType> {
   render() {
     const item = this.props.item;
     if (!SelectableDimensions.is(item)) {

--- a/lib/ReactViews/Workbench/Controls/TimerSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/TimerSection.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Component } from "react";
 import PropTypes from "prop-types";
 import { observer } from "mobx-react";
 import defined from "terriajs-cesium/Source/Core/defined";
@@ -8,7 +8,7 @@ import { withTranslation } from "react-i18next";
 import Styles from "./timer-section.scss";
 
 @observer
-class TimerSection extends React.Component {
+class TimerSection extends Component {
   static propTypes = {
     item: PropTypes.object.isRequired,
     t: PropTypes.func.isRequired
@@ -23,10 +23,11 @@ class TimerSection extends React.Component {
 
   isEnabled() {
     return (
+      // only show refresh timer for refresh intervals less than 30 minutes
       defined(this.props.item) &&
       this.props.item.isPolling &&
       defined(this.props.item.nextScheduledUpdateTime) &&
-      this.props.item.refreshInterval < 30 * 60 * 1000 // only show refresh timer for refresh intervals less than 30 minutes
+      this.props.item.refreshInterval < 30 * 60 * 1000
     );
   }
 

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.tsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.tsx
@@ -1,7 +1,7 @@
 import { sortBy, uniqBy } from "lodash";
 import { action, computed, runInAction, makeObservable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { withTranslation, WithTranslation } from "react-i18next";
 import styled from "styled-components";
 import createGuid from "terriajs-cesium/Source/Core/createGuid";
@@ -94,7 +94,7 @@ interface PropsType extends WithTranslation {
 }
 
 @observer
-class ViewingControls extends React.Component<
+class ViewingControls extends Component<
   PropsType,
   { isMapZoomingToCatalogItem: boolean }
 > {

--- a/lib/ReactViews/Workbench/Controls/WorkbenchItemControls.tsx
+++ b/lib/ReactViews/Workbench/Controls/WorkbenchItemControls.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import TerriaError from "../../../Core/TerriaError";
 import { Complete } from "../../../Core/TypeModifiers";
 import DiscretelyTimeVaryingMixin from "../../../ModelMixins/DiscretelyTimeVaryingMixin";
@@ -81,7 +81,7 @@ export const hideAllControls: Complete<WorkbenchControls> = {
   legend: false
 };
 
-const WorkbenchItemControls: React.FC<WorkbenchItemControlsProps> = observer(
+const WorkbenchItemControls: FC<WorkbenchItemControlsProps> = observer(
   ({ item, viewState, controls: controlsWithoutDefaults }) => {
     // Apply controls from props on top of defaultControls
     const controls = { ...defaultControls, ...controlsWithoutDefaults };

--- a/lib/ReactViews/Workbench/PositionRightOfWorkbench.tsx
+++ b/lib/ReactViews/Workbench/PositionRightOfWorkbench.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import styled from "styled-components";
 import ViewState from "../../ReactViewModels/ViewState";
 
@@ -21,8 +21,8 @@ type PositionRightOfWorkbenchProps = {
  *    `;
  *
  */
-const PositionRightOfWorkbench: React.FC<PositionRightOfWorkbenchProps> =
-  observer((props) => {
+const PositionRightOfWorkbench: FC<PositionRightOfWorkbenchProps> = observer(
+  (props) => {
     return (
       <Container
         className={props.className}
@@ -31,7 +31,8 @@ const PositionRightOfWorkbench: React.FC<PositionRightOfWorkbenchProps> =
         {props.children}
       </Container>
     );
-  });
+  }
+);
 
 const Container = styled.div<{ isMapFullScreen: boolean }>`
   position: absolute;

--- a/lib/ReactViews/Workbench/TerrainSide.tsx
+++ b/lib/ReactViews/Workbench/TerrainSide.tsx
@@ -1,6 +1,6 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
@@ -25,7 +25,7 @@ interface ITerrainSideProps {
   activeColor: string;
 }
 
-const TerrainSide: React.FC<ITerrainSideProps> = observer(
+const TerrainSide: FC<ITerrainSideProps> = observer(
   (props: ITerrainSideProps) => {
     const { t } = useTranslation();
     const theme = useTheme();

--- a/lib/ReactViews/Workbench/Workbench.tsx
+++ b/lib/ReactViews/Workbench/Workbench.tsx
@@ -1,7 +1,7 @@
 import { TFunction } from "i18next";
 import { action, runInAction, makeObservable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { withTranslation, WithTranslation } from "react-i18next";
 import getPath from "../../Core/getPath";
 import Terria from "../../Models/Terria";
@@ -24,7 +24,7 @@ interface IProps extends WithTranslation {
 }
 
 @observer
-class Workbench extends React.Component<IProps> {
+class Workbench extends Component<IProps> {
   constructor(props: IProps) {
     super(props);
     makeObservable(this);

--- a/lib/ReactViews/Workbench/WorkbenchButton.tsx
+++ b/lib/ReactViews/Workbench/WorkbenchButton.tsx
@@ -1,5 +1,5 @@
 "use strict";
-import React from "react";
+import { FC } from "react";
 import styled from "styled-components";
 import Box from "../../Styled/Box";
 import { SpacingSpan } from "../../Styled/Spacing";
@@ -88,7 +88,7 @@ interface IProps {
   onClick?: (e?: any) => void;
 }
 
-const WorkbenchButton: React.FC<IProps> = (props: IProps) => {
+const WorkbenchButton: FC<IProps> = (props: IProps) => {
   const { children, title, primary, inverted, disabled, iconOnly } = props;
 
   return (

--- a/lib/ReactViews/Workbench/WorkbenchItem.tsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.tsx
@@ -1,7 +1,7 @@
 import { TFunction } from "i18next";
 import { action, computed, makeObservable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import { sortable } from "react-anything-sortable";
 import { WithTranslation, withTranslation } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
@@ -38,7 +38,7 @@ interface IProps extends WithTranslation {
 }
 
 @observer
-class WorkbenchItemRaw extends React.Component<IProps> {
+class WorkbenchItemRaw extends Component<IProps> {
   static displayName = "WorkbenchItem";
   constructor(props: IProps) {
     super(props);

--- a/lib/ReactViews/Workbench/WorkbenchList.tsx
+++ b/lib/ReactViews/Workbench/WorkbenchList.tsx
@@ -1,7 +1,7 @@
 import "!!style-loader!css-loader?sourceMap!./sortable.css";
 import { action, makeObservable } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { Component } from "react";
 import Sortable from "react-anything-sortable";
 import styled from "styled-components";
 import Terria from "../../Models/Terria";
@@ -25,7 +25,7 @@ interface IProps {
 }
 
 @observer
-class WorkbenchList extends React.Component<IProps> {
+class WorkbenchList extends Component<IProps> {
   constructor(props: IProps) {
     super(props);
     makeObservable(this);

--- a/lib/ReactViews/Workbench/WorkbenchSplitScreen.tsx
+++ b/lib/ReactViews/Workbench/WorkbenchSplitScreen.tsx
@@ -2,7 +2,7 @@
 // import styled from "styled-components";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 import Terria from "../../Models/Terria";
@@ -16,7 +16,7 @@ import TerrainSide from "./TerrainSide";
 interface IWorkbenchSplitScreenProps {
   terria: Terria;
 }
-const WorkbenchSplitScreen: React.FC<IWorkbenchSplitScreenProps> = observer(
+const WorkbenchSplitScreen: FC<IWorkbenchSplitScreenProps> = observer(
   (props: IWorkbenchSplitScreenProps) => {
     const { t } = useTranslation();
     const theme = useTheme();

--- a/lib/ReactViews/Workflow/Panel.tsx
+++ b/lib/ReactViews/Workflow/Panel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { ReactNode, FC, useEffect, useState } from "react";
 import styled from "styled-components";
 import isDefined from "../../Core/isDefined";
 import { IButtonProps, RawButton } from "../../Styled/Button";
@@ -9,8 +9,8 @@ import { CollapseIcon } from "../Custom/Collapsible/Collapsible";
 export type PanelProps = {
   title?: string;
   icon?: IconProps["glyph"];
-  menuComponent?: React.ReactNode;
-  children?: React.ReactNode;
+  menuComponent?: ReactNode;
+  children?: ReactNode;
   className?: string;
   /** Collapsible will replace menuComponent. Title must be defined */
   collapsible?: boolean;
@@ -24,7 +24,7 @@ export type PanelProps = {
 /**
  * A generic panel component for left, right, context items etc.
  */
-export const Panel: React.FC<PanelProps> = (props) => {
+export const Panel: FC<PanelProps> = (props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   useEffect(() => {
     isDefined(props.isOpen) ? setIsOpen(props.isOpen) : null;
@@ -66,7 +66,7 @@ export const Panel: React.FC<PanelProps> = (props) => {
 };
 
 /** Simple PanelButton - this mimics style of CollapsibleTitleBar */
-export const PanelButton: React.FC<{ onClick: () => void; title: string }> = ({
+export const PanelButton: FC<{ onClick: () => void; title: string }> = ({
   onClick,
   title
 }) => (

--- a/lib/ReactViews/Workflow/PanelMenu.tsx
+++ b/lib/ReactViews/Workflow/PanelMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { MouseEventHandler, FC, MouseEvent, useEffect, useState } from "react";
 import styled from "styled-components";
 import { GLYPHS, StyledIcon } from "../../Styled/Icon";
 import Text from "../../Styled/Text";
@@ -6,14 +6,14 @@ import Text from "../../Styled/Text";
 export type PanelMenuProps = {
   options: {
     text: string;
-    onSelect: React.MouseEventHandler<HTMLButtonElement>;
+    onSelect: MouseEventHandler<HTMLButtonElement>;
     disabled?: boolean;
   }[];
 };
 /**
  * A popup overflow menu for the panel
  */
-export const PanelMenu: React.FC<PanelMenuProps> = ({ options }) => {
+export const PanelMenu: FC<PanelMenuProps> = ({ options }) => {
   const [isOpen, setIsOpen] = useState(false);
   const hideMenu = () => setIsOpen(false);
 
@@ -28,8 +28,8 @@ export const PanelMenu: React.FC<PanelMenuProps> = ({ options }) => {
   );
 
   const handleClick = (
-    onSelect: React.MouseEventHandler<HTMLButtonElement>,
-    event: React.MouseEvent<HTMLButtonElement>
+    onSelect: MouseEventHandler<HTMLButtonElement>,
+    event: MouseEvent<HTMLButtonElement>
   ) => {
     // If onSelect decides to stop event propagation,
     // clickAnywhereToCloseMenu() will not work. So we close the menu before

--- a/lib/ReactViews/Workflow/SelectableDimensionWorkflow.tsx
+++ b/lib/ReactViews/Workflow/SelectableDimensionWorkflow.tsx
@@ -1,6 +1,6 @@
 import { action } from "mobx";
 import { observer } from "mobx-react";
-import React from "react";
+import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { getName } from "../../ModelMixins/CatalogMemberMixin";
 import { filterSelectableDimensions } from "../../Models/SelectableDimensions/SelectableDimensions";
@@ -17,7 +17,7 @@ import WorkflowPanel from "./WorkflowPanel";
  * - Title panel with `title`, item `WorkbenchItemControls` and menu
  * - Panel for each top-level selectable dimension
  */
-const SelectableDimensionWorkflow: React.FC = observer(() => {
+const SelectableDimensionWorkflow: FC = observer(() => {
   const viewState = useViewState();
   const terria = viewState.terria;
   const [t] = useTranslation();

--- a/lib/ReactViews/Workflow/WorkflowPanel.tsx
+++ b/lib/ReactViews/Workflow/WorkflowPanel.tsx
@@ -1,6 +1,6 @@
 import { action, runInAction } from "mobx";
 import { observer } from "mobx-react";
-import React, { useEffect } from "react";
+import { FC, ReactNode, Component, useEffect } from "react";
 import styled from "styled-components";
 import ViewState from "../../ReactViewModels/ViewState";
 import Button from "../../Styled/Button";
@@ -25,7 +25,7 @@ type PropsType = {
 };
 
 /** Wraps component in Portal, adds TitleBar, ErrorBoundary and Footer (PanelButton) */
-const WorkflowPanel: React.FC<PropsType> = observer((props) => {
+const WorkflowPanel: FC<PropsType> = observer((props) => {
   const viewState = props.viewState;
 
   useEffect(function hideTerriaSidePanelOnMount() {
@@ -73,10 +73,10 @@ const WorkflowPanel: React.FC<PropsType> = observer((props) => {
 
 type ErrorBoundaryProps = {
   viewState: ViewState;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
-class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
+class ErrorBoundary extends Component<ErrorBoundaryProps> {
   state = { hasError: false };
 
   static getDerivedStateFromError() {

--- a/lib/ReactViews/Workflow/WorkflowPanelPortal.tsx
+++ b/lib/ReactViews/Workflow/WorkflowPanelPortal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import styled from "styled-components";
 import { Portal } from "../StandardUserInterface/Portal";
 import { useViewState } from "../Context";
@@ -8,7 +8,7 @@ type PropsType = {
   show: boolean;
 };
 
-const WorkflowPanelPortal: React.FC<PropsType> = ({ show }) => {
+const WorkflowPanelPortal: FC<PropsType> = ({ show }) => {
   const viewState = useViewState();
   return (
     <Container

--- a/lib/Styled/Box.tsx
+++ b/lib/Styled/Box.tsx
@@ -1,4 +1,4 @@
-import React, { Ref } from "react";
+import { ElementType, Ref } from "react";
 import styled from "styled-components";
 import { Overflow, WhiteSpace, WordBreak } from "./Styled.types";
 
@@ -65,7 +65,7 @@ export interface IBoxPropsBase {
   scroll?: boolean;
   style?: any;
   gap?: number | boolean;
-  as?: React.ElementType | keyof JSX.IntrinsicElements;
+  as?: ElementType | keyof JSX.IntrinsicElements;
 }
 
 export type IBoxProps = IBoxPropsBase & Column;
@@ -243,7 +243,7 @@ export const Box = styled.div<IBoxProps>`
 `;
 
 export const BoxSpan = styled(Box).attrs(
-  (_props: { as?: React.ElementType | keyof JSX.IntrinsicElements }) => ({
+  (_props: { as?: ElementType | keyof JSX.IntrinsicElements }) => ({
     as: "span"
   })
 )``;

--- a/lib/Styled/Button.tsx
+++ b/lib/Styled/Button.tsx
@@ -242,6 +242,9 @@ export const Button: FC<ButtonProps> = (props) => {
   );
 };
 
-export default forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
-  <Button {...props} buttonRef={ref} />
-));
+const ButtonWithRef = forwardRef<HTMLButtonElement, ButtonProps>(
+  (props, ref) => <Button {...props} buttonRef={ref} />
+);
+ButtonWithRef.displayName = "Button";
+
+export default ButtonWithRef;

--- a/lib/Styled/Button.tsx
+++ b/lib/Styled/Button.tsx
@@ -1,4 +1,11 @@
-import React from "react";
+import {
+  ReactChild,
+  ReactChildren,
+  Ref,
+  ComponentPropsWithoutRef,
+  FC,
+  forwardRef
+} from "react";
 import styled from "styled-components";
 import { BoxSpan } from "./Box";
 import { TextSpan } from "./Text";
@@ -163,7 +170,7 @@ export const RawButton = styled.button<IButtonProps>`
 `;
 
 export type ButtonProps = {
-  renderIcon?: () => React.ReactChild;
+  renderIcon?: () => ReactChild;
   iconProps?: any;
   primary?: boolean;
   secondary?: boolean;
@@ -171,13 +178,13 @@ export type ButtonProps = {
   textLight?: boolean;
   rightIcon?: boolean;
   textProps?: any;
-  children?: React.ReactChildren;
-  buttonRef?: React.Ref<HTMLButtonElement>;
+  children?: ReactChildren;
+  buttonRef?: Ref<HTMLButtonElement>;
   title?: string;
-} & React.ComponentPropsWithoutRef<typeof StyledButton>;
+} & ComponentPropsWithoutRef<typeof StyledButton>;
 
 // Icon and props-children-mandatory-text-wrapping is a mess here so it's all very WIP
-export const Button: React.FC<ButtonProps> = (props) => {
+export const Button: FC<ButtonProps> = (props) => {
   const {
     primary,
     secondary,
@@ -235,6 +242,6 @@ export const Button: React.FC<ButtonProps> = (props) => {
   );
 };
 
-export default React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (props, ref) => <Button {...props} buttonRef={ref} />
-);
+export default forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => (
+  <Button {...props} buttonRef={ref} />
+));

--- a/lib/Styled/Checkbox/Checkbox.tsx
+++ b/lib/Styled/Checkbox/Checkbox.tsx
@@ -1,4 +1,7 @@
-import React, {
+import {
+  Children,
+  isValidElement,
+  cloneElement,
   ChangeEvent,
   forwardRef,
   memo,
@@ -53,11 +56,11 @@ const Checkbox = forwardRef(function Checkbox(
   const id = useUID();
 
   // Add props to children
-  const childrenWithProps = React.Children.map(children, (child) => {
+  const childrenWithProps = Children.map(children, (child) => {
     // Checking isValidElement is the safe way and avoids a typescript
     // error too.
-    if (React.isValidElement(child)) {
-      return React.cloneElement(
+    if (isValidElement(child)) {
+      return cloneElement(
         child as ReactElement<{
           isDisabled: boolean;
           isChecked: boolean;

--- a/lib/Styled/Checkbox/Elements/CheckboxIcon.tsx
+++ b/lib/Styled/Checkbox/Elements/CheckboxIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import styled from "styled-components";
 import { GLYPHS, StyledIcon } from "../../Icon";
 import { CheckboxIconProps } from "../types";
@@ -19,9 +19,7 @@ const StyledCheckboxIcon = styled(StyledIcon).attrs({
   `}
 `;
 
-const CheckboxIcon: React.FC<CheckboxIconProps> = (
-  props: CheckboxIconProps
-) => {
+const CheckboxIcon: FC<CheckboxIconProps> = (props: CheckboxIconProps) => {
   if (props.isDisabled) {
     return (
       <StyledCheckboxIcon

--- a/lib/Styled/Checkbox/Elements/HiddenCheckbox.tsx
+++ b/lib/Styled/Checkbox/Elements/HiddenCheckbox.tsx
@@ -1,16 +1,16 @@
-import React from "react";
+import { HTMLProps, ChangeEventHandler, Ref, forwardRef } from "react";
 
-export interface HiddenCheckboxProps extends React.HTMLProps<HTMLInputElement> {
+export interface HiddenCheckboxProps extends HTMLProps<HTMLInputElement> {
   disabled?: boolean;
   checked?: boolean;
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
   value?: number | string;
   name?: string;
   isIndeterminate?: boolean;
 }
-export default React.forwardRef(function HiddenCheckbox(
+export default forwardRef(function HiddenCheckbox(
   { isIndeterminate, ...props }: HiddenCheckboxProps,
-  ref: React.Ref<HTMLInputElement>
+  ref: Ref<HTMLInputElement>
 ) {
   return (
     <input

--- a/lib/Styled/Checkbox/types.ts
+++ b/lib/Styled/Checkbox/types.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { ChangeEvent, ReactChild } from "react";
 import { ITextProps } from "../Text";
 
 export type ICheckboxProps = {
@@ -28,7 +28,7 @@ export type ICheckboxProps = {
    * be called with an object containing the react synthetic event. Use
    * currentTarget to get value, name and checked
    */
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => any;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => any;
   /** The value to be used in the checkbox input. This is the value that will be
    * returned on form submission. */
   value?: number | string;
@@ -38,7 +38,7 @@ export type ICheckboxProps = {
    * style `font-size: inherit` and props `isDisabled` and `isChecked` will be
    * applied to all child elements.
    */
-  children?: React.ReactChild;
+  children?: ReactChild;
 
   textProps?: ITextProps;
 

--- a/lib/Styled/Icon.tsx
+++ b/lib/Styled/Icon.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React from "react";
+import { FC } from "react";
 import styled from "styled-components";
 
 // Icon
@@ -151,7 +151,7 @@ export interface IconProps {
   className?: string;
   rotation?: number;
 }
-export const Icon: React.FC<IconProps> = (props: IconProps) => {
+export const Icon: FC<IconProps> = (props: IconProps) => {
   return (
     <svg
       viewBox="0 0 100 100"

--- a/lib/Styled/Input.tsx
+++ b/lib/Styled/Input.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { InputHTMLAttributes, FC } from "react";
 import styled, { css, useTheme } from "styled-components";
 import Box, { IBoxProps } from "./Box";
 
@@ -19,8 +19,8 @@ export interface CommonProps {
   styledMaxHeight?: string;
 }
 
-type InputProps = React.InputHTMLAttributes<HTMLInputElement> & CommonProps;
-type TextAreaProps = React.InputHTMLAttributes<HTMLTextAreaElement> &
+type InputProps = InputHTMLAttributes<HTMLInputElement> & CommonProps;
+type TextAreaProps = InputHTMLAttributes<HTMLTextAreaElement> &
   CommonProps & {
     lineHeight?: string;
   };
@@ -124,7 +124,7 @@ export const StyledInput = styled.input<InputProps>`
   ${commonStyles}
 `;
 
-const Input: React.FC<InputProps> = (props: InputProps) => {
+const Input: FC<InputProps> = (props: InputProps) => {
   const { boxProps, ...rest }: InputProps = props;
   useTheme();
   return (

--- a/lib/Styled/Select.tsx
+++ b/lib/Styled/Select.tsx
@@ -25,7 +25,7 @@ or with overrides on icon
 </Select>
  */
 
-import React from "react";
+import { ReactNode, FC } from "react";
 import styled, { useTheme } from "styled-components";
 import Box from "./Box";
 import { GLYPHS, StyledIcon } from "./Icon";
@@ -78,13 +78,13 @@ export interface SelectProps {
   boxProps?: any;
   dropdownIconProps?: any;
   light?: boolean;
-  leftIcon?: () => React.ReactNode;
+  leftIcon?: () => ReactNode;
   paddingForLeftIcon?: string;
-  children: React.ReactNode;
+  children: ReactNode;
   [spread: string]: any;
 }
 
-const Select: React.FC<SelectProps> = (props) => {
+const Select: FC<SelectProps> = (props) => {
   const {
     leftIcon,
     children,

--- a/lib/Styled/Text.tsx
+++ b/lib/Styled/Text.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps } from "react";
+import { ElementType, ComponentProps } from "react";
 import styled from "styled-components";
 
 interface ITextSize {
@@ -40,7 +40,7 @@ export interface ITextPropsBase {
   primary?: boolean;
   fullWidth?: boolean;
   noWrap?: boolean;
-  as?: React.ElementType | keyof JSX.IntrinsicElements;
+  as?: ElementType | keyof JSX.IntrinsicElements;
   styledLineHeight?: string;
   highlightLinks?: boolean;
   overflowHide?: boolean;
@@ -217,7 +217,7 @@ export const Text = styled.div<ITextProps>`
 
 export const TextSpan = styled(Text).attrs<{
   as?: React.ElementType | keyof JSX.IntrinsicElements;
-}>((props: { as?: React.ElementType | keyof JSX.IntrinsicElements }) => ({
+}>((props: { as?: ElementType | keyof JSX.IntrinsicElements }) => ({
   as: props.as || "span"
 }))``;
 

--- a/lib/ViewModels/CompositeBar/CompositeBarItemController.ts
+++ b/lib/ViewModels/CompositeBar/CompositeBarItemController.ts
@@ -1,5 +1,5 @@
 import { makeObservable, observable, runInAction } from "mobx";
-import React from "react";
+import { RefObject, createRef } from "react";
 import ViewerMode from "../../Models/ViewerMode";
 
 export interface ICompositeBarItemController {
@@ -11,14 +11,14 @@ export interface ICompositeBarItemController {
   visible: boolean;
   readonly glyph: any;
   readonly viewerMode: ViewerMode | undefined;
-  itemRef: React.RefObject<HTMLDivElement>;
+  itemRef: RefObject<HTMLDivElement>;
 }
 
 export abstract class CompositeBarItemController
   implements ICompositeBarItemController
 {
   static id: string;
-  itemRef: React.RefObject<HTMLDivElement> = React.createRef();
+  itemRef: RefObject<HTMLDivElement> = createRef();
 
   constructor() {
     makeObservable(this);

--- a/lib/ViewModels/MapNavigation/MapToolbar.ts
+++ b/lib/ViewModels/MapNavigation/MapToolbar.ts
@@ -1,5 +1,5 @@
 import { action, computed, makeObservable } from "mobx";
-import React from "react";
+import { ComponentType } from "react";
 import createGuid from "terriajs-cesium/Source/Core/createGuid";
 import TerriaError from "../../Core/TerriaError";
 import ViewerMode from "../../Models/ViewerMode";
@@ -32,7 +32,7 @@ export interface ToolConfig {
    *  }
    * ```
    */
-  toolComponentLoader: () => Promise<{ default: React.ComponentType<any> }>;
+  toolComponentLoader: () => Promise<{ default: ComponentType<any> }>;
 
   /**
    * The tool button configuration

--- a/test/Map/StyledHtmlSpec.tsx
+++ b/test/Map/StyledHtmlSpec.tsx
@@ -1,5 +1,4 @@
 import { create } from "react-test-renderer";
-import React from "react";
 import { runInAction } from "mobx";
 import { ThemeProvider } from "styled-components";
 import { act } from "react-dom/test-utils";

--- a/test/ReactViews/BottomDock/BottomDockSpec.tsx
+++ b/test/ReactViews/BottomDock/BottomDockSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act, create, ReactTestRenderer } from "react-test-renderer";
 import Terria from "../../../lib/Models/Terria";
 import ViewState from "../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/BottomDock/MapDataCountSpec.tsx
+++ b/test/ReactViews/BottomDock/MapDataCountSpec.tsx
@@ -1,5 +1,4 @@
 const create: any = require("react-test-renderer").create;
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../lib/Models/Terria";
 import ViewState from "../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/ChartSpec.jsx
+++ b/test/ReactViews/ChartSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-import React from "react";
 import { getMountedInstance } from "./MoreShallowTools";
 
 import Chart from "../../lib/ReactViews/Custom/Chart/Chart";

--- a/test/ReactViews/ClipboardSpec.tsx
+++ b/test/ReactViews/ClipboardSpec.tsx
@@ -1,5 +1,4 @@
 const create: any = require("react-test-renderer").create;
-import React from "react";
 import { act } from "react-dom/test-utils";
 import { ThemeProvider } from "styled-components";
 import { terriaTheme } from "../../lib/ReactViews/StandardUserInterface";

--- a/test/ReactViews/Custom/Chart/MomentPointsChartSpec.tsx
+++ b/test/ReactViews/Custom/Chart/MomentPointsChartSpec.tsx
@@ -2,7 +2,6 @@ import { scaleLinear, scaleTime } from "@visx/scale";
 import { Glyph, GlyphSquare } from "@visx/glyph";
 import maxBy from "lodash-es/maxBy";
 import minBy from "lodash-es/minBy";
-import React from "react";
 import TestRenderer from "react-test-renderer";
 import MomentPointsChart from "../../../../lib/ReactViews/Custom/Chart/MomentPointsChart";
 

--- a/test/ReactViews/Custom/Chart/PointOnMapSpec.tsx
+++ b/test/ReactViews/Custom/Chart/PointOnMapSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act } from "react-dom/test-utils";
 import TestRenderer, { ReactTestRenderer } from "react-test-renderer";
 import GeoJsonCatalogItem from "../../../../lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem";

--- a/test/ReactViews/DataCatalog/CatalogGroupSpec.tsx
+++ b/test/ReactViews/DataCatalog/CatalogGroupSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import CatalogGroup from "../../../lib/ReactViews/DataCatalog/CatalogGroup";
 import Loader from "../../../lib/ReactViews/Loader";
 import { ThemeProvider } from "styled-components";

--- a/test/ReactViews/DataCatalog/DataCatalogItemSpec.tsx
+++ b/test/ReactViews/DataCatalog/DataCatalogItemSpec.tsx
@@ -1,5 +1,4 @@
 import { runInAction } from "mobx";
-import React from "react";
 import { findAllWithType } from "react-shallow-testutils";
 import CatalogMemberMixin from "../../../lib/ModelMixins/CatalogMemberMixin";
 import WebMapServiceCatalogItem from "../../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";

--- a/test/ReactViews/DataCatalogSpec.jsx
+++ b/test/ReactViews/DataCatalogSpec.jsx
@@ -3,7 +3,6 @@ import DataCatalogMember from "../../lib/ReactViews/DataCatalog/DataCatalogMembe
 import { DataCatalog } from "../../lib/ReactViews/DataCatalog/DataCatalog";
 import { findAllWithType } from "react-shallow-testutils";
 import { getShallowRenderedOutput } from "./MoreShallowTools";
-import React from "react";
 import Terria from "../../lib/Models/Terria";
 import ViewState from "../../lib/ReactViewModels/ViewState";
 import { USER_ADDED_CATEGORY_ID } from "../../lib/Core/addedByUser";

--- a/test/ReactViews/DimensionSelectorSectionSpec.tsx
+++ b/test/ReactViews/DimensionSelectorSectionSpec.tsx
@@ -1,5 +1,4 @@
 import { runInAction } from "mobx";
-import React from "react";
 import ReactSelect from "react-select";
 import TestRenderer from "react-test-renderer";
 import { ThemeProvider } from "styled-components";

--- a/test/ReactViews/DisclaimerSpec.tsx
+++ b/test/ReactViews/DisclaimerSpec.tsx
@@ -1,5 +1,4 @@
 import { runInAction } from "mobx";
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../lib/Models/Terria";
 import ViewState from "../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/FeatureInfoPanelSpec.tsx
+++ b/test/ReactViews/FeatureInfoPanelSpec.tsx
@@ -1,7 +1,5 @@
 "use strict";
 
-// import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
-import React from "react";
 import { findWithType } from "react-shallow-testutils";
 import { getShallowRenderedOutput } from "./MoreShallowTools";
 import { runInAction } from "mobx";

--- a/test/ReactViews/Generic/PromptSpec.tsx
+++ b/test/ReactViews/Generic/PromptSpec.tsx
@@ -1,5 +1,4 @@
 const create: any = require("react-test-renderer").create;
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../lib/Models/Terria";
 import ViewState from "../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/Map/Navigation/Compass/CompassSpec.tsx
+++ b/test/ReactViews/Map/Navigation/Compass/CompassSpec.tsx
@@ -1,6 +1,5 @@
 // CompassSpec.tsx
 const create: any = require("react-test-renderer").create;
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../../../lib/Models/Terria";
 import ViewState from "../../../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/Map/Navigation/Compass/GyroscopeGuidanceSpec.tsx
+++ b/test/ReactViews/Map/Navigation/Compass/GyroscopeGuidanceSpec.tsx
@@ -1,5 +1,4 @@
 const create: any = require("react-test-renderer").create;
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../../../lib/Models/Terria";
 import ViewState from "../../../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/Map/Panels/HelpPanel/HelpPanelSpec.tsx
+++ b/test/ReactViews/Map/Panels/HelpPanel/HelpPanelSpec.tsx
@@ -1,5 +1,4 @@
 import { runInAction } from "mobx";
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../../../lib/Models/Terria";
 import ViewState from "../../../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/Map/Panels/HelpPanel/VideoGuideSpec.tsx
+++ b/test/ReactViews/Map/Panels/HelpPanel/VideoGuideSpec.tsx
@@ -1,5 +1,4 @@
 const create: any = require("react-test-renderer").create;
-import React from "react";
 import { act } from "react-dom/test-utils";
 import { ThemeProvider } from "styled-components";
 import { terriaTheme } from "../../../../../lib/ReactViews/StandardUserInterface";

--- a/test/ReactViews/Map/Panels/LangPanel/LangPanelSpec.tsx
+++ b/test/ReactViews/Map/Panels/LangPanel/LangPanelSpec.tsx
@@ -1,5 +1,4 @@
 import { create } from "react-test-renderer";
-import React from "react";
 import { act } from "react-dom/test-utils";
 
 import Terria from "../../../../../lib/Models/Terria";

--- a/test/ReactViews/MeasureToolSpec.jsx
+++ b/test/ReactViews/MeasureToolSpec.jsx
@@ -1,7 +1,5 @@
 "use strict";
 
-// import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
-import React from "react";
 import Terria from "../../lib/Models/Terria";
 import { getMountedInstance } from "./MoreShallowTools";
 

--- a/test/ReactViews/Preview/DescriptionSpec.tsx
+++ b/test/ReactViews/Preview/DescriptionSpec.tsx
@@ -1,5 +1,4 @@
 import { runInAction } from "mobx";
-import React from "react";
 import { act } from "react-dom/test-utils";
 import { create, ReactTestRenderer } from "react-test-renderer";
 import { ThemeProvider } from "styled-components";

--- a/test/ReactViews/ScalesSpec.jsx
+++ b/test/ReactViews/ScalesSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-import React from "react";
 import { getMountedInstance } from "./MoreShallowTools";
 
 import Scales from "../../lib/Charts/Scales";

--- a/test/ReactViews/Search/BreadcrumbsSpec.tsx
+++ b/test/ReactViews/Search/BreadcrumbsSpec.tsx
@@ -1,5 +1,4 @@
 const create: any = require("react-test-renderer").create;
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../lib/Models/Terria";
 import CatalogGroup from "../../../lib/Models/Catalog/CatalogGroup";

--- a/test/ReactViews/Search/SearchBoxAndResultsSpec.tsx
+++ b/test/ReactViews/Search/SearchBoxAndResultsSpec.tsx
@@ -1,5 +1,4 @@
 const create: any = require("react-test-renderer").create;
-import React from "react";
 import { act } from "react-dom/test-utils";
 import { runInAction } from "mobx";
 import Terria from "../../../lib/Models/Terria";

--- a/test/ReactViews/Search/SearchBoxSpec.tsx
+++ b/test/ReactViews/Search/SearchBoxSpec.tsx
@@ -1,5 +1,4 @@
 const create: any = require("react-test-renderer").create;
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../lib/Models/Terria";
 import ViewState from "../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/ShortReportSpec.tsx
+++ b/test/ReactViews/ShortReportSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act } from "react-dom/test-utils";
 import {
   create,

--- a/test/ReactViews/SidePanel/BrandingSpec.tsx
+++ b/test/ReactViews/SidePanel/BrandingSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import TestRenderer from "react-test-renderer";
 import Terria from "../../../lib/Models/Terria";
 import ViewState from "../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/StandardUserInterface/TrainerBar/TrainerBarSpec.tsx
+++ b/test/ReactViews/StandardUserInterface/TrainerBar/TrainerBarSpec.tsx
@@ -1,5 +1,4 @@
 import { runInAction } from "mobx";
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../../lib/Models/Terria";
 import ViewState from "../../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/StandardUserInterfaceSpec.jsx
+++ b/test/ReactViews/StandardUserInterfaceSpec.jsx
@@ -1,6 +1,5 @@
 "use strict";
 
-import React from "react";
 import { findWithClass } from "react-shallow-testutils";
 import { getShallowRenderedOutput } from "./MoreShallowTools";
 import {

--- a/test/ReactViews/Story/StoryPanel/StoryBodySpec.tsx
+++ b/test/ReactViews/Story/StoryPanel/StoryBodySpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import StoryBody from "../../../../lib/ReactViews/Story/StoryPanel/StoryBody";
 import { act } from "react-dom/test-utils";
 import {

--- a/test/ReactViews/Story/StorySpec.jsx
+++ b/test/ReactViews/Story/StorySpec.jsx
@@ -1,6 +1,5 @@
 import Story, { StoryRaw } from "../../../lib/ReactViews/Story/Story";
 import { getShallowRenderedOutput } from "../MoreShallowTools";
-import React from "react";
 import { sortable } from "react-anything-sortable";
 
 describe("Story", function () {

--- a/test/ReactViews/TimelineSpec.jsx
+++ b/test/ReactViews/TimelineSpec.jsx
@@ -1,7 +1,5 @@
 "use strict";
 
-// import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
-import React from "react";
 import { getMountedInstance } from "./MoreShallowTools";
 
 const Terria = require("../../lib/Models/Terria");

--- a/test/ReactViews/ToolSpec.tsx
+++ b/test/ReactViews/ToolSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../lib/Models/Terria";
 import ViewState from "../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
+++ b/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
@@ -1,5 +1,4 @@
 import "../../../SpecMain";
-import React from "react";
 import {
   act,
   create,

--- a/test/ReactViews/Tools/ItemSearchTool/SearchFormSpec.tsx
+++ b/test/ReactViews/Tools/ItemSearchTool/SearchFormSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act, create, ReactTestRenderer } from "react-test-renderer";
 import timeout from "../../../../lib/Core/timeout";
 import ItemSearchProvider from "../../../../lib/Models/ItemSearchProviders/ItemSearchProvider";

--- a/test/ReactViews/Tour/TourPortalSpec.tsx
+++ b/test/ReactViews/Tour/TourPortalSpec.tsx
@@ -1,5 +1,5 @@
 import { runInAction } from "mobx";
-import React from "react";
+import { createRef } from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../../lib/Models/Terria";
 import ViewState from "../../../lib/ReactViewModels/ViewState";
@@ -56,9 +56,9 @@ describe("TourPortal", function () {
         expect(() => testRenderer.root.findByType(TourExplanation)).toThrow();
       });
       it("renders something using the TourGrouping path under showPortal conditions", function () {
-        const testRef: any = React.createRef();
-        const testRef2: any = React.createRef();
-        const testRef3: any = React.createRef();
+        const testRef: any = createRef();
+        const testRef2: any = createRef();
+        const testRef3: any = createRef();
         act(() => {
           testRenderer = createWithContexts(
             viewState,

--- a/test/ReactViews/WarningBoxSpec.tsx
+++ b/test/ReactViews/WarningBoxSpec.tsx
@@ -1,5 +1,4 @@
 import { create } from "react-test-renderer";
-import React from "react";
 import { act } from "react-dom/test-utils";
 import { ThemeProvider } from "styled-components";
 import { terriaTheme } from "../../lib/ReactViews/StandardUserInterface";

--- a/test/ReactViews/WelcomeMessageSpec.tsx
+++ b/test/ReactViews/WelcomeMessageSpec.tsx
@@ -1,5 +1,4 @@
 import { runInAction } from "mobx";
-import React from "react";
 import { act } from "react-dom/test-utils";
 import Terria from "../../lib/Models/Terria";
 import ViewState from "../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/Workbench/Controls/ChartItemSelectorSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/ChartItemSelectorSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act } from "react-dom/test-utils";
 import TestRenderer, { ReactTestRenderer } from "react-test-renderer";
 import ChartableMixin, {

--- a/test/ReactViews/Workbench/Controls/DateTimePickerSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/DateTimePickerSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act } from "react-dom/test-utils";
 import TestRenderer, { ReactTestRenderer } from "react-test-renderer";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";

--- a/test/ReactViews/Workbench/Controls/DateTimeSelectorSectionSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/DateTimeSelectorSectionSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act } from "react-dom/test-utils";
 import TestRenderer, { ReactTestRenderer } from "react-test-renderer";
 import WebMapServiceCatalogItem from "../../../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";

--- a/test/ReactViews/Workbench/Controls/FilterSectionSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/FilterSectionSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act } from "react-dom/test-utils";
 import TestRenderer, { ReactTestRenderer } from "react-test-renderer";
 import FilterSection from "../../../../lib/ReactViews/Workbench/Controls/FilterSection";

--- a/test/ReactViews/Workbench/Controls/IdealZoomSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/IdealZoomSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { act } from "react-dom/test-utils";
 import TestRenderer, { ReactTestRenderer } from "react-test-renderer";
 import Terria from "../../../../lib/Models/Terria";

--- a/test/ReactViews/Workbench/Controls/ViewingControlsSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/ViewingControlsSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { create } from "react-test-renderer";
 import ViewingControls from "../../../../lib/ReactViews/Workbench/Controls/ViewingControls";
 import Terria from "../../../../lib/Models/Terria";

--- a/test/ReactViews/Workbench/WorkbenchItemSpec.jsx
+++ b/test/ReactViews/Workbench/WorkbenchItemSpec.jsx
@@ -2,7 +2,6 @@ import WorkbenchItem, {
   WorkbenchItemRaw
 } from "../../../lib/ReactViews/Workbench/WorkbenchItem";
 import { getShallowRenderedOutput } from "../MoreShallowTools";
-import React from "react";
 import { sortable } from "react-anything-sortable";
 import Terria from "../../../lib/Models/Terria";
 import ViewState from "../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/Workflows/WorkflowPanelSpec.tsx
+++ b/test/ReactViews/Workflows/WorkflowPanelSpec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import TestRenderer, { act, ReactTestRenderer } from "react-test-renderer";
 import Terria from "../../../lib/Models/Terria";
 import ViewState from "../../../lib/ReactViewModels/ViewState";

--- a/test/ReactViews/withContext.tsx
+++ b/test/ReactViews/withContext.tsx
@@ -1,18 +1,18 @@
-import React from "react";
+import { ReactNode } from "react";
 import { create, TestRendererOptions } from "react-test-renderer";
 import { ThemeProvider } from "styled-components";
 import ViewState from "../../lib/ReactViewModels/ViewState";
 import { terriaTheme } from "../../lib/ReactViews/StandardUserInterface";
 import { ViewStateProvider } from "../../lib/ReactViews/Context/ViewStateContext";
 
-export function withThemeContext(node: React.ReactNode) {
+export function withThemeContext(node: ReactNode) {
   return <ThemeProvider theme={terriaTheme}>{node}</ThemeProvider>;
 }
 
 /** Wrap react node in viewState and theme provider */
 export function createWithContexts(
   viewState: ViewState,
-  node: React.ReactNode,
+  node: ReactNode,
   testRendererOptions?: TestRendererOptions
 ) {
   return create(


### PR DESCRIPTION
### What this PR does

Small step toward #6538
Run `upgrade-react-imports` codemod to update react imports so they can work in react 17/18. Partially supersedes #7051. 

Don't worry about merge conflicts first PR is only changes by codemod so it is easy to recreate 

### Test me

Tested locally `yarn build-for-node` and `yarn gulp build`. All tests passes. Running the app locally works 

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
