### PR TITLE
Add TileMapServiceCatalogItem.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 #### next release (8.10.1)
 
 - Warn the user when the story causes shareData size exceed the limit set on the server as `shareMaxRequestSize`. #7636
+- Adds new `TileMapServiceCatalogItem` for loading Tile Map Service (TMS) imagery tilesets.
 - [The next improvement]
 
 #### 8.10.0 - 2025-07-08

--- a/lib/Models/Catalog/CatalogItems/TileMapServiceCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/TileMapServiceCatalogItem.ts
@@ -1,12 +1,11 @@
-import { computed, makeObservable, observable, runInAction, trace } from "mobx";
-import { fromPromise } from "mobx-utils";
+import { computed, makeObservable, observable, runInAction } from "mobx";
 import TileMapServiceImageryProvider from "terriajs-cesium/Source/Scene/TileMapServiceImageryProvider";
 import CatalogMemberMixin from "../../../ModelMixins/CatalogMemberMixin";
 import MappableMixin, { MapItem } from "../../../ModelMixins/MappableMixin";
 import TileMapServiceCatalogItemTraits from "../../../Traits/TraitsClasses/TileMapServiceCatalogItemTraits";
 import CreateModel from "../../Definition/CreateModel";
-import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
 import { ModelConstructorParameters } from "../../Definition/Model";
+import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
 
 /**
  * A catalog item that loads a Tile Map Service imagery tileset created using

--- a/lib/Models/Catalog/CatalogItems/TileMapServiceCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/TileMapServiceCatalogItem.ts
@@ -1,0 +1,67 @@
+import { computed, makeObservable, observable, runInAction, trace } from "mobx";
+import { fromPromise } from "mobx-utils";
+import TileMapServiceImageryProvider from "terriajs-cesium/Source/Scene/TileMapServiceImageryProvider";
+import CatalogMemberMixin from "../../../ModelMixins/CatalogMemberMixin";
+import MappableMixin, { MapItem } from "../../../ModelMixins/MappableMixin";
+import TileMapServiceCatalogItemTraits from "../../../Traits/TraitsClasses/TileMapServiceCatalogItemTraits";
+import CreateModel from "../../Definition/CreateModel";
+import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
+import { ModelConstructorParameters } from "../../Definition/Model";
+
+/**
+ * A catalog item that loads a Tile Map Service imagery tileset created using
+ * MapTiler or gdal2tiles.
+ */
+export default class TileMapServiceCatalogItem extends MappableMixin(
+  CatalogMemberMixin(CreateModel(TileMapServiceCatalogItemTraits))
+) {
+  static readonly type = "tms";
+
+  constructor(...args: ModelConstructorParameters) {
+    super(...args);
+    makeObservable(this);
+  }
+
+  @observable
+  private imageryProvider: TileMapServiceImageryProvider | undefined;
+
+  get type() {
+    return TileMapServiceCatalogItem.type;
+  }
+
+  protected async forceLoadMapItems(): Promise<void> {
+    let imageryProvider: TileMapServiceImageryProvider | undefined;
+    if (this.url) {
+      imageryProvider = await TileMapServiceImageryProvider.fromUrl(
+        proxyCatalogItemUrl(this, this.url),
+        {
+          minimumLevel: this.minimumLevel,
+          maximumLevel: this.maximumLevel,
+          tileWidth: this.tileWidth,
+          tileHeight: this.tileHeight,
+          credit: this.attribution
+        }
+      );
+    }
+
+    runInAction(() => {
+      this.imageryProvider = imageryProvider;
+    });
+  }
+
+  @computed
+  get mapItems(): MapItem[] {
+    return this.imageryProvider
+      ? [
+          {
+            imageryProvider: this.imageryProvider,
+            show: this.show,
+            alpha: this.opacity,
+            clippingRectangle: this.clipToRectangle
+              ? this.cesiumRectangle
+              : undefined
+          }
+        ]
+      : [];
+  }
+}

