### PR TITLE
Check return value of xml2json

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.10.1)
 
+- Check return value of xml2json.
 - Fix app crash when encountering unsupported WPS input types.
 - Warn the user when the story causes shareData size exceed the limit set on the server as `shareMaxRequestSize`. #7636
 - Adds new `TileMapServiceCatalogItem` for loading Tile Map Service (TMS) imagery tilesets.

--- a/lib/ModelMixins/ExportWebCoverageServiceMixin.ts
+++ b/lib/ModelMixins/ExportWebCoverageServiceMixin.ts
@@ -65,7 +65,7 @@ class WebCoverageServiceCapabilitiesStratum extends LoadableStratum(
       proxyCatalogItemUrl(catalogItem, url)
     );
     const json = xml2json(capabilitiesXml);
-    if (!isDefined(json.ServiceMetadata)) {
+    if (!json || typeof json === "string" || !isDefined(json.ServiceMetadata)) {
       throw networkRequestError({
         title: "Invalid GetCapabilities",
         message:
@@ -132,7 +132,11 @@ class WebCoverageServiceDescribeCoverageStratum extends LoadableStratum(
       proxyCatalogItemUrl(catalogItem, url)
     );
     const json = xml2json(capabilitiesXml);
-    if (typeof json.CoverageDescription?.CoverageId !== "string") {
+    if (
+      !json ||
+      typeof json === "string" ||
+      typeof json.CoverageDescription?.CoverageId !== "string"
+    ) {
       throw networkRequestError({
         title: "Invalid DescribeCoverage",
         message:

--- a/lib/Models/Catalog/Ows/SensorObservationServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/SensorObservationServiceCatalogItem.ts
@@ -662,11 +662,11 @@ async function loadSoapBody(
   }
 
   const json = xml2json(responseXml);
-  if (json.Exception) {
+  if (!json || typeof json === "string" || json.Exception) {
     let errorMessage = i18next.t(
       "models.sensorObservationService.unknownError"
     );
-    if (json.Exception.ExceptionText) {
+    if (json && typeof json !== "string" && json.Exception?.ExceptionText) {
       errorMessage = i18next.t(
         "models.sensorObservationService.exceptionMessage",
         { exceptionText: json.Exception.ExceptionText }

--- a/lib/Models/Catalog/Ows/WebFeatureServiceCapabilities.ts
+++ b/lib/Models/Catalog/Ows/WebFeatureServiceCapabilities.ts
@@ -1,5 +1,4 @@
 import { createTransformer } from "mobx-utils";
-import defined from "terriajs-cesium/Source/Core/defined";
 import isDefined from "../../../Core/isDefined";
 import loadXML from "../../../Core/loadXML";
 import TerriaError from "../../../Core/TerriaError";
@@ -178,7 +177,11 @@ export default class WebFeatureServiceCapabilities {
     createTransformer((url: string) => {
       return loadXML(url).then(function (capabilitiesXml: any) {
         const json = xml2json(capabilitiesXml);
-        if (!defined(json.ServiceIdentification)) {
+        if (
+          !json ||
+          typeof json === "string" ||
+          !isDefined(json.ServiceIdentification)
+        ) {
           throw new TerriaError({
             title: "Invalid GetCapabilities",
             message:

--- a/lib/Models/Catalog/Ows/WebFeatureServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebFeatureServiceCatalogItem.ts
@@ -431,7 +431,11 @@ class WebFeatureServiceCatalogItem extends GetCapabilitiesMixin(
     ) {
       let errorMessage: string | undefined;
       try {
-        errorMessage = xml2json(getFeatureResponse).Exception?.ExceptionText;
+        const jsonResponse = xml2json(getFeatureResponse);
+        errorMessage =
+          jsonResponse && typeof jsonResponse !== "string"
+            ? jsonResponse.Exception?.ExceptionText
+            : undefined;
       } catch {}
 
       const originalError = isDefined(errorMessage)

--- a/lib/Models/Catalog/Ows/WebMapServiceCapabilities.ts
+++ b/lib/Models/Catalog/Ows/WebMapServiceCapabilities.ts
@@ -1,5 +1,5 @@
 import { createTransformer } from "mobx-utils";
-import defined from "terriajs-cesium/Source/Core/defined";
+import isDefined from "../../../Core/isDefined";
 import isReadOnlyArray from "../../../Core/isReadOnlyArray";
 import loadXML from "../../../Core/loadXML";
 import { networkRequestError } from "../../../Core/TerriaError";
@@ -163,7 +163,12 @@ export default class WebMapServiceCapabilities {
     createTransformer((url: string) => {
       return Promise.resolve(loadXML(url)).then(function (capabilitiesXml) {
         const json = xml2json(capabilitiesXml);
-        if (!capabilitiesXml || !defined(json.Capability)) {
+        if (
+          !capabilitiesXml ||
+          !json ||
+          typeof json === "string" ||
+          !isDefined(json.Capability)
+        ) {
           throw networkRequestError({
             title: "Invalid GetCapabilities",
             message:

--- a/lib/Models/Catalog/Ows/WebMapTileServiceCapabilities.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCapabilities.ts
@@ -131,7 +131,12 @@ export default class WebMapTileServiceCapabilities {
     createTransformer((url: string) => {
       return Promise.resolve(loadXML(url)).then(function (capabilitiesXml) {
         const json = xml2json(capabilitiesXml);
-        if (!capabilitiesXml || !defined(json.ServiceIdentification)) {
+        if (
+          !capabilitiesXml ||
+          !json ||
+          typeof json === "string" ||
+          !defined(json.ServiceIdentification)
+        ) {
           throw networkRequestError({
             title: i18next.t(
               "models.webMapTileServiceCatalogGroup.invalidCapabilitiesTitle"
@@ -145,7 +150,10 @@ export default class WebMapTileServiceCapabilities {
           });
         }
 
-        return new WebMapTileServiceCapabilities(capabilitiesXml, json);
+        return new WebMapTileServiceCapabilities(
+          capabilitiesXml,
+          json as CapabilitiesJson
+        );
       });
     });
 

--- a/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunction.ts
+++ b/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunction.ts
@@ -145,7 +145,11 @@ class WpsLoadableStratum extends LoadableStratum(
     }
 
     const json = xml2json(xml);
-    if (!isDefined(json.ProcessDescription)) {
+    if (
+      !json ||
+      typeof json === "string" ||
+      !isDefined(json.ProcessDescription)
+    ) {
       throw networkRequestError({
         sender: this,
         title: i18next.t(

--- a/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunctionJob.ts
+++ b/lib/Models/Catalog/Ows/WebProcessingServiceCatalogFunctionJob.ts
@@ -232,13 +232,19 @@ export default class WebProcessingServiceCatalogFunctionJob extends XmlRequestMi
     // Check if finished
     if (this.checkStatus(json)) {
       // set result
-      runInAction(() => this.setTrait(CommonStrata.user, "wpsResponse", json));
+      runInAction(() =>
+        this.setTrait(CommonStrata.user, "wpsResponse", json as JsonObject)
+      );
       return true;
     }
 
     // If not finished, set response URL for polling
     runInAction(() =>
-      this.setTrait(CommonStrata.user, "wpsResponseUrl", json.statusLocation)
+      this.setTrait(
+        CommonStrata.user,
+        "wpsResponseUrl",
+        (json as unknown as JsonObject).statusLocation as string | undefined
+      )
     );
 
     return false;
@@ -249,7 +255,7 @@ export default class WebProcessingServiceCatalogFunctionJob extends XmlRequestMi
    */
   @action
   checkStatus(json: any) {
-    const status = json.Status;
+    const status = json && typeof json !== "string" ? json.Status : undefined;
     if (!isDefined(status)) {
       throw new TerriaError({
         sender: this,
@@ -296,7 +302,13 @@ export default class WebProcessingServiceCatalogFunctionJob extends XmlRequestMi
       const url = proxyCatalogItemUrl(this, this.wpsResponseUrl, "0d");
       const wpsResponse = xml2json(await this.getXml(url));
       runInAction(() => {
-        this.setTrait(CommonStrata.user, "wpsResponse", wpsResponse);
+        this.setTrait(
+          CommonStrata.user,
+          "wpsResponse",
+          !wpsResponse || typeof wpsResponse === "string"
+            ? undefined
+            : wpsResponse
+        );
       });
     }
 

--- a/lib/ThirdParty/xml2json.d.ts
+++ b/lib/ThirdParty/xml2json.d.ts
@@ -1,4 +1,4 @@
 export default function xml2json(
   xml: XMLDocument | string | undefined,
   extended?: boolean
-): any;
+): { [key: string]: any } | string | null | undefined;


### PR DESCRIPTION
### What this PR does

The xml2json function can return
a string, null, and undefined,
so add that to the return type
in the type declaration file
and check the return value at
the callers.

### Test me

I believe this is tested by CI?

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
