### PR TITLE
Add splitter support for points and billboards in vector datasets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Replace react-uid with react useId hook for generating unique ids.
 - Remove ts-essentials dependency and replace with custom type utility.
 - Remove fs-extra dependency and replace with native fs.
+- Added support for using splitter with points and billboards in vector datasets.
 - [The next improvement]
 
 #### 8.11.3 - 2026-02-02

--- a/lib/Core/runWhenObserved.ts
+++ b/lib/Core/runWhenObserved.ts
@@ -8,7 +8,7 @@ import { IReactionDisposer, onBecomeObserved, onBecomeUnobserved } from "mobx";
  * @param prop An observable property belonging to object
  * @param startReaction The reaction to run when the `prop` is observed.
  */
-export default function runWhenObserved<T extends Object, P extends keyof T>(
+export default function runWhenObserved<T extends object, P extends keyof T>(
   obj: T,
   prop: P,
   startReaction: () => IReactionDisposer

--- a/lib/Core/runWhenObserved.ts
+++ b/lib/Core/runWhenObserved.ts
@@ -1,0 +1,25 @@
+import { IReactionDisposer, onBecomeObserved, onBecomeUnobserved } from "mobx";
+
+/**
+ * Starts the given reaction when the property becomes observed and destroys it when
+ * it becomes unobserved.
+ *
+ * @param obj Any object
+ * @param prop An observable property belonging to object
+ * @param startReaction The reaction to run when the `prop` is observed.
+ */
+export default function runWhenObserved<T extends Object, P extends keyof T>(
+  obj: T,
+  prop: P,
+  startReaction: () => IReactionDisposer
+) {
+  let reactionDisposer: IReactionDisposer | undefined;
+  onBecomeObserved(obj, prop, () => {
+    reactionDisposer = startReaction();
+  });
+
+  onBecomeUnobserved(obj, prop, () => {
+    reactionDisposer?.();
+    reactionDisposer = undefined;
+  });
+}

--- a/lib/ModelMixins/GeojsonMixin.ts
+++ b/lib/ModelMixins/GeojsonMixin.ts
@@ -8,9 +8,9 @@ import {
 } from "geojson";
 import i18next from "i18next";
 import {
+  IReactionDisposer,
   action,
   computed,
-  IReactionDisposer,
   makeObservable,
   observable,
   onBecomeObserved,
@@ -23,7 +23,6 @@ import {
 import { createTransformer } from "mobx-utils";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
-import clone from "terriajs-cesium/Source/Core/clone";
 import Color from "terriajs-cesium/Source/Core/Color";
 import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import Iso8601 from "terriajs-cesium/Source/Core/Iso8601";
@@ -31,6 +30,7 @@ import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import PolygonHierarchy from "terriajs-cesium/Source/Core/PolygonHierarchy";
 import TimeInterval from "terriajs-cesium/Source/Core/TimeInterval";
 import TimeIntervalCollection from "terriajs-cesium/Source/Core/TimeIntervalCollection";
+import clone from "terriajs-cesium/Source/Core/clone";
 import BillboardGraphics from "terriajs-cesium/Source/DataSources/BillboardGraphics";
 import ColorMaterialProperty from "terriajs-cesium/Source/DataSources/ColorMaterialProperty";
 import ConstantProperty from "terriajs-cesium/Source/DataSources/ConstantProperty";
@@ -47,24 +47,24 @@ import Property from "terriajs-cesium/Source/DataSources/Property";
 import HeightReference from "terriajs-cesium/Source/Scene/HeightReference";
 import ImageryLayerFeatureInfo from "terriajs-cesium/Source/Scene/ImageryLayerFeatureInfo";
 import AbstractConstructor from "../Core/AbstractConstructor";
-import filterOutUndefined from "../Core/filterOutUndefined";
-import formatPropertyValue from "../Core/formatPropertyValue";
 import {
-  explodeMultiPoint,
   FeatureCollectionWithCrs,
+  explodeMultiPoint,
   isPoint
 } from "../Core/GeoJson";
-import hashFromString from "../Core/hashFromString";
-import isDefined from "../Core/isDefined";
 import {
+  JsonObject,
   isJsonArray,
   isJsonNumber,
-  isJsonObject,
-  JsonObject
+  isJsonObject
 } from "../Core/Json";
-import { isJson } from "../Core/loadBlob";
 import StandardCssColors from "../Core/StandardCssColors";
 import TerriaError, { networkRequestError } from "../Core/TerriaError";
+import filterOutUndefined from "../Core/filterOutUndefined";
+import formatPropertyValue from "../Core/formatPropertyValue";
+import hashFromString from "../Core/hashFromString";
+import isDefined from "../Core/isDefined";
+import { isJson } from "../Core/loadBlob";
 import ProtomapsImageryProvider, {
   ProtomapsData
 } from "../Map/ImageryProvider/ProtomapsImageryProvider";
@@ -74,17 +74,17 @@ import Reproject from "../Map/Vector/Reproject";
 import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
 import UrlMixin from "../ModelMixins/UrlMixin";
 import proxyCatalogItemUrl from "../Models/Catalog/proxyCatalogItemUrl";
-import createStratumInstance from "../Models/Definition/createStratumInstance";
 import LoadableStratum from "../Models/Definition/LoadableStratum";
 import Model, { BaseModel } from "../Models/Definition/Model";
 import StratumOrder from "../Models/Definition/StratumOrder";
+import createStratumInstance from "../Models/Definition/createStratumInstance";
 import TerriaFeature from "../Models/Feature/Feature";
 import { TerriaFeatureData } from "../Models/Feature/FeatureData";
 import { ViewingControl } from "../Models/ViewingControls";
 import TableStylingWorkflow from "../Models/Workflows/TableStylingWorkflow";
-import createLongitudeLatitudeFeaturePerRow from "../Table/createLongitudeLatitudeFeaturePerRow";
 import TableAutomaticStylesStratum from "../Table/TableAutomaticStylesStratum";
 import TableStyle, { createRowGroupId } from "../Table/TableStyle";
+import createLongitudeLatitudeFeaturePerRow from "../Table/createLongitudeLatitudeFeaturePerRow";
 import { GeoJsonTraits } from "../Traits/TraitsClasses/GeoJsonTraits";
 import { RectangleTraits } from "../Traits/TraitsClasses/MappableTraits";
 import StyleTraits from "../Traits/TraitsClasses/StyleTraits";
@@ -674,11 +674,11 @@ function GeoJsonMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
         const dataSource = new CustomDataSource(this.name || "Table");
         dataSource.entities.suspendEvents();
 
-        const features: Entity[] = createLongitudeLatitudeFeaturePerRow(
-          style,
+        const features: Entity[] = createLongitudeLatitudeFeaturePerRow(style, {
           longitudes,
-          latitudes
-        );
+          latitudes,
+          splitDirection: this.splitDirectionProperty
+        });
 
         // _catalogItem property is needed for some feature picking functions (eg FeatureInfoUrlTemplateMixin)
         features.forEach((f) => {
@@ -1022,6 +1022,8 @@ function GeoJsonMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
 
       const dataSource = await GeoJsonDataSource.load(geoJson, styles);
       const entities = dataSource.entities;
+
+      dataSource.entities.suspendEvents();
       for (let i = 0; i < entities.values.length; ++i) {
         const entity = entities.values[i];
 
@@ -1170,7 +1172,16 @@ function GeoJsonMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
             createPolylineFromPolygon(entities, entity, now);
           }
         }
+
+        if (entity.point) {
+          entity.point.splitDirection = this.splitDirectionProperty;
+        }
+
+        if (entity.billboard) {
+          entity.billboard.splitDirection = this.splitDirectionProperty;
+        }
       }
+      dataSource.entities.resumeEvents();
       return dataSource;
     }
 

--- a/lib/Table/createLongitudeLatitudeFeaturePerId.ts
+++ b/lib/Table/createLongitudeLatitudeFeaturePerId.ts
@@ -146,12 +146,15 @@ class PreSampledPositionProperty {
  * Create lat/lon features, one for each id group in the table
  */
 export default function createLongitudeLatitudeFeaturePerId(
-  style: RequiredTableStyle
+  style: RequiredTableStyle,
+  options?: {
+    splitDirection?: ConstantProperty;
+  }
 ): TerriaFeature[] {
   const features: TerriaFeature[] = [];
   for (let i = 0; i < style.rowGroups.length; i++) {
     const [featureId, rowIds] = style.rowGroups[i];
-    features.push(createFeature(featureId, rowIds, style));
+    features.push(createFeature(featureId, rowIds, style, options));
   }
 
   return features;
@@ -166,7 +169,10 @@ function createProperty(type: Packable, interpolate: boolean) {
 function createFeature(
   _featureId: string,
   rowIds: number[],
-  style: RequiredTableStyle
+  style: RequiredTableStyle,
+  options?: {
+    splitDirection?: ConstantProperty;
+  }
 ): TerriaFeature {
   const isSampled = !!style.isSampled;
   const tableHasScalarColumn = !!style.tableModel.tableColumns.find(
@@ -406,14 +412,16 @@ function createFeature(
       ? new PointGraphics({
           ...convertPreSampledProperties(pointGraphicsTimeProperties),
           show,
-          heightReference: HeightReference.CLAMP_TO_GROUND
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          splitDirection: options?.splitDirection
         })
       : undefined,
     billboard: !usePointGraphicsForId
       ? new BillboardGraphics({
           ...convertPreSampledProperties(billboardGraphicsTimeProperties),
+          show,
           heightReference: HeightReference.CLAMP_TO_GROUND,
-          show
+          splitDirection: options?.splitDirection
         })
       : undefined,
     path: pathGraphicsTimeProperties

--- a/lib/Table/createLongitudeLatitudeFeaturePerRow.ts
+++ b/lib/Table/createLongitudeLatitudeFeaturePerRow.ts
@@ -11,12 +11,23 @@ import TerriaFeature from "../Models/Feature/Feature";
 import { getFeatureStyle } from "./getFeatureStyle";
 import TableColumn from "./TableColumn";
 import TableStyle from "./TableStyle";
+import ConstantProperty from "terriajs-cesium/Source/DataSources/ConstantProperty";
+
+interface Options {
+  longitudes?: (number | null)[];
+  latitudes?: (number | null)[];
+  splitDirection?: ConstantProperty;
+}
 
 export default function createLongitudeLatitudeFeaturePerRow(
   style: TableStyle,
-  longitudes = style.longitudeColumn?.valuesAsNumbers.values,
-  latitudes = style.latitudeColumn?.valuesAsNumbers.values
+  options?: Options
 ): TerriaFeature[] {
+  const longitudes =
+    options?.longitudes ?? style.longitudeColumn?.valuesAsNumbers.values;
+  const latitudes =
+    options?.latitudes ?? style.latitudeColumn?.valuesAsNumbers.values;
+
   if (!longitudes || !latitudes) return [];
 
   const tableColumns = style.tableModel.tableColumns;
@@ -50,14 +61,16 @@ export default function createLongitudeLatitudeFeaturePerRow(
         pointGraphicsOptions && usePointGraphics
           ? new PointGraphics({
               ...pointGraphicsOptions,
-              heightReference: HeightReference.CLAMP_TO_GROUND
+              heightReference: HeightReference.CLAMP_TO_GROUND,
+              splitDirection: options?.splitDirection
             })
           : undefined,
       billboard:
         billboardGraphicsOptions && !usePointGraphics
           ? new BillboardGraphics({
               ...billboardGraphicsOptions,
-              heightReference: HeightReference.CLAMP_TO_GROUND
+              heightReference: HeightReference.CLAMP_TO_GROUND,
+              splitDirection: options?.splitDirection
             })
           : undefined,
       label: labelGraphicsOptions

--- a/test/Core/runWhenObservedSpec.ts
+++ b/test/Core/runWhenObservedSpec.ts
@@ -1,0 +1,67 @@
+import { makeAutoObservable, reaction, runInAction, when } from "mobx";
+import runWhenObserved from "../../lib/Core/runWhenObserved";
+
+describe("runWhenObserved", function () {
+  let testObj: { value: string; items: unknown[] };
+  let valueCopy: string | undefined;
+  let observer: Promise<void> & { cancel: () => void };
+
+  beforeEach(function () {
+    testObj = new (class {
+      value = "first";
+      items = [];
+
+      constructor() {
+        makeAutoObservable(this);
+      }
+    })();
+
+    runWhenObserved(testObj, "items", () =>
+      // this reaction will be started when observableValue is observed
+      reaction(
+        () => testObj.value,
+        (newValue) => {
+          // If the reaction is running then valueCopy will mirror the observableValue
+          valueCopy = newValue;
+        },
+        { fireImmediately: true }
+      )
+    );
+
+    observer = when(() => testObj.items.length === Infinity);
+  });
+
+  afterEach(function () {
+    observer.cancel();
+  });
+
+  it("starts the given reaction when observableValue becomes observed", function () {
+    expect(valueCopy).toBe("first");
+    runInAction(() => {
+      // This change should trigger the runWhenObserved reaction which sets valueCopy to "second"
+      testObj.value = "second";
+    });
+    expect(valueCopy).toBe("second");
+  });
+
+  it("stops the reaction when the observableValue becomes unobserved", function () {
+    runInAction(() => {
+      // This change should trigger runWhenObserved reaction which sets valueCopy to "hundred"
+      testObj.value = "hundred";
+    });
+    expect(valueCopy).toBe("hundred");
+
+    runInAction(() => {
+      // destroy observer
+      observer.cancel();
+    });
+
+    runInAction(() => {
+      // This change should not trigger the runWhenObserved reaction
+      testObj.value = "hundred and one";
+    });
+
+    // valueCopy stays "hundred" as the observer has been destroyed
+    expect(valueCopy).toBe("hundred");
+  });
+});

--- a/test/ModelMixins/TableMixinSpec.ts
+++ b/test/ModelMixins/TableMixinSpec.ts
@@ -1,7 +1,10 @@
 import { runInAction } from "mobx";
 import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
 import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSource";
+import HorizontalOrigin from "terriajs-cesium/Source/Scene/HorizontalOrigin";
 import LabelStyle from "terriajs-cesium/Source/Scene/LabelStyle";
+import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
+import VerticalOrigin from "terriajs-cesium/Source/Scene/VerticalOrigin";
 import { getMakiIcon } from "../../lib/Map/Icons/Maki/MakiIcons";
 import { ImageryParts } from "../../lib/ModelMixins/MappableMixin";
 import CsvCatalogItem from "../../lib/Models/Catalog/CatalogItems/CsvCatalogItem";
@@ -11,6 +14,7 @@ import updateModelFromJson from "../../lib/Models/Definition/updateModelFromJson
 import TerriaFeature from "../../lib/Models/Feature/Feature";
 import { TerriaFeatureData } from "../../lib/Models/Feature/FeatureData";
 import Terria from "../../lib/Models/Terria";
+import ScaleByDistanceTraits from "../../lib/Traits/TraitsClasses/ScaleByDistanceTraits";
 import TableColorStyleTraits from "../../lib/Traits/TraitsClasses/Table/ColorStyleTraits";
 import TableLabelStyleTraits, {
   EnumLabelSymbolTraits,
@@ -31,27 +35,26 @@ import TableTrailStyleTraits, {
   BinTrailSymbolTraits,
   EnumTrailSymbolTraits
 } from "../../lib/Traits/TraitsClasses/Table/TrailStyleTraits";
-import HorizontalOrigin from "terriajs-cesium/Source/Scene/HorizontalOrigin";
-import VerticalOrigin from "terriajs-cesium/Source/Scene/VerticalOrigin";
-import ScaleByDistanceTraits from "../../lib/Traits/TraitsClasses/ScaleByDistanceTraits";
-import LatLonValCsv from "../../wwwroot/test/csv/lat_lon_val.csv";
+import regionMapping from "../../wwwroot/data/regionMapping.json";
+import regionIdsLgaName from "../../wwwroot/data/regionids/region_map-FID_LGA_2011_AUST_LGA_NAME11.json";
+import regionIdsLgaNameStates from "../../wwwroot/data/regionids/region_map-FID_LGA_2011_AUST_STE_NAME11.json";
+import regionIdsLgaCode from "../../wwwroot/data/regionids/region_map-FID_LGA_2015_AUST_LGA_CODE15.json";
+import regionIdsSte from "../../wwwroot/data/regionids/region_map-STE_2016_AUST_STE_NAME16.json";
+import BadDatesCsv from "../../wwwroot/test/csv/bad-dates.csv";
 import LatLonEnumCsv from "../../wwwroot/test/csv/lat_lon_enum.csv";
-import LatLonValCsvDuplicate from "../../wwwroot/test/csv/lat_lon_val_with_duplicate_row.csv";
 import LatLonEnumDateIdCsv from "../../wwwroot/test/csv/lat_lon_enum_date_id.csv";
 import LatLonEnumDateIdWithRegionCsv from "../../wwwroot/test/csv/lat_lon_enum_date_id_with_regions.csv";
-
+import LatLonValCsv from "../../wwwroot/test/csv/lat_lon_val.csv";
+import LatLonValCsvDuplicate from "../../wwwroot/test/csv/lat_lon_val_with_duplicate_row.csv";
+import LegendDecimalPlacesCsv from "../../wwwroot/test/csv/legend-decimal-places.csv";
 import LgaWithDisambigCsv from "../../wwwroot/test/csv/lga_state_disambig.csv";
 import ParkingSensorDataCsv from "../../wwwroot/test/csv/parking-sensor-data.csv";
-import LegendDecimalPlacesCsv from "../../wwwroot/test/csv/legend-decimal-places.csv";
-import BadDatesCsv from "../../wwwroot/test/csv/bad-dates.csv";
-import regionMapping from "../../wwwroot/data/regionMapping.json";
 import additionalRegionMapping from "../../wwwroot/test/regionMapping/additionalRegion.json";
-import regionIdsSte from "../../wwwroot/data/regionids/region_map-STE_2016_AUST_STE_NAME16.json";
-import regionIdsLgaName from "../../wwwroot/data/regionids/region_map-FID_LGA_2011_AUST_LGA_NAME11.json";
-import regionIdsLgaCode from "../../wwwroot/data/regionids/region_map-FID_LGA_2015_AUST_LGA_CODE15.json";
-import regionIdsLgaNameStates from "../../wwwroot/data/regionids/region_map-FID_LGA_2011_AUST_STE_NAME11.json";
 
 const NUMBER_OF_REGION_MAPPING_TYPES = 154;
+
+const BILLBOARD_IMAGE =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAZNJREFUWIXtlrFLQlEUxr/QPGYhTbYEhhgWErjU0twQ9AdEGNnU0CiBL60pMBqC2gSHhgoamhoFt8ZaIugtQhFFY1Hmp0EN+ehZDd3e84ngB493733vnPPjXj7OdaPFcncA2h3AIyLrJBMiskcy01QAEdkgmTavkTTeaQDpbyFdtgKQXFH5/y9SPQKPefII7PuB2Xqe0xGRgE4ONxOgQX4gbppOHpGlmGIOW10wCoRUY2wFKP0jxhJAHMAqgCCAawBRpwEO6o8VWQKYjqK8lYAEA3Bd3UGf0BBxFOBYg6+n+3M8HkJkaQqVXAFexwCM4oZ2F+HNFdRytHczeq017sJyHi8Aeh0DmMniaSeB96EBeC5ucJ4vYlI1hyWA4iX8Y1/tSbm4ZQCJohxegHgDcD3fQtczDtswtgafMe4PIxLZRElPqfUDW13QN9jiZlR5UI+xBPBWA9wmG96fNN+GVZhuRWfzP74rFVcGEJFtkinVIrYBkNQAaKYlj4hkSc6JyCHJZFMBflG1XjRpXM+dBrCsDsAHoPtrwlSQt8wAAAAASUVORK5CYII=";
 
 describe("TableMixin", function () {
   let item: CsvCatalogItem;
@@ -866,15 +869,12 @@ describe("TableMixin", function () {
     it("supports image marker style - data URI", async function () {
       item.setTrait(CommonStrata.user, "csvString", LatLonValCsv);
 
-      const image =
-        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAZNJREFUWIXtlrFLQlEUxr/QPGYhTbYEhhgWErjU0twQ9AdEGNnU0CiBL60pMBqC2gSHhgoamhoFt8ZaIugtQhFFY1Hmp0EN+ehZDd3e84ngB493733vnPPjXj7OdaPFcncA2h3AIyLrJBMiskcy01QAEdkgmTavkTTeaQDpbyFdtgKQXFH5/y9SPQKPefII7PuB2Xqe0xGRgE4ONxOgQX4gbppOHpGlmGIOW10wCoRUY2wFKP0jxhJAHMAqgCCAawBRpwEO6o8VWQKYjqK8lYAEA3Bd3UGf0BBxFOBYg6+n+3M8HkJkaQqVXAFexwCM4oZ2F+HNFdRytHczeq017sJyHi8Aeh0DmMniaSeB96EBeC5ucJ4vYlI1hyWA4iX8Y1/tSbm4ZQCJohxegHgDcD3fQtczDtswtgafMe4PIxLZRElPqfUDW13QN9jiZlR5UI+xBPBWA9wmG96fNN+GVZhuRWfzP74rFVcGEJFtkinVIrYBkNQAaKYlj4hkSc6JyCHJZFMBflG1XjRpXM+dBrCsDsAHoPtrwlSQt8wAAAAASUVORK5CYII=";
-
       item.setTrait(CommonStrata.user, "styles", [
         createStratumInstance(TableStyleTraits, {
           id: "test-style",
           point: createStratumInstance(TablePointStyleTraits, {
             null: createStratumInstance(PointSymbolTraits, {
-              marker: image,
+              marker: BILLBOARD_IMAGE,
               height: 20
             })
           })
@@ -891,7 +891,7 @@ describe("TableMixin", function () {
           feature.billboard?.image?.getValue(
             item.terria.timelineClock.currentTime
           )
-        ).toBe(image);
+        ).toBe(BILLBOARD_IMAGE);
 
         expect(
           feature.billboard?.height?.getValue(
@@ -2106,6 +2106,44 @@ describe("TableMixin", function () {
             far: 50000,
             farValue: 10
           })
+        )
+      );
+    });
+
+    it("correctly sets splitDirection for points", async function () {
+      item.setTrait(CommonStrata.user, "csvString", LatLonValCsv);
+      item.setTrait(CommonStrata.user, "splitDirection", SplitDirection.LEFT);
+      await item.loadMapItems();
+      const mapItem = item.mapItems[0] as CustomDataSource;
+      mapItem.entities.values.forEach((entity) =>
+        expect(entity.point?.splitDirection?.getValue()).toEqual(
+          SplitDirection.LEFT
+        )
+      );
+    });
+
+    it("correctly sets splitDirection for billboards", async function () {
+      item.setTrait(CommonStrata.user, "csvString", LatLonValCsv);
+      item.setTrait(CommonStrata.user, "splitDirection", SplitDirection.LEFT);
+
+      item.setTrait(CommonStrata.user, "styles", [
+        createStratumInstance(TableStyleTraits, {
+          id: "test-style",
+          point: createStratumInstance(TablePointStyleTraits, {
+            null: createStratumInstance(PointSymbolTraits, {
+              marker: BILLBOARD_IMAGE,
+              height: 20
+            })
+          })
+        })
+      ]);
+      item.setTrait(CommonStrata.user, "activeStyle", "test-style");
+
+      await item.loadMapItems();
+      const mapItem = item.mapItems[0] as CustomDataSource;
+      mapItem.entities.values.forEach((entity) =>
+        expect(entity.billboard?.splitDirection?.getValue()).toEqual(
+          SplitDirection.LEFT
         )
       );
     });

--- a/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
@@ -833,7 +833,7 @@ describe("GeoJsonCatalogItemSpec", () => {
           ?.toCssColorString()
       ).toBe("rgb(103,0,13)");
 
-      expect(geojson.disableSplitter).toBeTruthy();
+      expect(geojson.disableSplitter).toBeFalsy();
     });
 
     it("Supports LegendOwnerTraits to override TableMixin.legends", async () => {
@@ -963,7 +963,7 @@ describe("GeoJsonCatalogItemSpec", () => {
       expect(geojson.useTableStylingAndProtomaps).toBeFalsy();
 
       expect(geojson.legends.length).toBe(0);
-      expect(geojson.disableSplitter).toBeTruthy();
+      expect(geojson.disableSplitter).toBeFalsy();
     });
 
     it("correctly matches feature _id_ with table rowId - with features with empty geoms", async () => {
@@ -1403,10 +1403,20 @@ describe("GeoJsonCatalogItemSpec", () => {
       ).toBeUndefined();
     });
 
-    it("cesium - points - splitter disabled", async function () {
+    it("cesium - points - splitter enabled", async function () {
       terria.addModel(geojson);
       const geojsonString = await loadText("test/GeoJSON/cemeteries.geojson");
       geojson.setTrait(CommonStrata.user, "geoJsonString", geojsonString);
+      await geojson.loadMapItems();
+
+      expect(geojson.disableSplitter).toBeFalsy();
+    });
+
+    it("cesium - only polygons - splitter disabled", async function () {
+      terria.addModel(geojson);
+      const geojsonString = await loadText("test/GeoJSON/api.geojson");
+      geojson.setTrait(CommonStrata.user, "geoJsonString", geojsonString);
+      geojson.setTrait(CommonStrata.user, "forceCesiumPrimitives", true);
       await geojson.loadMapItems();
 
       expect(geojson.disableSplitter).toBeTruthy();


### PR DESCRIPTION
### What this PR does

Merge after https://github.com/TerriaJS/terriajs/pull/7648

Adds splitter support for points and billboards in vector datasets.

### Test me

- Open this CI link
-  Verify that splitter works for points and billboards for CSV and GeoJSON datasets

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
