### PR TITLE
test: remove leftover debug printout

### DIFF
--- a/test/Models/Catalog/esri/ArcGisImageServerCatalogItemSpec.ts
+++ b/test/Models/Catalog/esri/ArcGisImageServerCatalogItemSpec.ts
@@ -387,9 +387,7 @@ describe("ArcGisImageServer", function () {
       // By observing mapItems, we can trigger a reload when the renderingRule changes
       const disposer = reaction(
         () => imageServerItem.mapItems,
-        () => {
-          console.log("woo");
-        }
+        () => 1
       );
 
       runInAction(() => {


### PR DESCRIPTION
### What this PR does

Put in a constant instead of
the leftover debug printout
that prints "woo".

### Test me

Run the tests and see that "woo" is no longer printed.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
