### PR TITLE
babel: use preset-typescript as name

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,7 @@
       }
     ],
     ["@babel/preset-react", { "runtime": "automatic" }],
-    ["@babel/typescript", { "allowNamespaces": true }]
+    ["@babel/preset-typescript", { "allowNamespaces": true }]
   ],
   "plugins": [
     ["@babel/plugin-proposal-decorators", { "legacy": true }],

--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -279,7 +279,7 @@ const defaultBabelLoader = ({ devMode }) => ({
         }
       ],
       ["@babel/preset-react", { runtime: "automatic" }],
-      ["@babel/typescript", { allowNamespaces: true }]
+      ["@babel/preset-typescript", { allowNamespaces: true }]
     ],
     plugins: [
       ["@babel/plugin-proposal-decorators", { legacy: true }],

--- a/buildprocess/webpack-tools.config.js
+++ b/buildprocess/webpack-tools.config.js
@@ -47,7 +47,7 @@ module.exports = function () {
       sourceMaps: !!devMode,
       presets: [
         ["@babel/preset-react", { runtime: "automatic" }],
-        ["@babel/typescript", { allowNamespaces: true }]
+        ["@babel/preset-typescript", { allowNamespaces: true }]
       ],
       plugins: [
         ["@babel/plugin-proposal-decorators", { legacy: true }],


### PR DESCRIPTION
### What this PR does

The Babel documentation, the devblog at
https://devblogs.microsoft.com/typescript/typescript-and-babel-7/ and anything I can find uses
babel/preset-typescript as name, so switch
the configuration to use that name.
This also aligns the configuration with
the name in package.json.

### Test me

Typescript transpilation is tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
