### PR TITLE
Update to plugin-error 2.0.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - TSify `DataCatalogTab` and convert it to functional component #7476
 - Update to shpjs 6.1.0.
 - Enable `noUncheckedSideEffectImports` in `tsconfig.json` to get errors from tsc when non-existent modules are imported for side effects.
+- Update to plugin-error 2.0.1
 - [The next improvement]
 
 #### 8.9.1 - 2025-03-24

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
     "karma-spec-reporter": "^0.0.36",
     "minimist": "^1.2.8",
     "node-notifier": "^10.0.1",
-    "plugin-error": "^1.0.1",
+    "plugin-error": "^2.0.1",
     "prettier": "2.7.1",
     "pretty-quick": "^4.0.0",
     "react-shallow-testutils": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8947,15 +8947,12 @@ pkg-dir@^7.0.0:
   dependencies:
     find-up "^6.3.0"
 
-plugin-error@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
-  integrity sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==
+plugin-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-2.0.1.tgz#f2ac92bac8c85e3e23492d76d0c3ca12f30eb00b"
+  integrity sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==
   dependencies:
     ansi-colors "^1.0.1"
-    arr-diff "^4.0.0"
-    arr-union "^3.1.0"
-    extend-shallow "^3.0.2"
 
 pmtiles@^3.0.7:
   version "3.2.1"


### PR DESCRIPTION
### What this PR does

This reduces the number of
dependencies.

### Test me

Edit gupfile.js and throw a `PluginError` from somewhere and see that it still fails.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [X] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
