### PR TITLE
eslint: warn about unused directives

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
     "no-alert": ["error"],
     "no-caller": ["error"],
     "no-div-regex": ["error"],
+    "no-empty": ["error", { allowEmptyCatch: true }],
     "no-eval": ["error"],
     "no-extend-native": ["error"],
     "no-fallthrough": 0,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,8 @@ gulp.task("lint", function (done) {
     "--ext",
     ".jsx,.js,.ts,.tsx",
     "--max-warnings",
-    "0"
+    "0",
+    "--report-unused-disable-directives"
   ]);
 
   done();

--- a/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
+++ b/lib/ModelMixins/DiscretelyTimeVaryingMixin.ts
@@ -115,9 +115,7 @@ function DiscretelyTimeVaryingMixin<
               tag: dt.tag !== undefined ? dt.tag : dt.time
             });
           }
-        } catch {
-          /* eslint-disable-line no-empty */
-        }
+        } catch {}
       }
       asJulian.sort((a, b) => JulianDate.compare(a.time, b.time));
       return asJulian;

--- a/lib/Models/Catalog/CatalogItems/CartoMapV3CatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/CartoMapV3CatalogItem.ts
@@ -289,9 +289,7 @@ async function callCartoApi(url: string, auth?: string, body?: JsonObject) {
             )
           );
         }
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
     }
     return Result.error(e);
   }

