### PR TITLE
Make StoryPanel draggable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Add `workbenchControlFlags` trait to all catalog members for enabling or disabling workbench controls.
 - Add `<settingspanel>` custom component to open Map settings panel from template code (like short report, feature info etc).
 - Add UI to show toast messages.
+- Make `<StoryPanel>` draggable
 - [The next improvement]
 
 #### 8.11.1 - 2025-12-04

--- a/lib/ReactViews/Drag/DragWrapper.tsx
+++ b/lib/ReactViews/Drag/DragWrapper.tsx
@@ -4,7 +4,7 @@ import { useDraggable } from "./useDraggable";
 
 interface DragWrapperProps {
   handleSelector?: string;
-  css?: CSSProp;
+  wrapperCSS?: CSSProp;
   style?: React.CSSProperties;
   children: ReactNode;
 }
@@ -13,14 +13,14 @@ const DragWrapper: FC<DragWrapperProps> = ({
   children,
   handleSelector,
   style,
-  css
+  wrapperCSS
 }) => {
   const [ref] = useDraggable({
     handleSelector
   });
 
   return (
-    <div css={css} style={style} ref={ref}>
+    <div css={wrapperCSS} style={style} ref={ref}>
       {children}
     </div>
   );

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
@@ -272,7 +272,7 @@ const StandardUserInterfaceBase: FC<StandardUserInterfaceProps> = observer(
                 }
               )}
               tabIndex={0}
