### PR TITLE
DragPoints: fix parameters

### DIFF
--- a/lib/Map/DragPoints/CesiumDragPoints.js
+++ b/lib/Map/DragPoints/CesiumDragPoints.js
@@ -66,7 +66,7 @@ CesiumDragPoints.prototype.setUp = function () {
   }
   this._scene = this._terria.cesium.scene;
   this._viewer = this._terria.cesium.cesiumWidget;
-  this._mouseHandler = new ScreenSpaceEventHandler(this._scene.canvas, false);
+  this._mouseHandler = new ScreenSpaceEventHandler(this._scene.canvas);
 
   var that = this;
 

--- a/lib/Map/DragPoints/LeafletDragPoints.js
+++ b/lib/Map/DragPoints/LeafletDragPoints.js
@@ -74,7 +74,7 @@ LeafletDragPoints.prototype.setUp = function () {
 LeafletDragPoints.prototype._onMouseDownOnPoint = function (entity) {
   if (
     !defined(this._draggableObjects.entities) ||
-    this._draggableObjects.entities.length === 0
+    this._draggableObjects.entities.values.length === 0
   ) {
     return;
   }


### PR DESCRIPTION
### What this PR does

Passes the right number of parameters to the `ScreenSpaceEventHandler` constructor, and checks the length of `entities.values` (which is filtered a few lines later) rather than just `entities`.

### Test me

Not sure how to test this.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
