### PR TITLE
import TFunction type from react-i18next for proper typing

### DIFF
--- a/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.tsx
+++ b/lib/ReactViews/Custom/Chart/ChartExpandAndDownloadButtons.tsx
@@ -1,9 +1,8 @@
 import classNames from "classnames";
-import { TFunction } from "i18next";
 import { action, makeObservable, observable, runInAction } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
-import { WithTranslation, withTranslation } from "react-i18next";
+import { WithTranslation, withTranslation, TFunction } from "react-i18next";
 import styled, { useTheme } from "styled-components";
 import filterOutUndefined from "../../../Core/filterOutUndefined";
 import ChartableMixin from "../../../ModelMixins/ChartableMixin";

--- a/lib/ReactViews/FeatureInfo/FeatureInfoDownload.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoDownload.tsx
@@ -1,6 +1,5 @@
-import { TFunction } from "i18next";
 import React from "react";
-import { withTranslation } from "react-i18next";
+import { withTranslation, TFunction } from "react-i18next";
 import DataUri from "../../Core/DataUri";
 import filterOutUndefined from "../../Core/filterOutUndefined";
 import JsonValue, { JsonObject } from "../../Core/Json";

--- a/lib/ReactViews/FeatureInfo/FeatureInfoPanel.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoPanel.tsx
@@ -1,9 +1,8 @@
 import classNames from "classnames";
-import { TFunction } from "i18next";
 import { action, reaction, runInAction, makeObservable } from "mobx";
 import { disposeOnUnmount, observer } from "mobx-react";
 import React from "react";
-import { withTranslation } from "react-i18next";
+import { withTranslation, TFunction } from "react-i18next";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";

