### PR TITLE
Release version 8.11.1.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,13 @@
 # Change Log
 
-#### next release (8.11.1)
+#### next release (8.11.2)
 
+- [The next improvement]
+
+#### 8.11.1 - 2025-12-04
+
+- ##### Security fixes
+  - Upgrades terriajs-server to v4.0.3. See [terriajs-server changes](https://github.com/TerriaJS/terriajs-server/blob/master/CHANGES.md#security-fixes).
 - Fix translations key typo "zoomCotrol".
 - Update docs for Client-side config: change `searchBar` parameter to `searchBarConfig`
 - Fix to show preview map when used outside the explorer panel.
@@ -9,7 +15,6 @@
 - Add `backgroundColor` trait to base maps for changing the map container background in 2D/Leaflet mode ([7718](https://github.com/TerriaJS/terriajs/pull/7718))
 - Keep camera steady when switching between viewer modes.
 - Fix a bug where some georeferenced tiles where incorrectly positioned in Terria.
-- [The next improvement]
 
 #### 8.11.0 - 2025-10-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.11.0",
+  "version": "8.11.1",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {
@@ -157,7 +157,7 @@
     "shpjs": "^6.1.0",
     "style-loader": "^4.0.0",
     "styled-components": "^5.3.11",
-    "terriajs-cesium": "21.0.0",
+    "terriajs-cesium": "21.0.1",
     "terriajs-cesium-widgets": "13.2.0",
     "terriajs-html2canvas": "1.0.0-alpha.12-terriajs-1",
     "terriajs-tiff-imagery-provider": "2.13.3-webpack5-3",
@@ -209,7 +209,7 @@
     "react-test-renderer": "^18.3.1",
     "sass": "^1.81.0",
     "svg-sprite": "^2.0.4",
-    "terriajs-server": "^4.0.2",
+    "terriajs-server": "^4.0.3",
     "utf-8-validate": "^6.0.3",
     "yaml": "^1.10.0"
   },


### PR DESCRIPTION
### What this PR does

Release v8.11.1

Also:
 -  upgrades `terriajs-server` to `4.0.3` that contains a [security fix](https://github.com/TerriaJS/terriajs-server/blob/master/CHANGES.md#security-fixes).
 - upgrades `terriajs-cesium` to `21.0.1` that contains a [fix for webpack](https://github.com/TerriaJS/cesium/pull/95) that is breaking the map in [CI/main](http://ci.terria.io/main)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
