### PR TITLE
geoRssConvertor: add missing return statement

### DIFF
--- a/lib/Map/Vector/geoRssConvertor.js
+++ b/lib/Map/Vector/geoRssConvertor.js
@@ -157,6 +157,7 @@ function getGeometryFromWhere(node) {
       result = getGeometryFromWhere(child);
     }
   }
+  return result;
 }
 
 function createGeoJsonGeometryFeatureFromGmlGeometry(geometry) {


### PR DESCRIPTION
### What this PR does

Adds a missing (?) return statement. If the intention is to return undefined when falling out of the loop, the result variable is unused and should be removed.

### Test me

Not sure how to test this.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
