### PR TITLE
Release version 8.9.3.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
-#### next release (8.9.3)
+#### next release (8.9.4)
+
+- [The next improvement]
+
+#### 8.9.3 - 2025-04-24
 
 - Remove unused d3-array dependency.
 - Update to plugin-error 2.0.1
@@ -17,7 +21,6 @@
 - Convert `ViewingControls` to a functional component. #7574
 - DOMPurify updated to 3.2.5 to fix CVE-2025-26791.
 - Fix pmtiles rendering issue. #7607
-- [The next improvement]
 
 #### 8.9.2 - 2025-03-31
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,3 +67,4 @@ The following people have contributed to TerriaJS:
 - [Giovanni Lughi](https://github.com/glughi)
 - [Andrew Cleland](https://github.com/aclel)
 - [Sidney Gijzen](https://github.com/sidneygijzen)
+- [Yuri Vyatkin](https://github.com/niktayv)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.9.2",
+  "version": "8.9.3",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### What this PR does

Release version 8.9.3.

Changes:
- Remove unused d3-array dependency.
- Update to plugin-error 2.0.1
- TSify `MenuButton` and convert it to functional component. #7576
- Convert `WorkbenchItem` to functional component #7564
- Remove BrowserStack and SauceLabs gulp tasks.
- Remove `test-travis` gulp task.
- Allow to modify `lookupCookie` for i18next
- TSify dropdown and convert it to a functional component. #7577
- Convert SettingPanel to a functional component. #7589
- Update html-to-react to 1.7.0
- Pass explicit refs to css transition component to avoid findDomNode usage. #7590
- TSify FadeIn component. #7590
- Convert `ViewingControls` to a functional component. #7574
- DOMPurify updated to 3.2.5 to fix CVE-2025-26791.
- Fix pmtiles rendering issue. #7607


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
