### PR TITLE
BuildShareLink: compare to enum value

### DIFF
--- a/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.ts
+++ b/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.ts
@@ -22,6 +22,7 @@ import Terria from "../../../../Models/Terria";
 import ViewState from "../../../../ReactViewModels/ViewState";
 import getDereferencedIfExists from "../../../../Core/getDereferencedIfExists";
 import CatalogMemberMixin from "../../../../ModelMixins/CatalogMemberMixin";
+import ViewerMode from "../../../../Models/ViewerMode";
 
 /** User properties (generated from URL hash parameters) to add to share link URL in PRODUCTION environment.
  * If in Dev, we add all user properties.
@@ -303,7 +304,7 @@ function addViewSettings(
   // };
 
   let viewerMode: ViewModeJson;
-  if (terria.mainViewer.viewerMode === "cesium") {
+  if (terria.mainViewer.viewerMode === ViewerMode.Cesium) {
     if (terria.mainViewer.viewerOptions.useTerrain) {
       viewerMode = "3d";
     } else {


### PR DESCRIPTION
### What this PR does

The type of terria.mainViewer.viewerMode
is the ViewerMode enum, so compare against
the element in that enum instead of a raw
string value.

### Test me

I believe this is tested by CI?

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
