### PR TITLE
DataPreviewUrl: convert to ES6 class

### DIFF
--- a/lib/ReactViews/Preview/DataPreviewUrl.jsx
+++ b/lib/ReactViews/Preview/DataPreviewUrl.jsx
@@ -1,25 +1,25 @@
-import React from "react";
-
-import createReactClass from "create-react-class";
-
+import { Component } from "react";
+import { makeObservable } from "mobx";
 import PropTypes from "prop-types";
-
 import Styles from "./data-preview.scss";
 import { Trans } from "react-i18next";
 
 /**
  * URL section of the preview.
  */
-const DataPreviewUrl = createReactClass({
-  displayName: "DataPreviewUrl",
-
-  propTypes: {
+class DataPreviewUrl extends Component {
+  static propTypes = {
     metadataItem: PropTypes.object.isRequired
-  },
+  };
+
+  constructor(props) {
+    super(props);
+    makeObservable(this);
+  }
 
   selectUrl(e) {
     e.target.select();
-  },
+  }
 
   render() {
     return (
@@ -84,6 +84,6 @@ const DataPreviewUrl = createReactClass({
       </div>
     );
   }
-});
+}
 
 export default DataPreviewUrl;


### PR DESCRIPTION
### What this PR does

Convert the call to createReactClass()
into a regular class that extends
Component.

Leave everything else as-is, there
are codemods for converting propTypes
to TypeScript types and various other
conversions.

### Test me

I believe this is tested by CI?

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
