### PR TITLE
fix chart item selector padding

### DIFF
--- a/lib/ReactViews/Workbench/Controls/ChartItemSelector.tsx
+++ b/lib/ReactViews/Workbench/Controls/ChartItemSelector.tsx
@@ -79,6 +79,7 @@ const ChartItemSelector: FC<IChartItemSelector> = observer(
         rounded
         backgroundColor={theme?.overlay}
         css={`
+          padding-left: ${theme.spacing}px;
           margin: 10px 5px;
         `}
       >

--- a/test/ReactViews/Workbench/Controls/ChartItemSelectorSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/ChartItemSelectorSpec.tsx
@@ -1,14 +1,16 @@
 import { act } from "react-dom/test-utils";
 import TestRenderer, { ReactTestRenderer } from "react-test-renderer";
+import { ThemeProvider } from "styled-components";
 import ChartableMixin, {
   ChartItem
 } from "../../../../lib/ModelMixins/ChartableMixin";
 import CreateModel from "../../../../lib/Models/Definition/CreateModel";
 import Terria from "../../../../lib/Models/Terria";
+import { terriaTheme } from "../../../../lib/ReactViews/StandardUserInterface";
 import ChartItemSelector from "../../../../lib/ReactViews/Workbench/Controls/ChartItemSelector";
-import UrlTraits from "../../../../lib/Traits/TraitsClasses/UrlTraits";
 import mixTraits from "../../../../lib/Traits/mixTraits";
 import MappableTraits from "../../../../lib/Traits/TraitsClasses/MappableTraits";
+import UrlTraits from "../../../../lib/Traits/TraitsClasses/UrlTraits";
 
 class SomeChartableItem extends ChartableMixin(
   CreateModel(mixTraits(UrlTraits, MappableTraits))
@@ -72,7 +74,11 @@ describe("ChartItemSelector", function () {
     terria.addModel(item);
     terria.workbench.add(item);
     act(() => {
-      testRenderer = TestRenderer.create(<ChartItemSelector item={item} />);
+      testRenderer = TestRenderer.create(
+        <ThemeProvider theme={terriaTheme}>
+          <ChartItemSelector item={item} />
+        </ThemeProvider>
+      );
     });
   });
 


### PR DESCRIPTION
### What this PR does

Fixes #7089 

Restores the padding for chart item selector
<img width="300" alt="image" src="https://github.com/user-attachments/assets/96395ece-ddc1-484d-8279-4b0640adb6bb" />

### Test me

Before: 
- Open http://ci.terria.io/main/#share=s-S9BBkqE96pSfIPNlIEFRiKBI7P
After:
- Open: http://ci.terria.io/fix-padding/#share=s-S9BBkqE96pSfIPNlIEFRiKBI7P

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
