### PR TITLE
BoxDrawing: stop triggering Cesium debug asserts

### DIFF
--- a/lib/Models/BoxDrawing.ts
+++ b/lib/Models/BoxDrawing.ts
@@ -838,7 +838,7 @@ export default class BoxDrawing {
    */
   private createSide(planeLocal: Plane): Side {
     const scene = this.scene;
-    const plane = new Plane(new Cartesian3(), 0);
+    const plane = new Plane(Cartesian3.UNIT_X, 0);
     const planeDimensions = new Cartesian3();
     const normalAxis = planeLocal.normal.x
       ? Axis.X

--- a/test/Models/BoxDrawingSpec.ts
+++ b/test/Models/BoxDrawingSpec.ts
@@ -46,7 +46,7 @@ describe("BoxDrawing", function () {
         new TranslationRotationScale(
           Cartesian3.ZERO,
           Quaternion.IDENTITY,
-          Cartesian3.ZERO
+          Cartesian3.ONE
         )
       );
       expect(boxDrawing).toBeDefined();


### PR DESCRIPTION
### What this PR does

Stops triggering Cesium debug asserts when running the test suite.

### Test me

The changed initialization in lib is the destination object, so that is immediately overwritten after creation, hence no functional change.

The changed initialization in test doesn't matter since the test only validates that the function returns a result.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
