### PR TITLE
Fix preview outside explorer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.11.1)
 
+- Fix to show preview map when used outside the explorer panel.
 - [The next improvement]
 
 #### 8.11.0 - 2025-10-09

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -74,10 +74,7 @@ class MappablePreview extends Component {
             <DataPreviewMap
               terria={this.props.terria}
               previewed={catalogItem}
-              showMap={
-                this.props.viewState.explorerPanelIsVisible ||
-                this.props.viewState.useSmallScreenInterface
-              }
+              showMap
             />
           )}
         <button


### PR DESCRIPTION
### What this PR does

The preview map is sometimes used outside the explorer context. This fix ensures it is always shown. It was previously hidden if the explorer panel is animating but that check had [to be removed](https://github.com/TerriaJS/terriajs/pull/7691) to fix a race condition. This change makes it so that the preview map is always shown.


### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
