### PR TITLE
Remove unused babel/parser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 #### next release (8.9.1)
 
+- Remove unused babel/parser dependency.
+- [The next improvement]
+
 #### 8.9.0 - 2025-03-17
 
 - **Breaking changes:**
@@ -51,7 +54,6 @@
 - Remove `request` dependency from CI scripts
 - Fix basemaps order to follow the order given by `enabledBaseMaps` setting. #7537
 - Modified DiffTool UI to use `WorkflowPanel` instead of floating side panel.
-- [The next improvement]
 
 #### 8.8.1 - 2025-02-27
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.23.5",
-    "@babel/parser": "^7.23.5",
     "@babel/plugin-proposal-decorators": "^7.22.7",
     "@babel/preset-env": "^7.23.5",
     "@babel/preset-react": "^7.23.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,7 +266,7 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.22.15", "@babel/parser@^7.23.5", "@babel/parser@^7.23.6", "@babel/parser@^7.4.3":
+"@babel/parser@^7.22.15", "@babel/parser@^7.23.6", "@babel/parser@^7.4.3":
   version "7.23.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.6.tgz#ba1c9e512bda72a47e285ae42aff9d2a635a9e3b"
   integrity sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==


### PR DESCRIPTION
### What this PR does

The installation instructions
for Babel only list babel/core,
babel/cli, and babel/preset-env:

https://babeljs.io/docs/usage#overview

so remove babel/parser from
package.json.

The babel/parser is still used,
but babel/core controls
the version through its dependencies.

### Test me

Run `yarn gulp build`, so tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [X] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
