### PR TITLE
Add coordinate result to mapbox search provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Fix app crash when encountering unsupported WPS input types.
 - Warn the user when the story causes shareData size exceed the limit set on the server as `shareMaxRequestSize`. #7636
 - Adds new `TileMapServiceCatalogItem` for loading Tile Map Service (TMS) imagery tilesets.
+- Add coordinate position to MapboxSearchProvider results when using reverse geocoder functionality (configurable).
 - [The next improvement]
 
 #### 8.10.0 - 2025-07-08

--- a/lib/Models/SearchProviders/MapboxSearchProvider.ts
+++ b/lib/Models/SearchProviders/MapboxSearchProvider.ts
@@ -198,14 +198,13 @@ export default class MapboxSearchProvider extends LocationSearchProviderMixin(
           // A new search has superseded this one, so ignore the result.
           return;
         }
-        let features = result.features;
 
         if (
-          (features.length === 0 &&
+          (result.features.length === 0 &&
             searchDirection === MapboxGeocodeDirection.Forward) ||
           //in the case where coordinate result is true, list is
           //not empty.
-          (features.length === 0 &&
+          (result.features.length === 0 &&
             searchDirection === MapboxGeocodeDirection.Reverse &&
             this.showCoordinatesInReverseGeocodeResult === false)
         ) {
@@ -215,7 +214,7 @@ export default class MapboxSearchProvider extends LocationSearchProviderMixin(
           return;
         }
 
-        const locations: SearchResult[] = features
+        const locations: SearchResult[] = result.features
           .filter(
             (feat) =>
               feat.properties && feat.geometry && feat.properties.full_address

--- a/lib/Models/SearchProviders/MapboxSearchProvider.ts
+++ b/lib/Models/SearchProviders/MapboxSearchProvider.ts
@@ -19,6 +19,7 @@ import SearchResult from "./SearchResult";
 import { Feature, Point } from "@turf/helpers";
 import isDefined from "../../Core/isDefined";
 import CommonStrata from "../Definition/CommonStrata";
+import prettifyCoordinates from "../../Map/Vector/prettifyCoordinates";
 
 enum MapboxGeocodeDirection {
   Forward = "forward",
@@ -95,10 +96,6 @@ export default class MapboxSearchProvider extends LocationSearchProviderMixin(
         isCoordinate.test(lonLat[0]) &&
         isCoordinate.test(lonLat[1])
       ) {
-        const formattedCoordinateString = `${parseFloat(lonLat[0]).toFixed(
-          5
-        )}, ${parseFloat(lonLat[1]).toFixed(5)}`;
-
         // need to reverse the coord order if true.
         if (this.latLonSearchOrder) {
           lonLat = lonLat.reverse();
@@ -106,10 +103,12 @@ export default class MapboxSearchProvider extends LocationSearchProviderMixin(
 
         const [lonf, latf] = lonLat.map(parseFloat);
 
+        const prettyCoords = prettifyCoordinates(lonf, latf);
+
         if (this.showCoordinatesInReverseGeocodeResult) {
           searchResults.results.push(
             new SearchResult({
-              name: formattedCoordinateString,
+              name: `${prettyCoords.latitude}, ${prettyCoords.longitude}`,
               clickAction: createZoomToFunction(this, {
                 geometry: {
                   coordinates: [lonf, latf]

--- a/lib/Models/SearchProviders/MapboxSearchProvider.ts
+++ b/lib/Models/SearchProviders/MapboxSearchProvider.ts
@@ -104,19 +104,21 @@ export default class MapboxSearchProvider extends LocationSearchProviderMixin(
           lonLat = lonLat.reverse();
         }
 
+        const [lonf, latf] = lonLat.map(parseFloat);
+
         if (this.showCoordinatesInReverseGeocodeResult) {
           searchResults.results.push(
             new SearchResult({
               name: formattedCoordinateString,
               clickAction: createZoomToFunction(this, {
                 geometry: {
-                  coordinates: [parseFloat(lonLat[0]), parseFloat(lonLat[1])]
+                  coordinates: [lonf, latf]
                 },
                 properties: {}
               }),
               location: {
-                longitude: parseFloat(lonLat[0]),
-                latitude: parseFloat(lonLat[1])
+                longitude: lonf,
+                latitude: latf
               }
             })
           );

--- a/lib/Models/SearchProviders/MapboxSearchProvider.ts
+++ b/lib/Models/SearchProviders/MapboxSearchProvider.ts
@@ -201,8 +201,13 @@ export default class MapboxSearchProvider extends LocationSearchProviderMixin(
         let features = result.features;
 
         if (
-          features.length === 0 &&
-          searchDirection === MapboxGeocodeDirection.Forward
+          (features.length === 0 &&
+            searchDirection === MapboxGeocodeDirection.Forward) ||
+          //in the case where coordinate result is true, list is
+          //not empty.
+          (features.length === 0 &&
+            searchDirection === MapboxGeocodeDirection.Reverse &&
+            this.showCoordinatesInReverseGeocodeResult === false)
         ) {
           searchResults.message = {
             content: "translate#viewModels.searchNoLocations"

--- a/lib/Models/SearchProviders/MapboxSearchProvider.ts
+++ b/lib/Models/SearchProviders/MapboxSearchProvider.ts
@@ -242,7 +242,6 @@ export default class MapboxSearchProvider extends LocationSearchProviderMixin(
         const attribution = result.attribution;
         if (attribution) {
           runInAction(() => {
-            console.log("in attribution");
             this.setTrait(CommonStrata.underride, "attributions", [
               attribution
             ]);

--- a/lib/Models/SearchProviders/MapboxSearchProvider.ts
+++ b/lib/Models/SearchProviders/MapboxSearchProvider.ts
@@ -103,9 +103,8 @@ export default class MapboxSearchProvider extends LocationSearchProviderMixin(
 
         const [lonf, latf] = lonLat.map(parseFloat);
 
-        const prettyCoords = prettifyCoordinates(lonf, latf);
-
         if (this.showCoordinatesInReverseGeocodeResult) {
+          const prettyCoords = prettifyCoordinates(lonf, latf);
           searchResults.results.push(
             new SearchResult({
               name: `${prettyCoords.latitude}, ${prettyCoords.longitude}`,

--- a/lib/Traits/SearchProviders/MapboxSearchProviderTraits.ts
+++ b/lib/Traits/SearchProviders/MapboxSearchProviderTraits.ts
@@ -77,4 +77,13 @@ export default class MapboxSearchProviderTraits extends mixTraits(
     the default is true, which is familar with most users from other platforms.`
   })
   latLonSearchOrder?: boolean = true;
+
+  @primitiveTrait({
+    type: "boolean",
+    name: "showCoordinatesInReverseGeocodeResult",
+    description: `When the user searches using coordinates, the first result in the list will be the
+    coordinate location. If using in conjunction with another search provider, this behaviour may not
+    be desired. Defaults to true.`
+  })
+  showCoordinatesInReverseGeocodeResult?: boolean = true;
 }

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "terriajs-typings-for-css-modules-loader": "^2.5.2",
     "thredds-catalog-crawler": "0.0.7",
     "ts-essentials": "^5.0.0",
-    "typescript": "^5.7.3",
+    "typescript": "5.7.3",
     "urijs": "^1.18.12",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4",


### PR DESCRIPTION
### What this PR does

Creates a new coordinate location feature when using the reverse geocoder functionality of MapboxSearchProvider, and adds it to the top of the results list.

Without with feature, a coordinate search will always return the nearest address (if close enough geographically). This is not desirable in a lot of cases where users will be wanting to find an exact location using coordinates.

This is configurable using the new trait parameter `showCoordinatesInReverseGeocodeResult`.

examples:
1. the coordinates `-41.107379944951006, 127.56722178479194` are too far from any known address to show results. However, with this feature the user can still go to the exact position:
<img width="594" height="437" alt="image" src="https://github.com/user-attachments/assets/77c65c10-b506-4157-9a59-a5e1314a6fbf" />

2. a user has a coordinate for an asset or POI, and wants to see to that position exactly, without this feature, the nearest address is not helpful as it is unlikely to be the same position.

### Test me

* use the MapboxSearchProvider, be sure to supply your API key.
* with `showCoordinatesInReverseGeocodeResult` set to default (true), search for `-9.30738831489543, 134.48433477770556`. You should get a coordinate position and no addresses.
* with `showCoordinatesInReverseGeocodeResult` set to false, the same search should return no results
* with `showCoordinatesInReverseGeocodeResult` set to default (true), search for `-37.62692208450191, 145.54355658542465`. You should get two results, a coordinate and an address which should be spatially different.

### Checklist

- [ X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ X] I've updated relevant documentation in `doc/`.
- [ X] I've updated CHANGES.md with what I changed.
- [ X] I've provided instructions in the PR description on how to test this PR.
