### PR TITLE
Bump version to 8.8.0.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
-#### next release (8.7.12)
+#### next release (8.8.1)
+
+- [The next improvement]
+
+#### 8.8.0 - 2025-02-18
 
 - **Breaking changes:**
   - Upgrade Webpack to version 5
@@ -18,7 +22,6 @@
 - Move `GeojsonSource` to new file `lib/Map/Vector/ProtomapsGeojsonSource.ts`.
 - support URL parameters in a GetLegendGraphic request for a layer without a style configured
 - Enhanced error processing for obtaining user location
-- [The next improvement]
 
 #### 8.7.11 - 2024-12-18
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.7.11",
+  "version": "8.8.0",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### What this PR does

Release v8.8.0

This release includes breaking changes upgrading webpack to v5 and sass upgrades.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
