### PR TITLE
Mock TMS metadata to fix spec.

### DIFF
--- a/test/Models/Catalog/CatalogItems/TileMapServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/TileMapServiceCatalogItemSpec.ts
@@ -10,7 +10,7 @@ describe("TileMapServiceCatalogItem", function () {
 
   beforeEach(function () {
     item = new TileMapServiceCatalogItem("test", new Terria());
-    item.setTrait(CommonStrata.user, "url", "some-url");
+    item.setTrait(CommonStrata.user, "url", "test/TMS");
   });
 
   it("can be loaded", async function () {

--- a/wwwroot/test/TMS/tilemapresource.xml
+++ b/wwwroot/test/TMS/tilemapresource.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <TileMap version="1.0.0" tilemapservice="http://tms.osgeo.org/1.0.0">
+      <Title>ne2-webmerc.tif</Title>
+      <Abstract></Abstract>
+      <SRS>EPSG:3857</SRS>
+      <BoundingBox minx="-180.00000000000000" miny="-84.99954727300629" maxx="180.00000000000000" maxy="85.00000000000000"/>
+      <Origin x="-180.00000000000000" y="-84.99954727300629"/>
+      <TileFormat width="256" height="256" mime-type="image/png" extension="png"/>
+      <TileSets profile="mercator">
+        <TileSet href="0" units-per-pixel="156543.03390000000945" order="0"/>
+        <TileSet href="1" units-per-pixel="78271.51695000000473" order="1"/>
+        <TileSet href="2" units-per-pixel="39135.75847500000236" order="2"/>
+        <TileSet href="3" units-per-pixel="19567.87923750000118" order="3"/>
+        <TileSet href="4" units-per-pixel="9783.93961875000059" order="4"/>
+        <TileSet href="5" units-per-pixel="4891.96980937500030" order="5"/>
+        <TileSet href="6" units-per-pixel="2445.98490468750015" order="6"/>
+        <TileSet href="7" units-per-pixel="1222.99245234375007" order="7"/>
+      </TileSets>
+    </TileMap>


### PR DESCRIPTION
### What this PR does

The recently add specs from [TMS PR](https://github.com/TerriaJS/terriajs/pull/7662) was breaking in spec runner when invoked from - http://localhost:3002/SpecRunner.html (but not in CI).

The `TileMapServiceImageryProvider` tries to fetch `tilemapresource.xml` and fails when it is not found. For some reason it works when karma runner is run explicitly from the CLI (like in CI) but not from the SpecRunner URL. This could be due to differences in HTTP error returned by both environment.

This PR adds a mock `tilemapresource.xml` which ensures the request does not fail and the specs succeed.

### Test me

- Build local terriajs checkout
- Make sure http://localhost:3002/SpecRunner.html does not show any errors

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
