### PR TITLE
CI: enforce using compatible engine

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
-        run: yarn install --ignore-engines
+        run: yarn install
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
 


### PR DESCRIPTION
### What this PR does

The workflow runs with the version
specified in .nvmrc, and that should
be a compatible engine, so error
out properly if there is an incompatible
engine for some reason.

### Test me

Run the workflow and see that it still works.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
