### PR TITLE
RelatedMaps: remove unused classes

### DIFF
--- a/lib/ReactViews/RelatedMaps/related-maps.scss
+++ b/lib/ReactViews/RelatedMaps/related-maps.scss
@@ -10,20 +10,10 @@
   }
 }
 
-.section {
-  composes: clearfix from "~terriajs/lib/Sass/common/_base.scss";
-  margin-bottom: 10px;
-  padding: 0;
-}
-
 .image {
   float: left;
   margin-right: 10px;
   margin-bottom: 10px;
   width: 200px;
   height: 150px;
-}
-
-.link {
-  composes: link from "~terriajs/lib/Sass/common/_base.scss";
 }

--- a/lib/ReactViews/RelatedMaps/related-maps.scss.d.ts
+++ b/lib/ReactViews/RelatedMaps/related-maps.scss.d.ts
@@ -3,8 +3,6 @@ declare namespace RelatedMapsScssNamespace {
     "dropdown-inner": string;
     dropdownInner: string;
     image: string;
-    link: string;
-    section: string;
   }
 }
 


### PR DESCRIPTION
### What this PR does

Remove two classes that are no longer
used.

### Test me

I can't regenerate `related-maps.scss.d.ts` with this file when running `yarn gulp build`, so I think something is wrong with it.

This PR doesn't change that, but it aligns the file with the other scss files which I think makes it less wrong.

Don't know how to test this.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