--- a/lib/Models/Catalog/registerCatalogMembers.ts
+++ b/lib/Models/Catalog/registerCatalogMembers.ts
@@ -10,6 +10,7 @@ import CartoMapV1CatalogItem from "./CatalogItems/CartoMapV1CatalogItem";
 import CartoMapV3CatalogItem from "./CatalogItems/CartoMapV3CatalogItem";
 import Cesium3DTilesCatalogItem from "./CatalogItems/Cesium3DTilesCatalogItem";
 import CesiumTerrainCatalogItem from "./CatalogItems/CesiumTerrainCatalogItem";
+import CogCatalogItem from "./CatalogItems/CogCatalogItem";
 import CompositeCatalogItem from "./CatalogItems/CompositeCatalogItem";
 import CsvCatalogItem from "./CatalogItems/CsvCatalogItem";
 import CzmlCatalogItem from "./CatalogItems/CzmlCatalogItem";
@@ -28,6 +29,7 @@ import SenapsLocationsCatalogItem from "./CatalogItems/SenapsLocationsCatalogIte
 import ShapefileCatalogItem from "./CatalogItems/ShapefileCatalogItem";
 import SocrataMapViewCatalogItem from "./CatalogItems/SocrataMapViewCatalogItem";
 import StubCatalogItem from "./CatalogItems/StubCatalogItem";
+import TileMapServiceCatalogItem from "./CatalogItems/TileMapServiceCatalogItem";
 import UrlTemplateImageryCatalogItem from "./CatalogItems/UrlTemplateImageryCatalogItem";
 import CatalogMemberFactory from "./CatalogMemberFactory";
 import CatalogIndexReference from "./CatalogReferences/CatalogIndexReference";
@@ -64,7 +66,6 @@ import WebProcessingServiceCatalogFunctionJob from "./Ows/WebProcessingServiceCa
 import WebProcessingServiceCatalogGroup from "./Ows/WebProcessingServiceCatalogGroup";
 import SdmxJsonCatalogGroup from "./SdmxJson/SdmxJsonCatalogGroup";
 import SdmxJsonCatalogItem from "./SdmxJson/SdmxJsonCatalogItem";
