### PR TITLE
Fix extension tests in ProtomapsImagerProvider.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.9.6)
 
+- Fix a bug where `.pmtiles` urls with a query string at the end was not being rendered as PMTILES.
 - [The next improvement]
 
 #### 8.9.5 - 2025-06-03

--- a/lib/Map/ImageryProvider/ProtomapsImageryProvider.ts
+++ b/lib/Map/ImageryProvider/ProtomapsImageryProvider.ts
@@ -183,14 +183,15 @@ export default class ProtomapsImageryProvider
     // Generate protomaps source based on this.data
     // - URL of pmtiles, geojson or pbf files
     if (typeof this.data === "string") {
-      if (this.data.endsWith(".pmtiles")) {
+      // Note: the `base` passed to URL is not relevant as we only use the
+      // parsed path. It still needs to be passed so that URL won't throw an
+      // error when passing relative URLs like /proxy/something.
+      const path = new URL(this.data, "http://example").pathname;
+      if (path.endsWith(".pmtiles")) {
         this.source = new PmtilesSource(this.data, false);
         const cache = new TileCache(this.source, TILE_CACHE_TILE_SIZE);
         this.view = new View(cache, this.maximumNativeZoom, 2);
-      } else if (
-        this.data.endsWith(".json") ||
-        this.data.endsWith(".geojson")
-      ) {
+      } else if (path.endsWith(".json") || path.endsWith(".geojson")) {
         this.source = new ProtomapsGeojsonSource(this.data);
       } else {
         this.source = new ZxySource(this.data, false);


### PR DESCRIPTION
### What this PR does

Fix extension test in `ProtomapsImagerProvider`.

Previously, urls like `https://example.com/some.pmtiles?foo=bar` wouldn't be recognized as `pmtiles` format because of the query string at the end. This PR fixes it by parsing the path from the URL to test the extension.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
