### PR TITLE
test: rename type-only variables

### DIFF
--- a/test/Types/FlattenedFromTraitsSpec.ts
+++ b/test/Types/FlattenedFromTraitsSpec.ts
@@ -59,21 +59,21 @@ expectFalse<
 
 const array = flattened.nestedArrayWithDefault;
 if (array) {
-  const first = array[0];
+  const _first = array[0];
 
   // Arrays may not _contain_ undefineds.
-  expectFalse<AllowsUndefined<typeof first>>();
+  expectFalse<AllowsUndefined<typeof _first>>();
 
   // Properties in traits in arrays allow undefined.
-  expectTrue<Equals<typeof first.withDefault, number | undefined>>();
-  expectTrue<Equals<typeof first.withoutDefault, number | undefined>>();
-  expectTrue<Equals<typeof first.unknownObject, JsonObject | undefined>>();
+  expectTrue<Equals<typeof _first.withDefault, number | undefined>>();
+  expectTrue<Equals<typeof _first.withoutDefault, number | undefined>>();
+  expectTrue<Equals<typeof _first.unknownObject, JsonObject | undefined>>();
   expectTrue<
-    Equals<typeof first.unknownObjectWithDefault, JsonObject | undefined>
+    Equals<typeof _first.unknownObjectWithDefault, JsonObject | undefined>
   >();
-  expectTrue<Equals<typeof first.withNull, string | null | undefined>>();
+  expectTrue<Equals<typeof _first.withNull, string | null | undefined>>();
 
   // Properties in traits in arrays can _not_ be modified.
-  expectFalse<IsWritable<typeof first, "withDefault">>();
-  expectFalse<IsWritable<typeof first, "withoutDefault">>();
+  expectFalse<IsWritable<typeof _first, "withDefault">>();
+  expectFalse<IsWritable<typeof _first, "withoutDefault">>();
 }

--- a/test/Types/ModelPropertiesFromTraitsSpec.ts
+++ b/test/Types/ModelPropertiesFromTraitsSpec.ts
@@ -35,18 +35,18 @@ expectFalse<IsWritable<typeof modelProperties, "withoutDefault">>();
 expectFalse<AllowsUndefined<typeof modelProperties.nestedWithDefault>>();
 expectFalse<AllowsUndefined<typeof modelProperties.nestedWithoutDefault>>();
 
-const nested = modelProperties.nestedWithDefault;
+const _nested = modelProperties.nestedWithDefault;
 
 // Nested properties allow undefined only if they do not have a default.
-expectTrue<Equals<typeof nested.withDefault, number>>();
-expectTrue<Equals<typeof nested.withoutDefault, number | undefined>>();
-expectTrue<Equals<typeof nested.unknownObject, JsonObject | undefined>>();
-expectTrue<Equals<typeof nested.unknownObjectWithDefault, JsonObject>>();
-expectTrue<Equals<typeof nested.withNull, string | null | undefined>>();
+expectTrue<Equals<typeof _nested.withDefault, number>>();
+expectTrue<Equals<typeof _nested.withoutDefault, number | undefined>>();
+expectTrue<Equals<typeof _nested.unknownObject, JsonObject | undefined>>();
+expectTrue<Equals<typeof _nested.unknownObjectWithDefault, JsonObject>>();
+expectTrue<Equals<typeof _nested.withNull, string | null | undefined>>();
 
 // Nested properties may not be modified.
-expectFalse<IsWritable<typeof nested, "withDefault">>();
-expectFalse<IsWritable<typeof nested, "withoutDefault">>();
+expectFalse<IsWritable<typeof _nested, "withDefault">>();
+expectFalse<IsWritable<typeof _nested, "withoutDefault">>();
 
 // Properties that are arrays of traits allow undefined only if they do not have a default.
 expectFalse<AllowsUndefined<typeof modelProperties.nestedArrayWithDefault>>();
