### PR TITLE
Add return types to exported functions

### DIFF
--- a/lib/Core/AsyncLoader.ts
+++ b/lib/Core/AsyncLoader.ts
@@ -150,7 +150,7 @@ export default class AsyncLoader {
    * `load(true)`.
    */
   @action
-  dispose() {
+  dispose(): void {
     this._forceReloadCount = -1;
     this.load();
   }

--- a/lib/Core/CorsProxy.ts
+++ b/lib/Core/CorsProxy.ts
@@ -65,7 +65,7 @@ export default class CorsProxy {
     serverConfig: any,
     baseProxyUrl: string = CorsProxy.DEFAULT_BASE_PROXY_PATH,
     proxyDomains: string[] = []
-  ) {
+  ): void {
     if (serverConfig !== null && serverConfig !== undefined) {
       this.isOpenProxy = !!serverConfig.proxyAllDomains;
       // ignore client list of allowed proxies in favour of definitive server list.
@@ -110,11 +110,11 @@ export default class CorsProxy {
    *       the cache headers with. E.g. '2d' for 2 days.
    * @returns The proxied URL
    */
-  getURL(resource: string, proxyFlag?: string) {
+  getURL(resource: string, proxyFlag?: string): string {
     return this.getProxyBaseURL(proxyFlag) + resource;
   }
 
-  getProxyBaseURL(proxyFlag: string | undefined) {
+  getProxyBaseURL(proxyFlag: string | undefined): string {
     const flag = proxyFlag === undefined ? "" : "_" + proxyFlag + "/";
     return this.baseProxyUrl + flag;
   }
@@ -132,7 +132,7 @@ export default class CorsProxy {
    *       the cache headers with. E.g. '2d' for 2 days.
    * @returns Either the URL passed in or a proxied URL if it should be proxied.
    */
-  getURLProxyIfNecessary(resource: string, proxyFlag?: string) {
+  getURLProxyIfNecessary(resource: string, proxyFlag?: string): string {
     if (this.shouldUseProxy(resource)) {
       return this.getURL(resource, proxyFlag);
     }

--- a/lib/Core/GoogleAnalytics.ts
+++ b/lib/Core/GoogleAnalytics.ts
@@ -14,7 +14,7 @@ export default class GoogleAnalytics implements Analytics {
   key: string | undefined = undefined;
   options: any = undefined;
 
-  start(configParameters: GoogleAnalyticsConfigParameters) {
+  start(configParameters: GoogleAnalyticsConfigParameters): void {
     this.key = configParameters.googleAnalyticsKey;
     this.options = configParameters.googleAnalyticsOptions;
 
@@ -24,7 +24,12 @@ export default class GoogleAnalytics implements Analytics {
     initializeGoogleAnalytics(this);
   }
 
-  logEvent(category: string, action: string, label?: string, value?: number) {
+  logEvent(
+    category: string,
+    action: string,
+    label?: string,
+    value?: number
+  ): void {
     const fieldObject: any = {
       hitType: "event",
       eventCategory: category,

--- a/lib/Core/Result.ts
+++ b/lib/Core/Result.ts
@@ -93,7 +93,7 @@ export default class Result<T = undefined> {
   }
 
   /** Convenience constructor to return a Result with no value (and potentially an error) */
-  static none(error?: unknown, overrides?: TerriaErrorOverrides) {
+  static none(error?: unknown, overrides?: TerriaErrorOverrides): Result {
     return error ? Result.error(error, overrides) : new Result(undefined);
   }
 
@@ -147,7 +147,7 @@ export default class Result<T = undefined> {
    *
    * @param errorOverrides can be used to add error context
    */
-  logError(errorOverrides?: TerriaErrorOverrides) {
+  logError(errorOverrides?: TerriaErrorOverrides): T {
     if (this._error) TerriaError.from(this._error, errorOverrides).log();
     return this.value;
   }
@@ -193,7 +193,7 @@ export default class Result<T = undefined> {
         });
   }
 
-  pushErrorTo(errors: TerriaError[], errorOverrides?: TerriaErrorOverrides) {
+  pushErrorTo(errors: TerriaError[], errorOverrides?: TerriaErrorOverrides): T {
     if (this._error) errors.push(TerriaError.from(this._error, errorOverrides));
     return this.value;
   }

--- a/lib/Core/TerriaError.ts
+++ b/lib/Core/TerriaError.ts
@@ -325,7 +325,7 @@ export default class TerriaError {
   }
 
   /** Print error to console */
-  log() {
+  log(): void {
     this.resolvedSeverity === TerriaErrorSeverity.Warning
       ? console.warn(this.toString())
       : console.error(this.toString());
@@ -467,7 +467,7 @@ export default class TerriaError {
     terria: Terria,
     errorOverrides?: TerriaErrorOverrides,
     forceRaiseToUser?: boolean
-  ) {
+  ): void {
     terria.raiseErrorToUser(this, errorOverrides, forceRaiseToUser);
   }
 }

--- a/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -54,7 +54,7 @@ export class ObservableCesium3DTileset extends Cesium3DTileset {
     makeObservable(this);
   }
 
-  destroy() {
+  destroy(): void {
     super.destroy();
     // TODO: we are running later to prevent this
     // modification from happening in some computed up the call chain.

--- a/lib/Models/AugmentedVirtuality.ts
+++ b/lib/Models/AugmentedVirtuality.ts
@@ -70,7 +70,7 @@ export default class AugmentedVirtuality {
     makeObservable(this);
   }
 
-  toggleEnabled() {
+  toggleEnabled(): void {
     if (this.active) {
       this.deactivate();
     } else {
@@ -94,13 +94,13 @@ export default class AugmentedVirtuality {
   }
 
   @action
-  activate() {
+  activate(): void {
     this.manualAlignment = false;
     this.startEventLoop(true);
   }
 
   @action
-  deactivate() {
+  deactivate(): void {
     this.resetAlignment();
     this.manualAlignment = false;
     this.startEventLoop(false);
@@ -110,7 +110,7 @@ export default class AugmentedVirtuality {
    * Toggles whether manual alignement is enabled or disabled.
    */
   @action
-  toggleManualAlignment() {
+  toggleManualAlignment(): void {
     this.setManualAlignment(!this.manualAlignment);
   }
 
@@ -129,7 +129,7 @@ export default class AugmentedVirtuality {
    * cameras orientation so that it matches the * correct orientation.
    */
   @action
-  toggleHoverHeight() {
+  toggleHoverHeight(): void {
     this.hoverLevel =
       (this.hoverLevel + 1) % AugmentedVirtuality.PRESET_HEIGHTS.length;
     this.hover(AugmentedVirtuality.PRESET_HEIGHTS[this.hoverLevel]);
@@ -222,7 +222,7 @@ export default class AugmentedVirtuality {
    *
    * When the manual alignment is enabled this function has no effect.
    */
-  moveTo(position: Cartographic, maximumHeight: number, flyTo: boolean) {
+  moveTo(position: Cartographic, maximumHeight: number, flyTo: boolean): void {
     // If we are in manual alignment mode we don't allow the viewer to move
     // (since this would create a jaring UX for most use cases).
     if (this.manualAlignment) return;
@@ -309,7 +309,7 @@ export default class AugmentedVirtuality {
   /**
    * Resets the alignment so that the alignement matches the devices absolute alignment.
    */
-  resetAlignment() {
+  resetAlignment(): void {
     this.orientationUpdated = true;
     this.realignAlpha = 0;
     this.realignHeading = 0;
@@ -354,7 +354,7 @@ export default class AugmentedVirtuality {
    *
    * @param  event Contains the updated device orientation (in .alpha, .beta, .gamma).
    */
-  storeOrientation(event: DeviceOrientationEvent) {
+  storeOrientation(event: DeviceOrientationEvent): void {
     const { alpha, beta, gamma } = event;
     if (alpha !== null && beta !== null && gamma !== null) {
       this.alpha = alpha;

--- a/lib/Models/BoxDrawing.ts
+++ b/lib/Models/BoxDrawing.ts
@@ -347,7 +347,7 @@ export default class BoxDrawing {
     return boxDrawing;
   }
 
-  public setTranslationRotationScale(trs: TranslationRotationScale) {
+  public setTranslationRotationScale(trs: TranslationRotationScale): void {
     Cartesian3.clone(trs.translation, this.trs.translation);
     Quaternion.clone(trs.rotation, this.trs.rotation);
     Cartesian3.clone(trs.scale, this.trs.scale);
@@ -357,7 +357,7 @@ export default class BoxDrawing {
   /**
    * A method to udpate the world transform.
    */
-  public setTransform(transform: Matrix4) {
+  public setTransform(transform: Matrix4): void {
     Matrix4.clone(transform, this.worldTransform);
     Matrix4.getTranslation(this.worldTransform, this.trs.translation);
     Matrix4.getScale(this.worldTransform, this.trs.scale);
@@ -445,7 +445,7 @@ export default class BoxDrawing {
   /**
    * Set the box position
    */
-  setPosition(position: Cartesian3) {
+  setPosition(position: Cartesian3): void {
     const moveStep = Cartesian3.subtract(
       position,
       this.trs.translation,

--- a/lib/Models/CameraView.ts
+++ b/lib/Models/CameraView.ts
@@ -103,7 +103,7 @@ export default class CameraView {
    * @param  {Object} [json.positionHeadingPitchRoll] If present, must include keys cameraLongitude, cameraLatitude, cameraHeight, heading, pitch, roll.
    * @return {CameraView} The camera view.
    */
-  static fromJson(json: JsonObject) {
+  static fromJson(json: JsonObject): CameraView {
     const lookAt = json.lookAt;
     const positionHeadingPitchRoll = json.positionHeadingPitchRoll;
 

--- a/lib/Models/Cesium.ts
+++ b/lib/Models/Cesium.ts
@@ -527,18 +527,18 @@ export default class Cesium extends GlobeOrMap {
     };
   }
 
-  getContainer() {
+  getContainer(): Element {
     return this.cesiumWidget.container;
   }
 
-  pauseMapInteraction() {
+  pauseMapInteraction(): void {
     ++this._pauseMapInteractionCount;
     if (this._pauseMapInteractionCount === 1) {
       this.scene.screenSpaceCameraController.enableInputs = false;
     }
   }
 
-  resumeMapInteraction() {
+  resumeMapInteraction(): void {
     --this._pauseMapInteractionCount;
     if (this._pauseMapInteractionCount === 0) {
       setTimeout(() => {
@@ -570,7 +570,7 @@ export default class Cesium extends GlobeOrMap {
     }
   }
 
-  destroy() {
+  destroy(): void {
     // Port old Cesium.prototype.destroy stuff
     // this._enableSelectExtent(cesiumWidget.scene, false);
     this.scene.renderError.removeEventListener(this.onRenderError);
@@ -813,7 +813,7 @@ export default class Cesium extends GlobeOrMap {
     };
   }
 
-  stopObserving() {
+  stopObserving(): void {
     if (this._disposeWorkbenchMapItemsSubscription !== undefined) {
       this._disposeWorkbenchMapItemsSubscription();
     }
@@ -948,7 +948,7 @@ export default class Cesium extends GlobeOrMap {
     return _zoom().finally(() => this.notifyRepaintRequired());
   }
 
-  notifyRepaintRequired() {
+  notifyRepaintRequired(): void {
     this.pauser.notifyRepaintRequired();
   }
 
@@ -1292,7 +1292,7 @@ export default class Cesium extends GlobeOrMap {
   async pickFromScreenPosition(
     screenPosition: Cartesian2,
     ignoreSplitter: boolean
-  ) {
+  ): Promise<void> {
     const pickRay = this.scene.camera.getPickRay(screenPosition);
     const pickPosition = isDefined(pickRay)
       ? this.scene.globe.pick(pickRay, this.scene)
@@ -1336,7 +1336,7 @@ export default class Cesium extends GlobeOrMap {
     latLngHeight: LatLonHeight,
     providerCoords: ProviderCoordsMap,
     existingFeatures: TerriaFeature[]
-  ) {
+  ): void {
     const pickPosition = this.scene.globe.ellipsoid.cartographicToCartesian(
       Cartographic.fromDegrees(
         latLngHeight.longitude,
@@ -1697,7 +1697,7 @@ export default class Cesium extends GlobeOrMap {
     );
   }
 
-  _selectFeature() {
+  _selectFeature(): void {
     const feature = this.terria.selectedFeature;
 
     this._highlightFeature(feature);

--- a/lib/Models/DefaultTimelineModel.ts
+++ b/lib/Models/DefaultTimelineModel.ts
@@ -31,7 +31,7 @@ export default class DefaultTimelineModel extends DiscretelyTimeVaryingMixin(
     );
   }
 
-  protected async forceLoadMapItems() {}
+  protected async forceLoadMapItems(): Promise<void> {}
 
   get mapItems() {
     return [];

--- a/lib/Models/GlobeOrMap.ts
+++ b/lib/Models/GlobeOrMap.ts
@@ -142,7 +142,7 @@ export default abstract class GlobeOrMap {
    */
   protected _createFeatureFromImageryLayerFeature(
     imageryFeature: ImageryLayerFeatureInfo
-  ) {
+  ): TerriaFeature {
     const feature = new TerriaFeature({
       id: imageryFeature.name
     });
@@ -215,7 +215,7 @@ export default abstract class GlobeOrMap {
     rectangle: Rectangle
   ): () => void;
 
-  async _highlightFeature(feature: TerriaFeature | undefined) {
+  async _highlightFeature(feature: TerriaFeature | undefined): Promise<void> {
     if (isDefined(this._removeHighlightCallback)) {
       await this._removeHighlightCallback();
       this._removeHighlightCallback = undefined;

--- a/lib/Models/Internationalization.ts
+++ b/lib/Models/Internationalization.ts
@@ -1,4 +1,4 @@
-import i18next, { ReactOptions } from "i18next";
+import i18next, { ReactOptions, TFunction } from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import HttpApi, { RequestCallback } from "i18next-http-backend";
 import { initReactI18next } from "react-i18next";
@@ -73,7 +73,7 @@ class Internationalization {
      */
     i18StartOptions: I18nStartOptions | undefined,
     terriajsResourcesBaseUrl: string
-  ) {
+  ): Promise<TFunction> {
     const languageConfig = Object.assign(
       defaultLanguageConfiguration,
       languageConfiguration

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -3,6 +3,7 @@ import {
   action,
   autorun,
   computed,
+  IReactionDisposer,
   makeObservable,
   observable,
   reaction,
@@ -300,18 +301,18 @@ export default class Leaflet extends GlobeOrMap {
     // this._dragboxcompleted = false;
   }
 
-  getContainer() {
+  getContainer(): HTMLElement {
     return this.map.getContainer();
   }
 
-  pauseMapInteraction() {
+  pauseMapInteraction(): void {
     ++this._pauseMapInteractionCount;
     if (this._pauseMapInteractionCount === 1) {
       this.map.dragging.disable();
     }
   }
 
-  resumeMapInteraction() {
+  resumeMapInteraction(): void {
     --this._pauseMapInteractionCount;
     if (this._pauseMapInteractionCount === 0) {
       setTimeout(() => {
@@ -322,7 +323,7 @@ export default class Leaflet extends GlobeOrMap {
     }
   }
 
-  destroy() {
+  destroy(): void {
     this._disposeSelectedFeatureSubscription &&
       this._disposeSelectedFeatureSubscription();
     this._disposeSplitterReaction();
@@ -558,7 +559,7 @@ export default class Leaflet extends GlobeOrMap {
     );
   }
 
-  notifyRepaintRequired() {
+  notifyRepaintRequired(): void {
     // No action necessary.
   }
 
@@ -566,7 +567,7 @@ export default class Leaflet extends GlobeOrMap {
     latLngHeight: LatLonHeight,
     providerCoords: ProviderCoordsMap,
     existingFeatures: TerriaFeature[]
-  ) {
+  ): void {
     this._pickFeatures(
       L.latLng({
         lat: latLngHeight.latitude,
@@ -848,7 +849,7 @@ export default class Leaflet extends GlobeOrMap {
     });
   }
 
-  _reactToSplitterChanges() {
+  _reactToSplitterChanges(): IReactionDisposer {
     return autorun(() => {
       const items = this.terria.mainViewer.items.get();
       const showSplitter = this.terria.showSplitter;

--- a/lib/Models/LeafletAttribution.ts
+++ b/lib/Models/LeafletAttribution.ts
@@ -28,7 +28,7 @@ export class LeafletAttribution extends L.Control.Attribution {
     this.dataAttributions = observable([]);
   }
 
-  onAdd(map: L.Map) {
+  onAdd(map: L.Map): HTMLElement {
     map.attributionControl = this;
     this.map = map;
 
@@ -45,11 +45,11 @@ export class LeafletAttribution extends L.Control.Attribution {
     return this._container;
   }
 
-  onRemove() {
+  onRemove(): void {
     this.map = undefined;
   }
 
-  _update() {
+  _update(): void {
     if (!this.map) {
       return;
     }
@@ -63,7 +63,7 @@ export class LeafletAttribution extends L.Control.Attribution {
     }
   }
 
-  addAttribution(text: string) {
+  addAttribution(text: string): this {
     super.addAttribution(text);
     if (this.map) {
       runInAction(() => {
@@ -73,7 +73,7 @@ export class LeafletAttribution extends L.Control.Attribution {
     return this;
   }
 
-  removeAttribution(text: string) {
+  removeAttribution(text: string): this {
     super.removeAttribution(text);
     if (this.map) {
       runInAction(() => {

--- a/lib/Models/NoViewer.ts
+++ b/lib/Models/NoViewer.ts
@@ -23,7 +23,7 @@ class NoViewer extends GlobeOrMap {
     this.terria = terriaViewer.terria;
   }
 
-  destroy() {}
+  destroy(): void {}
 
   doZoomTo(
     v: CameraView | Rectangle | MappableMixin.Instance,
@@ -37,13 +37,13 @@ class NoViewer extends GlobeOrMap {
     return Promise.resolve();
   }
 
-  notifyRepaintRequired() {}
+  notifyRepaintRequired(): void {}
 
   pickFromLocation(
     _latLngHeight: LatLonHeight,
     _providerCoords: ProviderCoordsMap,
     _existingFeatures: TerriaFeature[]
-  ) {}
+  ): void {}
 
   getCurrentCameraView(): CameraView {
     return this._currentView;
@@ -53,8 +53,8 @@ class NoViewer extends GlobeOrMap {
     return undefined;
   }
 
-  pauseMapInteraction() {}
-  resumeMapInteraction() {}
+  pauseMapInteraction(): void {}
+  resumeMapInteraction(): void {}
   _addVectorTileHighlight(
     _imageryProvider:
       | MapboxVectorTileImageryProvider

--- a/lib/Models/ShareDataService.ts
+++ b/lib/Models/ShareDataService.ts
@@ -28,7 +28,7 @@ export default class ShareDataService {
     this.url = options.url;
   }
 
-  init(serverConfig: any) {
+  init(serverConfig: any): void {
     this.url = defaultValue(
       this.url,
       defaultValue(this.terria.configParameters.shareUrl, "share")

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -766,7 +766,7 @@ export default class Terria {
     error: unknown,
     overrides?: TerriaErrorOverrides,
     forceRaiseToUser = false
-  ) {
+  ): void {
     const terriaError = TerriaError.from(error, overrides);
 
     // Set shouldRaiseToUser true if forceRaiseToUser agrument is true
@@ -838,7 +838,7 @@ export default class Terria {
   }
 
   @action
-  addModel(model: BaseModel, shareKeys?: string[]) {
+  addModel(model: BaseModel, shareKeys?: string[]): void {
     if (model.uniqueId === undefined) {
       throw new DeveloperError("A model without a `uniqueId` cannot be added.");
     }
@@ -859,7 +859,7 @@ export default class Terria {
    * Remove references to a model from Terria.
    */
   @action
-  removeModelReferences(model: BaseModel) {
+  removeModelReferences(model: BaseModel): void {
     this.removeSelectedFeaturesForModel(model);
     this.workbench.remove(model);
     if (model.uniqueId) {
@@ -868,7 +868,7 @@ export default class Terria {
   }
 
   @action
-  removeSelectedFeaturesForModel(model: BaseModel) {
+  removeSelectedFeaturesForModel(model: BaseModel): void {
     const pickedFeatures = this.pickedFeatures;
     if (pickedFeatures) {
       // Remove picked features that belong to the catalog item
@@ -932,14 +932,14 @@ export default class Terria {
   }
 
   @action
-  addShareKey(id: string, shareKey: string) {
+  addShareKey(id: string, shareKey: string): void {
     if (id === shareKey || this.shareKeysMap.has(shareKey)) return;
     this.shareKeysMap.set(shareKey, id);
     this.modelIdShareKeysMap.get(id)?.push(shareKey) ??
       this.modelIdShareKeysMap.set(id, [shareKey]);
   }
 
-  setupInitializationUrls(baseUri: uri.URI, config: any) {
+  setupInitializationUrls(baseUri: uri.URI, config: any): void {
     const initializationUrls: string[] = config?.initializationUrls || [];
     const initSources: InitSource[] = initializationUrls.map((url) => ({
       name: `Init URL from config ${url}`,
@@ -991,7 +991,7 @@ export default class Terria {
     this.initSources.push(...initSources);
   }
 
-  async start(options: StartOptions) {
+  async start(options: StartOptions): Promise<void> {
     // Some hashProperties need to be set before anything else happens
     const hashProperties = queryToObject(new URI(window.location).fragment());
 
@@ -1184,7 +1184,7 @@ export default class Terria {
   }
 
   @action
-  setUseNativeResolution(useNativeResolution: boolean) {
+  setUseNativeResolution(useNativeResolution: boolean): void {
     this.useNativeResolution = useNativeResolution;
   }
 
@@ -1193,7 +1193,7 @@ export default class Terria {
     this.baseMaximumScreenSpaceError = baseMaximumScreenSpaceError;
   }
 
-  async loadPersistedOrInitBaseMap() {
+  async loadPersistedOrInitBaseMap(): Promise<void> {
     const baseMapItems = this.baseMapsModel.baseMapItems;
     // Set baseMap fallback to first option
     let baseMap = baseMapItems[0];
@@ -1233,11 +1233,11 @@ export default class Terria {
   /**
    * Asynchronously loads init sources
    */
-  loadInitSources() {
+  loadInitSources(): Promise<Result<void>> {
     return this._initSourceLoader.load();
   }
 
-  dispose() {
+  dispose(): void {
     this._initSourceLoader.dispose();
   }
 
@@ -1247,7 +1247,7 @@ export default class Terria {
     name: string = "Application start data",
     /** Error severity to use for loading startData init sources - default will be `TerriaErrorSeverity.Error` */
     errorSeverity?: TerriaErrorSeverity
-  ) {
+  ): Promise<Result<void>> {
     try {
       await interpretStartData(this, startData, name, errorSeverity);
     } catch (e) {
@@ -1257,7 +1257,7 @@ export default class Terria {
     return await this.loadInitSources();
   }
 
-  async updateApplicationUrl(newUrl: string) {
+  async updateApplicationUrl(newUrl: string): Promise<Result<void>> {
     const uri = new URI(newUrl);
     const hash = uri.fragment();
     const hashProperties = queryToObject(hash);
@@ -1941,7 +1941,7 @@ export default class Terria {
   }
 
   @action
-  loadHomeCamera(homeCameraInit: JsonObject | HomeCameraInit) {
+  loadHomeCamera(homeCameraInit: JsonObject | HomeCameraInit): void {
     this.mainViewer.homeCamera = CameraView.fromJson(homeCameraInit);
   }
 
@@ -1957,7 +1957,7 @@ export default class Terria {
     magdaCatalogConfigUrl: string,
     config?: any,
     configUrlHeaders?: { [key: string]: string }
-  ) {
+  ): Promise<void> {
     const theConfig = config
       ? config
       : await loadJson5(magdaCatalogConfigUrl, configUrlHeaders);
@@ -1999,7 +1999,11 @@ export default class Terria {
     }
   }
 
-  async loadMagdaConfig(configUrl: string, config: any, baseUri: uri.URI) {
+  async loadMagdaConfig(
+    configUrl: string,
+    config: any,
+    baseUri: uri.URI
+  ): Promise<void> {
     const aspects = config.aspects;
     const configParams = aspects["terria-config"]?.parameters;
 
@@ -2129,7 +2133,10 @@ export default class Terria {
     });
   }
 
-  async initCorsProxy(config: ConfigParameters, serverConfig: any) {
+  async initCorsProxy(
+    config: ConfigParameters,
+    serverConfig: any
+  ): Promise<void> {
     if (config.proxyableDomainsUrl) {
       console.warn(i18next.t("models.terria.proxyableDomainsDeprecation"));
     }

--- a/lib/Models/TimelineStack.ts
+++ b/lib/Models/TimelineStack.ts
@@ -44,7 +44,7 @@ export default class TimelineStack {
     makeObservable(this);
   }
 
-  activate() {
+  activate(): void {
     // Keep the Cesium clock in sync with the top layer's clock.
     this._disposeClockAutorun = autorun(() => {
       const topLayer = this.top;
@@ -89,7 +89,7 @@ export default class TimelineStack {
     });
   }
 
-  deactivate() {
+  deactivate(): void {
     if (this._disposeClockAutorun) {
       this._disposeClockAutorun();
     }
@@ -142,7 +142,7 @@ export default class TimelineStack {
    * @param item
    */
   @action
-  addToTop(item: TimeVarying) {
+  addToTop(item: TimeVarying): void {
     const currentIndex = this.items.indexOf(item);
     this.items.unshift(item);
     if (currentIndex > -1) {
@@ -157,7 +157,7 @@ export default class TimelineStack {
    * @param item;
    */
   @action
-  remove(item: TimeVarying) {
+  remove(item: TimeVarying): void {
     const index = this.items.indexOf(item);
     this.items.splice(index, 1);
   }
@@ -166,7 +166,7 @@ export default class TimelineStack {
    * Removes all layers.
    */
   @action
-  removeAll() {
+  removeAll(): void {
     this.items = [];
   }
 
@@ -177,7 +177,7 @@ export default class TimelineStack {
    * @param item
    */
   @action
-  promoteToTop(item: TimeVarying) {
+  promoteToTop(item: TimeVarying): void {
     const currentIndex = this.items.indexOf(item);
     if (currentIndex > -1) {
       this.addToTop(item);
@@ -191,7 +191,7 @@ export default class TimelineStack {
    * @param clock The clock to sync to.
    */
   @action
-  syncToClock(stratumId: string) {
+  syncToClock(stratumId: string): void {
     const clock = this.clock;
     const currentTime = JulianDate.toIso8601(
       clock.currentTime,
@@ -226,7 +226,7 @@ export default class TimelineStack {
   }
 
   @action
-  setAlwaysShowTimeline(show = true) {
+  setAlwaysShowTimeline(show = true): void {
     if (!show) {
       this.defaultTimeVarying = undefined;
     } else {

--- a/lib/Models/UserDrawing.ts
+++ b/lib/Models/UserDrawing.ts
@@ -188,7 +188,7 @@ export default class UserDrawing extends MappableMixin(
     return this.getRectangleForShape();
   }
 
-  enterDrawMode() {
+  enterDrawMode(): void {
     // Create and setup a new dragHelper
     this.dragHelper = new DragPoints(this.terria, (customDataSource) => {
       if (typeof this.onPointMoved === "function") {
@@ -346,7 +346,7 @@ export default class UserDrawing extends MappableMixin(
     }
   }
 
-  endDrawing() {
+  endDrawing(): void {
     this.dragHelper?.destroy();
     if (this.disposePickedFeatureSubscription) {
       this.disposePickedFeatureSubscription();
@@ -517,7 +517,7 @@ export default class UserDrawing extends MappableMixin(
   /**
    * User has finished or cancelled; restore initial state.
    */
-  cleanUp() {
+  cleanUp(): void {
     this.terria.overlays.remove(this);
     this.pointEntities = new CustomDataSource("Points");
     this.otherEntities = new CustomDataSource("Lines and polygons");
@@ -556,7 +556,7 @@ export default class UserDrawing extends MappableMixin(
    *     373.45 km
    *     Click to add another point
    */
-  getDialogMessage() {
+  getDialogMessage(): string {
     let message =
       "<strong>" +
       (typeof this.messageHeader === "function"
@@ -588,7 +588,7 @@ export default class UserDrawing extends MappableMixin(
   /**
    * Figure out the text for the dialog button.
    */
-  getButtonText() {
+  getButtonText(): any {
     return defaultValue(
       this.buttonText,
       this.pointEntities.entities.values.length >= 2
@@ -600,7 +600,7 @@ export default class UserDrawing extends MappableMixin(
   /**
    * Return a list of the coords for the user drawing
    */
-  getPointsForShape() {
+  getPointsForShape(): Cartesian3[] | undefined {
     if (isDefined(this.pointEntities.entities)) {
       const pos = [];
       for (let i = 0; i < this.pointEntities.entities.values.length; i++) {

--- a/lib/Models/Workbench.ts
+++ b/lib/Models/Workbench.ts
@@ -77,7 +77,7 @@ export default class Workbench {
    * @param item The model.
    */
   @action
-  remove(item: BaseModel) {
+  remove(item: BaseModel): void {
     const index = this.indexOf(item);
     if (index >= 0) {
       this._items.splice(index, 1);
@@ -88,7 +88,7 @@ export default class Workbench {
    * Removes all models from the workbench.
    */
   @action
-  removeAll() {
+  removeAll(): void {
     this._items.clear();
   }
 
@@ -96,7 +96,7 @@ export default class Workbench {
    * Collapses all models from the workbench.
    */
   @action
-  collapseAll() {
+  collapseAll(): void {
     this.items.map((item) => {
       item.setTrait(CommonStrata.user, "isOpenInWorkbench", false);
     });
@@ -106,7 +106,7 @@ export default class Workbench {
    * Expands all models from the workbench.
    */
   @action
-  expandAll() {
+  expandAll(): void {
     this.items.map((item) => {
       item.setTrait(CommonStrata.user, "isOpenInWorkbench", true);
     });
@@ -240,7 +240,7 @@ export default class Workbench {
    * @param item The model.
    * @returns True if the model or its dereferenced equivalent exists on the workbench; otherwise, false.
    */
-  contains(item: BaseModel) {
+  contains(item: BaseModel): boolean {
     return this.indexOf(item) >= 0;
   }
 
@@ -249,7 +249,7 @@ export default class Workbench {
    * @param item The model.
    * @returns The index of the model or its dereferenced equivalent, or -1 if neither exist on the workbench.
    */
-  indexOf(item: BaseModel) {
+  indexOf(item: BaseModel): number {
     return this.items.findIndex(
       (model) =>
         model === item || dereferenceModel(model) === dereferenceModel(item)
@@ -262,7 +262,7 @@ export default class Workbench {
    * @param newIndex The new index to shift the model to.
    */
   @action
-  moveItemToIndex(item: BaseModel, newIndex: number) {
+  moveItemToIndex(item: BaseModel, newIndex: number): void {
     if (!this.contains(item)) {
       return;
     }

--- a/lib/ReactViewModels/MouseCoords.ts
+++ b/lib/ReactViewModels/MouseCoords.ts
@@ -81,13 +81,13 @@ export default class MouseCoords {
   }
 
   @action.bound
-  toggleUseProjection() {
+  toggleUseProjection(): void {
     this.useProjection = !this.useProjection;
     this.updateEvent.raiseEvent();
   }
 
   @action
-  updateCoordinatesFromCesium(terria: Terria, position: Cartesian2) {
+  updateCoordinatesFromCesium(terria: Terria, position: Cartesian2): void {
     if (!terria.cesium) {
       return;
     }
@@ -190,7 +190,10 @@ export default class MouseCoords {
   }
 
   @action
-  updateCoordinatesFromLeaflet(terria: Terria, mouseMoveEvent: MouseEvent) {
+  updateCoordinatesFromLeaflet(
+    terria: Terria,
+    mouseMoveEvent: MouseEvent
+  ): void {
     if (!terria.leaflet) {
       return;
     }
@@ -206,7 +209,7 @@ export default class MouseCoords {
   }
 
   @action
-  cartographicToFields(coordinates: Cartographic, errorBar?: number) {
+  cartographicToFields(coordinates: Cartographic, errorBar?: number): void {
     this.cartographic = Cartographic.clone(coordinates, scratchCartographic);
 
     const latitude = CesiumMath.toDegrees(coordinates.latitude);
@@ -238,7 +241,7 @@ export default class MouseCoords {
   sampleAccurateHeight(
     terrainProvider: TerrainProvider,
     position: Cartographic
-  ) {
+  ): void {
     if (this.tileRequestInFlight) {
       // A tile request is already in flight, so reschedule for later.
       this.debounceSampleAccurateHeight.cancel();

--- a/lib/ReactViewModels/NotificationState.ts
+++ b/lib/ReactViewModels/NotificationState.ts
@@ -34,7 +34,7 @@ export default class NotificationState {
   }
 
   @action
-  addNotificationToQueue(notification: Notification) {
+  addNotificationToQueue(notification: Notification): void {
     const alreadyQueued =
       this.notifications.filter(
         (item) =>

--- a/lib/ReactViewModels/SearchState.ts
+++ b/lib/ReactViewModels/SearchState.ts
@@ -92,7 +92,7 @@ export default class SearchState {
     );
   }
 
-  dispose() {
+  dispose(): void {
     this._catalogSearchDisposer();
     this._locationSearchDisposer();
     this._unifiedSearchDisposer();
@@ -117,7 +117,7 @@ export default class SearchState {
   }
 
   @action
-  searchCatalog() {
+  searchCatalog(): void {
     if (this.isWaitingToStartCatalogSearch) {
       this.isWaitingToStartCatalogSearch = false;
       if (this.catalogSearchResults) {
@@ -132,12 +132,12 @@ export default class SearchState {
   }
 
   @action
-  setCatalogSearchText(newText: string) {
+  setCatalogSearchText(newText: string): void {
     this.catalogSearchText = newText;
   }
 
   @action
-  searchLocations() {
+  searchLocations(): void {
     if (this.isWaitingToStartLocationSearch) {
       this.isWaitingToStartLocationSearch = false;
       this.locationSearchResults.forEach((results) => {
@@ -150,7 +150,7 @@ export default class SearchState {
   }
 
   @action
-  searchUnified() {
+  searchUnified(): void {
     if (this.isWaitingToStartUnifiedSearch) {
       this.isWaitingToStartUnifiedSearch = false;
       this.unifiedSearchResults.forEach((results) => {

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -159,19 +159,19 @@ export default class ViewState {
     [];
 
   @action
-  setSelectedTrainerItem(trainerItem: string) {
+  setSelectedTrainerItem(trainerItem: string): void {
     this.selectedTrainerItem = trainerItem;
   }
   @action
-  setTrainerBarVisible(bool: boolean) {
+  setTrainerBarVisible(bool: boolean): void {
     this.trainerBarVisible = bool;
   }
   @action
-  setTrainerBarShowingAllSteps(bool: boolean) {
+  setTrainerBarShowingAllSteps(bool: boolean): void {
     this.trainerBarShowingAllSteps = bool;
   }
   @action
-  setTrainerBarExpanded(bool: boolean) {
+  setTrainerBarExpanded(bool: boolean): void {
     this.trainerBarExpanded = bool;
     // if collapsing trainer bar, also hide steps
     if (!bool) {
@@ -179,17 +179,17 @@ export default class ViewState {
     }
   }
   @action
-  setCurrentTrainerItemIndex(index: number) {
+  setCurrentTrainerItemIndex(index: number): void {
     this.currentTrainerItemIndex = index;
     this.currentTrainerStepIndex = 0;
   }
   @action
-  setCurrentTrainerStepIndex(index: number) {
+  setCurrentTrainerStepIndex(index: number): void {
     this.currentTrainerStepIndex = index;
   }
 
   @action
-  setActionBarVisible(visible: boolean) {
+  setActionBarVisible(visible: boolean): void {
     this.isActionBarVisible = visible;
   }
 
@@ -198,7 +198,7 @@ export default class ViewState {
    */
   @observable bottomDockHeight: number = 0;
   @action
-  setBottomDockHeight(height: number) {
+  setBottomDockHeight(height: number): void {
     if (this.bottomDockHeight !== height) {
       this.bottomDockHeight = height;
     }
@@ -274,11 +274,11 @@ export default class ViewState {
       );
   }
   @action
-  setTourIndex(index: number) {
+  setTourIndex(index: number): void {
     this.currentTourIndex = index;
   }
   @action
-  setShowTour(bool: boolean) {
+  setShowTour(bool: boolean): void {
     this.showTour = bool;
     // If we're enabling the tour, make sure the trainer is collapsed
     if (bool) {
@@ -286,19 +286,19 @@ export default class ViewState {
     }
   }
   @action
-  closeTour() {
+  closeTour(): void {
     this.currentTourIndex = -1;
     this.showTour = false;
   }
   @action
-  previousTourPoint() {
+  previousTourPoint(): void {
     const currentIndex = this.currentTourIndex;
     if (currentIndex !== 0) {
       this.currentTourIndex = currentIndex - 1;
     }
   }
   @action
-  nextTourPoint() {
+  nextTourPoint(): void {
     const totalTourPoints = this.tourPointsWithValidRefs.length;
     const currentIndex = this.currentTourIndex;
     if (currentIndex >= totalTourPoints - 1) {
@@ -308,18 +308,18 @@ export default class ViewState {
     }
   }
   @action
-  closeCollapsedNavigation() {
+  closeCollapsedNavigation(): void {
     this.showCollapsedNavigation = false;
   }
 
   @action
-  updateAppRef(refName: string, ref: Ref<HTMLElement>) {
+  updateAppRef(refName: string, ref: Ref<HTMLElement>): void {
     if (!this.appRefs.get(refName) || this.appRefs.get(refName) !== ref) {
       this.appRefs.set(refName, ref);
     }
   }
   @action
-  deleteAppRef(refName: string) {
+  deleteAppRef(refName: string): void {
     this.appRefs.delete(refName);
   }
 
@@ -537,7 +537,7 @@ export default class ViewState {
     );
   }
 
-  dispose() {
+  dispose(): void {
     this._pickedFeaturesSubscription();
     this._disclaimerVisibleSubscription();
     this._mobileMenuSubscription();
@@ -552,7 +552,7 @@ export default class ViewState {
   }
 
   @action
-  triggerResizeEvent() {
+  triggerResizeEvent(): void {
     triggerResize();
   }
 
@@ -560,7 +560,7 @@ export default class ViewState {
   setIsMapFullScreen(
     bool: boolean,
     animationDuration = WORKBENCH_RESIZE_ANIMATION_DURATION
-  ) {
+  ): void {
     this.isMapFullScreen = bool;
     // Allow any animations to finish, then trigger a resize.
 
@@ -576,44 +576,44 @@ export default class ViewState {
   }
 
   @action
-  toggleStoryBuilder() {
+  toggleStoryBuilder(): void {
     this.storyBuilderShown = !this.storyBuilderShown;
   }
 
   @action
-  setTopElement(key: string) {
+  setTopElement(key: string): void {
     this.topElement = key;
   }
 
   @action
-  openAddData() {
+  openAddData(): void {
     this.explorerPanelIsVisible = true;
     this.activeTabCategory = DATA_CATALOG_NAME;
     this.switchMobileView(this.mobileViewOptions.data);
   }
 
   @action
-  openUserData() {
+  openUserData(): void {
     this.explorerPanelIsVisible = true;
     this.activeTabCategory = USER_DATA_NAME;
   }
 
   @action
-  closeCatalog() {
+  closeCatalog(): void {
     this.explorerPanelIsVisible = false;
     this.switchMobileView(null);
     this.clearPreviewedItem();
   }
 
   @action
-  searchInCatalog(query: string) {
+  searchInCatalog(query: string): void {
     this.openAddData();
     this.searchState.catalogSearchText = query;
     this.searchState.searchCatalog();
   }
 
   @action
-  clearPreviewedItem() {
+  clearPreviewedItem(): void {
     this.userDataPreviewedItem = undefined;
     this._previewedItem = undefined;
   }
@@ -696,12 +696,12 @@ export default class ViewState {
   }
 
   @action
-  switchMobileView(viewName: string | null) {
+  switchMobileView(viewName: string | null): void {
     this.mobileView = viewName;
   }
 
   @action
-  showHelpPanel() {
+  showHelpPanel(): void {
     this.terria.analytics?.logEvent(Category.help, HelpAction.panelOpened);
     this.showHelpMenu = true;
     this.helpPanelExpanded = false;
@@ -713,7 +713,7 @@ export default class ViewState {
   openHelpPanelItemFromSharePanel(
     evt: React.MouseEvent<HTMLDivElement>,
     itemName: string
-  ) {
+  ): void {
     evt.preventDefault();
     evt.stopPropagation();
     this.setRetainSharePanel(true);
@@ -722,48 +722,48 @@ export default class ViewState {
   }
 
   @action
-  selectHelpMenuItem(key: string) {
+  selectHelpMenuItem(key: string): void {
     this.selectedHelpMenuItem = key;
     this.helpPanelExpanded = true;
   }
 
   @action
-  hideHelpPanel() {
+  hideHelpPanel(): void {
     this.showHelpMenu = false;
   }
 
   @action
-  setRetainSharePanel(retain: boolean) {
+  setRetainSharePanel(retain: boolean): void {
     this.retainSharePanel = retain;
   }
 
   @action
-  changeSearchState(newText: string) {
+  changeSearchState(newText: string): void {
     this.searchState.catalogSearchText = newText;
   }
 
   @action
-  setDisclaimerVisible(bool: boolean) {
+  setDisclaimerVisible(bool: boolean): void {
     this.disclaimerVisible = bool;
   }
 
   @action
-  hideDisclaimer() {
+  hideDisclaimer(): void {
     this.setDisclaimerVisible(false);
   }
 
   @action
-  setShowSatelliteGuidance(showSatelliteGuidance: boolean) {
+  setShowSatelliteGuidance(showSatelliteGuidance: boolean): void {
     this.showSatelliteGuidance = showSatelliteGuidance;
   }
 
   @action
-  setShowWelcomeMessage(welcomeMessageShown: boolean) {
+  setShowWelcomeMessage(welcomeMessageShown: boolean): void {
     this.showWelcomeMessage = welcomeMessageShown;
   }
 
   @action
-  setVideoGuideVisible(videoName: string) {
+  setVideoGuideVisible(videoName: string): void {
     this.videoGuideVisible = videoName;
   }
 
@@ -771,7 +771,7 @@ export default class ViewState {
    * Removes references of a model from viewState
    */
   @action
-  removeModelReferences(model: BaseModel) {
+  removeModelReferences(model: BaseModel): void {
     if (this._previewedItem === model) this._previewedItem = undefined;
     if (this.userDataPreviewedItem === model)
       this.userDataPreviewedItem = undefined;
@@ -782,7 +782,7 @@ export default class ViewState {
     feature: string,
     state: boolean,
     persistent: boolean = false
-  ) {
+  ): void {
     const featureIndexInPrompts = this.featurePrompts.indexOf(feature);
     if (
       state &&
@@ -798,27 +798,27 @@ export default class ViewState {
     }
   }
 
-  viewingUserData() {
+  viewingUserData(): boolean {
     return this.activeTabCategory === USER_DATA_NAME;
   }
 
-  afterTerriaStarted() {
+  afterTerriaStarted(): void {
     if (this.terria.configParameters.openAddData) {
       this.openAddData();
     }
   }
 
   @action
-  openTool(tool: Tool) {
+  openTool(tool: Tool): void {
     this.currentTool = tool;
   }
 
   @action
-  closeTool() {
+  closeTool(): void {
     this.currentTool = undefined;
   }
 
-  @action setPrintWindow(window: Window | null) {
+  @action setPrintWindow(window: Window | null): void {
     if (this.printWindow) {
       this.printWindow.close();
     }
@@ -826,13 +826,13 @@ export default class ViewState {
   }
 
   @action
-  toggleMobileMenu() {
+  toggleMobileMenu(): void {
     this.setTopElement("mobileMenu");
     this.mobileMenuVisible = !this.mobileMenuVisible;
   }
 
   @action
-  runStories() {
+  runStories(): void {
     this.storyBuilderShown = false;
     this.storyShown = true;
 

--- a/lib/Table/TableColorMap.ts
+++ b/lib/Table/TableColorMap.ts
@@ -693,7 +693,7 @@ export default class TableColorMap {
   }
 
   // TODO: Make TableColorMap use Result to pass warnings up model layer
-  invalidColorPaletteWarning() {
+  invalidColorPaletteWarning(): void {
     if (
       this.colorColumn?.name &&
       this.colorColumn?.tableModel.activeStyle === this.colorColumn?.name

--- a/lib/Table/TableColumn.ts
+++ b/lib/Table/TableColumn.ts
@@ -157,7 +157,12 @@ export default class TableColumn {
    * @param rowIndex row number
    * @param value value to transform
    */
-  mexpColumnValuePairs(rowIndex: number, value: number) {
+  mexpColumnValuePairs(
+    rowIndex: number,
+    value: number
+  ): {
+    [key: string]: number | null;
+  } {
     return this.mexpColumnTokens.reduce<{ [key: string]: number | null }>(
       (pairs, token) => {
         if (token.token !== THIS_COLUMN_EXPRESSION_TOKEN)

--- a/lib/Table/TableFeatureInfoStratum.ts
+++ b/lib/Table/TableFeatureInfoStratum.ts
@@ -17,7 +17,7 @@ export default class TableFeatureInfoStratum extends LoadableStratum(
     makeObservable(this);
   }
 
-  static load(item: TableMixin.Instance) {
+  static load(item: TableMixin.Instance): TableFeatureInfoStratum {
     return new TableFeatureInfoStratum(item);
   }
 

--- a/lib/Table/TableLegendStratum.ts
+++ b/lib/Table/TableLegendStratum.ts
@@ -35,7 +35,7 @@ export class TableAutomaticLegendStratum extends LoadableStratum(
     ) as this;
   }
 
-  static load(item: TableMixin.Instance) {
+  static load(item: TableMixin.Instance): TableAutomaticLegendStratum {
     return new TableAutomaticLegendStratum(item);
   }
 

--- a/lib/ViewModels/TerriaViewer.ts
+++ b/lib/ViewModels/TerriaViewer.ts
@@ -59,7 +59,7 @@ export default class TerriaViewer {
     return this._baseMap;
   }
 
-  async setBaseMap(baseMap?: MappableMixin.Instance) {
+  async setBaseMap(baseMap?: MappableMixin.Instance): Promise<void> {
     if (!baseMap) return;
 
     const result = await baseMap.loadMapItems();
@@ -228,18 +228,18 @@ export default class TerriaViewer {
   // Pull out attaching logic into it's own step. This allows constructing a TerriaViewer
   // before its UI element is mounted in React to set basemap, items, viewermode
   @action
-  attach(mapContainer?: string | HTMLElement) {
+  attach(mapContainer?: string | HTMLElement): void {
     this.mapContainer = mapContainer;
   }
 
   @action
-  detach() {
+  detach(): void {
     // Detach from a container
     this.mapContainer = undefined;
     this.destroyCurrentViewer();
   }
 
-  destroy() {
+  destroy(): void {
     this.detach();
   }
 


### PR DESCRIPTION
### What this PR does

This saves the compiler the effort of
having to infer the types during
compilation, which shortens compilation
times.

This commit is just the code fixes, but
there is also a typescript-eslint
rule for this:

https://typescript-eslint.io/rules/explicit-module-boundary-types/

The annotations were generated from
the fixes in the TypeScript compiler
with:

ts-fix -t ./tsconfig-node.json -e 9008 --write --ignoreGitStatus --file lib/**/*.ts

### Test me

Tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
