### PR TITLE
fix bing log event name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Refactor the `DateTimePicker` component and split it into multiple components. #7585
 - Update data-attribution and terms of conditions links to point to terria.io. #7627
 - Hide the related maps button. #7627
+- Change `BingMapSearchProvider` to correctly logs bing search action. #7601
 - [The next improvement]
 
 #### 8.9.3 - 2025-04-24

--- a/lib/Models/SearchProviders/BingMapsSearchProvider.ts
+++ b/lib/Models/SearchProviders/BingMapsSearchProvider.ts
@@ -58,7 +58,7 @@ export default class BingMapsSearchProvider extends LocationSearchProviderMixin(
   protected logEvent(searchText: string) {
     this.terria.analytics?.logEvent(
       Category.search,
-      SearchAction.gazetteer,
+      SearchAction.bing,
       searchText
     );
   }


### PR DESCRIPTION
### What this PR does

Fixes #7078

BingMapsSearchProvider incorectly logs the Gazetteer search event to analytics, this changes the behavior to correctly logs the bing event.

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
