### PR TITLE
Share the default timeline settings.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 #### next release (8.11.4)
 
+- Capture default timeline state in share links including current time,
+  playback etc.
 - [The next improvement]
 
 #### 8.11.3 - 2026-02-02

--- a/lib/Models/Catalog/registerCatalogMembers.ts
+++ b/lib/Models/Catalog/registerCatalogMembers.ts
@@ -1,3 +1,4 @@
+import DefaultTimelineModel from "../DefaultTimelineModel";
 import YDYRCatalogFunction from "./CatalogFunctions/YDYRCatalogFunction";
 import YDYRCatalogFunctionJob from "./CatalogFunctions/YDYRCatalogFunctionJob";
 import CatalogGroup from "./CatalogGroup";
@@ -70,6 +71,10 @@ import SdmxJsonCatalogItem from "./SdmxJson/SdmxJsonCatalogItem";
 export default function registerCatalogMembers() {
   CatalogMemberFactory.register(CatalogGroup.type, CatalogGroup);
   CatalogMemberFactory.register(StubCatalogItem.type, StubCatalogItem);
+  CatalogMemberFactory.register(
+    DefaultTimelineModel.type,
+    DefaultTimelineModel
+  );
   CatalogMemberFactory.register(
     WebMapServiceCatalogItem.type,
     WebMapServiceCatalogItem

--- a/lib/Models/DefaultTimelineModel.ts
+++ b/lib/Models/DefaultTimelineModel.ts
@@ -9,7 +9,7 @@ import Terria from "./Terria";
 export default class DefaultTimelineModel extends DiscretelyTimeVaryingMixin(
   CreateModel(DiscretelyTimeVaryingTraits)
 ) {
-  static readonly type = "default-timeline-model";
+  static readonly type = "default-timeline";
 
   get type() {
     return DefaultTimelineModel.type;

--- a/lib/Models/DefaultTimelineModel.ts
+++ b/lib/Models/DefaultTimelineModel.ts
@@ -9,6 +9,12 @@ import Terria from "./Terria";
 export default class DefaultTimelineModel extends DiscretelyTimeVaryingMixin(
   CreateModel(DiscretelyTimeVaryingTraits)
 ) {
+  static readonly type = "default-timeline-model";
+
+  get type() {
+    return DefaultTimelineModel.type;
+  }
+
   constructor(uniqueId: string | undefined, terria: Terria) {
     super(uniqueId, terria);
 

--- a/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.ts
+++ b/lib/ReactViews/Map/Panels/SharePanel/BuildShareLink.ts
@@ -308,11 +308,6 @@ function addViewSettings(
 ) {
   const viewer = terria.mainViewer;
 
-  // const time = {
-  //   dayNumber: terria.timelineClock.currentTime.dayNumber,
-  //   secondsOfDay: terria.timelineClock.currentTime.secondsOfDay
-  // };
-
   let viewerMode: ViewModeJson;
   if (terria.mainViewer.viewerMode === ViewerMode.Cesium) {
     if (terria.mainViewer.viewerOptions.useTerrain) {

--- a/test/Models/Catalog/allCatalogModelsSpec.ts
+++ b/test/Models/Catalog/allCatalogModelsSpec.ts
@@ -35,7 +35,9 @@ describe("All Catalog models", () => {
       .filter(
         ([modelName, model]) =>
           !ReferenceMixin.isMixedInto(model) &&
-          !["stub", "group", "cesium-terrain"].includes(modelName)
+          !["stub", "group", "cesium-terrain", "default-timeline"].includes(
+            modelName
+          )
       )
       .forEach(([modelName, model]) => {
         return expect(

--- a/test/Models/TimelineStackSpec.ts
+++ b/test/Models/TimelineStackSpec.ts
@@ -1,6 +1,7 @@
+import { runInAction, when } from "mobx";
 import WebMapServiceCatalogItem from "../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
+import DefaultTimelineModel from "../../lib/Models/DefaultTimelineModel";
 import Terria from "../../lib/Models/Terria";
-import { when } from "mobx";
 
 describe("TimelineStack", function () {
   let terria: Terria;
@@ -58,5 +59,37 @@ describe("TimelineStack", function () {
     wms2.setTrait("user", "isPaused", true);
     await when(() => terria.timelineStack.top?.isPaused === true);
     expect(terria.timelineStack.clock.shouldAnimate).toBe(false);
+  });
+
+  describe("toggling always show timeline", function () {
+    const DEFAULT_TIMELINE_MODEL_ID = "defaultTimeline";
+
+    it("adds the default timeline model to terria when enabled", function () {
+      expect(terria.timelineStack.alwaysShowingTimeline).toBe(false);
+      expect(
+        terria.getModelById(DefaultTimelineModel, DEFAULT_TIMELINE_MODEL_ID)
+      ).toBeUndefined();
+      runInAction(() => {
+        terria.timelineStack.setAlwaysShowTimeline(true);
+      });
+      expect(
+        terria.getModelById(DefaultTimelineModel, DEFAULT_TIMELINE_MODEL_ID)
+      ).toBe(terria.timelineStack.defaultTimeVarying as any);
+    });
+
+    it("adds removes the default timeline  model to terria when enabled", function () {
+      runInAction(() => {
+        terria.timelineStack.setAlwaysShowTimeline(true);
+      });
+      expect(
+        terria.getModelById(DefaultTimelineModel, DEFAULT_TIMELINE_MODEL_ID)
+      ).toBe(terria.timelineStack.defaultTimeVarying as any);
+      runInAction(() => {
+        terria.timelineStack.setAlwaysShowTimeline(false);
+      });
+      expect(
+        terria.getModelById(DefaultTimelineModel, DEFAULT_TIMELINE_MODEL_ID)
+      ).toBe(undefined);
+    });
   });
 });

--- a/test/Models/TimelineStackSpec.ts
+++ b/test/Models/TimelineStackSpec.ts
@@ -61,7 +61,7 @@ describe("TimelineStack", function () {
     expect(terria.timelineStack.clock.shouldAnimate).toBe(false);
   });
 
-  describe("toggling always show timeline", function () {
+  describe("toggling 'always show timeline'", function () {
     const DEFAULT_TIMELINE_MODEL_ID = "defaultTimeline";
 
     it("adds the default timeline model to terria when enabled", function () {
@@ -77,7 +77,7 @@ describe("TimelineStack", function () {
       ).toBe(terria.timelineStack.defaultTimeVarying as any);
     });
 
-    it("adds removes the default timeline  model to terria when enabled", function () {
+    it("removes the default timeline model from terria when disabled", function () {
       runInAction(() => {
         terria.timelineStack.setAlwaysShowTimeline(true);
       });


### PR DESCRIPTION
### What this PR does

In v7 it used to be possible to share the default timeline state. Re-implement it in v8 so that we can capture scenes showing shadows at a particular time of the day in stories.

Note that the default timeline state is captured in the init source as a model with ID `defaultTimeline` instead of introducing a hardcoded config key for timeline settings.

### Test me

Run through [this story](http://ci.terria.io/share-default-timeline/#share=s-nft9MX2L285f1Ho2gnfapWBQoZP), observe that it captures different times of the day and the timeline playback state.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
