### PR TITLE
fix: analytics tracking for mapbox search provider should log mapbox action not bing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Add coordinate position to MapboxSearchProvider results when using reverse geocoder functionality (configurable).
 - Removes webpack-dev-server from dependencies as it is no longer used.
 - Upgrade babel to the latest version 7.27/7.28
+- Fix analytics tracking for the MapboxSearchProvider.
 - [The next improvement]
 
 #### 8.10.0 - 2025-07-08

--- a/lib/Core/AnalyticEvents/analyticEvents.ts
+++ b/lib/Core/AnalyticEvents/analyticEvents.ts
@@ -17,7 +17,8 @@ export enum SearchAction {
   catalog = "Catalog",
   gazetteer = "Gazetteer",
   nominatim = "nominatim",
-  cesium = "Cesium"
+  cesium = "Cesium",
+  mapbox = "Mapbox"
 }
 
 export enum LaunchAction {

--- a/lib/Models/SearchProviders/MapboxSearchProvider.ts
+++ b/lib/Models/SearchProviders/MapboxSearchProvider.ts
@@ -61,7 +61,7 @@ export default class MapboxSearchProvider extends LocationSearchProviderMixin(
   protected logEvent(searchText: string) {
     this.terria.analytics?.logEvent(
       Category.search,
-      SearchAction.bing,
+      SearchAction.mapbox,
       searchText
     );
   }


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Bing action is incorrectly logged when mapbox search provider is used

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

~- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)~
~- [ ] I've updated relevant documentation in `doc/`.~
- [X] I've updated CHANGES.md with what I changed.
~- [ ] I've provided instructions in the PR description on how to test this PR.~
