### PR TITLE
RegionPicker: pass id to catalog item constructors

### DIFF
--- a/lib/ReactViews/Analytics/RegionPicker.jsx
+++ b/lib/ReactViews/Analytics/RegionPicker.jsx
@@ -133,6 +133,7 @@ const RegionPicker = createReactClass({
 
     if (defined(feature.data) && feature.data.type === "Feature") {
       this._selectedRegionCatalogItem = new GeoJsonCatalogItem(
+        undefined,
         this.props.previewed.terria
       );
       this._selectedRegionCatalogItem.name = "Selected Polygon";
@@ -176,6 +177,7 @@ const RegionPicker = createReactClass({
       }
 
       that._regionsCatalogItem = new WebMapServiceCatalogItem(
+        undefined,
         that.props.previewed.terria
       );
       that._regionsCatalogItem.name = "Available Regions";
@@ -219,6 +221,7 @@ const RegionPicker = createReactClass({
 
         if (defined(feature) && feature.type === "Feature") {
           that._selectedRegionCatalogItem = new GeoJsonCatalogItem(
+            undefined,
             that.props.previewed.terria
           );
           that._selectedRegionCatalogItem.name = t("analytics.selectedPolygon");

--- a/lib/ReactViews/Analytics/RegionPicker.jsx
+++ b/lib/ReactViews/Analytics/RegionPicker.jsx
@@ -18,10 +18,10 @@ import Styles from "./parameter-editors.scss";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 
 const knockout = {
-  defineProperty() {
+  defineProperty(_cls, _name, _fn) {
     throw new Error("This component needs to be fixed to not use Knockout.");
   },
-  getObservable() {
+  getObservable(_cls, _name) {
     throw new Error("This component needs to be fixed to not use Knockout.");
   }
 };


### PR DESCRIPTION
### What this PR does

The constructors expect 2 or more arguments,
where the first is an id, and the second
is Terria. Pass in undefined for id
so at least the second argument gets
the expected value.

Also throw in a commit that aligns
the number of arguments for
the "stub" Knockout functions.

### Test me

Not sure how to test this.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
