### PR TITLE
gulpfile.js: update to V4 syntax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Replace node-fetch with node native fetch.
 - Refactor tests to use @testing-library/react instead of react-test-renderer and react-shallow-testutils, and remove deprecated libraries. (#7755, #7763)
 - TSify most of `lib/Core`. [#7417](https://github.com/TerriaJS/terriajs/pull/7417/)
+- Update gulpfile.js to gulp V4 syntax, which provides task descriptions in `yarn gulp --tasks`.
 - [The next improvement]
 
 #### 8.11.3 - 2026-02-02

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,6 @@ function buildSpecs(done) {
 
   runWebpack(webpack, webpackConfig, done);
 }
-buildSpecs.displayName = "build-specs";
 
 function releaseSpecs(done) {
   var runWebpack = require("./buildprocess/runWebpack.js");
@@ -27,7 +26,6 @@ function releaseSpecs(done) {
 
   runWebpack(webpack, webpackConfig, done);
 }
-releaseSpecs.displayName = "release-specs";
 
 function watchSpecs(done) {
   var watchWebpack = require("./buildprocess/watchWebpack");
@@ -36,7 +34,6 @@ function watchSpecs(done) {
 
   watchWebpack(webpack, webpackConfig, done);
 }
-watchSpecs.displayName = "watch-specs";
 
 function lint(done) {
   var runExternalModule = require("./buildprocess/runExternalModule");
@@ -86,7 +83,6 @@ function copyCesiumWorkers() {
     })
     .pipe(gulp.dest("wwwroot/build/Cesium/build/Workers"));
 }
-copyCesiumWorkers.displayName = "copy-cesium-workers";
 
 function copyCesiumThirdparty() {
   var path = require("path");
@@ -102,7 +98,6 @@ function copyCesiumThirdparty() {
     })
     .pipe(gulp.dest("wwwroot/build/Cesium/build/ThirdParty"));
 }
-copyCesiumThirdparty.displayName = "copy-cesium-thirdparty";
 
 function copyCesiumSourceAssets() {
   var path = require("path");
@@ -118,7 +113,6 @@ function copyCesiumSourceAssets() {
     })
     .pipe(gulp.dest("wwwroot/build/Cesium/build/Assets"));
 }
-copyCesiumSourceAssets.displayName = "copy-cesium-source-assets";
 
 function testFirefox(done) {
   runKarma("./buildprocess/karma-firefox.conf.js", done);
@@ -270,7 +264,6 @@ const copyCesiumAssets = gulp.series(
   copyCesiumWorkers,
   copyCesiumThirdparty
 );
-copyCesiumAssets.displayName = "copy-cesium-assets";
 
 const build = gulp.series(copyCesiumAssets, buildSpecs);
 build.description = "Build non-minified version of TerriaJS tests.";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,31 +11,34 @@
 var gulp = require("gulp");
 var terriajsServerGulpTask = require("./buildprocess/terriajsServerGulpTask");
 
-gulp.task("build-specs", function (done) {
+function buildSpecs(done) {
   var runWebpack = require("./buildprocess/runWebpack.js");
   var webpack = require("webpack");
   var webpackConfig = require("./buildprocess/webpack.config.make.js")(true);
 
   runWebpack(webpack, webpackConfig, done);
-});
+}
+buildSpecs.displayName = "build-specs";
 
-gulp.task("release-specs", function (done) {
+function releaseSpecs(done) {
   var runWebpack = require("./buildprocess/runWebpack.js");
   var webpack = require("webpack");
   var webpackConfig = require("./buildprocess/webpack.config.make.js")(false);
 
   runWebpack(webpack, webpackConfig, done);
-});
+}
+releaseSpecs.displayName = "release-specs";
 
-gulp.task("watch-specs", function (done) {
+function watchSpecs(done) {
   var watchWebpack = require("./buildprocess/watchWebpack");
   var webpack = require("webpack");
   var webpackConfig = require("./buildprocess/webpack.config.make.js")(true);
 
   watchWebpack(webpack, webpackConfig, done);
-});
+}
+watchSpecs.displayName = "watch-specs";
 
-gulp.task("lint", function (done) {
+function lint(done) {
   var runExternalModule = require("./buildprocess/runExternalModule");
   var path = require("path");
 
@@ -52,9 +55,10 @@ gulp.task("lint", function (done) {
   ]);
 
   done();
-});
+}
+lint.description = "Run ESLint.";
 
-gulp.task("reference-guide", function (done) {
+function jsdoc(done) {
   var runExternalModule = require("./buildprocess/runExternalModule");
 
   runExternalModule("jsdoc/jsdoc.js", [
@@ -64,9 +68,11 @@ gulp.task("reference-guide", function (done) {
   ]);
 
   done();
-});
+}
+jsdoc.description = "Build developer reference documentation.";
+jsdoc.displayName = "reference-guide";
 
-gulp.task("copy-cesium-workers", function () {
+function copyCesiumWorkers() {
   var path = require("path");
 
   var cesiumPackage = require.resolve("terriajs-cesium/package.json");
@@ -79,9 +85,10 @@ gulp.task("copy-cesium-workers", function () {
       encoding: false
     })
     .pipe(gulp.dest("wwwroot/build/Cesium/build/Workers"));
-});
+}
+copyCesiumWorkers.displayName = "copy-cesium-workers";
 
-gulp.task("copy-cesium-thirdparty", function () {
+function copyCesiumThirdparty() {
   var path = require("path");
 
   var cesiumPackage = require.resolve("terriajs-cesium/package.json");
@@ -94,9 +101,10 @@ gulp.task("copy-cesium-thirdparty", function () {
       encoding: false
     })
     .pipe(gulp.dest("wwwroot/build/Cesium/build/ThirdParty"));
-});
+}
+copyCesiumThirdparty.displayName = "copy-cesium-thirdparty";
 
-gulp.task("copy-cesium-source-assets", function () {
+function copyCesiumSourceAssets() {
   var path = require("path");
 
   var cesiumPackage = require.resolve("terriajs-cesium/package.json");
@@ -109,15 +117,19 @@ gulp.task("copy-cesium-source-assets", function () {
       encoding: false
     })
     .pipe(gulp.dest("wwwroot/build/Cesium/build/Assets"));
-});
+}
+copyCesiumSourceAssets.displayName = "copy-cesium-source-assets";
 
-gulp.task("test-firefox", function (done) {
+function testFirefox(done) {
   runKarma("./buildprocess/karma-firefox.conf.js", done);
-});
+}
+testFirefox.description = "Run tests with Firefox.";
+testFirefox.displayName = "test-firefox";
 
-gulp.task("test", function (done) {
+function test(done) {
   runKarma("./buildprocess/karma-local.conf.js", done);
-});
+}
+test.description = "Run tests.";
 
 function runKarma(configFile, done) {
   const { Server } = require("karma");
@@ -141,7 +153,7 @@ search:
 # Attributions
 `;
 
-gulp.task("code-attribution", function userAttribution(done) {
+function codeAttribution(done) {
   var spawnSync = require("child_process").spawnSync;
   const { writeFileSync } = require("node:fs");
 
@@ -163,101 +175,133 @@ gulp.task("code-attribution", function userAttribution(done) {
     );
   }
   done();
-});
+}
+codeAttribution.description = "Generate doc/acknowledgements/attributions.md.";
+codeAttribution.displayName = "code-attribution";
 
-gulp.task("build-for-doc-generation", function buildForDocGeneration(done) {
+function buildForDocGeneration(done) {
   var runWebpack = require("./buildprocess/runWebpack.js");
   var webpack = require("webpack");
   var webpackConfig = require("./buildprocess/webpack-tools.config.js")();
 
   runWebpack(webpack, webpackConfig, done);
-});
+}
 
-gulp.task(
-  "render-guide",
-  gulp.series(
-    function copyToBuild(done) {
-      const fs = require("node:fs");
-      fs.cpSync("doc", "build/doc", { recursive: true });
-      done();
-    },
-    function generateMemberPages(done) {
-      const fs = require("node:fs");
-      const PluginError = require("plugin-error");
-      const spawnSync = require("child_process").spawnSync;
+const renderGuide = gulp.series(
+  function copyToBuild(done) {
+    const fs = require("node:fs");
+    fs.cpSync("doc", "build/doc", { recursive: true });
+    done();
+  },
+  function generateMemberPages(done) {
+    const fs = require("node:fs");
+    const PluginError = require("plugin-error");
+    const spawnSync = require("child_process").spawnSync;
 
-      fs.mkdirSync("build/doc/connecting-to-data/catalog-type-details", {
-        recursive: true
-      });
+    fs.mkdirSync("build/doc/connecting-to-data/catalog-type-details", {
+      recursive: true
+    });
 
-      const result = spawnSync("node", ["generateDocs.js"], {
+    const result = spawnSync("node", ["generateDocs.js"], {
+      cwd: "build",
+      stdio: "inherit",
+      shell: false
+    });
+
+    if (result.status !== 0) {
+      throw new PluginError(
+        "user-doc",
+        "Generating catalog members pages exited with an error.",
+        { showStack: false }
+      );
+    }
+    done();
+  },
+  function mkdocs(done) {
+    const PluginError = require("plugin-error");
+    const spawnSync = require("child_process").spawnSync;
+
+    const result = spawnSync(
+      "mkdocs",
+      ["build", "--clean", "--config-file", "mkdocs.yml"],
+      {
         cwd: "build",
         stdio: "inherit",
         shell: false
-      });
-
-      if (result.status !== 0) {
-        throw new PluginError(
-          "user-doc",
-          "Generating catalog members pages exited with an error.",
-          { showStack: false }
-        );
       }
-      done();
-    },
-    function mkdocs(done) {
-      const PluginError = require("plugin-error");
-      const spawnSync = require("child_process").spawnSync;
-
-      const result = spawnSync(
-        "mkdocs",
-        ["build", "--clean", "--config-file", "mkdocs.yml"],
+    );
+    if (result.status !== 0) {
+      throw new PluginError(
+        "user-doc",
+        `Mkdocs exited with an error. Maybe you didn't install mkdocs and other python dependencies in requirements.txt - see https://docs.terria.io/guide/contributing/development-environment/#documentation?`,
         {
-          cwd: "build",
-          stdio: "inherit",
-          shell: false
+          showStack: false
         }
       );
-      if (result.status !== 0) {
-        throw new PluginError(
-          "user-doc",
-          `Mkdocs exited with an error. Maybe you didn't install mkdocs and other python dependencies in requirements.txt - see https://docs.terria.io/guide/contributing/development-environment/#documentation?`,
-          {
-            showStack: false
-          }
-        );
-      }
-      done();
     }
-  )
+    done();
+  }
 );
