### PR TITLE
Remove unused webpack.config.dev.js

### DIFF
--- a/buildprocess/webpack.config.dev.js
+++ b/buildprocess/webpack.config.dev.js
@@ -1,1 +1,0 @@
-module.exports = require("./webpack.config.make")(true);


### PR DESCRIPTION
### What this PR does

The gulpfile requires webpack.config.make,
so remove this unused file.

### Test me


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