--- a/lib/ReactViews/FeatureInfo/FeatureInfoSection.tsx
+++ b/lib/ReactViews/FeatureInfo/FeatureInfoSection.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import { TFunction } from "i18next";
 import { isEmpty, merge } from "lodash-es";
 import {
   action,
@@ -13,7 +12,7 @@ import { observer } from "mobx-react";
 import { IDisposer } from "mobx-utils";
 import Mustache from "mustache";
 import React from "react";
-import { withTranslation } from "react-i18next";
+import { withTranslation, TFunction } from "react-i18next";
 import styled from "styled-components";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";

--- a/lib/ReactViews/Loader.tsx
+++ b/lib/ReactViews/Loader.tsx
@@ -1,6 +1,5 @@
-import { TFunction } from "i18next";
 import React from "react";
-import { withTranslation, WithTranslation } from "react-i18next";
+import { withTranslation, WithTranslation, TFunction } from "react-i18next";
 import Box from "../Styled/Box";
 import { TextSpan } from "../Styled/Text";
 import AnimatedSpinnerIcon from "../Styled/AnimatedSpinnerIcon";

--- a/lib/ReactViews/Map/MapNavigation/Items/Compass/Compass.tsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/Compass/Compass.tsx
@@ -9,11 +9,10 @@
  * styles, and will be leaving it as is for now
  */
 //
-import { TFunction } from "i18next";
 import { computed, runInAction, when } from "mobx";
 import debounce from "lodash-es/debounce";
 import React from "react";
-import { WithTranslation, withTranslation } from "react-i18next";
+import { WithTranslation, withTranslation, TFunction } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";

--- a/lib/ReactViews/Map/MapNavigation/Items/ZoomControl.tsx
+++ b/lib/ReactViews/Map/MapNavigation/Items/ZoomControl.tsx
@@ -1,6 +1,5 @@
-import { TFunction } from "i18next";
 import React from "react";
-import { withTranslation, WithTranslation } from "react-i18next";
+import { withTranslation, WithTranslation, TFunction } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import Ellipsoid from "terriajs-cesium/Source/Core/Ellipsoid";

--- a/lib/ReactViews/Map/MapNavigation/MapNavigation.tsx
+++ b/lib/ReactViews/Map/MapNavigation/MapNavigation.tsx
@@ -1,4 +1,3 @@
-import { TFunction } from "i18next";
 import { debounce } from "lodash-es";
 import {
   action,
@@ -11,7 +10,7 @@ import {
 } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
-import { WithTranslation, withTranslation } from "react-i18next";
+import { WithTranslation, withTranslation, TFunction } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import ViewState from "../../../ReactViewModels/ViewState";
 import Box from "../../../Styled/Box";

--- a/lib/ReactViews/Map/Panels/SettingPanel.tsx
+++ b/lib/ReactViews/Map/Panels/SettingPanel.tsx
@@ -1,4 +1,3 @@
-import { TFunction } from "i18next";
 import {
   action,
   computed,
@@ -9,7 +8,7 @@ import {
 import { observer } from "mobx-react";
 import Slider from "rc-slider";
 import React, { ChangeEvent, ComponentProps, MouseEvent } from "react";
-import { withTranslation, WithTranslation } from "react-i18next";
+import { withTranslation, WithTranslation, TFunction } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
 import MappableMixin from "../../../ModelMixins/MappableMixin";

--- a/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/SharePanel.tsx
@@ -1,8 +1,11 @@
 import classNames from "classnames";
-import { TFunction } from "i18next";
 import { observer } from "mobx-react";
 import React from "react";
-import { WithTranslation, withTranslation } from "react-i18next";
+import {
+  WithTranslation,
+  withTranslation,
+  type TFunction
+} from "react-i18next";
 import Terria from "../../../../Models/Terria";
 import ViewState from "../../../../ReactViewModels/ViewState";
 import Box from "../../../../Styled/Box";

--- a/lib/ReactViews/Search/SearchBoxAndResults.d.ts
+++ b/lib/ReactViews/Search/SearchBoxAndResults.d.ts
@@ -1,5 +1,5 @@
-import { TFunction } from "i18next";
 import React from "react";
+import type { TFunction } from "react-i18next";
 import Terria from "../../Models/Terria";
 import ViewState from "../../ReactViewModels/ViewState";
 

--- a/lib/ReactViews/StandardUserInterface/TrainerBar/TrainerBar.tsx
+++ b/lib/ReactViews/StandardUserInterface/TrainerBar/TrainerBar.tsx
@@ -1,7 +1,11 @@
-import { TFunction } from "i18next";
 import { observer } from "mobx-react";
-import React from "react";
-import { Translation, WithTranslation, withTranslation } from "react-i18next";
+import React, { type ReactNode } from "react";
+import {
+  Translation,
+  WithTranslation,
+  withTranslation,
+  TFunction
+} from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import {
   HelpContentItem,
@@ -72,7 +76,7 @@ const renderStep = (
   options: {
     renderDescription: boolean;
     comfortable: boolean;
-    footerComponent?: () => void;
+    footerComponent?: () => ReactNode;
   } = {
     renderDescription: true,
     comfortable: false,

--- a/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
+++ b/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
@@ -1,5 +1,4 @@
 import hoistStatics from "hoist-non-react-statics";
-import { TFunction } from "i18next";
 import {
   action,
   computed,
@@ -12,7 +11,7 @@ import { observer } from "mobx-react";
 import { IDisposer } from "mobx-utils";
 import React, { useState } from "react";
 import ReactDOM from "react-dom";
-import { WithTranslation, withTranslation } from "react-i18next";
+import { WithTranslation, withTranslation, TFunction } from "react-i18next";
 import styled, { DefaultTheme, useTheme, withTheme } from "styled-components";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
 import createGuid from "terriajs-cesium/Source/Core/createGuid";

--- a/lib/ReactViews/Tools/ItemSearchTool/SearchForm.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/SearchForm.tsx
@@ -1,10 +1,10 @@
-import { WithT } from "i18next";
 import isEmpty from "lodash-es/isEmpty";
 import React, { useEffect, useState } from "react";
 import {
   useTranslation,
   WithTranslation,
-  withTranslation
+  withTranslation,
+  TFunction
 } from "react-i18next";
 import ReactSelect, {
   ActionMeta,
@@ -129,11 +129,12 @@ const SearchForm: React.FC<SearchFormProps> = (props) => {
   );
 };
 
-interface ParameterProps extends WithT {
+interface ParameterProps {
   parameter: ItemSearchParameter;
   onChange: (value: any) => void;
   value?: any;
   disabled: boolean;
+  t: TFunction;
 }
 
 const Parameter: React.FC<ParameterProps> = (props) => {
@@ -148,10 +149,11 @@ const Parameter: React.FC<ParameterProps> = (props) => {
   }
 };
 
-interface NumericParameterProps extends WithT {
+interface NumericParameterProps {
   parameter: NumericItemSearchParameter;
   onChange: (value: { start?: number; end?: number } | undefined) => void;
   value?: { start: number; end: number };
+  t: TFunction;
 }
 
 export const NumericParameter: React.FC<NumericParameterProps> = (props) => {

--- a/lib/ReactViews/Tools/ToolModal.tsx
+++ b/lib/ReactViews/Tools/ToolModal.tsx
@@ -1,7 +1,6 @@
-import { TFunction } from "i18next";
 import { observer } from "mobx-react";
 import React, { useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation, TFunction } from "react-i18next";
 import styled, { useTheme } from "styled-components";
 import ViewState from "../../ReactViewModels/ViewState";
 import Box, { BoxSpan } from "../../Styled/Box";

--- a/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.tsx
+++ b/lib/ReactViews/Workbench/Controls/DateTimeSelectorSection.tsx
@@ -1,9 +1,8 @@
 import dateFormat from "dateformat";
-import { TFunction } from "i18next";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
-import { WithTranslation, withTranslation } from "react-i18next";
+import { WithTranslation, withTranslation, TFunction } from "react-i18next";
 import styled from "styled-components";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import isDefined from "../../../Core/isDefined";

--- a/lib/ReactViews/Workbench/Controls/OpacitySection.tsx
+++ b/lib/ReactViews/Workbench/Controls/OpacitySection.tsx
@@ -1,9 +1,8 @@
-import { TFunction } from "i18next";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import Slider from "rc-slider";
 import React from "react";
-import { WithTranslation, withTranslation } from "react-i18next";
+import { WithTranslation, withTranslation, TFunction } from "react-i18next";
 import styled from "styled-components";
 import CommonStrata from "../../../Models/Definition/CommonStrata";
 import hasTraits from "../../../Models/Definition/hasTraits";

--- a/lib/ReactViews/Workbench/Workbench.tsx
+++ b/lib/ReactViews/Workbench/Workbench.tsx
@@ -1,8 +1,7 @@
-import { TFunction } from "i18next";
 import { action, runInAction, makeObservable } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
-import { withTranslation, WithTranslation } from "react-i18next";
+import { withTranslation, WithTranslation, TFunction } from "react-i18next";
 import getPath from "../../Core/getPath";
 import Terria from "../../Models/Terria";
 import ViewState from "../../ReactViewModels/ViewState";

--- a/lib/ReactViews/Workbench/WorkbenchItem.tsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.tsx
@@ -1,9 +1,8 @@
-import { TFunction } from "i18next";
 import { action, computed, makeObservable } from "mobx";
 import { observer } from "mobx-react";
 import React from "react";
 import { sortable } from "react-anything-sortable";
-import { WithTranslation, withTranslation } from "react-i18next";
+import { WithTranslation, withTranslation, TFunction } from "react-i18next";
 import styled, { DefaultTheme, withTheme } from "styled-components";
 import getPath from "../../Core/getPath";
 import CatalogMemberMixin, {


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

`TFunction` type should be imported from `react-i18next` instead of `i18next` directly. It will cause issues in new versions of react

### Test me

Those are typeonly changes so it tested by CI

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
