### PR TITLE
Update types/file-saver to 2.0.7 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@
 - Update empty workbench help text
 - Remove unused `arraysAreEqual`, `autoUpdate`, `flattenNested`, `freezeInDebug`, `isPromise`, `loadJsonp`, `OrUndefined`, and `superGet` files from lib/Core.
 - Update to react-virtual 2.10.4.
+- Update types/file-saver to 2.0.7.
 - [The next improvement]
 
 #### 8.8.1 - 2025-02-27

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/d3-transition": "^3.0.8",
     "@types/dateformat": "^5.0.1",
     "@types/dompurify": "^2.4.0",
-    "@types/file-saver": "^1.3.0",
+    "@types/file-saver": "^2.0.7",
     "@types/flexsearch": "^0.7.1",
     "@types/fs-extra": "^7.0.0",
     "@types/geojson-vt": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1921,10 +1921,10 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/file-saver@^1.3.0":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-1.3.1.tgz#55d76b3c78b5fcc8a7588ead428dce0822464120"
-  integrity sha512-A+lNc0nnhtX3iTLEYd/DisKTZdNKTf1bN0aSfQD/fG8bQ6SfUe5u8Fm2ab8qQHaMY5GVZumAXLnYptwX+mmQgg==
+"@types/file-saver@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.7.tgz#8dbb2f24bdc7486c54aa854eb414940bbd056f7d"
+  integrity sha512-dNKVfHd/jk0SkR/exKGj2ggkB45MAkzvWCaqLUUgkyjITkGNzH8H+yUwr+BLJUBjZOe9w8X3wgmXhZDRg1ED6A==
 
 "@types/flexsearch@^0.7.1":
   version "0.7.2"


### PR DESCRIPTION
### What this PR does

This aligns the major version
with the version of the file-saver
dependency.

### Test me

Tested by building, so tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [X] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
