### PR TITLE
Fix sourcemaps in devmode.

### DIFF
--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -57,7 +57,7 @@ function configureWebpack({
   config.module = config.module || {};
   config.module.rules = config.module.rules || [];
 
-  babelLoader = babelLoader || defaultBabelLoader(devMode);
+  babelLoader = babelLoader || defaultBabelLoader({ devMode });
   // Use Babel to compile our JavaScript and TypeScript files.
   config.module.rules.push({
     test: /\.(ts|js)x?$/,


### PR DESCRIPTION
### What this PR does

Sourcemap was broken in dev mode after webpack 5 refactoring.

This change fixes it.

### Test me

- Open current `main` in CI - http://ci.terria.io/main
- Open sourcemap for some file like Terria.ts from the debugger, note that it actually shows transpiled code (generated by babel)
- Now open sourcemap for same file for this branch - http://ci.terria.io/fix-sourcemap
- It should show the original typescript source

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
