### PR TITLE
bump react-swipeable to v7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.9.2)
 
 - Replace clipboardjs with native browser clipboard
+- Update react-swipeable to v7. #7542
 - [The next improvement]
 
 #### 8.9.1 - 2025-03-24

--- a/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
@@ -1,9 +1,9 @@
 import classNames from "classnames";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
-import { RefObject, createRef, Component } from "react";
+import { Component, RefObject, createRef, type ReactNode } from "react";
 import { WithTranslation, withTranslation } from "react-i18next";
-import { Swipeable } from "react-swipeable";
+import { useSwipeable, type SwipeableProps } from "react-swipeable";
 import { DefaultTheme, withTheme } from "styled-components";
 import {
   Category,
@@ -14,8 +14,8 @@ import getPath from "../../../Core/getPath";
 import TerriaError from "../../../Core/TerriaError";
 import Terria from "../../../Models/Terria";
 import Box from "../../../Styled/Box";
-import { onStoryButtonClick } from "../../Map/MenuBar/StoryButton/StoryButton";
 import { WithViewState, withViewState } from "../../Context";
+import { onStoryButtonClick } from "../../Map/MenuBar/StoryButton/StoryButton";
 import { Story } from "../Story";
 import Styles from "../story-panel.scss";
 import StoryBody from "./StoryBody";
@@ -80,6 +80,15 @@ interface State {
   inView: boolean;
   isCollapsed: boolean;
 }
+
+const Swipeable = ({
+  children,
+  ...props
+}: { children: ReactNode } & SwipeableProps) => {
+  const handlers = useSwipeable(props);
+
+  return <div {...handlers}>{children}</div>;
+};
 
 @observer
 class StoryPanel extends Component<Props, State> {

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "react-i18next": "^11.18.0",
     "react-responsive": "^10.0.0",
     "react-select": "^3.1.1",
-    "react-swipeable": "^5.1.0",
+    "react-swipeable": "^7.0.2",
     "react-transition-group": "^4.3.0",
     "react-uid": "^2.3.0",
     "react-virtual": "^2.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9599,12 +9599,10 @@ react-shallow-testutils@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-shallow-testutils/-/react-shallow-testutils-3.0.1.tgz#41beb19aac29617569469cfe7945eaf525522432"
   integrity sha512-QeQJEexPeDOCcn8gQuLCGCnBnbwAko3zcs24+qXNUB0BrfbbbOIvXkTOTkJdL4WhwwQXQ3f/5yvdzO11n6eh7w==
 
-react-swipeable@^5.1.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-5.5.1.tgz#48ae6182deaf62f21d4b87469b60281dbd7c4a76"
-  integrity sha512-EQObuU3Qg3JdX3WxOn5reZvOSCpU4fwpUAs+NlXSN3y+qtsO2r8VGkVnOQzmByt3BSYj9EWYdUOUfi7vaMdZZw==
-  dependencies:
-    prop-types "^15.6.2"
+react-swipeable@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-7.0.2.tgz#ef8858096a47144ba7060675af1cd672e00ecc12"
+  integrity sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==
 
 react-test-renderer@^16.3.2:
   version "16.14.0"


### PR DESCRIPTION
### What this PR does

Fixes #7517

New Swipeable component is implemented as described in migration guide https://github.com/FormidableLabs/react-swipeable/blob/v6.2.2/migration.md

### Test me

- open https://ci.terria.io/bump-react-swipeable/#share=s-mdJQ5uRLMfMJuWuseprWUisohGW on mobile or change browser to mobile
- run story
- try changing current story by swiping left-right

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
