### PR TITLE
ThreddsCatalogGroup: fix interface types

### DIFF
--- a/lib/Models/Catalog/CatalogGroups/ThreddsCatalogGroup.ts
+++ b/lib/Models/Catalog/CatalogGroups/ThreddsCatalogGroup.ts
@@ -29,8 +29,8 @@ interface ThreddsCatalog {
   datasets: ThreddsDataset[];
   catalogs: ThreddsCatalog[];
   getAllChildDatasets: () => void;
-  loadAllNestedCatalogs: () => void;
-  loadNestedCatalogById: () => void;
+  loadAllNestedCatalogs: () => Promise<void>;
+  loadNestedCatalogById: () => Promise<void>;
   parentCatalog: ThreddsCatalog;
 }
 
@@ -43,7 +43,7 @@ export interface ThreddsDataset {
   isParentDataset: boolean;
   datasets: ThreddsDataset[];
   catalogs: ThreddsCatalog[];
-  loadAllNestedCatalogs: () => void;
+  loadAllNestedCatalogs: () => Promise<void>;
 }
 
 export class ThreddsStratum extends LoadableStratum(ThreddsCatalogGroupTraits) {


### PR DESCRIPTION
### What this PR does

Add a missing Promise<> around the void
for the return types.

Faulty types were discovered by @na9da in the initial version of #7355.

### Test me


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
