### PR TITLE
gulpfile: throw right exception

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -145,10 +145,10 @@ gulp.task("code-attribution", function userAttribution(done) {
     }
   );
   if (result.status !== 0) {
-    throw new Error(
+    throw new PluginError(
+      "code-attribution",
       "Generating code attribution exited with an error.\n" +
-        result.stderr.toString(),
-      { showStack: false }
+        result.stderr.toString()
     );
   }
   done();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@
 // the devDependencies available.  Individual tasks, other than `post-npm-install` and any tasks it
 // calls, may require in `devDependency` modules locally.
 var gulp = require("gulp");
+const PluginError = require("plugin-error");
 var terriajsServerGulpTask = require("./buildprocess/terriajsServerGulpTask");
 
 gulp.task("build-specs", function (done) {
@@ -171,7 +172,6 @@ gulp.task(
     },
     function generateMemberPages(done) {
       const fse = require("fs-extra");
-      const PluginError = require("plugin-error");
       const spawnSync = require("child_process").spawnSync;
 
       fse.mkdirpSync("build/doc/connecting-to-data/catalog-type-details");
@@ -185,14 +185,12 @@ gulp.task(
       if (result.status !== 0) {
         throw new PluginError(
           "user-doc",
-          "Generating catalog members pages exited with an error.",
-          { showStack: false }
+          "Generating catalog members pages exited with an error."
         );
       }
       done();
     },
     function mkdocs(done) {
-      const PluginError = require("plugin-error");
       const spawnSync = require("child_process").spawnSync;
 
       const result = spawnSync(
@@ -207,10 +205,9 @@ gulp.task(
       if (result.status !== 0) {
         throw new PluginError(
           "user-doc",
-          `Mkdocs exited with an error. Maybe you didn't install mkdocs and other python dependencies in requirements.txt - see https://docs.terria.io/guide/contributing/development-environment/#documentation?`,
-          {
-            showStack: false
-          }
+          "Mkdocs exited with an error. Maybe you didn't install mkdocs and " +
+            "other python dependencies in requirements.txt - see " +
+            "https://docs.terria.io/guide/contributing/development-environment/#documentation"
         );
       }
       done();


### PR DESCRIPTION
### What this PR does

Throw a PluginError exception
instead of the previous Error
exception.

The previous code had the wrong
number of arguments for the
constructor, so that did not
work as intended.

Also hoist the imports to the top
level, break a long string into
multiple lines, and remove
the showStack argument which
already had the default value for
the past ~10 years.

### Test me

Trigger the error and see that the exception is the expected one.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
