### PR TITLE
replace react sfc with react fc

### DIFF
--- a/lib/ReactViews/Generic/TooltipWrapper.tsx
+++ b/lib/ReactViews/Generic/TooltipWrapper.tsx
@@ -236,7 +236,7 @@ type ButtonLauncherProps = {
   [spread: string]: any;
 };
 
-export const TooltipWithButtonLauncher: React.SFC<ButtonLauncherProps> = (
+export const TooltipWithButtonLauncher: React.FC<ButtonLauncherProps> = (
   props
 ) => {
   const { launcherComponent, children, dismissOnLeave, orientation, ...rest } =


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

React SFC is deprecated and removed in new react versions.

### Test me
This is type only change


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
