### PR TITLE
geoJsonGeometryFrom: use number for coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - TSify `DataCatalogTab` and convert it to functional component #7476
 - Update to shpjs 6.1.0.
 - Enable `noUncheckedSideEffectImports` in `tsconfig.json` to get errors from tsc when non-existent modules are imported for side effects.
+- Return lat/lon as numbers from `geoJsonGeometryFromGeoRssSimpleGeometry` and `geoJsonGeometryFromW3cGeometry`.
 - [The next improvement]
 
 #### 8.9.1 - 2025-03-24

--- a/lib/Map/Vector/geoJsonGeometryFromGeoRssSimpleGeometry.js
+++ b/lib/Map/Vector/geoJsonGeometryFromGeoRssSimpleGeometry.js
@@ -50,10 +50,10 @@ function createGeometryFromBox(bboxGeometry) {
   if (coordinates.length !== 4) {
     throw new RuntimeError("geometry not valid");
   }
-  var minLat = coordinates[0];
-  var minLon = coordinates[1];
-  var maxLat = coordinates[2];
-  var maxLon = coordinates[3];
+  var minLat = parseFloat(coordinates[0]);
+  var minLon = parseFloat(coordinates[1]);
+  var maxLat = parseFloat(coordinates[2]);
+  var maxLon = parseFloat(coordinates[3]);
 
   return {
     type: "Polygon",

--- a/lib/Map/Vector/geoJsonGeometryFromW3cGeometry.js
+++ b/lib/Map/Vector/geoJsonGeometryFromW3cGeometry.js
@@ -30,7 +30,7 @@ function createPointGeometry(geometry) {
   var longitude = geometry.getElementsByTagNameNS("*", "long")[0].textContent;
   return {
     type: "Point",
-    coordinates: [longitude, latitude]
+    coordinates: [parseFloat(longitude), parseFloat(latitude)]
   };
 }
 


### PR DESCRIPTION
### What this PR does

The other functions in these
files perform a parseFloat()
on the text values before
making them into coordinates,
so convert the two places
that create coordinates as
strings to also use numbers.

### Test me

Not sure how to test this.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
