### PR TITLE
Remove redundant type constituents

### DIFF
--- a/lib/Core/Json.ts
+++ b/lib/Core/Json.ts
@@ -13,10 +13,7 @@ export interface JsonArray<T = JsonValue> extends Array<T> {}
 
 export default JsonValue;
 
-export function isJsonObject(
-  value: unknown | undefined,
-  deep = true
-): value is JsonObject {
+export function isJsonObject(value: unknown, deep = true): value is JsonObject {
   return (
     value !== undefined &&
     typeof value === "object" &&
@@ -26,15 +23,15 @@ export function isJsonObject(
   );
 }
 
-export function isJsonBoolean(value: unknown | undefined): value is boolean {
+export function isJsonBoolean(value: unknown): value is boolean {
   return typeof value === "boolean";
 }
 
-export function isJsonNumber(value: unknown | undefined): value is number {
+export function isJsonNumber(value: unknown): value is number {
   return typeof value === "number";
 }
 
-export function isJsonString(value: unknown | undefined): value is string {
+export function isJsonString(value: unknown): value is string {
   return typeof value === "string";
 }
 
@@ -50,10 +47,7 @@ export function isJsonValue(value: unknown, deep = true): value is JsonValue {
   );
 }
 
-export function isJsonArray(
-  value: unknown | undefined,
-  deep = true
-): value is JsonArray {
+export function isJsonArray(value: unknown, deep = true): value is JsonArray {
   return (
     Array.isArray(value) &&
     (!deep || value.every((child) => isJsonValue(child, true)))
@@ -61,7 +55,7 @@ export function isJsonArray(
 }
 
 export function isJsonObjectArray(
-  value: unknown | undefined,
+  value: unknown,
   deep = true
 ): value is JsonArray<JsonObject> {
   return (
@@ -69,15 +63,11 @@ export function isJsonObjectArray(
   );
 }
 
-export function isJsonStringArray(
-  value: unknown | undefined
-): value is JsonArray<string> {
+export function isJsonStringArray(value: unknown): value is JsonArray<string> {
   return Array.isArray(value) && value.every((child) => isJsonString(child));
 }
 
-export function isJsonNumberArray(
-  value: unknown | undefined
-): value is JsonArray<number> {
+export function isJsonNumberArray(value: unknown): value is JsonArray<number> {
   return Array.isArray(value) && value.every((child) => isJsonNumber(child));
 }
 

--- a/lib/Models/Catalog/Gltf/GLTF.ts
+++ b/lib/Models/Catalog/Gltf/GLTF.ts
@@ -20,7 +20,7 @@ export interface AccessorSparseIndices {
   /**
    * The indices data type.
    */
-  componentType: number | number | number | number;
+  componentType: number;
   extensions?: any;
   extras?: any;
   [k: string]: any;
@@ -76,7 +76,7 @@ export interface Accessor {
   /**
    * The datatype of the accessor's components.
    */
-  componentType: number | number | number | number | number | number | number;
+  componentType: number;
   /**
    * Specifies whether integer data values are normalized before usage.
    */
@@ -88,7 +88,7 @@ export interface Accessor {
   /**
    * Specifies if the accessor's elements are scalars, vectors, or matrices.
    */
-  type: any | any | any | any | any | any | any | string;
+  type: any | string;
   /**
    * Maximum value of each component in this accessor.
    */
@@ -117,7 +117,7 @@ export interface AnimationChannelTarget {
   /**
    * The name of the node's TRS property to animate, or the `"weights"` of the Morph Targets it instantiates. For the `"translation"` property, the values that are provided by the sampler are the translation along the X, Y, and Z axes. For the `"rotation"` property, the values are a quaternion in the order (x, y, z, w), where w is the scalar. For the `"scale"` property, the values are the scaling factors along the X, Y, and Z axes.
    */
-  path: any | any | any | any | string;
+  path: any | string;
   extensions?: any;
   extras?: any;
   [k: string]: any;
@@ -149,7 +149,7 @@ export interface AnimationSampler {
   /**
    * Interpolation algorithm.
    */
-  interpolation?: any | any | any | string;
+  interpolation?: any | string;
   /**
    * The index of an accessor, containing keyframe output values.
    */
@@ -239,7 +239,7 @@ export interface BufferView {
   /**
    * The hint representing the intended GPU buffer type to use with this buffer view.
    */
-  target?: number | number | number;
+  target?: number;
   name?: any;
   extensions?: any;
   extras?: any;
@@ -308,7 +308,7 @@ export interface Camera {
   /**
    * Specifies if the camera uses a perspective or orthographic projection.
    */
-  type: any | any | string;
+  type: any | string;
   name?: any;
   extensions?: any;
   extras?: any;
@@ -325,7 +325,7 @@ export interface Image {
   /**
    * The image's media type. This field **MUST** be defined when `bufferView` is defined.
    */
-  mimeType?: any | any | string;
+  mimeType?: any | string;
   /**
    * The index of the bufferView that contains the image. This field **MUST NOT** be defined when `uri` is defined.
    */
@@ -431,7 +431,7 @@ export interface Material {
   /**
    * The alpha rendering mode of the material.
    */
-  alphaMode?: any | any | any | string;
+  alphaMode?: any | string;
   /**
    * The alpha cutoff value of the material.
    */
@@ -463,7 +463,7 @@ export interface MeshPrimitive {
   /**
    * The topology type of primitives to render.
    */
-  mode?: number | number | number | number | number | number | number | number;
+  mode?: number;
   /**
    * An array of morph targets.
    */
@@ -543,19 +543,19 @@ export interface Sampler {
   /**
    * Magnification filter.
    */
-  magFilter?: number | number | number;
+  magFilter?: number;
   /**
    * Minification filter.
    */
-  minFilter?: number | number | number | number | number | number | number;
+  minFilter?: number;
   /**
    * S (U) wrapping mode.
    */
-  wrapS?: number | number | number | number;
+  wrapS?: number;
   /**
    * T (V) wrapping mode.
    */
-  wrapT?: number | number | number | number;
+  wrapT?: number;
   name?: any;
   extensions?: any;
   extras?: any;

--- a/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
@@ -176,7 +176,7 @@ class StoryPanel extends React.Component<Props, State> {
   }
 
   // This is in StoryPanel and StoryBuilder
-  activateStory(_story: Story | any) {
+  activateStory(_story: Story) {
     const story = _story ? _story : this.props.viewState.terria.stories[0];
     activateStory(story, this.props.viewState.terria);
   }


### PR DESCRIPTION
### What this PR does

The type "unknown | undefined" can
be described by just "unknown".

The same logic applies to "any | X",
but the any type annotation should
eventually be remved, so keep
the "| X", but remove any extra
"any | any" so there's just one
"any |" in the type. Also remove
duplicate "number | number" in types.

### Test me

Run the typechecker and see that it still passes.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
