### PR TITLE
ReactViews: add missing constructor args

### DIFF
--- a/lib/ReactViews/Custom/Chart/LineAndPointChart.jsx
+++ b/lib/ReactViews/Custom/Chart/LineAndPointChart.jsx
@@ -16,8 +16,8 @@ export default class LineAndPointChart extends PureComponent {
     glyph: PropTypes.string
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.lineRef = createRef();
     this.pointRef = createRef();
   }

--- a/lib/ReactViews/Generic/Timer/Timer.jsx
+++ b/lib/ReactViews/Generic/Timer/Timer.jsx
@@ -20,8 +20,8 @@ if (typeof document.hidden !== "undefined") {
 }
 
 class Timer extends PureComponent {
-  constructor(_props) {
-    super();
+  constructor(props) {
+    super(props);
 
     // We need a unique selector for the timer container. If there are multiple timers, we need to know which one to
     // draw to.

--- a/lib/ReactViews/Guide/SatelliteGuide.jsx
+++ b/lib/ReactViews/Guide/SatelliteGuide.jsx
@@ -16,8 +16,8 @@ class SatelliteGuide extends Component {
     t: PropTypes.func.isRequired
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     makeObservable(this);
   }
 


### PR DESCRIPTION
### What this PR does

The super constructor expects 1-2 arguments,
so add the props argument that is present
in the other PureComponent constructors.

### Test me

No idea how to test this.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
