### PR TITLE
Pin types/flexsearch 0.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/dateformat": "^5.0.1",
     "@types/dompurify": "^2.4.0",
     "@types/file-saver": "^1.3.0",
-    "@types/flexsearch": "^0.7.1",
+    "@types/flexsearch": "0.7.6",
     "@types/fs-extra": "^7.0.0",
     "@types/geojson-vt": "^3.2.1",
     "@types/jasmine": "^2.8.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,10 +1926,10 @@
   resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-1.3.1.tgz#55d76b3c78b5fcc8a7588ead428dce0822464120"
   integrity sha512-A+lNc0nnhtX3iTLEYd/DisKTZdNKTf1bN0aSfQD/fG8bQ6SfUe5u8Fm2ab8qQHaMY5GVZumAXLnYptwX+mmQgg==
 
-"@types/flexsearch@^0.7.1":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@types/flexsearch/-/flexsearch-0.7.2.tgz#05d982d292e70fcb9fc59347a4a4f98c4ecd9e56"
-  integrity sha512-Nq0CSpOCyUhaF7tAXSvMtoyBMPGlhNyF+uElhIrrgSiXDmX/bnn9jUX7Us3l81Hzowb9rcgNISke0Nj+3xhd3g==
+"@types/flexsearch@0.7.6":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@types/flexsearch/-/flexsearch-0.7.6.tgz#240c11d16825c56833ec0c66eb1de3ea0e162a49"
+  integrity sha512-H5IXcRn96/gaDmo+rDl2aJuIJsob8dgOXDqf8K0t8rWZd1AFNaaspmRsElESiU+EWE33qfbFPgI0OC/B1g9FCA==
 
 "@types/fs-extra@^7.0.0":
   version "7.0.0"


### PR DESCRIPTION
### What this PR does

Putting this as a draft PR so we first get a chance to not have the CI fail when a package gets updated.

The next version deprecates
the package and tells us to
use the types that are now
distributed as a part of
flexsearch.

### Test me

Tested by CI.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