-              onClick={action(() => {
+              onPointerDown={action(() => {
                 props.viewState.topElement = "FeatureInfo";
               })}
             >
@@ -285,10 +285,14 @@ const StandardUserInterfaceBase: FC<StandardUserInterfaceProps> = observer(
                   Styles.storyPanel,
                   props.viewState.topElement === "StoryPanel"
                     ? "top-element"
-                    : ""
+                    : "",
+                  {
+                    [Styles.storyPanelFullScreen]:
+                      props.viewState.isMapFullScreen
+                  }
                 )}
                 tabIndex={0}
-                onClick={action(() => {
+                onPointerDown={action(() => {
                   props.viewState.topElement = "StoryPanel";
                 })}
               >

--- a/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
+++ b/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
@@ -279,7 +279,22 @@ const StandardUserInterfaceBase: FC<StandardUserInterfaceProps> = observer(
               <FeatureInfoPanel />
             </div>
             <DragDropFile />
-            {showStoryPanel && <StoryPanel />}
+            {showStoryPanel && (
+              <div
+                className={classNames(
+                  Styles.storyPanel,
+                  props.viewState.topElement === "StoryPanel"
+                    ? "top-element"
+                    : ""
+                )}
+                tabIndex={0}
+                onClick={action(() => {
+                  props.viewState.topElement = "StoryPanel";
+                })}
+              >
+                <StoryPanel />
+              </div>
+            )}
           </div>
           {props.terria.configParameters.storyEnabled && showStoryBuilder && (
             <StoryBuilder

--- a/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
+++ b/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
@@ -95,7 +95,7 @@
   pointer-events: none;
   left: 0;
 
-  @media (min-width: variables.$md) {
+  @media (min-width: variables.$sm) {
     left: variables.$work-bench-width + 22px;
     top: 62px;
     right: 96px;
@@ -138,7 +138,7 @@
   pointer-events: none;
   left: 0;
 
-  @media (min-width: variables.$md) {
+  @media (min-width: variables.$sm) {
     left: variables.$work-bench-width + 22px;
     top: 62px;
     right: 96px;

--- a/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
+++ b/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
@@ -125,10 +125,6 @@
   }
 }
 
-.featureInfoFullScreen {
-  left: 0;
-}
-
 .storyPanel {
   z-index: variables.$front-component-z-index - 20;
   position: absolute;
@@ -149,6 +145,11 @@
     pointer-events: auto;
     position: absolute;
   }
+}
+
+.featureInfoFullScreen,
+.storyPanelFullScreen {
+  left: 0;
 }
 
 .showWorkbenchButton {

--- a/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
+++ b/lib/ReactViews/StandardUserInterface/standard-user-interface.scss
@@ -129,6 +129,28 @@
   left: 0;
 }
 
+.storyPanel {
+  z-index: variables.$front-component-z-index - 20;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  pointer-events: none;
+  left: 0;
+
+  @media (min-width: variables.$md) {
+    left: variables.$work-bench-width + 22px;
+    top: 62px;
+    right: 96px;
+    bottom: 0;
+  }
+
+  & > div {
+    pointer-events: auto;
+    position: absolute;
+  }
+}
+
 .showWorkbenchButton {
   position: fixed;
   top: 18px;

--- a/lib/ReactViews/StandardUserInterface/standard-user-interface.scss.d.ts
+++ b/lib/ReactViews/StandardUserInterface/standard-user-interface.scss.d.ts
@@ -11,6 +11,7 @@ declare namespace StandardUserInterfaceScssNamespace {
     showWorkbenchButtonisVisible: string;
     sidePanel: string;
     "story-wrapper": string;
+    storyPanel: string;
     storyWrapper: string;
     ui: string;
     "ui-root": string;

--- a/lib/ReactViews/StandardUserInterface/standard-user-interface.scss.d.ts
+++ b/lib/ReactViews/StandardUserInterface/standard-user-interface.scss.d.ts
@@ -12,6 +12,7 @@ declare namespace StandardUserInterfaceScssNamespace {
     sidePanel: string;
     "story-wrapper": string;
     storyPanel: string;
+    storyPanelFullScreen: string;
     storyWrapper: string;
     ui: string;
     "ui-root": string;

--- a/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
@@ -219,6 +219,10 @@ class StoryPanel extends Component<Props, State> {
     const stories = this.props.viewState.terria.stories || [];
     const story = stories[this.props.viewState.currentStoryId];
 
+    if (!story) {
+      return null;
+    }
+
     return (
       <DragWrapper
         handleSelector=".drag-handle"
@@ -231,38 +235,38 @@ class StoryPanel extends Component<Props, State> {
           width: "min(80%, 700px)"
         }}
       >
-        <Swipeable
-          onSwipedLeft={() => this.goToNextStory()}
-          onSwipedRight={() => this.goToPrevStory()}
-        >
-          <Box onClick={() => this.onClickContainer()}>
+        <Box onClick={() => this.onClickContainer()}>
+          <Box
+            column
+            rounded
+            className={classNames(Styles.storyContainer, {
+              [Styles.isMounted]: this.state.inView
+            })}
+            key={story.id}
+            ref={this.slideRef as RefObject<HTMLDivElement>}
+            css={`
+              border-radius: 6px;
+              overflow: hidden;
+            `}
+          >
             <Box
+              backgroundColor={this.props.theme.dark}
+              css={{ color: "white", cursor: "move" }}
+              paddedRatio={3}
               column
-              rounded
-              className={classNames(Styles.storyContainer, {
-                [Styles.isMounted]: this.state.inView
-              })}
-              key={story.id}
-              ref={this.slideRef as RefObject<HTMLDivElement>}
-              css={`
-                border-radius: 6px;
-                overflow: hidden;
-              `}
+              className="drag-handle"
             >
-              <Box
-                backgroundColor={this.props.theme.dark}
-                css={{ color: "white", cursor: "move" }}
-                paddedRatio={3}
-                column
-                className="drag-handle"
-              >
-                <TitleBar
-                  title={story.title}
-                  isCollapsed={this.state.isCollapsed}
-                  collapseHandler={() => this.toggleCollapse()}
-                  closeHandler={() => this.exitStory()}
-                />
-              </Box>
+              <TitleBar
+                title={story.title}
+                isCollapsed={this.state.isCollapsed}
+                collapseHandler={() => this.toggleCollapse()}
+                closeHandler={() => this.exitStory()}
+              />
+            </Box>
+            <Swipeable
+              onSwipedLeft={() => this.goToNextStory()}
+              onSwipedRight={() => this.goToPrevStory()}
+            >
               <Box
                 css={{
                   backgroundColor: "rgba(255, 255, 255, 0.85)",
@@ -297,9 +301,9 @@ class StoryPanel extends Component<Props, State> {
                   }}
                 />
               </Box>
-            </Box>
+            </Swipeable>
           </Box>
-        </Swipeable>
+        </Box>
       </DragWrapper>
     );
   }

--- a/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
+++ b/lib/ReactViews/Story/StoryPanel/StoryPanel.tsx
@@ -21,11 +21,12 @@ import Styles from "../story-panel.scss";
 import StoryBody from "./StoryBody";
 import FooterBar from "./StoryFooterBar";
 import TitleBar from "./TitleBar";
+import DragWrapper from "../../Drag/DragWrapper";
 
 /**
  *
- * @param {any} story
- * @param {Terria} terria
+ * @param scene The story scene to activate
+ * @param terria The Terria instance
  */
 
 export async function activateStory(scene: Story, terria: Terria) {
@@ -94,6 +95,7 @@ const Swipeable = ({
 class StoryPanel extends Component<Props, State> {
   keydownListener: EventListener | undefined;
   slideRef: RefObject<HTMLElement>;
+  dragWrapperCallbackRef: (node: HTMLDivElement | null) => void;
 
   constructor(props: Props) {
     super(props);
@@ -102,6 +104,14 @@ class StoryPanel extends Component<Props, State> {
       inView: false
     };
     this.slideRef = createRef();
+    this.dragWrapperCallbackRef = (node: HTMLDivElement | null) => {
+      if (node) {
+        // Calculate and set initial centered position
+        const width = node.offsetWidth;
+        const halfWidth = width / 2;
+        node.style.marginLeft = `-${halfWidth}px`;
+      }
+    };
   }
 
   componentDidMount() {
@@ -219,112 +229,91 @@ class StoryPanel extends Component<Props, State> {
     const story = stories[this.props.viewState.currentStoryId];
 
     return (
-      <Swipeable
-        onSwipedLeft={() => this.goToNextStory()}
-        onSwipedRight={() => this.goToPrevStory()}
-      >
-        <Box
-          className={classNames(
-            this.props.viewState.topElement === "StoryPanel"
-              ? "top-element"
-              : ""
-          )}
-          centered
-          fullWidth
-          paddedHorizontally={4}
-          position="absolute"
-          onClick={() => this.onClickContainer()}
-          css={`
-            transition: padding, 0.2s;
-            bottom: ${this.props.viewState.terria.timelineStack.top !==
-            undefined
+      <DragWrapper
+        handleSelector=".drag-handle"
+        style={{
+          bottom:
+            this.props.viewState.terria.timelineStack.top !== undefined
               ? "146px"
-              : "80px"};
-            pointer-events: none;
-            ${!this.props.viewState.storyShown && "display: none;"}
-            @media (min-width: 992px) {
-              ${this.props.viewState.isMapFullScreen &&
-              `
-                transition-delay: 0.5s;
-              `}
-              ${!this.props.viewState.isMapFullScreen &&
-              `
-                padding-left: calc(30px + ${this.props.theme.workbenchWidth}px);
-                padding-right: 50px;
-              `}
-              bottom: ${this.props.viewState.terria.timelineStack.top !==
-              undefined
-                ? "146px"
-                : "80px"};
-            }
-          `}
-        >
-          <Box
-            column
-            rounded
-            className={classNames(Styles.storyContainer, {
-              [Styles.isMounted]: this.state.inView
-            })}
-            key={story.id}
-            ref={this.slideRef as RefObject<HTMLDivElement>}
-            css={`
-              @media (min-width: 992px) {
-                max-width: 36vw;
-              }
-              border-radius: 6px;
-              overflow: hidden;
-            `}
+              : "80px",
+          left: "50%"
+        }}
+      >
+        <div ref={this.dragWrapperCallbackRef}>
+          <Swipeable
+            onSwipedLeft={() => this.goToNextStory()}
+            onSwipedRight={() => this.goToPrevStory()}
           >
-            <Box
-              backgroundColor={this.props.theme.dark}
-              css={{ color: "white" }}
-              paddedRatio={3}
-              column
-            >
-              <TitleBar
-                title={story.title}
-                isCollapsed={this.state.isCollapsed}
-                collapseHandler={() => this.toggleCollapse()}
-                closeHandler={() => this.exitStory()}
-              />
+            <Box onClick={() => this.onClickContainer()}>
+              <Box
+                column
+                rounded
+                className={classNames(Styles.storyContainer, {
+                  [Styles.isMounted]: this.state.inView
+                })}
+                key={story.id}
+                ref={this.slideRef as RefObject<HTMLDivElement>}
+                css={`
+                  border-radius: 6px;
+                  overflow: hidden;
+                `}
+              >
+                <Box
+                  backgroundColor={this.props.theme.dark}
+                  css={{ color: "white", cursor: "move" }}
+                  paddedRatio={3}
+                  column
+                  className="drag-handle"
+                >
+                  <TitleBar
+                    title={story.title}
+                    isCollapsed={this.state.isCollapsed}
+                    collapseHandler={() => this.toggleCollapse()}
+                    closeHandler={() => this.exitStory()}
+                  />
+                </Box>
+                <Box
+                  css={{
+                    backgroundColor: "rgba(255, 255, 255, 0.85)",
+                    backdropFilter: this.props.theme.blur
+                  }}
+                >
+                  <StoryBody
+                    isCollapsed={this.state.isCollapsed}
+                    story={story}
+                  />
+                </Box>
+                <Box
+                  backgroundColor={this.props.theme.dark}
+                  css={{ color: "white" }}
+                  paddedHorizontally={3}
+                  fullWidth
+                >
+                  <FooterBar
+                    goPrev={() => this.goToPrevStory()}
+                    goNext={() => this.goToNextStory()}
+                    jumpToStory={(index: number) => this.navigateStory(index)}
+                    zoomTo={() => this.onCenterScene(story)}
+                    currentHumanIndex={this.props.viewState.currentStoryId + 1}
+                    totalStories={stories.length}
+                    listStories={() => {
+                      runInAction(() => {
+                        this.props.viewState.storyShown = false;
+                      });
+                      onStoryButtonClick({
+                        terria: this.props.viewState.terria,
+                        theme: this.props.theme,
+                        viewState: this.props.viewState,
+                        animationDuration: 250
+                      })();
+                    }}
+                  />
+                </Box>
+              </Box>
             </Box>
-            <Box
-              css={{
-                backgroundColor: "rgba(255, 255, 255, 0.85)",
-                backdropFilter: this.props.theme.blur
-              }}
-            >
-              <StoryBody isCollapsed={this.state.isCollapsed} story={story} />
-            </Box>
-            <Box
-              backgroundColor={this.props.theme.dark}
-              css={{ color: "white" }}
-              paddedHorizontally={3}
-              fullWidth
-            >
-              <FooterBar
-                goPrev={() => this.goToPrevStory()}
-                goNext={() => this.goToNextStory()}
-                jumpToStory={(index: number) => this.navigateStory(index)}
-                zoomTo={() => this.onCenterScene(story)}
-                currentHumanIndex={this.props.viewState.currentStoryId + 1}
-                totalStories={stories.length}
-                listStories={() => {
-                  runInAction(() => {
-                    this.props.viewState.storyShown = false;
-                  });
-                  onStoryButtonClick({
-                    terria: this.props.viewState.terria,
-                    theme: this.props.theme,
-                    viewState: this.props.viewState,
-                    animationDuration: 250
-                  })();
-                }}
-              />
-            </Box>
-          </Box>
-        </Box>
-      </Swipeable>
+          </Swipeable>
+        </div>
+      </DragWrapper>
     );
   }
 }

--- a/lib/ReactViews/Story/story-panel.scss
+++ b/lib/ReactViews/Story/story-panel.scss
@@ -16,6 +16,10 @@
   box-shadow: 0px 1px 0px 0px #1f2937 inset;
   border-radius: 6px;
 
+  @media (min-width: 992px) {
+    max-width: 36vw;
+  }
+
   a,
   a:visited,
   a:focus {

--- a/lib/ReactViews/Story/story-panel.scss
+++ b/lib/ReactViews/Story/story-panel.scss
@@ -9,16 +9,11 @@
   opacity: 0;
   width: 100%;
   min-height: 2em;
-  max-width: 1200px;
   color: variables.$text-dark;
   text-align: left;
   box-sizing: border-box;
   box-shadow: 0px 1px 0px 0px #1f2937 inset;
   border-radius: 6px;
-
-  @media (min-width: 992px) {
-    max-width: 36vw;
-  }
 
   a,
   a:visited,


### PR DESCRIPTION
### What this PR does

Fixes #7242

There's a few places where the Story panel obscures other controls, such as the chart, controls in scene editor and the compare tool.

Make Story playback panel draggable.
- Change breakpoint so story panel and feature info can no longer drag under workbench at screen-md
- Fix non working `css` prop on `DragWrapper`

### Test me
http://ci.terria.io/draggable-story-panel/#share=s-eK4PjihAfNlsrdGumKL3sXBoyx7

- Create a Story and play it, the panel should now be draggable within the map area

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
