### PR TITLE
Hide story button when story is being played

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
 - Remove unused pmtiles dependency.
 - Update data styling docs
 - Remove unused babel/eslint-parser dependency.
+- Hide 'Story' button in mobile view if story panel is active.
 - [The next improvement]
 
 #### 8.8.1 - 2025-02-27

--- a/lib/ReactViews/Map/BottomLeftBar/BottomLeftBar.tsx
+++ b/lib/ReactViews/Map/BottomLeftBar/BottomLeftBar.tsx
@@ -28,7 +28,9 @@ const shouldShowPlayStoryButton = (viewState: ViewState) =>
   viewState.terria.configParameters.storyEnabled &&
   defined(viewState.terria.stories) &&
   viewState.terria.stories.length > 0 &&
-  viewState.useSmallScreenInterface;
+  viewState.useSmallScreenInterface &&
+  // Don't show story button if story panel is visible
+  viewState.storyShown !== true;
 
 const BottomLeftBar: FC = observer(() => {
   const { t } = useTranslation();


### PR DESCRIPTION
### What this PR does

Hide Story button in mobile view when story panel is visible

### Test me

Before ([test link](http://ci.terria.io/main/#share=s-r2wOLmPwas5qWVrnGTovXYnBwrd) open in mobile view):
![image](https://github.com/user-attachments/assets/7f6432d5-93dd-4202-a869-3c9994b18eef)


After ([test link](http://ci.terria.io/hide-active-story-button/#share=s-r2wOLmPwas5qWVrnGTovXYnBwrd)):
shown when story panel is closed:
![image](https://github.com/user-attachments/assets/684df252-247f-4046-a823-f94259f3e0ae)

hidden when story panel is active:
![image](https://github.com/user-attachments/assets/a2bbdd61-3bab-418f-9b5a-8a87e09c847a)



### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
