### PR TITLE
fix: splitter fails for local file catalog items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - Refactor tests to use @testing-library/react instead of react-test-renderer and react-shallow-testutils, and remove deprecated libraries. (#7755, #7763)
 - TSify most of `lib/Core`. [#7417](https://github.com/TerriaJS/terriajs/pull/7417/)
 - Update gulpfile.js to gulp V4 syntax, which provides task descriptions in `yarn gulp --tasks`.
+- Fix splitter failing for local file catalog items by storing file data as blob URLs in the `url` trait instead of private instance fields, ensuring `duplicateModel()` preserves the data. [#7762](https://github.com/TerriaJS/terriajs/pull/7762)
 - [The next improvement]
 
 #### 8.11.3 - 2026-02-02

--- a/lib/Models/Catalog/CatalogItems/ShapefileCatalogItem.ts
+++ b/lib/Models/Catalog/CatalogItems/ShapefileCatalogItem.ts
@@ -1,13 +1,13 @@
 import { FeatureCollection } from "geojson";
 import i18next from "i18next";
-import { computed, makeObservable } from "mobx";
+import { action, computed, makeObservable } from "mobx";
 import { FeatureCollectionWithFilename, parseZip } from "shpjs";
-import isDefined from "../../../Core/isDefined";
 import { isJsonObject } from "../../../Core/Json";
 import loadBlob, { isZip } from "../../../Core/loadBlob";
 import TerriaError from "../../../Core/TerriaError";
 import GeoJsonMixin from "../../../ModelMixins/GeojsonMixin";
 import ShapefileCatalogItemTraits from "../../../Traits/TraitsClasses/ShapefileCatalogItemTraits";
+import CommonStrata from "../../Definition/CommonStrata";
 import CreateModel from "../../Definition/CreateModel";
 import { ModelConstructorParameters } from "../../Definition/Model";
 import HasLocalData from "../../HasLocalData";
@@ -44,25 +44,22 @@ class ShapefileCatalogItem
     return i18next.t("models.shapefile.name");
   }
 
-  protected _file?: File;
-
+  @action
   setFileInput(file: File) {
-    this._file = file;
+    this.setTrait(
+      CommonStrata.user,
+      "url",
+      URL.createObjectURL(file) + "#" + file.name
+    );
   }
 
   @computed get hasLocalData(): boolean {
-    return isDefined(this._file);
+    return this.url?.startsWith("blob:") ?? false;
   }
 
   protected async forceLoadGeojsonData() {
-    // ShapefileCatalogItem._file
-    if (this._file) {
-      return await parseShapefile(this._file);
-    }
-    // GeojsonTraits.url
-    else if (this.url) {
-      // URL to zipped fle
-      if (isZip(this.url)) {
+    if (this.url) {
+      if (this.hasLocalData || isZip(this.url)) {
         if (typeof FileReader === "undefined") {
           throw fileApiNotSupportedError(this.terria);
         }

--- a/test/Models/Catalog/CatalogReferences/SplitItemReferenceSpec.ts
+++ b/test/Models/Catalog/CatalogReferences/SplitItemReferenceSpec.ts
@@ -57,6 +57,9 @@ describe("SplitItemReference", function () {
     expect(HasLocalData.is(cloneGeoJson)).toBe(true);
     if (HasLocalData.is(cloneGeoJson)) {
       expect(cloneGeoJson.hasLocalData).toBe(true);
+      expect(cloneGeoJson.url).toBe(sourceItem.url);
     }
+
+    URL.revokeObjectURL(sourceItem.url?.split("#")[0] ?? "");
   });
 });

--- a/test/Models/Catalog/CatalogReferences/SplitItemReferenceSpec.ts
+++ b/test/Models/Catalog/CatalogReferences/SplitItemReferenceSpec.ts
@@ -4,6 +4,8 @@ import CommonStrata from "../../../../lib/Models/Definition/CommonStrata";
 import SplitItemReference from "../../../../lib/Models/Catalog/CatalogReferences/SplitItemReference";
 import Terria from "../../../../lib/Models/Terria";
 import WebMapServiceCatalogItem from "../../../../lib/Models/Catalog/Ows/WebMapServiceCatalogItem";
+import GeoJsonCatalogItem from "../../../../lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem";
+import HasLocalData from "../../../../lib/Models/HasLocalData";
 
 describe("SplitItemReference", function () {
   it("can dereference the source item", async function () {
@@ -21,5 +23,40 @@ describe("SplitItemReference", function () {
     });
     await splitRef.loadReference();
     expect(splitRef.target instanceof WebMapServiceCatalogItem).toBe(true);
+  });
+
+  it("preserves local file data when splitting", async function () {
+    const terria = new Terria();
+    const sourceItem = new GeoJsonCatalogItem(createGuid(), terria);
+    const file = new File(
+      ['{"type":"FeatureCollection","features":[]}'],
+      "test.geojson",
+      { type: "application/json" }
+    );
+    sourceItem.setFileInput(file);
+
+    const splitRef = new SplitItemReference(createGuid(), terria);
+    terria.addModel(sourceItem);
+    terria.addModel(splitRef);
+    runInAction(() => {
+      splitRef.setTrait(
+        CommonStrata.user,
+        "splitSourceItemId",
+        sourceItem.uniqueId
+      );
+    });
+
+    await splitRef.loadReference();
+
+    const clone = splitRef.target;
+    expect(clone).toBeDefined();
+    expect(clone instanceof GeoJsonCatalogItem).toBe(true);
+
+    const cloneGeoJson = clone as GeoJsonCatalogItem;
+    expect(cloneGeoJson.url).toBe(sourceItem.url);
+    expect(HasLocalData.is(cloneGeoJson)).toBe(true);
+    if (HasLocalData.is(cloneGeoJson)) {
+      expect(cloneGeoJson.hasLocalData).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
### What this PR does

Fixes #7757

Store local file data as blob URLs in the URL trait instead of private instance fields, and follow the same approach already used for GLTF and Assimp catalogue items. This ensures duplicateModel() preserves the data since traits are copied during duplication. One potential downside of this approach is that we are currently not disposing the catalogue items from memory on remove (here is a ticket to track that https://github.com/TerriaJS/terriajs/issues/4816) 

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
