### PR TITLE
Add description to CatalogIndexReference doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Reviewers are welcome to make minor edits to a pull request (e.g. fixing typos) 
 
 After you merge a pull request, delete the associated branch if you can. You will see an option for this on the GitHub pull request page.
 
-More information in the [Contributor's Guide](https://terria.io/Documentation/guide/contributing/)
+More information in the [Contributor's Guide](https://docs.terria.io/guide/contributing/)
 
 ## License
 

--- a/lib/Traits/TraitsClasses/CatalogIndexReferenceTraits.ts
+++ b/lib/Traits/TraitsClasses/CatalogIndexReferenceTraits.ts
@@ -1,6 +1,7 @@
 import primitiveArrayTrait from "../Decorators/primitiveArrayTrait";
 import primitiveTrait from "../Decorators/primitiveTrait";
 import mixTraits from "../mixTraits";
+import { traitClass } from "../Trait";
 import CatalogMemberReferenceTraits from "./CatalogMemberReferenceTraits";
 
 @traitClass({

--- a/lib/Traits/TraitsClasses/CatalogIndexReferenceTraits.ts
+++ b/lib/Traits/TraitsClasses/CatalogIndexReferenceTraits.ts
@@ -3,6 +3,14 @@ import primitiveTrait from "../Decorators/primitiveTrait";
 import mixTraits from "../mixTraits";
 import CatalogMemberReferenceTraits from "./CatalogMemberReferenceTraits";
 
+@traitClass({
+  description: `See [CatalogIndex](/guide/customizing/search-providers/#catalogindex) guide. 
+
+If your TerriaMap has many dynamic groups which need to be loaded, it may be worth generating a static catalog index JSON file.
+- \`yarn build-tools\`
+- \`node ./build/generateCatalogIndex.js -c config-url -b base-url\``
+})
+  
 export default class CatalogIndexReferenceTraits extends mixTraits(
   CatalogMemberReferenceTraits
 ) {

--- a/lib/Traits/TraitsClasses/CatalogIndexReferenceTraits.ts
+++ b/lib/Traits/TraitsClasses/CatalogIndexReferenceTraits.ts
@@ -8,6 +8,7 @@ import CatalogMemberReferenceTraits from "./CatalogMemberReferenceTraits";
   description: `See [CatalogIndex](/guide/customizing/search-providers/#catalogindex) guide. 
 
 If your TerriaMap has many dynamic groups which need to be loaded, it may be worth generating a static catalog index JSON file.
+
 - \`yarn build-tools\`
 - \`node ./build/generateCatalogIndex.js -c config-url -b base-url\``
 })

--- a/lib/Traits/TraitsClasses/CatalogIndexReferenceTraits.ts
+++ b/lib/Traits/TraitsClasses/CatalogIndexReferenceTraits.ts
@@ -12,7 +12,6 @@ If your TerriaMap has many dynamic groups which need to be loaded, it may be wor
 - \`yarn build-tools\`
 - \`node ./build/generateCatalogIndex.js -c config-url -b base-url\``
 })
-  
 export default class CatalogIndexReferenceTraits extends mixTraits(
   CatalogMemberReferenceTraits
 ) {


### PR DESCRIPTION

### What this PR does

The `CatalogIndexReference` could add a reference to the `search-providers/#catalogindex` page to help understand what this catalog reference item type does. 

### Test me
Build doc and test doc page 

Before: https://docs.terria.io/guide/connecting-to-data/catalog-type-details/catalog-index-reference/

After: https://deploy-preview-7702--terriajs-docs-v8.netlify.app/guide/connecting-to-data/catalog-type-details/catalog-index-reference/

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