-import CogCatalogItem from "./CatalogItems/CogCatalogItem";
 
 export default function registerCatalogMembers() {
   CatalogMemberFactory.register(CatalogGroup.type, CatalogGroup);
@@ -240,6 +241,10 @@ export default function registerCatalogMembers() {
   CatalogMemberFactory.register(
     UrlTemplateImageryCatalogItem.type,
     UrlTemplateImageryCatalogItem
+  );
+  CatalogMemberFactory.register(
+    TileMapServiceCatalogItem.type,
+    TileMapServiceCatalogItem
   );
   CatalogMemberFactory.register(AssImpCatalogItem.type, AssImpCatalogItem);
   CatalogMemberFactory.register(CogCatalogItem.type, CogCatalogItem);

--- a/lib/Traits/TraitsClasses/TileMapServiceCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/TileMapServiceCatalogItemTraits.ts
@@ -1,0 +1,25 @@
+import { traitClass } from "../Trait";
+import mixTraits from "../mixTraits";
+import CatalogMemberTraits from "./CatalogMemberTraits";
+import ImageryProviderTraits from "./ImageryProviderTraits";
+import LayerOrderingTraits from "./LayerOrderingTraits";
+import LegendOwnerTraits from "./LegendOwnerTraits";
+import MappableTraits from "./MappableTraits";
+import UrlTraits from "./UrlTraits";
+
+@traitClass({
+  description: `Creates one catalog item for a Tile Map Service (TMS) imagery tileset.`,
+  example: {
+    type: "tms",
+    name: "Natural Earth II (TMS)",
+    url: "https://storage.googleapis.com/terria-datasets-public/basemaps/natural-earth-tiles"
+  }
+})
+export default class TileMapServiceCatalogItemTraits extends mixTraits(
+  ImageryProviderTraits,
+  LayerOrderingTraits,
+  UrlTraits,
+  MappableTraits,
+  CatalogMemberTraits,
+  LegendOwnerTraits
+) {}

--- a/test/Models/Catalog/CatalogItems/TileMapServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/TileMapServiceCatalogItemSpec.ts
@@ -5,7 +5,7 @@ import Terria from "../../../../lib/Models/Terria";
 import { ImageryParts } from "../../../../lib/ModelMixins/MappableMixin";
 import updateModelFromJson from "../../../../lib/Models/Definition/updateModelFromJson";
 
-fdescribe("TileMapServiceCatalogItem", function () {
+describe("TileMapServiceCatalogItem", function () {
   let item: TileMapServiceCatalogItem;
 
   beforeEach(function () {

--- a/test/Models/Catalog/CatalogItems/TileMapServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/TileMapServiceCatalogItemSpec.ts
@@ -1,0 +1,61 @@
+import TileMapServiceImageryProvider from "terriajs-cesium/Source/Scene/TileMapServiceImageryProvider";
+import TileMapServiceCatalogItem from "../../../../lib/Models/Catalog/CatalogItems/TileMapServiceCatalogItem";
+import CommonStrata from "../../../../lib/Models/Definition/CommonStrata";
+import Terria from "../../../../lib/Models/Terria";
+import { ImageryParts } from "../../../../lib/ModelMixins/MappableMixin";
+import updateModelFromJson from "../../../../lib/Models/Definition/updateModelFromJson";
+
+fdescribe("TileMapServiceCatalogItem", function () {
+  let item: TileMapServiceCatalogItem;
+
+  beforeEach(function () {
+    item = new TileMapServiceCatalogItem("test", new Terria());
+    item.setTrait(CommonStrata.user, "url", "some-url");
+  });
+
+  it("can be loaded", async function () {
+    await item.loadMapItems();
+  });
+
+  describe("when loaded", function () {
+    it("returns the imageryProvider as mapItems", async function () {
+      await item.loadMapItems();
+      expect(
+        (item.mapItems[0] as any).imageryProvider instanceof
+          TileMapServiceImageryProvider
+      ).toBe(true);
+    });
+
+    it("correctly sets the imagerProvider options", async function () {
+      item.setTrait(CommonStrata.user, "minimumLevel", 1);
+      item.setTrait(CommonStrata.user, "maximumLevel", 9);
+      item.setTrait(CommonStrata.user, "attribution", "foo");
+      await item.loadMapItems();
+      const imageryProvider = (item.mapItems[0] as any)
+        .imageryProvider as TileMapServiceImageryProvider;
+
+      expect(imageryProvider.minimumLevel).toBe(1);
+      expect(imageryProvider.maximumLevel).toBe(9);
+      expect(imageryProvider.credit.html).toBe("foo");
+    });
+
+    it("correctly sets the imageryParts options", async function () {
+      updateModelFromJson(item, CommonStrata.user, {
+        show: false,
+        opacity: 0.5,
+        rectangle: {
+          west: 80,
+          north: 0,
+          south: -10,
+          east: 82
+        }
+      });
+      await item.loadMapItems();
+      const imageryParts = item.mapItems[0] as ImageryParts;
+
+      expect(imageryParts.show).toBe(false);
+      expect(imageryParts.alpha).toBe(0.5);
+      expect(imageryParts.clippingRectangle).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
### What this PR does

Adds `TileMapServiceCatalogItem` using Cesium's [TileMapServiceImagerProvider](https://cesium.com/learn/cesiumjs/ref-doc/TileMapServiceImageryProvider.html).

Example catalog:
```json
    {
      "type": "tms",
      "name": "Natural Earth II (TMS)",
      "url": "https://storage.googleapis.com/terria-datasets-public/basemaps/natural-earth-tiles"
    }
```

### Test me

- Open [this share URL](http://ci.terria.io/tms/#https://gist.githubusercontent.com/na9da/fe2a7e7300caa5625c10ae6898a385dc/raw/52c58529751fb52ad78f368ffb3fb2f81611837b/tms.json) 
- Switch to `Openstreet map` basemap if you are using `Natural Earth II`
- Add the `Natural Earth II (TMS)` dataset from the catalog ([defined as](https://gist.githubusercontent.com/na9da/fe2a7e7300caa5625c10ae6898a385dc/raw/52c58529751fb52ad78f368ffb3fb2f81611837b/tms.json))
- Make sure the dataset loads correctly and reacts to changes to opacity etc.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
