### PR TITLE
polygon parameter should provide properties object in geojson

### DIFF
--- a/lib/Models/FunctionParameters/PolygonParameter.ts
+++ b/lib/Models/FunctionParameters/PolygonParameter.ts
@@ -25,15 +25,7 @@ export default class PolygonParameter
   static formatValueForUrl(value: PolygonCoordinates) {
     return JSON.stringify({
       type: "FeatureCollection",
-      features: [
-        {
-          type: "Feature",
-          geometry: {
-            type: "Polygon",
-            coordinates: value
-          }
-        }
-      ]
+      features: [PolygonParameter.getGeoJsonFeature(value)]
     });
   }
 


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

While working on #7610 I noticed that we don't pass properties as part of geojson input and some libraries will consider geojson invalid in that case and throw an error. This changes the code to use a `getGeoJsonFeature` method so it is the same as for other parameters (Point, Line)

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
