### PR TITLE
Keep camera steady when switching between viewer modes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Update docs for Client-side config: change `searchBar` parameter to `searchBarConfig`
 - Fix to show preview map when used outside the explorer panel.
 - Update `csv-geo-au` support to include the latest Australian Government regions.
+- Keep camera steady when switching between viewer modes.
 - [The next improvement]
 
 #### 8.11.0 - 2025-10-09

--- a/lib/Models/GlobeOrMap.ts
+++ b/lib/Models/GlobeOrMap.ts
@@ -103,6 +103,11 @@ export default abstract class GlobeOrMap {
     );
   }
 
+  /**
+   * Set initial camera view
+   */
+  abstract setInitialView(cameraView: CameraView): void;
+
   abstract getCurrentCameraView(): CameraView;
 
   /* Gets the current container element.

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -90,6 +90,11 @@ export default class Leaflet extends GlobeOrMap {
   @observable nw: L.Point | undefined;
   @observable se: L.Point | undefined;
 
+  /**
+   * Initial view set when the viewer is created
+   */
+  private _initialView: CameraView | undefined;
+
   @action
   private updateMapObservables() {
     this.size = this.map.getSize();
@@ -339,6 +344,7 @@ export default class Leaflet extends GlobeOrMap {
     this.dataSourceDisplay.destroy();
     this.map.off("move");
     this.map.off("zoom");
+    this.map.off("zoomlevelschange");
     this.map.remove();
   }
 
@@ -501,7 +507,6 @@ export default class Leaflet extends GlobeOrMap {
       return Promise.resolve();
     }
     let bounds;
-
     if (isDefined(target.entities)) {
       if (isDefined(this.dataSourceDisplay)) {
         bounds = this.dataSourceDisplay.getLatLngBounds(target);
@@ -549,7 +554,30 @@ export default class Leaflet extends GlobeOrMap {
     return Promise.resolve();
   }
 
+  setInitialView(view: CameraView) {
+    this.doZoomTo(view, 0);
+    this._initialView = view;
+    this.map.addOneTimeEventListener("move", () => {
+      this._initialView = undefined;
+    });
+  }
+
+  /**
+   * Return the initial view if it hasn't changed. Otherwise return undefined.
+   */
+  getInitialView(): CameraView | undefined {
+    return this._initialView;
+  }
+
   getCurrentCameraView(): CameraView {
+    // Return the initial view if the camera hasn't changed since setting it.
+    // This ensures that the view remains constant when switching between
+    // viewer modes.
+    const initialView = this.getInitialView();
+    if (initialView) {
+      return initialView;
+    }
+
     const bounds = this.map.getBounds();
     return new CameraView(
       Rectangle.fromDegrees(

--- a/lib/Models/NoViewer.ts
+++ b/lib/Models/NoViewer.ts
@@ -36,6 +36,10 @@ class NoViewer extends GlobeOrMap {
     return Promise.resolve();
   }
 
+  setInitialView(view: CameraView) {
+    this._currentView = view;
+  }
+
   notifyRepaintRequired(): void {}
 
   pickFromLocation(

--- a/lib/ViewModels/TerriaViewer.ts
+++ b/lib/ViewModels/TerriaViewer.ts
@@ -220,7 +220,7 @@ export default class TerriaViewer {
     }
 
     this._lastViewer = newViewer;
-    newViewer.zoomTo(currentView || untracked(() => this.homeCamera), 0.0);
+    newViewer.setInitialView(currentView || untracked(() => this.homeCamera));
 
     return newViewer;
   }

--- a/test/Models/CesiumSpec.ts
+++ b/test/Models/CesiumSpec.ts
@@ -435,7 +435,7 @@ describeIfSupported("Cesium Model", function () {
   });
 
   describe("getCurrentCameraView", function () {
-    let rectangleDegrees = ({ west, south, east, north }: Rectangle) => ({
+    const rectangleDegrees = ({ west, south, east, north }: Rectangle) => ({
       west: CesiumMath.toDegrees(west),
       south: CesiumMath.toDegrees(south),
       east: CesiumMath.toDegrees(east),
@@ -454,7 +454,7 @@ describeIfSupported("Cesium Model", function () {
     });
 
     describe("when initial camera view is set", function () {
-      let viewRectangle = {
+      const viewRectangle = {
         west: 119.04785,
         south: -33.6512,
         east: 156.31347,

--- a/test/Models/CesiumSpec.ts
+++ b/test/Models/CesiumSpec.ts
@@ -475,10 +475,7 @@ describeIfSupported("Cesium Model", function () {
       });
 
       it("returns a new view if the camera view changes", async function () {
-        await cesium.doZoomTo(
-          Rectangle.fromDegrees(107.53236, -17.32317, 151.45236, 6.61319),
-          0
-        );
+        cesium.scene.camera.changed.raiseEvent(1.0);
         const view = cesium.getCurrentCameraView();
         const rectangle = rectangleDegrees(view.rectangle);
         expect(rectangle.west).not.toBe(119.04785);

--- a/test/Models/CesiumSpec.ts
+++ b/test/Models/CesiumSpec.ts
@@ -476,7 +476,8 @@ describeIfSupported("Cesium Model", function () {
 
       it("returns a new view if the camera view changes", async function () {
         await cesium.doZoomTo(
-          Rectangle.fromDegrees(107.53236, -17.32317, 151.45236, 6.61319)
+          Rectangle.fromDegrees(107.53236, -17.32317, 151.45236, 6.61319),
+          0
         );
         const view = cesium.getCurrentCameraView();
         const rectangle = rectangleDegrees(view.rectangle);

--- a/test/Models/CesiumSpec.ts
+++ b/test/Models/CesiumSpec.ts
@@ -3,6 +3,7 @@ import { action, computed, observable, runInAction, when } from "mobx";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import CesiumTerrainProvider from "terriajs-cesium/Source/Core/CesiumTerrainProvider";
 import EllipsoidTerrainProvider from "terriajs-cesium/Source/Core/EllipsoidTerrainProvider";
+import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 import GeoJsonDataSource from "terriajs-cesium/Source/DataSources/GeoJsonDataSource";
 import Cesium3DTileset from "terriajs-cesium/Source/Scene/Cesium3DTileset";
@@ -10,7 +11,9 @@ import Scene from "terriajs-cesium/Source/Scene/Scene";
 import WebMapServiceImageryProvider from "terriajs-cesium/Source/Scene/WebMapServiceImageryProvider";
 import filterOutUndefined from "../../lib/Core/filterOutUndefined";
 import runLater from "../../lib/Core/runLater";
+import supportsWebGL from "../../lib/Core/supportsWebGL";
 import MappableMixin, { MapItem } from "../../lib/ModelMixins/MappableMixin";
+import CameraView from "../../lib/Models/CameraView";
 import CesiumTerrainCatalogItem from "../../lib/Models/Catalog/CatalogItems/CesiumTerrainCatalogItem";
 import CatalogMemberFactory from "../../lib/Models/Catalog/CatalogMemberFactory";
 import WebMapServiceCatalogItem from "../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
@@ -24,7 +27,6 @@ import MappableTraits, {
   RectangleTraits
 } from "../../lib/Traits/TraitsClasses/MappableTraits";
 import TerriaViewer from "../../lib/ViewModels/TerriaViewer";
-import supportsWebGL from "../../lib/Core/supportsWebGL";
 
 const describeIfSupported = supportsWebGL() ? describe : xdescribe;
 
@@ -429,6 +431,60 @@ describeIfSupported("Cesium Model", function () {
       expect(currentNotificationTitle).toBe(
         "map.cesium.terrainServerErrorTitle"
       );
+    });
+  });
+
+  describe("getCurrentCameraView", function () {
+    let rectangleDegrees = ({ west, south, east, north }: Rectangle) => ({
+      west: CesiumMath.toDegrees(west),
+      south: CesiumMath.toDegrees(south),
+      east: CesiumMath.toDegrees(east),
+      north: CesiumMath.toDegrees(north)
+    });
+
+    it("returns the current camera view", function () {
+      const cameraView = cesium.getCurrentCameraView();
+      const { west, south, east, north } = rectangleDegrees(
+        cameraView.rectangle
+      );
+      expect(west).toBeCloseTo(-180);
+      expect(south).toBeCloseTo(-90);
+      expect(east).toBeCloseTo(180);
+      expect(north).toBeCloseTo(90);
+    });
+
+    describe("when initial camera view is set", function () {
+      let viewRectangle = {
+        west: 119.04785,
+        south: -33.6512,
+        east: 156.31347,
+        north: -22.83694
+      };
+
+      beforeEach(function () {
+        const initialView = CameraView.fromJson(viewRectangle);
+        cesium.setInitialView(initialView);
+      });
+
+      it("returns the initial view", function () {
+        const r = rectangleDegrees(cesium.getCurrentCameraView().rectangle);
+        expect(r.west).toBe(viewRectangle.west);
+        expect(r.south).toBe(viewRectangle.south);
+        expect(r.east).toBe(viewRectangle.east);
+        expect(r.north).toBe(viewRectangle.north);
+      });
+
+      it("returns a new view if the camera view changes", async function () {
+        await cesium.doZoomTo(
+          Rectangle.fromDegrees(107.53236, -17.32317, 151.45236, 6.61319)
+        );
+        const view = cesium.getCurrentCameraView();
+        const rectangle = rectangleDegrees(view.rectangle);
+        expect(rectangle.west).not.toBe(119.04785);
+        expect(rectangle.south).not.toBe(-33.6512);
+        expect(rectangle.east).not.toBe(156.31347);
+        expect(rectangle.north).not.toBe(-22.83694);
+      });
     });
   });
 });

--- a/test/Models/LeafletSpec.ts
+++ b/test/Models/LeafletSpec.ts
@@ -186,7 +186,7 @@ describe("Leaflet Model", function () {
   });
 
   describe("getCurrentCameraView", function () {
-    let rectangleDegrees = ({ west, south, east, north }: Rectangle) => ({
+    const rectangleDegrees = ({ west, south, east, north }: Rectangle) => ({
       west: CesiumMath.toDegrees(west),
       south: CesiumMath.toDegrees(south),
       east: CesiumMath.toDegrees(east),
@@ -207,7 +207,7 @@ describe("Leaflet Model", function () {
     });
 
     describe("when initial camera view is set", function () {
-      let viewRectangle = {
+      const viewRectangle = {
         west: 119.04785,
         south: -33.6512,
         east: 156.31347,

--- a/test/Models/LeafletSpec.ts
+++ b/test/Models/LeafletSpec.ts
@@ -193,19 +193,6 @@ describe("Leaflet Model", function () {
       north: CesiumMath.toDegrees(north)
     });
 
-    it("returns the current camera view", function () {
-      const cameraView = leaflet.getCurrentCameraView();
-      const { west, south, east, north } = rectangleDegrees(
-        cameraView.rectangle
-      );
-      // These values match the hard-coded coordinates in call to map.setView()
-      // during Leaflet initialization
-      expect(west).toBeCloseTo(98.085);
-      expect(south).toBeCloseTo(-28.5);
-      expect(east).toBeCloseTo(171.914);
-      expect(north).toBeCloseTo(-28.497);
-    });
-
     describe("when initial camera view is set", function () {
       const viewRectangle = {
         west: 119.04785,

--- a/test/Models/LeafletSpec.ts
+++ b/test/Models/LeafletSpec.ts
@@ -1,5 +1,8 @@
 import L from "leaflet";
 import { action, computed, when } from "mobx";
+import CesiumMath from "terriajs-cesium/Source/Core/Math";
+import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
+import CameraView from "../../lib/Models/CameraView";
 import WebMapServiceCatalogItem from "../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
 import CommonStrata from "../../lib/Models/Definition/CommonStrata";
 import createStratumInstance from "../../lib/Models/Definition/createStratumInstance";
@@ -179,6 +182,62 @@ describe("Leaflet Model", function () {
       expect(longitude).not.toBeNaN();
       expect(latitude).not.toBeNaN();
       expect(height).toBe(0);
+    });
+  });
+
+  describe("getCurrentCameraView", function () {
+    let rectangleDegrees = ({ west, south, east, north }: Rectangle) => ({
+      west: CesiumMath.toDegrees(west),
+      south: CesiumMath.toDegrees(south),
+      east: CesiumMath.toDegrees(east),
+      north: CesiumMath.toDegrees(north)
+    });
+
+    it("returns the current camera view", function () {
+      const cameraView = leaflet.getCurrentCameraView();
+      const { west, south, east, north } = rectangleDegrees(
+        cameraView.rectangle
+      );
+      // These values match the hard-coded coordinates in call to map.setView()
+      // during Leaflet initialization
+      expect(west).toBeCloseTo(98.085);
+      expect(south).toBeCloseTo(-28.5);
+      expect(east).toBeCloseTo(171.914);
+      expect(north).toBeCloseTo(-28.497);
+    });
+
+    describe("when initial camera view is set", function () {
+      let viewRectangle = {
+        west: 119.04785,
+        south: -33.6512,
+        east: 156.31347,
+        north: -22.83694
+      };
+
+      beforeEach(function () {
+        const initialView = CameraView.fromJson(viewRectangle);
+        leaflet.setInitialView(initialView);
+      });
+
+      it("returns the initial view", function () {
+        const r = rectangleDegrees(leaflet.getCurrentCameraView().rectangle);
+        expect(r.west).toBe(viewRectangle.west);
+        expect(r.south).toBe(viewRectangle.south);
+        expect(r.east).toBe(viewRectangle.east);
+        expect(r.north).toBe(viewRectangle.north);
+      });
+
+      it("returns a new view if the camera view changes", async function () {
+        await leaflet.doZoomTo(
+          Rectangle.fromDegrees(107.53236, -17.32317, 151.45236, 6.61319)
+        );
+        const view = leaflet.getCurrentCameraView();
+        const rectangle = rectangleDegrees(view.rectangle);
+        expect(rectangle.west).not.toBe(119.04785);
+        expect(rectangle.south).not.toBe(-33.6512);
+        expect(rectangle.east).not.toBe(156.31347);
+        expect(rectangle.north).not.toBe(-22.83694);
+      });
     });
   });
 });

--- a/test/ViewModels/TerriaViewerSpec.ts
+++ b/test/ViewModels/TerriaViewerSpec.ts
@@ -74,7 +74,7 @@ describe("TerriaViewer", function () {
   });
 
   describe("currentViewer", function () {
-    let rectangleDegrees = ({ west, south, east, north }: Rectangle) => ({
+    const rectangleDegrees = ({ west, south, east, north }: Rectangle) => ({
       west: CesiumMath.toDegrees(west),
       south: CesiumMath.toDegrees(south),
       east: CesiumMath.toDegrees(east),

--- a/test/ViewModels/TerriaViewerSpec.ts
+++ b/test/ViewModels/TerriaViewerSpec.ts
@@ -18,14 +18,14 @@ describe("TerriaViewer", function () {
     });
     container = document.createElement("div");
     document.body.appendChild(container);
-    terria.mainViewer.attach(container);
-    terriaViewer = terria.mainViewer;
     terria.loadHomeCamera({
       west: 45,
       south: -20,
       east: 55,
       north: -10
     });
+    terria.mainViewer.attach(container);
+    terriaViewer = terria.mainViewer;
 
     setViewerMode("3d", terriaViewer);
 

--- a/test/ViewModels/TerriaViewerSpec.ts
+++ b/test/ViewModels/TerriaViewerSpec.ts
@@ -1,6 +1,8 @@
+import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import Terria from "../../lib/Models/Terria";
 import ViewerMode, { setViewerMode } from "../../lib/Models/ViewerMode";
 import TerriaViewer from "../../lib/ViewModels/TerriaViewer";
+import Rectangle from "terriajs-cesium/Source/Core/Rectangle";
 
 const mockBeforeViewerChanges = jasmine.createSpy("", () => {});
 const mockAfterViewerChanges = jasmine.createSpy("", () => {});
@@ -68,6 +70,25 @@ describe("TerriaViewer", function () {
       expect(mockBeforeViewerChanges).toHaveBeenCalledTimes(2);
       expect(mockAfterViewerChanges).toHaveBeenCalledTimes(2);
       expect(terriaViewer.viewerMode).toBe(ViewerMode.Cesium);
+    });
+  });
+
+  describe("currentViewer", function () {
+    let rectangleDegrees = ({ west, south, east, north }: Rectangle) => ({
+      west: CesiumMath.toDegrees(west),
+      south: CesiumMath.toDegrees(south),
+      east: CesiumMath.toDegrees(east),
+      north: CesiumMath.toDegrees(north)
+    });
+
+    it("should return the home camera view", function () {
+      const r = rectangleDegrees(
+        terriaViewer.currentViewer.getCurrentCameraView().rectangle
+      );
+      expect(r.west).toBe(45);
+      expect(r.south).toBe(-20);
+      expect(r.east).toBe(55);
+      expect(r.north).toBe(-10);
     });
   });
 });


### PR DESCRIPTION
Split from #7626 
Required for #6845 

### What this PR does

Track initial camera view for viewers and return the same view unless the viewer camera has changed.

Previously, the camera view would drift when switching between viewer modes. This is because each time we switch the viewer, we get the current view from leaflet/cesium instance and the value changes slightly each time depending on how the viewer sets the camera. The drift becomes even more noticeable when using custom projections and the extent used with the custom projection is not compatible with the other map modes. This can be a problem when restoring share links and the viewer is first initialized in 3d/cesium mode and then switches to leaflet/2d mode.

This change makes sure that the view remains stable if the camera hasn't changed after setting the initial view.

### Test me

- Open this main branch [CI link](http://ci.terria.io/main)
- Then from the settings panel, switch between 3D and 2D a few times (7-8 times)
- Observe the camera view drift from home camera (Australia) to the global view.
- Now repeat the same with [this branch](http://ci.terria.io/initial-camera-view)
- Observe that the camera view is stable no matter how many times we switch the viewer modes.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
