### PR TITLE
Update model-dimensions.md

### DIFF
--- a/doc/connecting-to-data/customizing-data-appearance/model-dimensions.md
+++ b/doc/connecting-to-data/customizing-data-appearance/model-dimensions.md
@@ -4,13 +4,13 @@ Model dimensions can be used to define dropdown menus in the workbench that upda
 
 ## Basic example
 
-For example - this renders a new drop down called "Color" that changes the `colorPalette` trait - [test link](http://ci.terria.io/main/#clean&start={%22initSources%22%3A[{%22homeCamera%22%3A{%22north%22%3A-8%2C%22east%22%3A158%2C%22south%22%3A-45%2C%22west%22%3A109}%2C%22workbench%22%3A[%22test%22]%2C%22catalog%22%3A[{%22type%22%3A%22csv%22%2C%22url%22%3A%22test%2FNSW_LGA_NEXIS_201212.csv%22%2C%22name%22%3A%22NSWLGANEXIS2012%22%2C%22id%22%3A%22test%22%2C%22modelDimensions%22%3A[{%22id%22%3A%22cols%22%2C%22name%22%3A%22Color%22%2C%22selectedId%22%3A%22Red%22%2C%22options%22%3A[{%22id%22%3A%22Red%22%2C%22value%22%3A{%22defaultStyle%22%3A{%22color%22%3A{%22colorPalette%22%3A%22Reds%22}}}}%2C{%22id%22%3A%22Blue%22%2C%22value%22%3A{%22defaultStyle%22%3A{%22color%22%3A{%22colorPalette%22%3A%22Blues%22}}}}]}]}]}]})
+For example - this renders a new drop down called "Color" that changes the `colorPalette` trait - [example link](http://ci.terria.io/main/#clean&start={%22initSources%22%3A[{%22homeCamera%22%3A{%22north%22%3A-8%2C%22east%22%3A158%2C%22south%22%3A-45%2C%22west%22%3A109}%2C%22workbench%22%3A[%22test%22]%2C%22catalog%22%3A[{%22type%22%3A%22csv%22%2C%22url%22%3A%22test%2Fexample_data.csv%22%2C%22name%22%3A%22ExampleDataset%22%2C%22id%22%3A%22test%22%2C%22modelDimensions%22%3A[{%22id%22%3A%22cols%22%2C%22name%22%3A%22Color%22%2C%22selectedId%22%3A%22Red%22%2C%22options%22%3A[{%22id%22%3A%22Red%22%2C%22value%22%3A{%22defaultStyle%22%3A{%22color%22%3A{%22colorPalette%22%3A%22Reds%22}}}}%2C{%22id%22%3A%22Blue%22%2C%22value%22%3A{%22defaultStyle%22%3A{%22color%22%3A{%22colorPalette%22%3A%22Blues%22}}}}]}]}]}]})
 
 ```json
 {
   "type": "csv",
-  "url": "test/NSW_LGA_NEXIS_201212.csv",
-  "name": "NSW LGA NEXIS 2012",
+  "url": "test/example_data.csv",
+  "name": "Example dataset",
   "modelDimensions": [
     {
       "id": "cols",
@@ -52,8 +52,8 @@ Model dimensions also supports the use of [Mustache templates](https://mustache.
 ```json
 {
   "type": "csv",
-  "url": "test/NSW_LGA_NEXIS_201212.csv",
-  "name": "NSW LGA NEXIS 2012",
+  "url": "test/example_data.csv",
+  "name": "Example dataset",
   "modelDimensions": [
     {
       "id": "Cols",


### PR DESCRIPTION
### What this PR does
This PR replaces outdated references to the **Nexis dataset** in `model-dimensions.md`  
with a new example dataset (`example_data.csv`), since Nexis data is no longer publicly available.

Fixes https://github.com/TerriaJS/terriajs/issues/7655

### Why this change
- Nexis dataset is no longer accessible to the public.
- The updated example (`example_data.csv`) keeps the documentation functional and self-contained.
- No code or behavior changes — documentation only.

### Test me
Before: https://docs.terria.io/guide/connecting-to-data/customizing-data-appearance/model-dimensions/
After: https://deploy-preview-7724--terriajs-docs-v8.netlify.app/guide/connecting-to-data/customizing-data-appearance/model-dimensions/

### Checklist
- [x] Documentation updated in `doc/`.
- [x] Verified rendered Markdown preview looks correct.
- [x] No code or functional changes required.