--- a/lib/Models/Catalog/Ows/WebFeatureServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebFeatureServiceCatalogItem.ts
@@ -431,9 +431,7 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
       let errorMessage: string | undefined;
       try {
         errorMessage = xml2json(getFeatureResponse).Exception?.ExceptionText;
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
 
       const originalError = isDefined(errorMessage)
         ? new TerriaError({

--- a/lib/ReactViews/Analytics/InvokeFunction.jsx
+++ b/lib/ReactViews/Analytics/InvokeFunction.jsx
@@ -52,12 +52,10 @@ class InvokeFunction extends React.Component {
     t: PropTypes.func.isRequired
   };
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     this.parametersViewModel = new FunctionViewModel(this.props.previewed);
   }
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillUpdate(nextProps, _nextState) {
     if (nextProps.previewed !== this.parametersViewModel.catalogFunction) {
       // Clear previous parameters view model, because this is a different catalog function.

--- a/lib/ReactViews/Analytics/RegionPicker.jsx
+++ b/lib/ReactViews/Analytics/RegionPicker.jsx
@@ -44,7 +44,6 @@ const RegionPicker = createReactClass({
     };
   },
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     this._loadingRegionProvider = undefined;
     this._selectedRegionCatalogItem = undefined;

--- a/lib/ReactViews/CleanDropdownPanel/CleanDropdownPanel.jsx
+++ b/lib/ReactViews/CleanDropdownPanel/CleanDropdownPanel.jsx
@@ -65,7 +65,6 @@ const CleanDropdownPanel = createReactClass({
     }
   },
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.forceClosed) {
       this.onDismissed();

--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.tsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.tsx
@@ -74,9 +74,7 @@ class ChartExpandAndDownloadButtons extends React.Component<PropsType> {
 
       try {
         terria.addModel(itemToExpand);
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       (await workbench.add(itemToExpand)).raiseError(terria, undefined, true);
     });
   }

--- a/lib/ReactViews/Custom/parseCustomHtmlToReact.ts
+++ b/lib/ReactViews/Custom/parseCustomHtmlToReact.ts
@@ -78,7 +78,6 @@ function getProcessingInstructions(context: ParseCustomHtmlToReactContext) {
     shouldProcessNode: (node: DomElement) => node.name === "a",
     processNode: function (node: DomElement, children, index) {
       // Make sure any <a href> tags open in a new window
-      // eslint-disable-line react/display-name
       const elementProps = {
         key: "anchor-" + keyIndex++,
         target: "_blank",

--- a/lib/ReactViews/Generic/Dropdown.jsx
+++ b/lib/ReactViews/Generic/Dropdown.jsx
@@ -39,7 +39,6 @@ const Dropdown = createReactClass({
     };
   },
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     // this._element is updated by the ref callback attribute, https://facebook.github.io/react/docs/more-about-refs.html
     this.buttonElement = undefined;

--- a/lib/ReactViews/Generic/Editor.jsx
+++ b/lib/ReactViews/Generic/Editor.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React, { useRef } from "react";
 import { Editor } from "@tinymce/tinymce-react";
 import PropTypes from "prop-types";

--- a/lib/ReactViews/HOCs/withControlledVisibility.tsx
+++ b/lib/ReactViews/HOCs/withControlledVisibility.tsx
@@ -13,7 +13,6 @@ interface WithControlledVisibilityProps {
  * as prop
  */
 export default <P extends object>(WrappedComponent: React.ComponentType<P>) => {
-  // eslint-disable-next-line require-jsdoc
   function WithControlledVisibility({
     elementConfig,
     ...props

--- a/lib/ReactViews/Map/Panels/DropdownPanel.jsx
+++ b/lib/ReactViews/Map/Panels/DropdownPanel.jsx
@@ -65,7 +65,6 @@ const DropdownPanel = createReactClass({
     }
   },
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.forceClosed) {
       this.onDismissed();
@@ -99,7 +98,6 @@ const DropdownPanel = createReactClass({
           ref={
             this.props.btnRef || ((element) => (this.buttonElement = element))
           }
-          /* eslint-disable-next-line react/no-unknown-property */
           isOpen={this.isOpen()}
           css={`
             ${(p) =>

--- a/lib/ReactViews/Map/Panels/InnerPanel.jsx
+++ b/lib/ReactViews/Map/Panels/InnerPanel.jsx
@@ -139,7 +139,6 @@ const InnerPanel = createReactClass({
           onClick={this.forceClose}
           title={t("general.close")}
           aria-label={t("general.close")}
-          /* eslint-disable-next-line react/no-unknown-property */
           showDropdownAsModal={this.props.showDropdownAsModal}
           css={`
             svg {

--- a/lib/ReactViews/Map/Panels/SharePanel/StorySharePanel.jsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/StorySharePanel.jsx
@@ -37,7 +37,6 @@ const StorySharePanel = createReactClass({
     }
   },
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.forceClosed) {
       this.onDismissed();

--- a/lib/ReactViews/Map/TerriaViewerWrapper/Splitter/dragHook.ts
+++ b/lib/ReactViews/Map/TerriaViewerWrapper/Splitter/dragHook.ts
@@ -23,9 +23,7 @@ try {
 
   window.addEventListener("test", callback, options);
   window.removeEventListener("test", callback, options);
-} catch (_err) {
-  /* eslint-disable-line no-empty */
-}
+} catch (_err) {}
 
 const notPassive = passiveSupported ? { passive: false } : false;
 

--- a/lib/ReactViews/Mobile/MobileModalWindow.jsx
+++ b/lib/ReactViews/Mobile/MobileModalWindow.jsx
@@ -78,7 +78,6 @@ class MobileModalWindow extends React.Component {
     });
   }
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillReceiveProps() {
     const numItems = this.props.terria.workbench.items.length;
     if (

--- a/lib/ReactViews/Notification/NotificationWindow.jsx
+++ b/lib/ReactViews/Notification/NotificationWindow.jsx
@@ -71,7 +71,6 @@ const NotificationWindow = createReactClass({
       <div className={classNames(Styles.wrapper, `${type}`)}>
         <div
           className={Styles.notification}
-          /* eslint-disable-next-line react/no-unknown-property */
           isStory={isStory}
           css={`
             background: ${(p) =>

--- a/lib/ReactViews/Search/SearchBox.jsx
+++ b/lib/ReactViews/Search/SearchBox.jsx
@@ -61,7 +61,6 @@ export const SearchBox = createReactClass({
     };
   },
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     this.searchWithDebounce = debounce(this.search, DEBOUNCE_INTERVAL);
   },

--- a/lib/ReactViews/StandardUserInterface/customizable/ResponsiveSwitch.jsx
+++ b/lib/ReactViews/StandardUserInterface/customizable/ResponsiveSwitch.jsx
@@ -7,7 +7,6 @@ import PropTypes from "prop-types";
  * passed to it is true or false.
  */
 export default (LargeScreenComponent, SmallScreenComponent) => {
-  // eslint-disable-next-line require-jsdoc
   function ResponsiveSwitch(props) {
     return props.smallScreen ? (
       <SmallScreenComponent {...props} />

--- a/lib/ReactViews/Story/StoryEditor.jsx
+++ b/lib/ReactViews/Story/StoryEditor.jsx
@@ -33,7 +33,6 @@ class StoryEditor extends React.Component {
     this.escKeyListener = null;
   }
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     const story = this.props.story;
     this.setState({

--- a/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
+++ b/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
@@ -100,9 +100,7 @@ class DiffTool extends React.Component<PropsType> {
         this.leftItem = leftItem;
         this.rightItem = rightItem;
       });
-    } catch {
-      /* eslint-disable-line no-empty */
-    }
+    } catch {}
   }
 
   @action

--- a/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
+++ b/lib/ReactViews/Workbench/Controls/ColorScaleRangeSection.jsx
@@ -23,14 +23,13 @@ const ColorScaleRangeSection = createReactClass({
     };
   },
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     this.setState({
       minRange: this.props.minValue,
       maxRange: this.props.maxValue
     });
   },
-  /* eslint-disable-next-line camelcase */
+
   UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       minRange: nextProps.minValue,

--- a/lib/ReactViews/Workbench/Controls/ViewingControls.tsx
+++ b/lib/ReactViews/Workbench/Controls/ViewingControls.tsx
@@ -110,7 +110,6 @@ class ViewingControls extends React.Component<
     };
   }
 
-  /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     window.addEventListener("click", this.hideMenu.bind(this));
   }

--- a/test/ModelMixins/TileErrorHandlerMixinSpec.ts
+++ b/test/ModelMixins/TileErrorHandlerMixinSpec.ts
@@ -110,9 +110,7 @@ describe("TileErrorHandlerMixin", function () {
     });
     try {
       await onTileLoadError(item, newError(400));
-    } catch {
-      /* eslint-disable-line no-empty */
-    }
+    } catch {}
     expect(item.tileFailures).toBe(0);
   });
 
@@ -125,9 +123,7 @@ describe("TileErrorHandlerMixin", function () {
           false
         );
         await onTileLoadError(item, newError(403));
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.tileFailures).toBe(0);
     });
 
@@ -139,9 +135,7 @@ describe("TileErrorHandlerMixin", function () {
           false
         );
         await onTileLoadError(item, newError(404));
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.tileFailures).toBe(0);
     });
 
@@ -162,9 +156,7 @@ describe("TileErrorHandlerMixin", function () {
           onTileLoadError(item, newError(404, 1)),
           onTileLoadError(item, newError(randomIntBetween(400, 499), 2))
         ]);
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.tileFailures).toBe(3);
     });
   });
@@ -177,9 +169,7 @@ describe("TileErrorHandlerMixin", function () {
           Promise.reject(error.error)
         );
         await onTileLoadError(item, error);
-      } catch (_e) {
-        /* eslint-disable-line no-empty */
-      }
+      } catch (_e) {}
       expect(Resource.fetchImage).toHaveBeenCalled();
     });
   });
@@ -204,9 +194,7 @@ describe("TileErrorHandlerMixin", function () {
       );
       try {
         await onTileLoadError(item, newError(undefined));
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.tileFailures).toBe(0);
       expect(raiseEvent.calls.count()).toBe(0);
     });
@@ -220,9 +208,7 @@ describe("TileErrorHandlerMixin", function () {
           target: {}
         } as Error;
         await onTileLoadError(item, tileProviderError);
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.tileFailures).toBe(1);
       expect(raiseEvent.calls.count()).toBe(1);
       expect(raiseEvent.calls.argsFor(0)[0]?.message).toContain(
@@ -233,9 +219,7 @@ describe("TileErrorHandlerMixin", function () {
     it("otherwise, it fails with unknown error", async function () {
       try {
         await onTileLoadError(item, newError(undefined));
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.tileFailures).toBe(1);
       expect(raiseEvent.calls.count()).toBe(1);
       expect(raiseEvent.calls.argsFor(0)[0]?.message).toContain(
@@ -252,9 +236,7 @@ describe("TileErrorHandlerMixin", function () {
           Promise.reject(error.error)
         );
         await onTileLoadError(item, error);
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(Resource.fetchImage).toHaveBeenCalledTimes(
         !Array.isArray(item.tileRetryOptions)
           ? item.tileRetryOptions.retries ?? 0
@@ -278,9 +260,7 @@ describe("TileErrorHandlerMixin", function () {
         await onTileLoadError(item, newError(randomIntBetween(500, 599), 3));
         await onTileLoadError(item, newError(randomIntBetween(500, 599), 4));
         await onTileLoadError(item, newError(randomIntBetween(500, 599), 5));
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.tileFailures).toEqual(1);
     });
 
@@ -293,9 +273,7 @@ describe("TileErrorHandlerMixin", function () {
         const result = onTileLoadError(item, error);
         item.setTrait(CommonStrata.user, "show", false);
         await result;
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.tileFailures).toEqual(0);
     });
   });
@@ -313,14 +291,10 @@ describe("TileErrorHandlerMixin", function () {
       spyOn(item.terria, "raiseErrorToUser");
       try {
         await onTileLoadError(item, newError(undefined));
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       try {
         await onTileLoadError(item, newError(undefined, 1));
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.tileFailures).toBe(2);
       expect(item.terria.raiseErrorToUser).toHaveBeenCalled();
     });
@@ -329,14 +303,10 @@ describe("TileErrorHandlerMixin", function () {
       expect(item.show).toBe(true);
       try {
         await onTileLoadError(item, newError(undefined));
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       try {
         await onTileLoadError(item, newError(undefined, 1));
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       expect(item.show).toBe(false);
     });
   });
@@ -347,25 +317,19 @@ describe("TileErrorHandlerMixin", function () {
 
     try {
       await onTileLoadError(item, error);
-    } catch {
-      /* eslint-disable-line no-empty */
-    }
+    } catch {}
     expect(item.tileFailures).toBe(1);
 
     try {
       error.timesRetried = 1;
       await onTileLoadError(item, error);
-    } catch {
-      /* eslint-disable-line no-empty */
-    }
+    } catch {}
     expect(item.tileFailures).toBe(2);
 
     try {
       error.timesRetried = 0;
       await onTileLoadError(item, error);
-    } catch {
-      /* eslint-disable-line no-empty */
-    }
+    } catch {}
     expect(item.tileFailures).toBe(1);
   });
 
@@ -374,9 +338,7 @@ describe("TileErrorHandlerMixin", function () {
     spyOn(item, "handleTileError");
     try {
       await onTileLoadError(item, newError(400));
-    } catch {
-      /* eslint-disable-line no-empty */
-    }
+    } catch {}
     expect(item.handleTileError).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/Models/Catalog/CatalogItems/Cesium3DTilesCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/Cesium3DTilesCatalogItemSpec.ts
@@ -144,9 +144,7 @@ describe("Cesium3DTilesCatalogItemSpec", function () {
         spyOn(IonResource, "fromAssetId").and.callThrough();
         try {
           await item.loadMapItems();
-        } catch {
-          /* eslint-disable-line no-empty */
-        }
+        } catch {}
         expect(IonResource.fromAssetId).toHaveBeenCalledWith(4242, {
           accessToken: "fakeToken",
           server: "fakeServer"
@@ -164,9 +162,7 @@ describe("Cesium3DTilesCatalogItemSpec", function () {
       });
       try {
         await item.loadMapItems();
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       const tileset = item.mapItems[0] as Cesium3DTileset;
       expect(tileset.maximumScreenSpaceError).toBe(3);
     });
@@ -177,9 +173,7 @@ describe("Cesium3DTilesCatalogItemSpec", function () {
     beforeEach(async function () {
       try {
         await item.loadMapItems();
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       // observe mapItems
       dispose = reaction(
         () => item.mapItems,

--- a/test/Models/Catalog/CatalogItems/I3SCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/I3SCatalogItemSpec.ts
@@ -74,9 +74,7 @@ describe("I3SCatalogItemSpec", function () {
     beforeEach(async function () {
       try {
         await item.loadMapItems();
-      } catch {
-        /* eslint-disable-line no-empty */
-      }
+      } catch {}
       dispose = reaction(
         () => item.mapItems,
         () => {}

--- a/test/Models/LeafletSpec.ts
+++ b/test/Models/LeafletSpec.ts
@@ -49,9 +49,7 @@ describe("Leaflet Model", function () {
     // TODO: calling destroy on our mobx leaflet model results in a tile error
     try {
       leaflet.destroy();
-    } catch {
-      /* eslint-disable-line no-empty */
-    }
+    } catch {}
     document.body.removeChild(container);
   });
 


### PR DESCRIPTION
### What this PR does

Make ESLint warn when directives
are not used, and remove the unused
directives from the source code.

The no-empty rule needs a comment
rather than an ignore directive
in empty catch blocks, so tweak
the config of the rule to admit
empty catch blocks, and report
on other empty bodies.

### Test me

Tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