+renderGuide.description = "Build user guide documentation.";
+renderGuide.displayName = "render-guide";
 
-gulp.task(
-  "docs",
-  gulp.series(
-    gulp.parallel("code-attribution", "build-for-doc-generation"),
-    "render-guide",
-    function docs(done) {
-      var fs = require("node:fs");
-      fs.cpSync("doc/index-redirect.html", "wwwroot/doc/index.html");
-      done();
-    }
-  )
+const docs = gulp.series(
+  gulp.parallel(codeAttribution, buildForDocGeneration),
+  renderGuide,
+  function copyIndex(done) {
+    var fs = require("node:fs");
+    fs.cpSync("doc/index-redirect.html", "wwwroot/doc/index.html");
+    done();
+  }
 );
+docs.description = "Generate developer- and user-documentation.";
 
-gulp.task("terriajs-server", terriajsServerGulpTask(3002));
+function terriajsServer(done) {
+  terriajsServerGulpTask(3002)(done);
+}
+terriajsServer.description = "Start TerriaJS server.";
+terriajsServer.displayName = "terriajs-server";
+terriajsServer.flags = {
+  "--terriajsServerArg": "Argument to pass to terriaJsServer"
+};
 
-gulp.task(
-  "copy-cesium-assets",
-  gulp.series(
-    "copy-cesium-source-assets",
-    "copy-cesium-workers",
-    "copy-cesium-thirdparty"
-  )
+const copyCesiumAssets = gulp.series(
+  copyCesiumSourceAssets,
+  copyCesiumWorkers,
+  copyCesiumThirdparty
 );
-gulp.task("build", gulp.series("copy-cesium-assets", "build-specs"));
-gulp.task("release", gulp.series("copy-cesium-assets", "release-specs"));
-gulp.task("watch", gulp.series("copy-cesium-assets", "watch-specs"));
-gulp.task("dev", gulp.parallel("terriajs-server", "watch"));
-gulp.task("post-npm-install", gulp.series("copy-cesium-assets"));
-gulp.task("default", gulp.series("lint", "build"));
+copyCesiumAssets.displayName = "copy-cesium-assets";
+
+const build = gulp.series(copyCesiumAssets, buildSpecs);
+build.description = "Build non-minified version of TerriaJS tests.";
+
+const release = gulp.series(copyCesiumAssets, releaseSpecs);
+release.description = "Build minified version of TerriaJS tests.";
+
+const watch = gulp.series(copyCesiumAssets, watchSpecs);
+watch.description = "Build TerriaJS tests when there are source changes.";
+
+const dev = gulp.parallel(terriajsServer, watch);
+dev.description = "Start TerriaJS server and watch for source changes.";
+
+const postNpmInstall = copyCesiumAssets;
+postNpmInstall.description = "Copy Cesium assets after installation.";
+postNpmInstall.displayName = "post-npm-install";
+
+const lintBuild = gulp.series(lint, build);
+lintBuild.description = "Run ESLint followed by build.";
+
+exports.lint = lint;
+exports.build = build;
+exports.watch = watch;
+exports.dev = dev;
+exports.terriajsServer = terriajsServer;
+exports.docs = docs;
+exports.jsdoc = jsdoc;
+exports.renderGuide = renderGuide;
+exports.codeAttribution = codeAttribution;
+exports.test = test;
+exports.testFirefox = testFirefox;
+exports.release = release;
+exports.postNpmInstall = postNpmInstall;
+exports.default = lintBuild;

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "flexsearch": "0.7.21",
     "fs-extra": "^7.0.1",
     "geojson-vt": "^3.2.1",
-    "gulp": "^5.0.0",
+    "gulp": "^5.0.1",
     "hoist-non-react-statics": "^3.3.2",
     "html-to-react": "^1.7.0",
     "i18next": "^21.8.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5577,10 +5577,10 @@ glob-parent@^6.0.1, glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob-stream@^8.0.0:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/glob-stream/-/glob-stream-8.0.2.tgz#09e5818e41c16dd85274d72c7a7158d307426313"
-  integrity sha512-R8z6eTB55t3QeZMmU1C+Gv+t5UnNRkA55c5yo67fAVfxODxieTwsjNG7utxS/73NdP1NbDgCrhVEg2h00y4fFw==
+glob-stream@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/glob-stream/-/glob-stream-8.0.3.tgz#87e63153aadf05bd0207cde1a253ee39d91458b9"
+  integrity sha512-fqZVj22LtFJkHODT+M4N1RJQ3TjnnQhfE9GwZI8qXscYarnhpip70poMldRnP8ipQ/w0B621kOhfc53/J9bd/A==
   dependencies:
     "@gulpjs/to-absolute-glob" "^4.0.0"
     anymatch "^3.1.3"
@@ -5700,17 +5700,17 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==
 
-gulp-cli@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-cli/-/gulp-cli-3.0.0.tgz#577008f5323fad6106b44db24803c27c3a649841"
-  integrity sha512-RtMIitkT8DEMZZygHK2vEuLPqLPAFB4sntSxg4NoDta7ciwGZ18l7JuhCTiS5deOJi2IoK0btE+hs6R4sfj7AA==
+gulp-cli@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/gulp-cli/-/gulp-cli-3.1.0.tgz#92590e9b209142b176c95ad5c7066d2592017268"
+  integrity sha512-zZzwlmEsTfXcxRKiCHsdyjZZnFvXWM4v1NqBJSYbuApkvVKivjcmOS2qruAJ+PkEHLFavcDKH40DPc1+t12a9Q==
   dependencies:
     "@gulpjs/messages" "^1.1.0"
     chalk "^4.1.2"
     copy-props "^4.0.0"
     gulplog "^2.2.0"
     interpret "^3.1.1"
-    liftoff "^5.0.0"
+    liftoff "^5.0.1"
     mute-stdout "^2.0.0"
     replace-homedir "^2.0.0"
     semver-greatest-satisfied-range "^2.0.0"
@@ -5718,15 +5718,15 @@ gulp-cli@^3.0.0:
     v8flags "^4.0.0"
     yargs "^16.2.0"
 
-gulp@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/gulp/-/gulp-5.0.0.tgz#78f4b8ac48a0bf61b354d39e5be844de2c5cc3f3"
-  integrity sha512-S8Z8066SSileaYw1S2N1I64IUc/myI2bqe2ihOBzO6+nKpvNSg7ZcWJt/AwF8LC/NVN+/QZ560Cb/5OPsyhkhg==
+gulp@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/gulp/-/gulp-5.0.1.tgz#c43f37aa34569e101fb6da4e0b464677305acd36"
+  integrity sha512-PErok3DZSA5WGMd6XXV3IRNO0mlB+wW3OzhFJLEec1jSERg2j1bxJ6e5Fh6N6fn3FH2T9AP4UYNb/pYlADB9sA==
   dependencies:
     glob-watcher "^6.0.0"
-    gulp-cli "^3.0.0"
+    gulp-cli "^3.1.0"
     undertaker "^2.0.0"
-    vinyl-fs "^4.0.0"
+    vinyl-fs "^4.0.2"
 
 gulplog@^2.2.0:
   version "2.2.0"
@@ -6823,10 +6823,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-liftoff@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-5.0.0.tgz#0e5ed275bc334caec0e551ecf08bb22be583e236"
-  integrity sha512-a5BQjbCHnB+cy+gsro8lXJ4kZluzOijzJ1UVVfyJYZC+IP2pLv1h4+aysQeKuTmyO8NAqfyQAk4HWaP/HjcKTg==
+liftoff@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-5.0.1.tgz#e2329e7f1e19e98c8dba71185f2078e6dbbc5c1f"
+  integrity sha512-wwLXMbuxSF8gMvubFcFRp56lkFV69twvbU5vDPbaw+Q+/rF8j0HKjGbIdlSi+LuJm9jf7k9PB+nTxnsLMPcv2Q==
   dependencies:
     extend "^3.0.2"
     findup-sync "^5.0.0"
@@ -9854,13 +9854,13 @@ vinyl-contents@^2.0.0:
     bl "^5.0.0"
     vinyl "^3.0.0"
 
-vinyl-fs@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-4.0.0.tgz#06cb36efc911c6e128452f230b96584a9133c3a1"
-  integrity sha512-7GbgBnYfaquMk3Qu9g22x000vbYkOex32930rBnc3qByw6HfMEAoELjCjoJv4HuEQxHAurT+nvMHm6MnJllFLw==
+vinyl-fs@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-4.0.2.tgz#d46557653e4a7109f29d626a9cf478680c7f8c70"
+  integrity sha512-XRFwBLLTl8lRAOYiBqxY279wY46tVxLaRhSwo3GzKEuLz1giffsOquWWboD/haGf5lx+JyTigCFfe7DWHoARIA==
   dependencies:
     fs-mkdirp-stream "^2.0.1"
-    glob-stream "^8.0.0"
+    glob-stream "^8.0.3"
     graceful-fs "^4.2.11"
     iconv-lite "^0.6.3"
     is-valid-glob "^1.0.0"
@@ -9871,7 +9871,7 @@ vinyl-fs@^4.0.0:
     streamx "^2.14.0"
     to-through "^3.0.0"
     value-or-function "^4.0.0"
-    vinyl "^3.0.0"
+    vinyl "^3.0.1"
     vinyl-sourcemap "^2.0.0"
 
 vinyl-sourcemap@^2.0.0:
@@ -9905,6 +9905,16 @@ vinyl@^3.0.0:
   dependencies:
     clone "^2.1.2"
     clone-stats "^1.0.0"
+    remove-trailing-separator "^1.1.0"
+    replace-ext "^2.0.0"
+    teex "^1.0.1"
+
+vinyl@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-3.0.1.tgz#5f5ff85255bda2b5da25e4b3bd80b3fc077fb5a9"
+  integrity sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==
+  dependencies:
+    clone "^2.1.2"
     remove-trailing-separator "^1.1.0"
     replace-ext "^2.0.0"
     teex "^1.0.1"


### PR DESCRIPTION
### What this PR does

The task() API is not recommended
any more according to the Gulp
documentation, so use the V4 syntax
where a regular function is used
and tasks are the functions that are
exported from the gulpfile.

This commit also hides what seems to
be gulp-internal targets, and adds
help texts for the public targets
that is shown in "gulp --tasks".

### Test me

Run gulp tasks, so reasonably well-tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [X] I've updated relevant documentation in `doc/`.
- [X] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