@@ -64,19 +64,19 @@ expectFalse<
 
 const array = modelProperties.nestedArrayWithDefault;
 if (array) {
-  const first = array[0];
+  const _first = array[0];
 
   // Arrays may not _contain_ undefineds.
-  expectFalse<AllowsUndefined<typeof first>>();
+  expectFalse<AllowsUndefined<typeof _first>>();
 
   // Properties in traits in arrays allow undefined only if they do not have a default.
-  expectTrue<Equals<typeof first.withDefault, number>>();
-  expectTrue<Equals<typeof first.withoutDefault, number | undefined>>();
-  expectTrue<Equals<typeof first.unknownObject, JsonObject | undefined>>();
-  expectTrue<Equals<typeof first.unknownObjectWithDefault, JsonObject>>();
-  expectTrue<Equals<typeof first.withNull, string | null | undefined>>();
+  expectTrue<Equals<typeof _first.withDefault, number>>();
+  expectTrue<Equals<typeof _first.withoutDefault, number | undefined>>();
+  expectTrue<Equals<typeof _first.unknownObject, JsonObject | undefined>>();
+  expectTrue<Equals<typeof _first.unknownObjectWithDefault, JsonObject>>();
+  expectTrue<Equals<typeof _first.withNull, string | null | undefined>>();
 
   // Properties in traits in arrays can not be modified.
-  expectFalse<IsWritable<typeof first, "withDefault">>();
-  expectFalse<IsWritable<typeof first, "withoutDefault">>();
+  expectFalse<IsWritable<typeof _first, "withDefault">>();
+  expectFalse<IsWritable<typeof _first, "withoutDefault">>();
 }

--- a/test/Types/StratumFromTraitsSpec.ts
+++ b/test/Types/StratumFromTraitsSpec.ts
@@ -66,24 +66,24 @@ expectTrue<
 
 const array = stratum.nestedArrayWithDefault;
 if (array) {
-  const first = array[0];
+  const _first = array[0];
 
   // Arrays may not _contain_ undefineds.
-  expectFalse<AllowsUndefined<typeof first>>();
+  expectFalse<AllowsUndefined<typeof _first>>();
 
   // Properties in traits in arrays allow undefined.
-  expectTrue<Equals<typeof first.withDefault, number | undefined>>();
-  expectTrue<Equals<typeof first.withoutDefault, number | undefined>>();
-  expectTrue<Equals<typeof first.unknownObject, JsonObject | undefined>>();
+  expectTrue<Equals<typeof _first.withDefault, number | undefined>>();
+  expectTrue<Equals<typeof _first.withoutDefault, number | undefined>>();
+  expectTrue<Equals<typeof _first.unknownObject, JsonObject | undefined>>();
   expectTrue<
-    Equals<typeof first.unknownObjectWithDefault, JsonObject | undefined>
+    Equals<typeof _first.unknownObjectWithDefault, JsonObject | undefined>
   >();
-  expectTrue<Equals<typeof first.withNull, string | null | undefined>>();
+  expectTrue<Equals<typeof _first.withNull, string | null | undefined>>();
 
   // Properties in traits in arrays can be modified.
-  expectTrue<IsWritable<typeof first, "withDefault">>();
-  expectTrue<IsWritable<typeof first, "withoutDefault">>();
-  expectTrue<IsWritable<typeof first, "unknownObject">>();
-  expectTrue<IsWritable<typeof first, "unknownObjectWithDefault">>();
-  expectTrue<IsWritable<typeof first, "withNull">>();
+  expectTrue<IsWritable<typeof _first, "withDefault">>();
+  expectTrue<IsWritable<typeof _first, "withoutDefault">>();
+  expectTrue<IsWritable<typeof _first, "unknownObject">>();
+  expectTrue<IsWritable<typeof _first, "unknownObjectWithDefault">>();
+  expectTrue<IsWritable<typeof _first, "withNull">>();
 }


### PR DESCRIPTION
### What this PR does

Variables that only appear in
types will be considered unused
in the next typescript-eslint,
so put an underscore on the name.

### Test me

Test only changes, tested by `gulp lint release`.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
