### PR TITLE
Use let/const instead of var

### DIFF
--- a/lib/Core/ServerConfig.js
+++ b/lib/Core/ServerConfig.js
@@ -32,7 +32,7 @@ ServerConfig.prototype.init = function (serverConfigUrl) {
     return Promise.resolve(this.config);
   }
   this.serverConfigUrl = defaultValue(serverConfigUrl, DEFAULT_URL);
-  var that = this;
+  const that = this;
   return loadJson(this.serverConfigUrl)
     .then(function (config) {
       that.config = config;

--- a/lib/Core/loadWithXhr.js
+++ b/lib/Core/loadWithXhr.js
@@ -3,7 +3,7 @@ import Resource from "terriajs-cesium/Source/Core/Resource";
 
 function loadWithXhr(options) {
   // Take advantage that most parameters are the same
-  var resource = new Resource(options);
+  const resource = new Resource(options);
 
   return resource._makeRequest({
     responseType: options.responseType,

--- a/lib/Core/sortedIndices.js
+++ b/lib/Core/sortedIndices.js
@@ -6,9 +6,9 @@
  * @return {Array} The sorted indices, such that array[sortedIndices[0]] = sortedArray[0].
  */
 function sortedIndices(array, compareFunction) {
-  var length = array.length;
-  var indices = new Array(length);
-  for (var i = 0; i < length; i++) {
+  const length = array.length;
+  const indices = new Array(length);
+  for (let i = 0; i < length; i++) {
     indices[i] = i;
   }
   if (!compareFunction) {

--- a/lib/Core/supportsWebGL.js
+++ b/lib/Core/supportsWebGL.js
@@ -21,15 +21,15 @@ function supportsWebGL() {
     result = false;
     return result;
   }
-  var canvas = document.createElement("canvas");
+  const canvas = document.createElement("canvas");
 
-  var webglOptions = {
+  const webglOptions = {
     alpha: false,
     stencil: false,
     failIfMajorPerformanceCaveat: true
   };
 
-  var gl =
+  let gl =
     canvas.getContext("webgl", webglOptions) ||
     canvas.getContext("experimental-webgl", webglOptions);
   if (!gl) {

--- a/lib/Map/DragPoints/CesiumDragPoints.js
+++ b/lib/Map/DragPoints/CesiumDragPoints.js
@@ -68,7 +68,7 @@ CesiumDragPoints.prototype.setUp = function () {
   this._viewer = this._terria.cesium.cesiumWidget;
   this._mouseHandler = new ScreenSpaceEventHandler(this._scene.canvas, false);
 
-  var that = this;
+  const that = this;
 
   // Mousedown event. This is called for all mousedown events, not just mousedown on entity events like the Leaflet
   // equivalent.
@@ -79,11 +79,11 @@ CesiumDragPoints.prototype.setUp = function () {
     ) {
       return;
     }
-    var pickedObject = that._scene.pick(click.position);
+    const pickedObject = that._scene.pick(click.position);
     that._originalPosition = click.position;
     if (defined(pickedObject)) {
-      var pickedEntity = pickedObject.id;
-      var draggedEntity = that._draggableObjects.entities.values.filter(
+      const pickedEntity = pickedObject.id;
+      const draggedEntity = that._draggableObjects.entities.values.filter(
         function (dragObjEntity) {
           return dragObjEntity.id === pickedEntity.id;
         }
@@ -105,7 +105,7 @@ CesiumDragPoints.prototype.setUp = function () {
     const pickRay = that._viewer.camera.getPickRay(move.endPosition);
     const cartesian = that._scene.globe.pick(pickRay, that._scene);
     that._entityDragged.position = cartesian;
-    for (var i = 0; i < that._draggableObjects.entities.values.length; i++) {
+    for (let i = 0; i < that._draggableObjects.entities.values.length; i++) {
       if (
         that._draggableObjects.entities.values[i].id === that._entityDragged.id
       ) {

--- a/lib/Map/DragPoints/DragPoints.js
+++ b/lib/Map/DragPoints/DragPoints.js
@@ -19,11 +19,11 @@ import ViewerMode from "../../Models/ViewerMode";
  * @param {Terria} terria The Terria instance.
  * @param {PointMovedCallback} pointMovedCallback A function that is called when a point is moved.
  */
-var DragPoints = function (terria, pointMovedCallback) {
+const DragPoints = function (terria, pointMovedCallback) {
   this._terria = terria;
   this._createDragPointsHelper(pointMovedCallback);
 
-  var that = this;
+  const that = this;
   // It's possible to change viewerMode while mid-drawing, but in that case we need to change the dragPoints helper.
   this._terria.mainViewer.afterViewerChanged.addEventListener(function () {
     that._createDragPointsHelper(pointMovedCallback);

--- a/lib/Map/DragPoints/LeafletDragPoints.js
+++ b/lib/Map/DragPoints/LeafletDragPoints.js
@@ -79,7 +79,7 @@ LeafletDragPoints.prototype._onMouseDownOnPoint = function (entity) {
     return;
   }
 
-  var dragEntity = this._draggableObjects.entities.values.filter(function (
+  const dragEntity = this._draggableObjects.entities.values.filter(function (
     dragObjEntity
   ) {
     // Not necessarily same entity, but will have same id.

--- a/lib/Map/Vector/EarthGravityModel1996.js
+++ b/lib/Map/Vector/EarthGravityModel1996.js
@@ -6,7 +6,7 @@ import loadArrayBuffer from "../../Core/loadArrayBuffer";
  * The Earth Gravity Model 1996 (EGM96) geoid.
  * @param {String} gridFileUrl The URL of the WW15MGH.DAC file.
  */
-var EarthGravityModel1996 = function (gridFileUrl) {
+const EarthGravityModel1996 = function (gridFileUrl) {
   this.gridFileUrl = gridFileUrl;
   this.data = undefined;
 
@@ -41,8 +41,8 @@ EarthGravityModel1996.prototype.getHeight = function (longitude, latitude) {
 
 EarthGravityModel1996.prototype.getHeights = function (cartographicArray) {
   return getHeightData(this).then(function (data) {
-    for (var i = 0; i < cartographicArray.length; ++i) {
-      var cartographic = cartographicArray[i];
+    for (let i = 0; i < cartographicArray.length; ++i) {
+      const cartographic = cartographicArray[i];
       cartographic.height = getHeightFromData(
         data,
         cartographic.longitude,
@@ -61,9 +61,9 @@ function getHeightData(model) {
   return Promise.resolve(model.data).then(function (data) {
     if (!(model.data instanceof Int16Array)) {
       // Data file is big-endian, all relevant platforms are little endian, so swap the byte order.
-      var byteView = new Uint8Array(data);
-      for (var k = 0; k < byteView.length; k += 2) {
-        var tmp = byteView[k];
+      const byteView = new Uint8Array(data);
+      for (let k = 0; k < byteView.length; k += 2) {
+        const tmp = byteView[k];
         byteView[k] = byteView[k + 1];
         byteView[k + 1] = tmp;
       }
@@ -75,7 +75,7 @@ function getHeightData(model) {
 }
 
 function getHeightFromData(data, longitude, latitude) {
-  var recordIndex = (720 * (CesiumMath.PI_OVER_TWO - latitude)) / Math.PI;
+  let recordIndex = (720 * (CesiumMath.PI_OVER_TWO - latitude)) / Math.PI;
   if (recordIndex < 0) {
     recordIndex = 0;
   } else if (recordIndex > 720) {
@@ -83,25 +83,25 @@ function getHeightFromData(data, longitude, latitude) {
   }
 
   longitude = CesiumMath.zeroToTwoPi(longitude);
-  var heightIndex = (1440 * longitude) / CesiumMath.TWO_PI;
+  let heightIndex = (1440 * longitude) / CesiumMath.TWO_PI;
   if (heightIndex < 0) {
     heightIndex = 0;
   } else if (heightIndex > 1440) {
     heightIndex = 1440;
   }
 
-  var i = heightIndex | 0;
-  var j = recordIndex | 0;
+  const i = heightIndex | 0;
+  const j = recordIndex | 0;
 
-  var xMinusX1 = heightIndex - i;
-  var yMinusY1 = recordIndex - j;
-  var x2MinusX = 1.0 - xMinusX1;
-  var y2MinusY = 1.0 - yMinusY1;
+  const xMinusX1 = heightIndex - i;
+  const yMinusY1 = recordIndex - j;
+  const x2MinusX = 1.0 - xMinusX1;
+  const y2MinusY = 1.0 - yMinusY1;
 
-  var f11 = getHeightValue(data, j, i);
-  var f21 = getHeightValue(data, j, i + 1);
-  var f12 = getHeightValue(data, j + 1, i);
-  var f22 = getHeightValue(data, j + 1, i + 1);
+  const f11 = getHeightValue(data, j, i);
+  const f21 = getHeightValue(data, j, i + 1);
+  const f12 = getHeightValue(data, j + 1, i);
+  const f22 = getHeightValue(data, j + 1, i + 1);
 
   return (
     (f11 * x2MinusX * y2MinusY +

--- a/lib/Map/Vector/geoJsonGeometryFromGeoRssSimpleGeometry.js
+++ b/lib/Map/Vector/geoJsonGeometryFromGeoRssSimpleGeometry.js
@@ -2,15 +2,15 @@ import defined from "terriajs-cesium/Source/Core/defined";
 import RuntimeError from "terriajs-cesium/Source/Core/RuntimeError";
 import i18next from "i18next";
 
-var featureCreators = {
+const featureCreators = {
   point: createPointGeometry,
   line: createLineGeometry,
   polygon: createPolygonGeometry,
   box: createGeometryFromBox
 };
 function geoJsonGeometryFromGeoRssSimpleGeometry(geometry) {
-  var type = geometry.localName;
-  var creator = featureCreators[type];
+  const type = geometry.localName;
+  const creator = featureCreators[type];
   if (!defined(creator)) {
     throw new RuntimeError(
       i18next.t("map.geoRssToGeoJson.containsUnsupportedFeatureType", {
@@ -43,17 +43,17 @@ function createPolygonGeometry(polygonGeometry) {
 }
 
 function createGeometryFromBox(bboxGeometry) {
-  var coordinates = bboxGeometry.textContent
+  const coordinates = bboxGeometry.textContent
     .trim()
     .split(/\s+/)
     .filter(isNotEmpty);
   if (coordinates.length !== 4) {
     throw new RuntimeError("geometry not valid");
   }
-  var minLat = coordinates[0];
-  var minLon = coordinates[1];
-  var maxLat = coordinates[2];
-  var maxLon = coordinates[3];
+  const minLat = coordinates[0];
+  const minLon = coordinates[1];
+  const maxLat = coordinates[2];
+  const maxLon = coordinates[3];
 
   return {
     type: "Polygon",
@@ -75,9 +75,9 @@ function isNotEmpty(s) {
 
 //Utility function to change esri gml positions to geojson positions
 function geom2coord(posList) {
-  var pnts = posList.split(/\s+/).filter(isNotEmpty);
-  var coords = [];
-  for (var i = 0; i < pnts.length; i += 2) {
+  const pnts = posList.split(/\s+/).filter(isNotEmpty);
+  const coords = [];
+  for (let i = 0; i < pnts.length; i += 2) {
     coords.push([parseFloat(pnts[i + 1]), parseFloat(pnts[i])]);
   }
   return coords;

--- a/lib/Map/Vector/geoJsonGeometryFromGmlGeometry.js
+++ b/lib/Map/Vector/geoJsonGeometryFromGmlGeometry.js
@@ -5,12 +5,12 @@ import defined from "terriajs-cesium/Source/Core/defined";
 const gmlNamespace = "http://www.opengis.net/gml";
 
 function createLineStringFromGmlGeometry(geometry) {
-  var coordinates = [];
+  const coordinates = [];
 
-  var posNodes = geometry.getElementsByTagNameNS(gmlNamespace, "posList");
-  for (var i = 0; i < posNodes.length; ++i) {
-    var positions = gml2coord(posNodes[i].textContent.trim());
-    for (var j = 0; j < positions.length; ++j) {
+  const posNodes = geometry.getElementsByTagNameNS(gmlNamespace, "posList");
+  for (let i = 0; i < posNodes.length; ++i) {
+    const positions = gml2coord(posNodes[i].textContent.trim());
+    for (let j = 0; j < positions.length; ++j) {
       coordinates.push(positions[j]);
     }
   }
@@ -22,7 +22,7 @@ function createLineStringFromGmlGeometry(geometry) {
 }
 
 function createPointFromGmlGeometry(geometry) {
-  var posNodes = geometry.getElementsByTagNameNS(gmlNamespace, "pos");
+  const posNodes = geometry.getElementsByTagNameNS(gmlNamespace, "pos");
   if (posNodes.length < 1) {
     throw new RuntimeError(i18next.t("map.gmlToGeoJson.missingPos"));
   }
@@ -64,9 +64,9 @@ function createPolygonFromEnvelope(geometry) {
 }
 
 function createMultiLineStringFromGmlGeometry(geometry) {
-  var curveMembers = geometry.getElementsByTagNameNS(gmlNamespace, "posList");
-  var curves = [];
-  for (var i = 0; i < curveMembers.length; ++i) {
+  const curveMembers = geometry.getElementsByTagNameNS(gmlNamespace, "posList");
+  const curves = [];
+  for (let i = 0; i < curveMembers.length; ++i) {
     curves.push(gml2coord(curveMembers[i].textContent));
   }
 
@@ -77,12 +77,12 @@ function createMultiLineStringFromGmlGeometry(geometry) {
 }
 
 function createMultiPolygonFromGmlGeomtry(geometry) {
-  var coordinates = [];
+  const coordinates = [];
 
-  var polygons = geometry.getElementsByTagNameNS(gmlNamespace, "Polygon");
-  for (var i = 0; i < polygons.length; ++i) {
-    var polygon = polygons[i];
-    var exteriorNodes = polygon.getElementsByTagNameNS(
+  const polygons = geometry.getElementsByTagNameNS(gmlNamespace, "Polygon");
+  for (let i = 0; i < polygons.length; ++i) {
+    const polygon = polygons[i];
+    const exteriorNodes = polygon.getElementsByTagNameNS(
       gmlNamespace,
       "exterior"
     );
@@ -90,20 +90,23 @@ function createMultiPolygonFromGmlGeomtry(geometry) {
       throw new RuntimeError(i18next.t("map.gmlToGeoJson.missingExteriorRing"));
     }
 
-    var polygonCoordinates = [];
+    const polygonCoordinates = [];
 
-    var exterior = exteriorNodes[0];
-    var posListNodes = exterior.getElementsByTagNameNS(gmlNamespace, "posList");
+    const exterior = exteriorNodes[0];
+    const posListNodes = exterior.getElementsByTagNameNS(
+      gmlNamespace,
+      "posList"
+    );
     if (posListNodes.length < 1) {
       throw new RuntimeError(i18next.t("map.gmlToGeoJson.missingPosList"));
     }
 
     polygonCoordinates.push(gml2coord(posListNodes[0].textContent));
 
-    var interiors = polygon.getElementsByTagNameNS(gmlNamespace, "interior");
-    for (var j = 0; j < interiors.length; ++j) {
-      var interior = interiors[j];
-      var interiorPosListNodes = interior.getElementsByTagNameNS(
+    const interiors = polygon.getElementsByTagNameNS(gmlNamespace, "interior");
+    for (let j = 0; j < interiors.length; ++j) {
+      const interior = interiors[j];
+      const interiorPosListNodes = interior.getElementsByTagNameNS(
         gmlNamespace,
         "posList"
       );
@@ -124,24 +127,27 @@ function createMultiPolygonFromGmlGeomtry(geometry) {
 }
 
 function createPolygonFromGmlGeometry(geometry) {
-  var polygonCoordinates = [];
+  const polygonCoordinates = [];
 
-  var exteriorNodes = geometry.getElementsByTagNameNS(gmlNamespace, "exterior");
+  const exteriorNodes = geometry.getElementsByTagNameNS(
+    gmlNamespace,
+    "exterior"
+  );
   if (exteriorNodes.length < 1) {
     throw new RuntimeError(i18next.t("map.gmlToGeoJson.missingExteriorRing"));
   }
-  var exterior = exteriorNodes[0];
-  var posListNodes = exterior.getElementsByTagNameNS(gmlNamespace, "posList");
+  const exterior = exteriorNodes[0];
+  const posListNodes = exterior.getElementsByTagNameNS(gmlNamespace, "posList");
   if (posListNodes.length < 1) {
     throw new RuntimeError(i18next.t("map.gmlToGeoJson.missingPosList"));
   }
 
   polygonCoordinates.push(gml2coord(posListNodes[0].textContent));
 
-  var interiors = geometry.getElementsByTagNameNS(gmlNamespace, "interior");
-  for (var j = 0; j < interiors.length; ++j) {
-    var interior = interiors[j];
-    var interiorPosListNodes = interior.getElementsByTagNameNS(
+  const interiors = geometry.getElementsByTagNameNS(gmlNamespace, "interior");
+  for (let j = 0; j < interiors.length; ++j) {
+    const interior = interiors[j];
+    const interiorPosListNodes = interior.getElementsByTagNameNS(
       gmlNamespace,
       "posList"
     );
@@ -159,10 +165,10 @@ function createPolygonFromGmlGeometry(geometry) {
 }
 
 function createMultiPointFromGmlGeometry(geometry) {
-  var posNodes = geometry.getElementsByTagNameNS(gmlNamespace, "pos");
-  var coordinates = [];
+  const posNodes = geometry.getElementsByTagNameNS(gmlNamespace, "pos");
+  const coordinates = [];
 
-  for (var i = 0; i < posNodes.length; ++i) {
+  for (let i = 0; i < posNodes.length; ++i) {
     coordinates.push(gml2coord(posNodes[i].textContent)[0]);
   }
 
@@ -172,7 +178,7 @@ function createMultiPointFromGmlGeometry(geometry) {
   };
 }
 
-var featureCreators = {
+const featureCreators = {
   Curve: createLineStringFromGmlGeometry,
   LineString: createLineStringFromGmlGeometry,
   Point: createPointFromGmlGeometry,
@@ -185,8 +191,8 @@ var featureCreators = {
 };
 
 function geoJsonGeometryFeatureFromGmlGeometry(geometry) {
-  var type = geometry.localName;
-  var creator = featureCreators[type];
+  const type = geometry.localName;
+  const creator = featureCreators[type];
   if (!defined(creator)) {
     throw new RuntimeError(
       i18next.t("map.gmlToGeoJson.containsUnsupportedFeatureType", {
@@ -204,9 +210,9 @@ function isNotEmpty(s) {
 
 //Utility function to change esri gml positions to geojson positions
 function gml2coord(posList) {
-  var pnts = posList.split(/[ ,]+/).filter(isNotEmpty);
-  var coords = [];
-  for (var i = 0; i < pnts.length; i += 2) {
+  const pnts = posList.split(/[ ,]+/).filter(isNotEmpty);
+  const coords = [];
+  for (let i = 0; i < pnts.length; i += 2) {
     coords.push([parseFloat(pnts[i + 1]), parseFloat(pnts[i])]);
   }
   return coords;

--- a/lib/Map/Vector/geoJsonGeometryFromW3cGeometry.js
+++ b/lib/Map/Vector/geoJsonGeometryFromW3cGeometry.js
@@ -2,13 +2,13 @@ import defined from "terriajs-cesium/Source/Core/defined";
 import RuntimeError from "terriajs-cesium/Source/Core/RuntimeError";
 import i18next from "i18next";
 
-var featureCreators = {
+const featureCreators = {
   Point: createPointGeometry
 };
 
 function geoJsonGeometryFromW3cGeometry(geometry) {
-  var type = "Point";
-  var creator = featureCreators[type];
+  const type = "Point";
+  const creator = featureCreators[type];
   if (!defined(creator)) {
     throw new RuntimeError(
       i18next.t("map.w3cToGeoJson.containsUnsupportedFeatureType", {
@@ -26,8 +26,8 @@ function createPointGeometry(geometry) {
     and we already know that Point in W3C geometry supports only lat and long elements
     http://www.w3.org/2003/01/geo/wgs84_pos# and http://www.w3.org/2003/01/geo/
    */
-  var latitude = geometry.getElementsByTagNameNS("*", "lat")[0].textContent;
-  var longitude = geometry.getElementsByTagNameNS("*", "long")[0].textContent;
+  const latitude = geometry.getElementsByTagNameNS("*", "lat")[0].textContent;
+  const longitude = geometry.getElementsByTagNameNS("*", "long")[0].textContent;
   return {
     type: "Point",
     coordinates: [longitude, latitude]

--- a/lib/Map/Vector/geoRssConvertor.js
+++ b/lib/Map/Vector/geoRssConvertor.js
@@ -10,23 +10,23 @@ import geoJsonGeometryFromW3cGeometry from "./geoJsonGeometryFromW3cGeometry";
  */
 export const geoRss2ToGeoJson = function (xml) {
   if (typeof xml === "string") {
-    var parser = new DOMParser();
+    const parser = new DOMParser();
     xml = parser.parseFromString(xml, "text/xml");
   }
-  var result = [];
+  const result = [];
 
-  var rss = xml.documentElement;
+  const rss = xml.documentElement;
   const channel = rss.getElementsByTagName("channel")[0];
   const items = channel.getElementsByTagName("item");
-  for (var itemIndex = 0; itemIndex < items.length; ++itemIndex) {
-    var item = items[itemIndex];
+  for (let itemIndex = 0; itemIndex < items.length; ++itemIndex) {
+    const item = items[itemIndex];
 
-    var properties = {};
+    const properties = {};
     const containsGeometry = getGeoRssPropertiesRecursively(item, properties);
     if (!containsGeometry) {
       continue;
     }
-    var feature = {
+    const feature = {
       type: "Feature",
       properties: properties,
       geometry: getGeometry(item)
@@ -48,22 +48,22 @@ export const geoRss2ToGeoJson = function (xml) {
  */
 export const geoRssAtomToGeoJson = function (xml) {
   if (typeof xml === "string") {
-    var parser = new DOMParser();
+    const parser = new DOMParser();
     xml = parser.parseFromString(xml, "text/xml");
   }
-  var result = [];
+  const result = [];
 
-  var feed = xml.documentElement;
+  const feed = xml.documentElement;
   const entries = feed.getElementsByTagName("entry");
-  for (var entryIndex = 0; entryIndex < entries.length; ++entryIndex) {
-    var entry = entries[entryIndex];
-    var properties = {};
+  for (let entryIndex = 0; entryIndex < entries.length; ++entryIndex) {
+    const entry = entries[entryIndex];
+    const properties = {};
 
     const containsGeometry = getGeoRssPropertiesRecursively(entry, properties);
     if (!containsGeometry) {
       continue;
     }
-    var feature = {
+    const feature = {
       type: "Feature",
       properties: properties,
       geometry: getGeometry(entry)
@@ -78,7 +78,7 @@ export const geoRssAtomToGeoJson = function (xml) {
   };
 };
 
-var gmlFeatureNames = [
+const gmlFeatureNames = [
   "Curve",
   "LineString",
   "Point",
@@ -90,16 +90,16 @@ var gmlFeatureNames = [
   "Envelope"
 ];
 
-var nodeWhere = ["where"];
-var identifyW3C = ["Point"];
+const nodeWhere = ["where"];
+const identifyW3C = ["Point"];
 
-var simpleGeometryNames = ["point", "line", "polygon", "box"];
+const simpleGeometryNames = ["point", "line", "polygon", "box"];
 
 function getGeoRssPropertiesRecursively(gmlNode, properties) {
-  var constainsGeometry = false;
+  let constainsGeometry = false;
 
-  for (var i = 0; i < gmlNode.childNodes.length; ++i) {
-    var child = gmlNode.childNodes[i];
+  for (let i = 0; i < gmlNode.childNodes.length; ++i) {
+    const child = gmlNode.childNodes[i];
 
     if (nodeWhere.indexOf(child.localName) >= 0) {
       constainsGeometry = true;
@@ -129,9 +129,9 @@ function getGeoRssPropertiesRecursively(gmlNode, properties) {
  * @param {*} node
  */
 function getGeometry(node) {
-  var result;
-  for (var i = 0; !defined(result) && i < node.childNodes.length; ++i) {
-    var child = node.childNodes[i];
+  let result;
+  for (let i = 0; !defined(result) && i < node.childNodes.length; ++i) {
+    const child = node.childNodes[i];
 
     if (nodeWhere.indexOf(child.localName) >= 0) {
       return getGeometryFromWhere(child);
@@ -146,9 +146,9 @@ function getGeometry(node) {
   return result;
 }
 function getGeometryFromWhere(node) {
-  var result;
-  for (var i = 0; !defined(result) && i < node.childNodes.length; ++i) {
-    var child = node.childNodes[i];
+  let result;
+  for (let i = 0; !defined(result) && i < node.childNodes.length; ++i) {
+    const child = node.childNodes[i];
     if (gmlFeatureNames.indexOf(child.localName) >= 0) {
       return createGeoJsonGeometryFeatureFromGmlGeometry(child);
     } else if (simpleGeometryNames.indexOf(child.localName) >= 0) {

--- a/lib/Map/Vector/gmlToGeoJson.js
+++ b/lib/Map/Vector/gmlToGeoJson.js
@@ -10,30 +10,30 @@ const gmlNamespace = "http://www.opengis.net/gml";
  */
 function gmlToGeoJson(xml) {
   if (typeof xml === "string") {
-    var parser = new DOMParser();
+    const parser = new DOMParser();
     xml = parser.parseFromString(xml, "text/xml");
   }
 
-  var result = [];
+  const result = [];
 
-  var featureCollection = xml.documentElement;
+  const featureCollection = xml.documentElement;
 
-  var featureMembers = featureCollection.getElementsByTagNameNS(
+  const featureMembers = featureCollection.getElementsByTagNameNS(
     gmlNamespace,
     "featureMember"
   );
   for (
-    var featureIndex = 0;
+    let featureIndex = 0;
     featureIndex < featureMembers.length;
     ++featureIndex
   ) {
-    var featureMember = featureMembers[featureIndex];
+    const featureMember = featureMembers[featureIndex];
 
-    var properties = {};
+    const properties = {};
 
     getGmlPropertiesRecursively(featureMember, properties);
 
-    var feature = {
+    const feature = {
       type: "Feature",
       geometry: getGmlGeometry(featureMember),
       properties: properties
@@ -51,7 +51,7 @@ function gmlToGeoJson(xml) {
   };
 }
 
-var gmlSimpleFeatureNames = [
+const gmlSimpleFeatureNames = [
   "Curve",
   "LineString",
   "Point",
@@ -63,10 +63,10 @@ var gmlSimpleFeatureNames = [
 ];
 
 function getGmlPropertiesRecursively(gmlNode, properties) {
-  var isSingleValue = true;
+  let isSingleValue = true;
 
-  for (var i = 0; i < gmlNode.childNodes.length; ++i) {
-    var child = gmlNode.childNodes[i];
+  for (let i = 0; i < gmlNode.childNodes.length; ++i) {
+    const child = gmlNode.childNodes[i];
 
     if (child.nodeType === Node.ELEMENT_NODE) {
       isSingleValue = false;
@@ -88,10 +88,10 @@ function getGmlPropertiesRecursively(gmlNode, properties) {
 }
 
 function getGmlGeometry(gmlNode) {
-  var result;
+  let result;
 
-  for (var i = 0; !defined(result) && i < gmlNode.childNodes.length; ++i) {
-    var child = gmlNode.childNodes[i];
+  for (let i = 0; !defined(result) && i < gmlNode.childNodes.length; ++i) {
+    const child = gmlNode.childNodes[i];
 
     if (gmlSimpleFeatureNames.indexOf(child.localName) >= 0) {
       return geoJsonGeometryFromGmlGeometry(child);

--- a/lib/Map/Vector/zoomRectangleFromPoint.js
+++ b/lib/Map/Vector/zoomRectangleFromPoint.js
@@ -12,9 +12,9 @@ export default function createZoomToFunction(
 ) {
   boundingBoxSize = defaultValue(boundingBoxSize, DEFAULT_BOUNDING_BOX_SIZE);
 
-  var south = parseFloat(latitude) - boundingBoxSize / 2;
-  var west = parseFloat(longitude) - boundingBoxSize / 2;
-  var north = parseFloat(latitude) + boundingBoxSize / 2;
-  var east = parseFloat(longitude) + boundingBoxSize / 2;
+  const south = parseFloat(latitude) - boundingBoxSize / 2;
+  const west = parseFloat(longitude) - boundingBoxSize / 2;
+  const north = parseFloat(latitude) + boundingBoxSize / 2;
+  const east = parseFloat(longitude) + boundingBoxSize / 2;
   return Rectangle.fromDegrees(west, south, east, north);
 }

--- a/lib/ViewModels/updateApplicationOnMessageFromParentWindow.js
+++ b/lib/ViewModels/updateApplicationOnMessageFromParentWindow.js
@@ -2,12 +2,12 @@ import { TerriaErrorSeverity } from "../Core/TerriaError";
 import defined from "terriajs-cesium/Source/Core/defined";
 
 const updateApplicationOnMessageFromParentWindow = function (terria, window) {
-  var allowOrigin;
+  let allowOrigin;
 
   window.addEventListener(
     "message",
     async function (event) {
-      var origin = event.origin;
+      let origin = event.origin;
       if (!defined(origin) && defined(event.originalEvent)) {
         // For Chrome, the origin property is in the event.originalEvent object.
         origin = event.originalEvent.origin;


### PR DESCRIPTION
### What this PR does

Switch the remaining javscript
files under lib to use let/const
instead of var.

This change was made on top of
the webpack5 branch to avoid
creating merge conflicts.

### Test me

I believe this is tested by CI?

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
