### PR TITLE
Fix Data Preview map not loading upon clicking About Data

### DIFF
--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -75,7 +75,7 @@ class MappablePreview extends Component {
               terria={this.props.terria}
               previewed={catalogItem}
               showMap={
-                !this.props.viewState.explorerPanelAnimating ||
+                this.props.viewState.explorerPanelIsVisible ||
                 this.props.viewState.useSmallScreenInterface
               }
             />


### PR DESCRIPTION
### What this PR does

Fixes #7687

The issue seemed to be caused by a race condition due to the animation checks.

### Test me

Before: 
1. Go to http://ci.terria.io/main, 
2. Load the "GeoJSON Test" item and press "Done" to close the Explorer.
3. Click "About data" and see that the map under "Preview Data" is missing.

After: 
1. Go to http://ci.terria.io/about-data-preview-map
2. Load the "GeoJSON Test" item and press "Done" to close the Explorer.
3. Click "About data" and see that the map under "Preview Data" has loaded.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
