### PR TITLE
Disclaimer: fix css parameter type

### DIFF
--- a/lib/ReactViews/Disclaimer.jsx
+++ b/lib/ReactViews/Disclaimer.jsx
@@ -112,16 +112,14 @@ class Disclaimer extends React.Component {
             <Text
               styledLineHeight={"18px"}
               textLight
-              css={(props) =>
-                `
+              css={`
                 // not sure of the ideal way to deal with this
                 a {
                   font-weight: 600;
-                  color: ${props.theme.colorPrimary};
+                  color: ${this.props.theme.colorPrimary};
                   text-decoration: none;
                 }
-              `
-              }
+              `}
             >
               {parseCustomMarkdownToReact(disclaimerMessage)}
             </Text>


### PR DESCRIPTION
### What this PR does

The css parameter is not
a function, so remove
the function and access
this.props directly.

### Test me

There is a DisclaimerSpec in the test suite, but it doesn't test css as far as I can tell.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
