### PR TITLE
Configurable branding via init file

### DIFF
--- a/doc/customizing/initialization-files.md
+++ b/doc/customizing/initialization-files.md
@@ -83,6 +83,7 @@ Init files can be edited two ways:
 | `showSplitter`    | no       | **`boolean`**                                                                                                                                                                                         | `false` | Show splitter initally.                                                                                                                                                                                                                                                                  |
 | `splitPosition`   | no       | **`number`**                                                                                                                                                                                          | `0.5`   | The position of splitter.                                                                                                                                                                                                                                                                |
 | `workbench`       | no       | **`string[]`**                                                                                                                                                                                        |         | List of items ids to initially add to workbench.                                                                                                                                                                                                                                         |
+| `parameters`      | no       | [**`parameters`**](#parameters)                                                                                                                                                                       |         | Parameter overrides applied from init files (e.g. branding).                                                                                                                                                                                                                             |
 | `previewedItemId` | no       | **`string`**                                                                                                                                                                                          |         | ID of the catalog member that is currently being previewed.                                                                                                                                                                                                                              |
 | `settings`        | no       | [**`settings`**](#advanced-settings)                                                                                                                                                                  |         | Additional (more advanced) settings.                                                                                                                                                                                                                                                     |
 
@@ -302,6 +303,33 @@ Definition of the baseMap model.
 | `x`  | yes      | **`number`** |         | The X component. |
 | `y`  | yes      | **`number`** |         | The Y component. |
 | `z`  | yes      | **`number`** |         | The Z component. |
+
+### <a id="parameters"></a>`parameters`
+
+Parameter overrides that are applied when the init file is loaded. These override values from the main `config.json` `parameters` object, allowing per-init-file customization of branding.
+
+| Name                    | Required | Type           | Default | Description                                                                                                       |
+| ----------------------- | -------- | -------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `brandBarElements`      | no       | **`string[]`** |         | An array of strings of HTML that fill up the top left logo space (see `brandBarSmallElements` for small screens). |
+| `brandBarSmallElements` | no       | **`string[]`** |         | An array of strings of HTML that fill up the top left logo space - used for small screens.                        |
+| `displayOneBrand`       | no       | **`number`**   | `0`     | Index of which `brandBarElements` to show for mobile header. Used if `brandBarSmallElements` is not defined.      |
+
+**Example**
+
+```json
+{
+  "parameters": {
+    "brandBarElements": [
+      "<a href='https://example.com'><img src='images/my-logo.png' height='50' /></a>"
+    ],
+    "brandBarSmallElements": [
+      "<a href='https://example.com'><img src='images/my-logo-small.png' height='30' /></a>"
+    ],
+    "displayOneBrand": 0
+  },
+  "catalog": [...]
+}
+```
 
 ### <a id="advanced-settings"></a>`settings`
 

--- a/lib/Models/InitSource.ts
+++ b/lib/Models/InitSource.ts
@@ -49,6 +49,7 @@ export interface ShareInitSourceData {
 export interface InitSourceData {
   stratum?: string;
   corsDomains?: string[];
+  parameters?: JsonObject;
   catalog?: JsonObject[];
   elements?: Map<string, IElementConfig>;
   stories?: StoryData[];

--- a/lib/Models/InitSource.ts
+++ b/lib/Models/InitSource.ts
@@ -49,7 +49,11 @@ export interface ShareInitSourceData {
 export interface InitSourceData {
   stratum?: string;
   corsDomains?: string[];
-  parameters?: JsonObject;
+  parameters?: {
+    brandBarElements?: string[];
+    brandBarSmallElements?: string[];
+    displayOneBrand?: number;
+  };
   catalog?: JsonObject[];
   elements?: Map<string, IElementConfig>;
   stories?: StoryData[];

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1709,7 +1709,8 @@ export default class Terria {
 
       const stringArrayFrom = (value: unknown): string[] | undefined => {
         if (!Array.isArray(value)) return undefined;
-        return value.every((item) => typeof item === "string")
+        return value.every((item) => typeof item === "string") &&
+          value.some((item) => item !== "")
           ? (value as string[]).slice()
           : undefined;
       };

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -1700,6 +1700,42 @@ export default class Terria {
         ? initData.stratum
         : CommonStrata.definition;
 
+    if (isJsonObject(initData.parameters)) {
+      const parameterOverrides: Partial<ConfigParameters> = {};
+      let hasOverrides = false;
+
+      const { brandBarElements, brandBarSmallElements, displayOneBrand } =
+        initData.parameters;
+
+      const stringArrayFrom = (value: unknown): string[] | undefined => {
+        if (!Array.isArray(value)) return undefined;
+        return value.every((item) => typeof item === "string")
+          ? (value as string[]).slice()
+          : undefined;
+      };
+
+      const overrideBrandElements = stringArrayFrom(brandBarElements);
+      if (overrideBrandElements) {
+        parameterOverrides.brandBarElements = overrideBrandElements;
+        hasOverrides = true;
+      }
+
+      const overrideBrandSmallElements = stringArrayFrom(brandBarSmallElements);
+      if (overrideBrandSmallElements) {
+        parameterOverrides.brandBarSmallElements = overrideBrandSmallElements;
+        hasOverrides = true;
+      }
+
+      if (isJsonNumber(displayOneBrand)) {
+        parameterOverrides.displayOneBrand = Number(displayOneBrand);
+        hasOverrides = true;
+      }
+
+      if (hasOverrides) {
+        this.updateParameters(parameterOverrides as JsonObject);
+      }
+    }
+
     // Extract the list of CORS-ready domains.
     if (Array.isArray(initData.corsDomains)) {
       this.corsProxy.corsDomains.push(...(initData.corsDomains as string[]));


### PR DESCRIPTION
### What this PR does

Added the ability to set `brandBarElements`, `brandBarSmallElements` and `displayOneBrand` in the init files. This way, using the init file in the URL you will be able to see brand elements other than the default ones.

### Test me

Add 
```
"parameters":{
        "brandBarElements": [
            "<a target=\"_blank\" href=\"https://www.bioretics.com\"><img src=\"https://www.bioretics.com/themes/bioretics/assets/images/Bioretics-logo.svg\" alt=\"Bioretics\"  height=\"52\" title=\"Bioretics\" /></a>"
        ]
    }
```
to an init file.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
