### PR TITLE
Actually add queryParameters to API table.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Fix a bug where `.pmtiles` urls with a query string at the end was not being rendered as PMTILES.
 - Add `MapboxSearchProvider` for geocoding using Mapbox.
 - Upgrade yarn to 1.22.22
+- Fix `ApiTableCatalogItem` to add `queryParameters` and `updateQueryParameters` to the API requests. These were previously being ignored.
 - [The next improvement]
 
 #### 8.9.5 - 2025-06-03

--- a/lib/Models/Catalog/CatalogItems/ApiTableCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/ApiTableCatalogItem.ts
@@ -87,7 +87,7 @@ export class ApiTableCatalogItem extends AutoRefreshingMixin(
   protected loadDataFromApis() {
     const apisWithUrl = this.apis.filter((api) => api.url);
     const apiUrls = apisWithUrl.map((api) =>
-      proxyCatalogItemUrl(this, api.url!)
+      proxyCatalogItemUrl(this, this.addQueryParams(api))
     );
     return Promise.all(
       apisWithUrl.map(async (api, idx) => {

--- a/test/Models/Catalog/CatalogItems/ApiTableCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/ApiTableCatalogItemSpec.ts
@@ -23,7 +23,7 @@ describe("ApiTableCatalogItem", function () {
     jasmine.Ajax.uninstall();
   });
 
-  fdescribe("query parameters", function () {
+  describe("query parameters", function () {
     beforeEach(function () {
       updateModelFromJson(apiCatalogItem, CommonStrata.definition, {
         idKey: "id",

--- a/test/Models/Catalog/CatalogItems/ApiTableCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/ApiTableCatalogItemSpec.ts
@@ -23,6 +23,55 @@ describe("ApiTableCatalogItem", function () {
     jasmine.Ajax.uninstall();
   });
 
+  fdescribe("query parameters", function () {
+    beforeEach(function () {
+      updateModelFromJson(apiCatalogItem, CommonStrata.definition, {
+        idKey: "id",
+        queryParameters: [
+          { name: "commonparam", value: "foo" },
+          { name: "dateparam", value: "DATE!yymmdd" }
+        ],
+        apis: [
+          {
+            url: "https://terria.io/values.json",
+            queryParameters: [{ name: "apiparam", value: "bar" }]
+          }
+        ]
+      });
+
+      jasmine.Ajax.stubRequest(
+        "build/TerriaJS/data/regionMapping.json"
+      ).andReturn({ responseJSON: regionMapping });
+
+      jasmine.Ajax.stubRequest(
+        new RegExp("https://terria.io/values.json")
+      ).andReturn({
+        responseJSON: valueApiResponse
+      });
+    });
+
+    it("adds common queryParameters to URL", async function () {
+      await apiCatalogItem.loadMapItems();
+      const request = jasmine.Ajax.requests.filter(/values\.json/)[0];
+      const params = new URL(request.url).searchParams;
+      expect(params.get("commonparam")).toBe("foo");
+    });
+
+    it("adds api specific queryParameters to URL", async function () {
+      await apiCatalogItem.loadMapItems();
+      const request = jasmine.Ajax.requests.filter(/values\.json/)[0];
+      const params = new URL(request.url).searchParams;
+      expect(params.get("apiparam")).toBe("bar");
+    });
+
+    it("substitutes date values", async function () {
+      await apiCatalogItem.loadMapItems();
+      const request = jasmine.Ajax.requests.filter(/values\.json/)[0];
+      const params = new URL(request.url).searchParams;
+      expect(params.get("dateparam")).toMatch(/^[0-9]{6}$/);
+    });
+  });
+
   it("creates a table from api calls", async function () {
     runInAction(() => {
       updateModelFromJson(apiCatalogItem, CommonStrata.definition, {


### PR DESCRIPTION
### What this PR does

Previously, the [queryParameter](https://docs.terria.io/guide/connecting-to-data/catalog-type-details/api-table/#:~:text=replace%20existing%20data.-,queryParameters,-QueryParamTraits%5B%5D) and [updateQueryParameters](https://docs.terria.io/guide/connecting-to-data/catalog-type-details/api-table/#:~:text=for%20each%20API.-,updateQueryParameters,-QueryParamTraits%5B%5D) were not being added to API table requests.

This PR fixes it and also adds some specs that tests the behaviour.

### Test me

- Open this main branch [CI link](http://ci.terria.io/main/#share=s-aZH7lOzOhBaGp7T6ryBbFRGtmEh&clean&https://gist.githubusercontent.com/na9da/e3dfd16e778ab9ec5fef00325126022f/raw/edfc7330df5408c2c038a0b16bfa79563c8ec984/pedestrian.json) for [this catalog definition](https://gist.github.com/na9da/e3dfd16e778ab9ec5fef00325126022f)
- In the network tab note how the `customdt` parameter is not being passed in requests to `melbournetestbed.opendatasoft.com`
- Now check network tab for [this branch](http://ci.terria.io/fix-api-table-queryparams/#share=s-aZH7lOzOhBaGp7T6ryBbFRGtmEh&clean&https://gist.githubusercontent.com/na9da/e3dfd16e778ab9ec5fef00325126022f/raw/edfc7330df5408c2c038a0b16bfa79563c8ec984/pedestrian.json)
- Note how the `customdt` param is added and the date value is generated correctly

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
