### PR TITLE
doc: remove deleted gulp tasks

### DIFF
--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -144,7 +144,6 @@ Run any of these tasks with `yarn gulp <task name>` from within the TerriaJS dir
 - `release` - The same as `build` except that it also minifies the build tests.
 - `lint` - Runs ESLint on the files in the `lib` folder and reports any problems. The ESLint rules are defined in the `.eslintrc.js` file in the root directory of TerriaJS.
 - `docs` - Generates the user guide and reference documentation. The user guide is served at `http://localhost:3002/doc/guide/` and the reference documentation is at `http://localhost:3002/doc/reference/`.
-- `make-schema` - Generates [JSON Schema](http://json-schema.org/) for the TerriaJS [Initialization Files](../customizing/initialization-files.md) from the source code. The schema is written to `wwwroot/schema`.
 - `test` - Detects browsers available on the local system and launches the test suite in each. The results are reported on the command line.
 - `test-electron` - Runs the tests in Electron, a headless (no UI) Chrome-like browser.
 - `test-saucelabs` - Runs the tests on a bunch of browsers on [Sauce Labs](https://saucelabs.com/). You will need to [Set up Sauce Labs](setting-up-saucelabs.md).

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -145,7 +145,6 @@ Run any of these tasks with `yarn gulp <task name>` from within the TerriaJS dir
 - `lint` - Runs ESLint on the files in the `lib` folder and reports any problems. The ESLint rules are defined in the `.eslintrc.js` file in the root directory of TerriaJS.
 - `docs` - Generates the user guide and reference documentation. The user guide is served at `http://localhost:3002/doc/guide/` and the reference documentation is at `http://localhost:3002/doc/reference/`.
 - `test` - Detects browsers available on the local system and launches the test suite in each. The results are reported on the command line.
-- `test-electron` - Runs the tests in Electron, a headless (no UI) Chrome-like browser.
 - `test-saucelabs` - Runs the tests on a bunch of browsers on [Sauce Labs](https://saucelabs.com/). You will need to [Set up Sauce Labs](setting-up-saucelabs.md).
 - `test-browserstack` - Runs the tests on a bunch of browsers on [BrowserStack](https://www.browserstack.com/). You will need to set up a BrowserStack account.
 

--- a/doc/contributing/development-environment.md
+++ b/doc/contributing/development-environment.md
@@ -145,6 +145,7 @@ Run any of these tasks with `yarn gulp <task name>` from within the TerriaJS dir
 - `lint` - Runs ESLint on the files in the `lib` folder and reports any problems. The ESLint rules are defined in the `.eslintrc.js` file in the root directory of TerriaJS.
 - `docs` - Generates the user guide and reference documentation. The user guide is served at `http://localhost:3002/doc/guide/` and the reference documentation is at `http://localhost:3002/doc/reference/`.
 - `test` - Detects browsers available on the local system and launches the test suite in each. The results are reported on the command line.
+- `test-firefox` - Runs the tests in a headless Firefox browser.
 - `test-saucelabs` - Runs the tests on a bunch of browsers on [Sauce Labs](https://saucelabs.com/). You will need to [Set up Sauce Labs](setting-up-saucelabs.md).
 - `test-browserstack` - Runs the tests on a bunch of browsers on [BrowserStack](https://www.browserstack.com/). You will need to set up a BrowserStack account.
 


### PR DESCRIPTION
### What this PR does

These gulp tasks were removed 1+ year ago.

### Test me

Documentation only changes.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [X] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
