### PR TITLE
Switch CI back to terriamap#main.

### DIFF
--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -23,7 +23,7 @@ yarn add -W request@2.83.0
 
 # Clone and build TerriaMap, using this version of TerriaJS
 TERRIAJS_COMMIT_HASH=$(git rev-parse HEAD)
-git clone -b webpack5 https://github.com/TerriaJS/TerriaMap.git
+git clone -b main https://github.com/TerriaJS/TerriaMap.git
 cd TerriaMap
 TERRIAMAP_COMMIT_HASH=$(git rev-parse HEAD)
 sed -i -e 's@"terriajs": ".*"@"terriajs": "'$GITHUB_REPOSITORY'#'${GITHUB_BRANCH}'"@g' package.json


### PR DESCRIPTION
### What this PR does

Switches CI back to terriamap#main branch, post[ webpack 5 merge](https://github.com/TerriaJS/TerriaMap/pull/718).

### Test me

- http://ci.terria.io/main should work as normal with terriajs v8.8.0

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
