### PR TITLE
Add missing children to prop types

### DIFF
--- a/lib/ReactViews/ActionBar/ActionBar.tsx
+++ b/lib/ReactViews/ActionBar/ActionBar.tsx
@@ -11,7 +11,7 @@ import { ActionBarPortalId } from "./ActionBarPortal";
  * {@link ActionButton} can be used as a themed button for the action bar
  * {@link ActionButtonGroup} can be used for grouping elements inside an action bar
  */
-export const ActionBar: FC<object> = (props) => {
+export const ActionBar: FC<{ children: React.ReactNode }> = (props) => {
   const viewState = useViewState();
 
   useEffect(function setVisibility() {

--- a/lib/ReactViews/Context/ViewStateContext.tsx
+++ b/lib/ReactViews/Context/ViewStateContext.tsx
@@ -4,10 +4,10 @@ import TerriaError from "../../Core/TerriaError";
 
 export const ViewStateContext = createContext<ViewState | undefined>(undefined);
 
-export const ViewStateProvider: FC<{ viewState: ViewState }> = ({
-  viewState,
-  children
-}) => (
+export const ViewStateProvider: FC<{
+  viewState: ViewState;
+  children: React.ReactNode;
+}> = ({ viewState, children }) => (
   <ViewStateContext.Provider value={viewState}>
     {children}
   </ViewStateContext.Provider>

--- a/lib/ReactViews/Custom/Collapsible/Collapsible.tsx
+++ b/lib/ReactViews/Custom/Collapsible/Collapsible.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react";
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useState, type ReactNode } from "react";
 import Box, { IBoxProps } from "../../../Styled/Box";
 import { RawButton } from "../../../Styled/Button";
 import { GLYPHS, StyledIcon } from "../../../Styled/Icon";
@@ -31,6 +31,8 @@ interface CollapsibleProps extends CollapsibleIconProps {
   titleTextProps?: any;
   bodyBoxProps?: IBoxProps;
   bodyTextProps?: any;
+
+  children?: ReactNode;
 }
 
 export const CollapseIcon: FC<CollapsibleIconProps> = (props) => {

--- a/lib/ReactViews/Custom/ExternalLink.tsx
+++ b/lib/ReactViews/Custom/ExternalLink.tsx
@@ -15,10 +15,7 @@ interface Props {
   children: ReactNode;
 }
 
-export const ExternalLinkWithWarning: FC<Props> = (props: {
-  attributes: AnchorHTMLAttributes<HTMLAnchorElement>;
-  children: ReactNode;
-}) => {
+export const ExternalLinkWithWarning: FC<Props> = (props: Props) => {
   const viewState = useViewState();
   const { t } = useTranslation();
 

--- a/lib/ReactViews/Generic/Responsive.tsx
+++ b/lib/ReactViews/Generic/Responsive.tsx
@@ -1,4 +1,5 @@
-import PropTypes, { InferProps } from "prop-types";
+import PropTypes from "prop-types";
+import type { ReactNode } from "react";
 import MediaQuery from "react-responsive";
 
 // This should come from some config some where
@@ -10,7 +11,9 @@ const large = 1300;
 const BreakpointPropTypes = {
   children: PropTypes.node
 };
-type BreakpointProps = InferProps<typeof BreakpointPropTypes>;
+type BreakpointProps = {
+  children: ReactNode;
+};
 
 export function ExtraSmall(props: BreakpointProps) {
   return <MediaQuery maxWidth={small}>{props.children}</MediaQuery>;

--- a/lib/ReactViews/Preview/WarningBox.tsx
+++ b/lib/ReactViews/Preview/WarningBox.tsx
@@ -22,6 +22,7 @@ const showErrorNotification = (viewState: ViewState, error: TerriaError) => {
 };
 
 const WarningBox: FC<{
+  children?: React.ReactNode;
   error?: TerriaError;
   viewState?: ViewState;
 }> = (props) => {

--- a/lib/ReactViews/SidePanel/SidePanel.tsx
+++ b/lib/ReactViews/SidePanel/SidePanel.tsx
@@ -117,6 +117,7 @@ const EmptyWorkbench: FC<EmptyWorkbenchProps> = observer(() => {
 
 type SidePanelButtonProps = {
   btnText?: string;
+  children?: React.ReactNode;
 } & ComponentPropsWithoutRef<typeof Button>;
 
 const SidePanelButton = forwardRef<HTMLButtonElement, SidePanelButtonProps>(

--- a/lib/ReactViews/StandardUserInterface/Portal.tsx
+++ b/lib/ReactViews/StandardUserInterface/Portal.tsx
@@ -38,6 +38,7 @@ export const Portal: FC<PortalProps> = ({ id, className }) => {
 export type PortalChildProps = {
   viewState: ViewState;
   portalId: string;
+  children: React.ReactNode;
 };
 
 /**

--- a/lib/ReactViews/StandardUserInterface/SidePanelContainer.tsx
+++ b/lib/ReactViews/StandardUserInterface/SidePanelContainer.tsx
@@ -1,12 +1,13 @@
 import { action } from "mobx";
 import styled from "styled-components";
 import ViewState from "../../ReactViewModels/ViewState";
-import { withViewState } from "../Context";
+import { withViewState, type WithViewState } from "../Context";
 
-type PropsType = {
+interface PropsType extends WithViewState {
   viewState: ViewState;
   show: boolean;
-};
+  children: React.ReactNode;
+}
 
 const SidePanelContainer = styled.div.attrs<PropsType>(({ viewState }) => ({
   className: viewState.topElement === "SidePanel" ? "top-element" : "",

--- a/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
+++ b/lib/ReactViews/Tools/DiffTool/DiffTool.tsx
@@ -777,6 +777,7 @@ class Main extends Component<MainPropsType> {
 interface DiffAccordionProps {
   viewState: ViewState;
   t: TFunction;
+  children: React.ReactNode;
 }
 
 const DiffAccordionToggle = styled(Box)`

--- a/lib/ReactViews/Tools/ItemSearchTool/BackButton.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/BackButton.tsx
@@ -5,7 +5,10 @@ import Button from "../../../Styled/Button";
 import { TextSpan } from "../../../Styled/Text";
 import { GLYPHS, StyledIcon } from "../../../Styled/Icon";
 
-const BackButton: FC<{ onClick: () => void }> = ({ children, onClick }) => {
+const BackButton: FC<{ onClick: () => void; children: React.ReactNode }> = ({
+  children,
+  onClick
+}) => {
   const theme = useTheme();
   return (
     <Button

--- a/lib/ReactViews/Tools/ItemSearchTool/ErrorComponent.tsx
+++ b/lib/ReactViews/Tools/ItemSearchTool/ErrorComponent.tsx
@@ -2,7 +2,11 @@ import { FC } from "react";
 
 import Text from "../../../Styled/Text";
 
-const ErrorComponent: FC = ({ children }) => {
+interface ErrorComponentProps {
+  children: React.ReactNode;
+}
+
+const ErrorComponent: FC<ErrorComponentProps> = ({ children }) => {
   return (
     <Text large textLight>
       {children}

--- a/lib/ReactViews/Tools/Tool.tsx
+++ b/lib/ReactViews/Tools/Tool.tsx
@@ -7,7 +7,8 @@ import {
   Component,
   Suspense,
   useEffect,
-  useState
+  useState,
+  type ReactNode
 } from "react";
 import { useTranslation } from "react-i18next";
 import TerriaError from "../../Core/TerriaError";
@@ -23,7 +24,9 @@ import { useViewState } from "../Context";
 
 interface ToolProps {
   toolName: string;
-  getToolComponent: () => ComponentType | Promise<ComponentType>;
+  getToolComponent: () =>
+    | ComponentType<unknown>
+    | Promise<ComponentType<unknown>>;
   params?: any;
 }
 
@@ -130,7 +133,7 @@ export class ToolButtonController extends MapNavigationItemController {
 interface ToolErrorBoundaryProps extends WithT {
   terria: Terria;
   toolName: string;
-  children: any;
+  children: ReactNode;
 }
 
 class ToolErrorBoundary extends Component<

--- a/lib/ReactViews/Tools/ToolModal.tsx
+++ b/lib/ReactViews/Tools/ToolModal.tsx
@@ -13,6 +13,7 @@ import { scrollBars } from "../../Styled/mixins";
 export interface FrameProps {
   title: string;
   viewState: ViewState;
+  children: React.ReactNode;
 }
 
 export const Frame: FC<FrameProps> = observer((props) => {

--- a/lib/ReactViews/Tour/TourPortal.d.ts
+++ b/lib/ReactViews/Tour/TourPortal.d.ts
@@ -1,6 +1,8 @@
-export declare const TourExplanation: React.FC<unknown>;
-export declare const TourPreface: React.FC<unknown>;
+export declare const TourExplanation: React.FC<
+  React.PropsWithChildren<unknown>
+>;
+export declare const TourPreface: React.FC<React.PropsWithChildren<unknown>>;
 
-declare const TourPortal: React.FC<object>;
+declare const TourPortal: React.FC<React.PropsWithChildren<object>>;
 
 export default TourPortal;

--- a/lib/ReactViews/Transitions/FadeIn/FadeIn.d.ts
+++ b/lib/ReactViews/Transitions/FadeIn/FadeIn.d.ts
@@ -1,4 +1,5 @@
 interface PropsType {
+  children: React.ReactNode;
   isVisible?: boolean;
   onEnter?: () => void;
   onExited?: () => void;

--- a/lib/ReactViews/Transitions/SlideUpFadeIn/SlideUpFadeIn.d.ts
+++ b/lib/ReactViews/Transitions/SlideUpFadeIn/SlideUpFadeIn.d.ts
@@ -3,6 +3,7 @@ interface PropsType {
   onEnter?: () => void;
   onExited?: () => void;
   transitionProps?: any;
+  children: React.ReactNode;
 }
 
 declare const SlideUpFadeIn: React.FC<PropsType>;

--- a/lib/ReactViews/Workbench/PositionRightOfWorkbench.tsx
+++ b/lib/ReactViews/Workbench/PositionRightOfWorkbench.tsx
@@ -6,6 +6,7 @@ import ViewState from "../../ReactViewModels/ViewState";
 type PositionRightOfWorkbenchProps = {
   viewState: ViewState;
   className?: string;
+  children: React.ReactNode;
 };
 
 /**

--- a/lib/ReactViews/Workbench/WorkbenchButton.tsx
+++ b/lib/ReactViews/Workbench/WorkbenchButton.tsx
@@ -77,7 +77,7 @@ const StyledWorkbenchButton = styled(RawButton)<IStyledWorkbenchButton>`
 `;
 
 interface IProps {
-  children?: any;
+  children?: React.ReactNode;
   primary?: boolean;
   disabled?: boolean;
   inverted?: boolean;

--- a/lib/ReactViews/Workflow/WorkflowPanel.tsx
+++ b/lib/ReactViews/Workflow/WorkflowPanel.tsx
@@ -18,6 +18,7 @@ type PropsType = {
   icon: IconProps["glyph"];
   onClose: () => void;
   closeButtonText: string;
+  children: ReactNode;
   footer?: {
     onClick: () => void;
     buttonText: string;

--- a/test/ReactViews/Workflows/WorkflowPanelSpec.tsx
+++ b/test/ReactViews/Workflows/WorkflowPanelSpec.tsx
@@ -30,7 +30,9 @@ describe("WorkflowPanel", function () {
           icon={{ id: "test-icon" }}
           closeButtonText="close"
           onClose={() => {}}
-        />
+        >
+          children
+        </WorkflowPanel>
       );
     });
     expect(viewState.terria.isWorkflowPanelActive).toBe(true);
@@ -45,7 +47,9 @@ describe("WorkflowPanel", function () {
           icon={{ id: "test-icon" }}
           closeButtonText="close"
           onClose={() => {}}
-        />
+        >
+          test
+        </WorkflowPanel>
       );
     });
     expect(viewState.terria.isWorkflowPanelActive).toBe(true);


### PR DESCRIPTION
### What this PR does

Fixes #7515

We already defined the children in most of the prop types, so making the changes using the codemod is not needed, I simply updated only components that missed those (with the codemod number of changed files was 100+). 

### Test me

Those are type only changes, so if the build and test pass in CI it works.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
