### PR TITLE
test: reject promise lazily

### DIFF
--- a/test/ModelMixins/TileErrorHandlerMixinSpec.ts
+++ b/test/ModelMixins/TileErrorHandlerMixinSpec.ts
@@ -173,7 +173,7 @@ describe("TileErrorHandlerMixin", function () {
     it("retries fetching the tile using xhr", async function () {
       try {
         const error = newError(randomIntBetween(500, 599));
-        spyOn(Resource, "fetchImage").and.returnValue(
+        spyOn(Resource, "fetchImage").and.callFake(() =>
           Promise.reject(error.error)
         );
         await onTileLoadError(item, error);
@@ -248,7 +248,7 @@ describe("TileErrorHandlerMixin", function () {
     it("it fails after retrying a maximum of specified number of times", async function () {
       try {
         const error = newError(randomIntBetween(500, 599));
-        spyOn(Resource, "fetchImage").and.returnValue(
+        spyOn(Resource, "fetchImage").and.callFake(() =>
           Promise.reject(error.error)
         );
         await onTileLoadError(item, error);
@@ -287,7 +287,7 @@ describe("TileErrorHandlerMixin", function () {
     it("gives up silently if the item is hidden", async function () {
       try {
         const error = newError(randomIntBetween(500, 599));
-        spyOn(Resource, "fetchImage").and.returnValue(
+        spyOn(Resource, "fetchImage").and.callFake(() =>
           Promise.reject(error.error)
         );
         const result = onTileLoadError(item, error);

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -462,7 +462,7 @@ describe("Terria", function () {
       const beforeRestoreAppState = jasmine
         .createSpy("beforeRestoreAppState")
         // It should also handle errors when calling beforeRestoreAppState
-        .and.returnValue(Promise.reject("some error"));
+        .and.callFake(() => Promise.reject("some error"));
 
       expect(terria.mainViewer.viewerMode).toBe(ViewerMode.Cesium);
       await terria.start({


### PR DESCRIPTION
### What this PR does

This avoids triggering unhandled promise rejection failures in afterAll, as described in:

https://github.com/jasmine/jasmine/issues/1648

Jasmine 3.5 contains rejectWith() that avoids
the problem, but we use Jasmine 2.99, so use
the fakeCall variant instead.

### Test me

Test only changes, so tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
