### PR TITLE
explicitly type useCallback arguments

### DIFF
--- a/lib/ReactViews/Analytics/DateParameterEditor.tsx
+++ b/lib/ReactViews/Analytics/DateParameterEditor.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { useCallback } from "react";
+import React from "react";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import DateParameter from "../../Models/FunctionParameters/DateParameter";
 import Styles from "./parameter-editors.scss";
@@ -15,18 +15,15 @@ const DateParameterEditor: React.FC<DateParameterEditorProps> = observer(
         ? Styles.field
         : Styles.fieldDatePlaceholder;
 
-    const onChangeDate = useCallback(
-      (e) => parameter.setValue(CommonStrata.user, e.target.value),
-      [parameter]
-    );
-
     return (
       <div>
         <input
           className={style}
           type="date"
           placeholder="YYYY-MM-DD"
-          onChange={onChangeDate}
+          onChange={(e) =>
+            parameter.setValue(CommonStrata.user, e.target.value)
+          }
           value={parameter.value ?? ""}
         />
       </div>

--- a/lib/ReactViews/Analytics/DateTimeParameterEditor.tsx
+++ b/lib/ReactViews/Analytics/DateTimeParameterEditor.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import React, { useCallback } from "react";
+import React from "react";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 import DateTimeParameter from "../../Models/FunctionParameters/DateTimeParameter";
 import Styles from "./parameter-editors.scss";
@@ -15,19 +15,15 @@ const DateTimeParameterEditor: React.FC<DateTimeParameterEditorProps> =
         ? Styles.field
         : Styles.fieldDatePlaceholder;
 
-    const onDateTimeChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) =>
-        parameter.setValue(CommonStrata.user, e.target.value),
-      [parameter]
-    );
-
     return (
       <div>
         <input
           className={style}
           type="datetime-local"
           value={parameter.value ?? ""}
-          onChange={onDateTimeChange}
+          onChange={(e) =>
+            parameter.setValue(CommonStrata.user, e.target.value)
+          }
         />
       </div>
     );


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

This is required in a newer versions of react

### Test me

Type only change; there is no benefit of `useCallback` here as it is passed directly to the input component there so we don't need to keep same reference always

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
