### PR TITLE
Update to mobx 6.13.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.8.2)
 
+- Update mobx to 6.13.6
 - [The next improvement]
 
 #### 8.8.1 - 2025-02-27

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "math-expression-evaluator": "^1.3.7",
     "mini-css-extract-plugin": "^2.9.2",
     "minisearch": "^3.0.2",
-    "mobx": "<6.13.0",
+    "mobx": "^6.13.6",
     "mobx-react": "7.6.0",
     "mobx-utils": "^6.0.5",
     "moment": "^2.30.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "target": "es2019",
+    // Use ES2024.collection, otherwise mobx 6.13 fails with:
+    // Cannot find name 'ReadonlySetLike'. Did you mean 'ReadonlySet'?
+    "lib": ["ES2024.collection", "DOM.Iterable", "ES2019"],
     "experimentalDecorators": true,
     "module": "esNext",
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,12 +2095,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0":
-  version "18.15.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
-  integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
-
-"@types/node@^22.13.1":
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@>=13.7.0", "@types/node@^22.13.1":
   version "22.13.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.4.tgz#3fe454d77cd4a2d73c214008b3e331bfaaf5038a"
   integrity sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==
@@ -8160,10 +8155,10 @@ mobx-utils@^6.0.5:
   resolved "https://registry.yarnpkg.com/mobx-utils/-/mobx-utils-6.0.6.tgz#99a2e0d54e958e4c9de4b35729e0c3768b6afc43"
   integrity sha512-lzJtxOWgj3Dp2HeXviInV3ZRY4YhThzRHXuy90oKXDH2g+ymJGIts4bdjb7NQuSi34V25cMZoQX7TkHJQuKLOQ==
 
-mobx@<6.13.0:
-  version "6.12.5"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.12.5.tgz#ed2e4312bc9dbe3d9ecd063c70a5ba9e7c2b823b"
-  integrity sha512-xRq2tyY6unAec0ItlsrgoCuxrWXLoIkM5cGPuerm/0nX/CI9FxAO6ttfRYfFa+B5Yz51d59IfKy0mJwxOEwqzQ==
+mobx@^6.13.6:
+  version "6.13.6"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.13.6.tgz#3b80895c7c9df456efc86ae0b6983ccea1da6cc6"
+  integrity sha512-r19KNV0uBN4b+ER8Z0gA4y+MzDYIQ2SvOmn3fUrqPnWXdQfakd9yfbPBDBF/p5I+bd3N5Rk1fHONIvMay+bJGA==
 
 moment@^2.17.1:
   version "2.29.1"


### PR DESCRIPTION
### What this PR does

Depends on: #7485

This was restricted in https://github.com/TerriaJS/terriajs/pull/7315
because mobx 6.13 started using
Iterator helper types introduced
in TypeScript 5.6.

### Test me

I believe this is tested by CI.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [X] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
