### PR TITLE
tsconfig: stop emitting files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noEmit": true,
     "target": "es2019",
     "experimentalDecorators": true,
     "module": "esNext",


### PR DESCRIPTION
### What this PR does

Running tsc with --diagnostics
with an empty dist/ shows that
emitting takes nearly 2 seconds
on a fast SSD:

I/O write: 0.12s
Emit time: 1.75s

Since nothing seems to use
the emitted files, disable
emitting files to save that
time.

### Test me

See that the CI tests still pass for this PR, and then empty `dist/` and run `yarn run tsc -b tsconfig-node.json --diagnostics` before/after the commit. 

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
