### PR TITLE
Remove unused defaults

### DIFF
--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -128,8 +128,6 @@ import { isViewerMode, setViewerMode } from "./ViewerMode";
 import Workbench from "./Workbench";
 import SelectableDimensionWorkflow from "./Workflows/SelectableDimensionWorkflow";
 
-// import overrides from "../Overrides/defaults.jsx";
-
 export interface ConfigParameters {
   /**
    * TerriaJS uses this name whenever it needs to display the name of the application.

--- a/lib/Overrides/defaults.jsx
+++ b/lib/Overrides/defaults.jsx
@@ -1,9 +1,0 @@
-export const overrides = {
-  // WelcomeMessagePrimaryBtnClick: () => {},
-  // WelcomeMessageSecondaryBtnClick: () => {},
-  WelcomeMessagePrimaryBtnClick: undefined,
-  // Pass a function to this to enable display of the secondary button on the welcome modal
-  WelcomeMessageSecondaryBtnClick: undefined
-};
-
-export default overrides;


### PR DESCRIPTION
### What this PR does

This was merged in a commented
out state in May 2020 (#4293).
Remove the file+commented out
import for now since the extra
functionality has not been
implemented in the past 4.5
years.

When the functionality gets
implemented, the person
implementing can revert this
commit.

### Test me

Check that nothing else uses defaults.jsx.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
