### PR TITLE
Remove unused pmtiles dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.8.2)
 
+- Remove unused pmtiles dependency.
 - [The next improvement]
 
 #### 8.8.1 - 2025-02-27

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "node-fetch": "^2.6.1",
     "papaparse": "^5.2.0",
     "pbf": "^3.0.1",
-    "pmtiles": "^3.0.7",
     "point-in-polygon": "^1.0.1",
     "proj4": "^2.4.4",
     "proj4-fully-loaded": "^0.2.0",


### PR DESCRIPTION
### What this PR does

This dependency was added in #7144,
but the only reference to pmtiles
was in the webpack configuration
with an alias. The webpack 5 upgrade
removed the alias:
https://github.com/TerriaJS/terriajs/pull/7351/files#r1949358253,
so remove the dependency too since
it is no longer referneced.

### Test me


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [X] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
