### PR TITLE
Tentative fix in ArcGisPortalItemReference.ts for 

### DIFF
--- a/lib/Models/Catalog/Esri/ArcGisPortalItemReference.ts
+++ b/lib/Models/Catalog/Esri/ArcGisPortalItemReference.ts
@@ -96,7 +96,7 @@ export class ArcGisPortalItemStratum extends LoadableStratum(
     if (this.arcgisPortalItem.type === "Scene Service")
       return `/i3s-to-3dtiles/${this.arcgisPortalItem.url}`;
     if (this.arcgisPortalItem.type === "Web Map")
-      return this.arcgisPortalItem._portalRootUrl;
+      return this.arcgisPortalItemReference._portalRootUrl;
     return this.arcgisPortalItem.url;
   }
 

--- a/lib/Models/Catalog/Esri/ArcGisPortalItemReference.ts
+++ b/lib/Models/Catalog/Esri/ArcGisPortalItemReference.ts
@@ -95,6 +95,8 @@ export class ArcGisPortalItemStratum extends LoadableStratum(
     if (this.arcgisPortalItem === undefined) return undefined;
     if (this.arcgisPortalItem.type === "Scene Service")
       return `/i3s-to-3dtiles/${this.arcgisPortalItem.url}`;
+    if (this.arcgisPortalItem.type === "Web Map")
+      return this.arcgisPortalItem._portalRootUrl;
     return this.arcgisPortalItem.url;
   }
 


### PR DESCRIPTION
Should allow handling of ArcGisPortalItemReference not only served by ArcGIS Enterprise Portals but also ArcGIS Online “Experience Builder 

See reference here 
https://github.com/TerriaJS/terriajs/issues/4937#issuecomment-3351340001

### What this PR does

Fixes #4937

WIP this is just an attempt at fixing error described in linked comment. 

### Test me

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
