### PR TITLE
editorconfig: remove redundant parts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,3 @@ trim_trailing_whitespace = false
 [doc/**.md]
 # mkdocs requires 4 spaces. With 2 space indents, nested lists do not work
 indent_size = 4
-
-[*.scss]
-indent_size = 2


### PR DESCRIPTION
### What this PR does

The indentation size for everything
has been 2 since commit a8c927db05
in 2019, so remove the extra section
for scss files that specify the same
value.

### Test me

Open an scss file in an editor that respects `.editorconfig` and see that the indentation size is still 2.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
