### PR TITLE
tsconfig: enable noUncheckedSideEffectImports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - TSify `DragDropNotification` and convert to functional component and styled-components. #7563
 - TSify `DataCatalogTab` and convert it to functional component #7476
 - Update to shpjs 6.1.0.
+- Enable `noUncheckedSideEffectImports` in `tsconfig.json` to get errors from tsc when non-existent modules are imported for side effects.
 - [The next improvement]
 
 #### 8.9.1 - 2025-03-24

--- a/lib/ThirdParty/global.d.ts
+++ b/lib/ThirdParty/global.d.ts
@@ -1,4 +1,5 @@
 declare module "*.DAC";
+declare module "*.css";
 declare module "*.csv";
 declare module "*.xml";
 declare module "*.svg";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "noUncheckedSideEffectImports": true,
     "useDefineForClassFields": true, // required for mobx6 - https://mobx.js.org/installation.html#use-spec-compliant-transpilation-for-class-properties
     "outDir": "ts-out",
     "resolveJsonModule": true,


### PR DESCRIPTION
### What this PR does

This makes tsc error when doing a side effect
import of a module that does not exist.

### Test me

Change `import "inobounce";` in `StandardUserInterface.tsx` to `import "missing-inobounce";`, then run `yarn run tsc -b` and see that there is an error reported.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
