### PR TITLE
CI: add --frozen-lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
 
       - name: Check formatting with prettier
         run: yarn prettier-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-      - run: npm install -g yarn@^1.19.0 && yarn install
+      - run: yarn install
 
       - name: Check formatting with prettier
         run: yarn prettier-check

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
-        run: yarn install --ignore-engines
+        run: yarn install --ignore-engines --frozen-lockfile
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,10 +38,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           node-version-file: ".nvmrc"
 
-      - name: Install yarn
-        if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
-        run: npm install -g yarn@^1.19.0
-
       - name: Install dependencies
         if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
         run: yarn install --ignore-engines

--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -18,7 +18,6 @@ gh api /repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA} -f state=pending -f co
 
 # Install some tools we need from npm
 npm install -g https://github.com/terriajs/sync-dependencies
-npm install -g yarn@^1.19.0
 yarn add -W request@2.83.0
 
 # Clone and build TerriaMap, using this version of TerriaJS

--- a/yarn.lock
+++ b/yarn.lock
@@ -2905,6 +2905,13 @@ append-transform@^1.0.0:
   dependencies:
     default-require-extensions "^2.0.0"
 
+arcgis-pbf-parser@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/arcgis-pbf-parser/-/arcgis-pbf-parser-0.0.4.tgz#0aa0cb5648e400cb20cb06911a649063c20993ea"
+  integrity sha512-ngieRsLNct1dPyH85DnASiierr+hYO+9ow3zC22lYvNcKtFxVrtd1jbfizwWs9Kp3NpKP4iNnPAONp3acCcceA==
+  dependencies:
+    pbf "^3.2.1"
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -8772,6 +8779,14 @@ pbf@^3.0.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.2.1.tgz#b4c1b9e72af966cd82c6531691115cc0409ffe2a"
   integrity sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==
+  dependencies:
+    ieee754 "^1.1.12"
+    resolve-protobuf-schema "^2.1.0"
+
+pbf@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.3.0.tgz#1790f3d99118333cc7f498de816028a346ef367f"
+  integrity sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==
   dependencies:
     ieee754 "^1.1.12"
     resolve-protobuf-schema "^2.1.0"


### PR DESCRIPTION
### What this PR does

This mirrors the behavior of
the TerriaMap repository and
will prevent yarn.lock from
being forgotten to be updated.

Also stop installing yarn since
it is already installed on the Github
CI runners.

### Test me

Run the CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
