### PR TITLE
test: convert require to import

### DIFF
--- a/test/Core/CorsProxySpec.js
+++ b/test/Core/CorsProxySpec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var CorsProxy = require("../../lib/Core/CorsProxy");
+import CorsProxy from "../../lib/Core/CorsProxy";
 
 describe("CorsProxy", function () {
   var corsProxy, loadDeferred, loadJson;

--- a/test/Core/sortedIndicesSpec.js
+++ b/test/Core/sortedIndicesSpec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var sortedIndices = require("../../lib/Core/sortedIndices");
+import sortedIndices from "../../lib/Core/sortedIndices";
 
 describe("sortedIndices", function () {
   it("works", function () {

--- a/test/Data/RegionMappingJsonSpec.js
+++ b/test/Data/RegionMappingJsonSpec.js
@@ -1,7 +1,7 @@
 "use strict";
 
-// tests will not build if this require statement is not valid
-var RegionMappingJson = require("../../wwwroot/data/regionMapping.json");
+// Tests will not build if this import statement is not valid.
+import RegionMappingJson from "../../wwwroot/data/regionMapping.json";
 
 describe("RegionMappingJson", function () {
   it("is valid JSON", function () {

--- a/test/Map/DragPointsSpec.js
+++ b/test/Map/DragPointsSpec.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var DragPoints = require("../../lib/Map/DragPoints/DragPoints");
-var Terria = require("../../lib/Models/Terria");
-var ViewerMode = require("../../lib/Models/ViewerMode");
-var Entity = require("terriajs-cesium/Source/DataSources/Entity.js").default;
+import DragPoints from "../../lib/Map/DragPoints/DragPoints";
+import Terria from "../../lib/Models/Terria";
+import ViewerMode from "../../lib/Models/ViewerMode";
+import Entity from "terriajs-cesium/Source/DataSources/Entity.js";
 
 describe("DragPoints", function () {
   var terria;

--- a/test/Map/EarthGravityModel1996Spec.js
+++ b/test/Map/EarthGravityModel1996Spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;
-var EarthGravityModel1996 = require("../../lib/Map/Vector/EarthGravityModel1996");
+import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
+import EarthGravityModel1996 from "../../lib/Map/Vector/EarthGravityModel1996";
 
 var describeIfSupported = EarthGravityModel1996.isSupported()
   ? describe

--- a/test/Models/CameraViewSpec.js
+++ b/test/Models/CameraViewSpec.js
@@ -1,14 +1,13 @@
 "use strict";
 
-var CameraView = require("../../lib/Models/CameraView");
-var Cartesian3 = require("terriajs-cesium/Source/Core/Cartesian3").default;
-var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;
-var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
-var CustomMatchers = require("../Utility/CustomMatchers");
-var Ellipsoid = require("terriajs-cesium/Source/Core/Ellipsoid").default;
-var HeadingPitchRange =
-  require("terriajs-cesium/Source/Core/HeadingPitchRange").default;
-var Rectangle = require("terriajs-cesium/Source/Core/Rectangle").default;
+import CameraView from "../../lib/Models/CameraView";
+import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
+import CesiumMath from "terriajs-cesium/Source/Core/Math";
+import CustomMatchers from "../Utility/CustomMatchers";
+import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
+import HeadingPitchRange from "terriajs-cesium/Source/Core/HeadingPitchRange";
+import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 
 describe("CameraView", function () {
   describe("fromJson", function () {

--- a/test/Models/Catalog/CatalogItems/CesiumTerrainCatalogItemSpec.js
+++ b/test/Models/Catalog/CatalogItems/CesiumTerrainCatalogItemSpec.js
@@ -1,10 +1,9 @@
 "use strict";
 
-var CesiumTerrainCatalogItem = require("../../../../lib/Models/Catalog/CatalogItems/CesiumTerrainCatalogItem");
-var CesiumTerrainProvider =
-  require("terriajs-cesium/Source/Core/CesiumTerrainProvider").default;
-var loadWithXhr = require("../../../../lib/Core/loadWithXhr");
-var Terria = require("../../../../lib/Models/Terria");
+import CesiumTerrainCatalogItem from "../../../../lib/Models/Catalog/CatalogItems/CesiumTerrainCatalogItem";
+import CesiumTerrainProvider from "terriajs-cesium/Source/Core/CesiumTerrainProvider";
+import loadWithXhr from "../../../../lib/Core/loadWithXhr";
+import Terria from "../../../../lib/Models/Terria";
 
 describe("CesiumTerrainCatalogItem", function () {
   var terria;

--- a/test/Models/Catalog/CatalogItems/ImageryLayerCatalogItemSpec.js
+++ b/test/Models/Catalog/CatalogItems/ImageryLayerCatalogItemSpec.js
@@ -1,25 +1,18 @@
 "use strict";
 
-const CesiumEvent = require("terriajs-cesium/Source/Core/Event").default;
-const ImageryLayer =
-  require("terriajs-cesium/Source/Scene/ImageryLayer").default;
-const ImageryProvider =
-  require("terriajs-cesium/Source/Scene/ImageryProvider").default;
-const ImageryState =
-  require("terriajs-cesium/Source/Scene/ImageryState").default;
-const JulianDate = require("terriajs-cesium/Source/Core/JulianDate").default;
-const pollToPromise = require("../../lib/Core/pollToPromise");
-const RequestErrorEvent =
-  require("terriajs-cesium/Source/Core/RequestErrorEvent").default;
-const Resource = require("terriajs-cesium/Source/Core/Resource").default;
-const runLater = require("../../../../lib/Core/runLater");
-const TimeIntervalCollection =
-  require("terriajs-cesium/Source/Core/TimeIntervalCollection").default;
-const TimeInterval =
-  require("terriajs-cesium/Source/Core/TimeInterval").default;
-
-const Terria = require("../../../../lib/Models/Terria");
-const ImageryLayerCatalogItem = require("../../lib/Models/ImageryLayerCatalogItem");
+import CesiumEvent from "terriajs-cesium/Source/Core/Event";
+import ImageryLayer from "terriajs-cesium/Source/Scene/ImageryLayer";
+import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
+import ImageryState from "terriajs-cesium/Source/Scene/ImageryState";
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import pollToPromise from "../../lib/Core/pollToPromise";
+import RequestErrorEvent from "terriajs-cesium/Source/Core/RequestErrorEvent";
+import Resource from "terriajs-cesium/Source/Core/Resource";
+import runLater from "../../../../lib/Core/runLater";
+import TimeIntervalCollection from "terriajs-cesium/Source/Core/TimeIntervalCollection";
+import TimeInterval from "terriajs-cesium/Source/Core/TimeInterval";
+import Terria from "../../../../lib/Models/Terria";
+import ImageryLayerCatalogItem from "../../lib/Models/ImageryLayerCatalogItem";
 
 describe("ImageryLayerCatalogItem", function () {
   describe("Time slider initial time as specified by initialTimeSource ", function () {

--- a/test/Models/Catalog/CatalogItems/KmlCatalogItemSpec.js
+++ b/test/Models/Catalog/CatalogItems/KmlCatalogItemSpec.js
@@ -1,12 +1,11 @@
 "use strict";
 
-var KmlCatalogItem = require("../../../../lib/Models/Catalog/CatalogItems/KmlCatalogItem");
-var TerriaError = require("../../../../lib/Core/TerriaError").default;
-var Terria = require("../../../../lib/Models/Terria");
-
-var loadBlob = require("../../../../lib/Core/loadBlob");
-var loadText = require("../../../../lib/Core/loadText");
-var loadXML = require("../../../../lib/Core/loadXML");
+import KmlCatalogItem from "../../../../lib/Models/Catalog/CatalogItems/KmlCatalogItem";
+import TerriaError from "../../../../lib/Core/TerriaError";
+import Terria from "../../../../lib/Models/Terria";
+import loadBlob from "../../../../lib/Core/loadBlob";
+import loadText from "../../../../lib/Core/loadText";
+import loadXML from "../../../../lib/Core/loadXML";
 
 // KML requires support for Blob.  See https://github.com/TerriaJS/terriajs/issues/508
 var describeIfSupported = typeof Blob !== "undefined" ? describe : xdescribe;

--- a/test/Models/Catalog/CatalogItems/TerrainCatalogItemSpec.js
+++ b/test/Models/Catalog/CatalogItems/TerrainCatalogItemSpec.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var CompositeCatalogItem = require("../../lib/Models/Catalog/CatalogItems/CompositeCatalogItem");
-var TerrainCatalogItem = require("../../lib/Models/TerrainCatalogItem");
-var Terria = require("../../lib/Models/Terria");
+import CompositeCatalogItem from "../../lib/Models/Catalog/CatalogItems/CompositeCatalogItem";
+import TerrainCatalogItem from "../../lib/Models/TerrainCatalogItem";
+import Terria from "../../lib/Models/Terria";
 
 describe("TerrainCatalogItem", function () {
   var terria;

--- a/test/Models/Catalog/CatalogMemberSpec.js
+++ b/test/Models/Catalog/CatalogMemberSpec.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var CatalogMember = require("../../lib/Models/CatalogMember");
-var Terria = require("../../../lib/Models/Terria");
+import CatalogMember from "../../lib/Models/CatalogMember";
+import Terria from "../../../lib/Models/Terria";
 
 describe("CatalogMember", function () {
   var terria;

--- a/test/Models/LeafletSpec.js
+++ b/test/Models/LeafletSpec.js
@@ -1,19 +1,17 @@
 "use strict";
 
-var Cartographic = require("terriajs-cesium/Source/Core/Cartographic").default;
-var CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
-var CesiumTileLayer = require("../../lib/Map/CesiumTileLayer");
-var Color = require("terriajs-cesium/Source/Core/Color").default;
-var Ellipsoid = require("terriajs-cesium/Source/Core/Ellipsoid").default;
-var Entity = require("terriajs-cesium/Source/DataSources/Entity").default;
-var GeoJsonDataSource =
-  require("terriajs-cesium/Source/DataSources/GeoJsonDataSource").default;
-var ImageryLayerFeatureInfo =
-  require("terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo").default;
-var L = require("leaflet");
-var Leaflet = require("../../lib/Models/Leaflet");
-var loadJson = require("../../lib/Core/loadJson").default;
-var Terria = require("../../lib/Models/Terria");
+import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
+import CesiumMath from "terriajs-cesium/Source/Core/Math";
+import CesiumTileLayer from "../../lib/Map/CesiumTileLayer";
+import Color from "terriajs-cesium/Source/Core/Color";
+import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
+import Entity from "terriajs-cesium/Source/DataSources/Entity";
+import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
+import ImageryLayerFeatureInfo from "terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo";
+import L from "leaflet";
+import Leaflet from "../../lib/Models/Leaflet";
+import loadJson from "../../lib/Core/loadJson";
+import Terria from "../../lib/Models/Terria";
 
 var DEFAULT_ZOOM_LEVEL = 5;
 

--- a/test/Models/TimeSeriesStackSpec.js
+++ b/test/Models/TimeSeriesStackSpec.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var TimelineStack = require("../../lib/Models/TimelineStack");
-var CatalogItem = require("../../lib/Models/CatalogItem");
-var Terria = require("../../lib/Models/Terria");
+import TimelineStack from "../../lib/Models/TimelineStack";
+import CatalogItem from "../../lib/Models/CatalogItem";
+import Terria from "../../lib/Models/Terria";
 
 describe("TimeSeriesStack", function () {
   var clock, stack, terria;

--- a/test/ReactViews/MeasureToolSpec.jsx
+++ b/test/ReactViews/MeasureToolSpec.jsx
@@ -6,16 +6,13 @@ import Terria from "../../lib/Models/Terria";
 import { getMountedInstance } from "./MoreShallowTools";
 
 import { MeasureTool } from "../../lib/ReactViews/Map/MapNavigation/MeasureTool";
-const Entity = require("terriajs-cesium/Source/DataSources/Entity.js").default;
-const Ellipsoid = require("terriajs-cesium/Source/Core/Ellipsoid.js").default;
-const ConstantPositionProperty =
-  require("terriajs-cesium/Source/DataSources/ConstantPositionProperty.js").default;
-const Cartesian3 = require("terriajs-cesium/Source/Core/Cartesian3").default;
-const Cartographic =
-  require("terriajs-cesium/Source/Core/Cartographic").default;
-const CustomDataSource =
-  require("terriajs-cesium/Source/DataSources/CustomDataSource").default;
-const CesiumMath = require("terriajs-cesium/Source/Core/Math").default;
+import Entity from "terriajs-cesium/Source/DataSources/Entity.js";
+import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid.js";
+import ConstantPositionProperty from "terriajs-cesium/Source/DataSources/ConstantPositionProperty.js";
+import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
+import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSource";
+import CesiumMath from "terriajs-cesium/Source/Core/Math";
 
 describe("MeasureTool-jsx", function () {
   let terria;

--- a/test/ReactViews/TimelineSpec.jsx
+++ b/test/ReactViews/TimelineSpec.jsx
@@ -3,14 +3,11 @@
 // import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import React from "react";
 import { getMountedInstance } from "./MoreShallowTools";
-
-const Terria = require("../../lib/Models/Terria");
-
-const ImageryLayerCatalogItem = require("../../lib/Models/ImageryLayerCatalogItem");
+import Terria from "../../lib/Models/Terria";
+import ImageryLayerCatalogItem from "../../lib/Models/ImageryLayerCatalogItem";
 import { Timeline } from "../../lib/ReactViews/BottomDock/Timeline/Timeline";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
-const DataSourceClock =
-  require("terriajs-cesium/Source/DataSources/DataSourceClock").default;
+import DataSourceClock from "terriajs-cesium/Source/DataSources/DataSourceClock";
 
 describe("Timeline", function () {
   describe("dateTime format", function () {

--- a/test/Utility/CustomMatchers.js
+++ b/test/Utility/CustomMatchers.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var defined = require("terriajs-cesium/Source/Core/defined").default;
+import defined from "terriajs-cesium/Source/Core/defined";
 
 function equals(util, customEqualityTesters, a, b) {
   return util.equals(a, b, customEqualityTesters);

--- a/test/Utility/loadAndStubTextResources.js
+++ b/test/Utility/loadAndStubTextResources.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var loadText = require("../../lib/Core/loadText");
+import loadText from "../../lib/Core/loadText";
 
 function loadTextResources(resources) {
   var result = {};


### PR DESCRIPTION
### What this PR does

These are the remaining requires in the
webpack5 PR that are just regular imports,
so convert them to imports.

This is preparation for upgrading
typescript-eslint to version 8.

### Test me

From what I've understood, the js files in test/ are not used, so this is untested.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
