### PR TITLE
set scalefactor=undefined when item trait=false

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Update data-attribution and terms of conditions links to point to terria.io. #7627
 - Hide the related maps button. #7627
 - Change `BingMapSearchProvider` to correctly logs bing search action. #7601
+- fix `MapboxStyleCatalogItem` scaleFactor bug where tiles are always scaled-up in Cesium. #7639
 - [The next improvement]
 
 #### 8.9.3 - 2025-04-24

--- a/lib/Models/Catalog/CatalogItems/MapboxStyleCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/MapboxStyleCatalogItem.ts
@@ -39,6 +39,7 @@ export default class MapboxStyleCatalogItem extends MappableMixin(
       styleId,
       accessToken,
       tilesize: this.tilesize,
+      //Cesium only checks if scaleFactor is definied or not.
       scaleFactor: this.scaleFactor ? this.scaleFactor : undefined,
       minimumLevel: this.minimumLevel,
       maximumLevel: this.maximumLevel,

--- a/lib/Models/Catalog/CatalogItems/MapboxStyleCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/MapboxStyleCatalogItem.ts
@@ -39,7 +39,7 @@ export default class MapboxStyleCatalogItem extends MappableMixin(
       styleId,
       accessToken,
       tilesize: this.tilesize,
-      scaleFactor: this.scaleFactor,
+      scaleFactor: this.scaleFactor ? this.scaleFactor : undefined,
       minimumLevel: this.minimumLevel,
       maximumLevel: this.maximumLevel,
       credit: this.attribution


### PR DESCRIPTION
### What this PR does

Cesium has a probable bug [here](https://github.com/CesiumGS/cesium/blob/9f116573ee0bfb9ad9c2d3ea7b7abe2bf39f15ec/packages/engine/Source/Scene/MapboxStyleImageryProvider.js#L91) concerning the `MapboxStyleImageryProvider`, where the `scaleFactor` option's null/undefined state is tested but not its boolean value. As a result, tiles are always scaled-up in Cesium, regardless of whether the trait has been set true or false. As a workaround fix, `MapboxStyleCatalogItem` should set the value of `scaleFactor` to `undefined` when false. 

### Test me

Add a `MapboxStyleCatalogItem` to your map's init file and toggle the `scaleFactor` trait between `true`, `false`, and not set, testing in 3D and 2D. Inspect the tile fetches to check that the `@2x` is present when `on` and absent when `off`.

### Checklist

- [x] No tests as test file does not exist for `MapboxStyleCatalogItem` and change is minor.
- [x] no`doc/` changes required--change is not public-facing.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
