### PR TITLE
webpack: parameterize build sources

### DIFF
--- a/buildprocess/configureWebpack.js
+++ b/buildprocess/configureWebpack.js
@@ -8,6 +8,7 @@ const webpack = require("webpack");
  * Supplements the given webpack config with options required to build TerriaJS
  *
  * @param [options.terriaJSBasePath] The TerriaJS source directory
+ * @param [options.jsExtraPaths] Additional include paths for js/ts files.
  * @param [options.config] Base webpack configuration
  * @param [options.devMode] Set to `true` to generate for development build, default is `false`.
  * @param [options.MiniCssExtractPlugin]
@@ -15,6 +16,7 @@ const webpack = require("webpack");
  */
 function configureWebpack({
   terriaJSBasePath,
+  jsExtraPaths,
   config,
   devMode,
   MiniCssExtractPlugin,
@@ -64,10 +66,10 @@ function configureWebpack({
     include: [
       path.resolve(terriaJSBasePath, "node_modules", "commander"),
       path.resolve(terriaJSBasePath, "lib"),
-      path.resolve(terriaJSBasePath, "test"),
       path.resolve(terriaJSBasePath, "buildprocess", "generateDocs.ts"),
       path.resolve(terriaJSBasePath, "buildprocess", "generateCatalogIndex.ts"),
-      path.resolve(terriaJSBasePath, "buildprocess", "patchNetworkRequests.ts")
+      path.resolve(terriaJSBasePath, "buildprocess", "patchNetworkRequests.ts"),
+      ...jsExtraPaths
     ],
     use: [babelLoader]
   });

--- a/buildprocess/webpack-tools.config.js
+++ b/buildprocess/webpack-tools.config.js
@@ -59,8 +59,11 @@ module.exports = function () {
     }
   };
 
+  const terriaJSBasePath = path.dirname(require.resolve("../package.json"));
+  const jsExtraPaths = [path.resolve(terriaJSBasePath, "test")];
   return configureWebpackForTerriaJS({
-    terriaJSBasePath: path.dirname(require.resolve("../package.json")),
+    terriaJSBasePath,
+    jsExtraPaths,
     config,
     devMode,
     MiniCssExtractPlugin,

--- a/buildprocess/webpack.config.make.js
+++ b/buildprocess/webpack.config.make.js
@@ -63,8 +63,10 @@ module.exports = function (devMode) {
     }
   };
 
+  const jsExtraPaths = [path.resolve(terriaJSBasePath, "test")];
   return configureWebpack({
     terriaJSBasePath,
+    jsExtraPaths,
     config,
     devMode,
     MiniCssExtractPlugin


### PR DESCRIPTION
### What this PR does

TerriaJS-part of https://github.com/TerriaJS/TerriaMap/issues/730

Add a new parameter that is a list
of paths that are included in the js/ts
rule for building, and pass in the test
directory through that path.

This allows TerriaMap to avoid building
the test sources, which means it no longer
requires TerriaJS's devDependencies to be
installed.

### Test me

In TerriaMap with https://github.com/TerriaJS/TerriaMap/pull/740 applied: remove `fetch-mock` from `package.json` followed by running `yarn install`, and then run `yarn gulp release` and see that TerriaMap builds.

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [X] I've provided instructions in the PR description on how to test this PR.
