### PR TITLE
Stop consuming onToggle events

### DIFF
--- a/lib/ReactViews/SelectableDimensions/Group.tsx
+++ b/lib/ReactViews/SelectableDimensions/Group.tsx
@@ -53,7 +53,7 @@ export const SelectableDimensionGroup: React.FC<{
                   CommonStrata.user,
                   isOpen ? "true" : "false"
                 );
-                return true;
+                return false;
               }
         }
         btnStyle={dim.type === "checkbox-group" ? "checkbox" : undefined}


### PR DESCRIPTION
### What this PR does

I had not understood that consuming
an event meant no state updates
in commit c8b8bf5. Return false
from both changed functions to
restore the previous behavior.

Error+fix discovered by @nf-s
in #7370.

### Test me

Restores the previous behavior.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
