### PR TITLE
MapboxVectorTileCatalogItem: move JSDoc

### DIFF
--- a/lib/Models/Catalog/CatalogItems/MapboxVectorTileCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/MapboxVectorTileCatalogItem.ts
@@ -146,11 +146,11 @@ class MapboxVectorTileCatalogItem extends MappableMixin(
     }
   }
 
-  @computed
   /** Convert traits into paint rules:
    * - `layer` and `fillColor`/`lineColor` into simple rules
    * - `parsedJsonStyle`
    */
+  @computed
   get paintRules(): PaintRule[] {
     const rules: PaintRule[] = [];
 


### PR DESCRIPTION
### What this PR does

Putting the JSDoc after the decorator
but before the rest of the declaration
confuses more recent versions of
Prettier, and possibly other tools as
well. Move the decorator next to
the declaration.

### Test me

Formatting change only.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
