### PR TITLE
Bump version to 8.11.0.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
-#### next release (8.10.1)
+#### next release (8.11.1)
+
+- [The next improvement]
+
+#### 8.11.0 - 2025-10-09
 
 - **Breaking changes:**
 
@@ -18,8 +22,8 @@
 - Remove unmaintained @mapbox/geojson-merge dependency and replace it with a simple merge function.
 - Upgrade Typescript to `^5.9.2`. Also switched the `target` in `tsconfig.json` to `esnext`.
 - Upgrade `mobx` to version `^6.13.7`.
+- Upgraded `terriajs-cesium` to `21.0.0` and `terriajs-cesium-widgets` to `13.2.0`.
 - Fix zooming by mouse wheel in charts #7654
-- [The next improvement]
 
 #### 8.10.0 - 2025-07-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.10.0",
+  "version": "8.11.0",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### What this PR does

Release version 8.11.0.

Changes in this release:
- **Breaking changes:**

  - Replace unmaintained `svg-sprite-loader` with custom implementation of SvgSprite plugin based on `svg-sprite` package.
    - New implementation consists of svg sprite loader that loads svgs and svg webpack plugin that compiles them into a single sprite file.

- Fix app crash when switching back and forth between 3D and 2D mode with clipping box enabled.
- Fix app crash when encountering unsupported WPS input types.
- Warn the user when the story causes shareData size exceed the limit set on the server as `shareMaxRequestSize`. #7636
- Adds new `TileMapServiceCatalogItem` for loading Tile Map Service (TMS) imagery tilesets.
- Add coordinate position to MapboxSearchProvider results when using reverse geocoder functionality (configurable).
- Removes webpack-dev-server from dependencies as it is no longer used.
- Upgrade babel to the latest version 7.27/7.28
- Fix analytics tracking for the MapboxSearchProvider.
- Remove unmaintained @mapbox/geojson-merge dependency and replace it with a simple merge function.
- Upgrade Typescript to `^5.9.2`. Also switched the `target` in `tsconfig.json` to `esnext`.
- Upgrade `mobx` to version `^6.13.7`.
- Upgraded `terriajs-cesium` to `21.0.0`.
- Fix zooming by mouse wheel in charts #7654


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
