### PR TITLE
Convert test done callbacks to async/await

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Replace react-uid with react useId hook for generating unique ids.
 - Remove ts-essentials dependency and replace with custom type utility.
 - Remove fs-extra dependency and replace with native fs.
+- Convert test `done` callbacks to async/await for modern test patterns.
 - [The next improvement]
 
 #### 8.11.3 - 2026-02-02

--- a/test/Map/EarthGravityModel1996Spec.js
+++ b/test/Map/EarthGravityModel1996Spec.js
@@ -17,14 +17,12 @@ describeIfSupported("EarthGravityModel1996", function () {
 
   // NGA calculator is here: http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm96/intpt.html
 
-  it("produces a single result consistent with NGA calculator", function (done) {
-    egm96.getHeight(0.0, 0.0).then(function (height) {
-      expect(height).toBe(17.16);
-      done();
-    });
+  it("produces a single result consistent with NGA calculator", async function () {
+    const height = await egm96.getHeight(0.0, 0.0);
+    expect(height).toBe(17.16);
   });
 
-  it("produces multiple results consistent with NGA calculator", function (done) {
+  it("produces multiple results consistent with NGA calculator", async function () {
     var testData = [
       // longitude, latitude, expected height
       0.0, 89.74, 13.92, 180.0, 89.74, 13.49, -180.0, 89.74, 13.49, 0.0, -89.74,
@@ -41,27 +39,21 @@ describeIfSupported("EarthGravityModel1996", function () {
       );
     }
 
-    egm96.getHeights(cartographics).then(function () {
-      for (var i = 0; i < cartographics.length; ++i) {
-        expect(
-          Math.abs(cartographics[i].height - testData[i * 3 + 2])
-        ).toBeLessThan(0.01);
-      }
-      done();
-    });
+    await egm96.getHeights(cartographics);
+    for (let i = 0; i < cartographics.length; ++i) {
+      expect(
+        Math.abs(cartographics[i].height - testData[i * 3 + 2])
+      ).toBeLessThan(0.01);
+    }
   });
 
-  it("works at the north pole", function (done) {
-    egm96.getHeight(0.0, Math.PI).then(function (height) {
-      expect(height).toBe(13.61);
-      done();
-    });
+  it("works at the north pole", async function () {
+    const height = await egm96.getHeight(0.0, Math.PI);
+    expect(height).toBe(13.61);
   });
 
-  it("works at the south pole", function (done) {
-    egm96.getHeight(0.0, -Math.PI).then(function (height) {
-      expect(height).toBe(-29.53);
-      done();
-    });
+  it("works at the south pole", async function () {
+    const height = await egm96.getHeight(0.0, -Math.PI);
+    expect(height).toBe(-29.53);
   });
 });

--- a/test/Models/Catalog/CatalogItems/CesiumTerrainCatalogItemSpec.js
+++ b/test/Models/Catalog/CatalogItems/CesiumTerrainCatalogItemSpec.js
@@ -21,7 +21,7 @@ describe("CesiumTerrainCatalogItem", function () {
     expect(item.typeName).toContain("Cesium");
   });
 
-  it("creates imagery provider with correct URL", function (done) {
+  it("creates imagery provider with correct URL", async function () {
     spyOn(loadWithXhr, "load").and.callFake(function (
       url,
       _responseType,
@@ -48,10 +48,7 @@ describe("CesiumTerrainCatalogItem", function () {
     item.url = "http://example.com/foo/bar";
     var terrainProvider = item._createTerrainProvider();
     expect(terrainProvider instanceof CesiumTerrainProvider).toBe(true);
-    terrainProvider.readyPromise
-      .then(function () {
-        expect(loadWithXhr.load.calls.any()).toBe(true);
-      })
-      .then(done);
+    await terrainProvider.readyPromise;
+    expect(loadWithXhr.load.calls.any()).toBe(true);
   });
 });

--- a/test/Models/Catalog/CatalogItems/CompositeCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/CompositeCatalogItemSpec.ts
@@ -17,7 +17,7 @@ describe("CompositeCatalogItem", function () {
     composite = new CompositeCatalogItem("test", terria);
   });
 
-  it("loads map items after members are added", function (done) {
+  it("loads map items after members are added", async function () {
     const item1 = new GeoJsonCatalogItem("item1", terria);
     const item2 = new WebMapServiceCatalogItem("item2", terria);
     const item3 = new WebMapServiceCatalogItem("item3", terria);
@@ -43,17 +43,13 @@ describe("CompositeCatalogItem", function () {
     composite.add(CommonStrata.definition, item1);
     composite.add(CommonStrata.definition, item2);
 
-    composite
-      .loadMapItems()
-      .then(() => {
-        expect(composite.mapItems.length).toBe(2);
-        composite.add(CommonStrata.definition, item3);
-        return composite.loadMapItems();
-      })
-      .then(() => {
-        expect(composite.mapItems.length).toBe(3);
-        done();
-      });
+    await composite.loadMapItems();
+
+    expect(composite.mapItems.length).toBe(2);
+    composite.add(CommonStrata.definition, item3);
+    await composite.loadMapItems();
+
+    expect(composite.mapItems.length).toBe(3);
   });
 
   it("updates from json, preserving order", function () {
@@ -107,8 +103,8 @@ describe("CompositeCatalogItem", function () {
     expect(item2.show).toEqual(false);
   });
 
-  // it("concatenates legends", function(done) {
-  //   composite
+  // it("concatenates legends", async function() {
+  //   await composite
   //     .updateFromJson({
   //       type: "composite",
   //       items: [
@@ -121,14 +117,10 @@ describe("CompositeCatalogItem", function () {
   //           legendUrl: "http://not.valid.either"
   //         }
   //       ]
-  //     })
-  //     .then(function() {
-  //       expect(composite.legendUrls.slice()).toEqual([
-  //         new LegendUrl("http://not.valid"),
-  //         new LegendUrl("http://not.valid.either")
-  //       ]);
-  //     })
-  //     .then(done)
-  //     .catch(fail);
+  //     });
+  //     expect(composite.legendUrls.slice()).toEqual([
+  //       new LegendUrl("http://not.valid"),
+  //       new LegendUrl("http://not.valid.either")
+  //     ]);
   // });
 });

--- a/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
+++ b/test/Models/Catalog/CatalogItems/GeoJsonCatalogItemSpec.ts
@@ -198,27 +198,22 @@ describe("GeoJsonCatalogItemSpec", () => {
          expect(geojson.dataUrl).toBe("test/GeoJSON/bike_racks.geojson");
          expect(geojson.dataUrlType).toBe("direct");
        })
-       it("use provided dataUrl", function(done) {
+       it("use provided dataUrl", async function() {
          geojson.url = "test/GeoJSON/bike_racks.geojson";
          geojson.dataUrl = "test/test.html";
          geojson.dataUrlType = "fake type";
-         geojson.load().then(function() {
-           expect(geojson.dataSource.entities.values.length).toBeGreaterThan(0);
-           expect(geojson.dataUrl).toBe("test/test.html");
-           expect(geojson.dataUrlType).toBe("fake type");
-           done();
-         });
+         await geojson.load();
+         expect(geojson.dataSource.entities.values.length).toBeGreaterThan(0);
+         expect(geojson.dataUrl).toBe("test/test.html");
+         expect(geojson.dataUrlType).toBe("fake type");
        })
 
-       it("works by blob", function(done) {
-         loadBlob("test/GeoJSON/bike_racks.geojson").then(function(blob) {
-           geojson.data = blob;
-           geojson.dataSourceUrl = "anything.geojson";
-           geojson.load().then(function() {
-             expect(geojson.dataSource.entities.values.length).toBeGreaterThan(0);
-             done();
-           });
-         });
+       it("works by blob", async function() {
+         const blob = await loadBlob("test/GeoJSON/bike_racks.geojson");
+         geojson.data = blob;
+         geojson.dataSourceUrl = "anything.geojson";
+         await geojson.load();
+         expect(geojson.dataSource.entities.values.length).toBeGreaterThan(0);
        }); */
     });
 
@@ -433,23 +428,19 @@ describe("GeoJsonCatalogItemSpec", () => {
     //     geojson.isEnabled = true;
     //   });
 
-    //   it("can add attribution", function(done) {
+    //   it("can add attribution", async function() {
     //     spyOn(currentViewer, "addAttribution");
     //     geojson.load();
-    //     geojson._loadForEnablePromise.then(function() {
-    //       expect(currentViewer.addAttribution).toHaveBeenCalled();
-    //       done();
-    //     });
+    //     await geojson._loadForEnablePromise;
+    //     expect(currentViewer.addAttribution).toHaveBeenCalled();
     //   });
 
-    //   it("can remove attribution", function(done) {
+    //   it("can remove attribution", async function() {
     //     spyOn(currentViewer, "removeAttribution");
     //     geojson.load();
-    //     geojson._loadForEnablePromise.then(function() {
-    //       geojson.isEnabled = false;
-    //       expect(currentViewer.removeAttribution).toHaveBeenCalled();
-    //       done();
-    //     });
+    //     await geojson._loadForEnablePromise;
+    //     geojson.isEnabled = false;
+    //     expect(currentViewer.removeAttribution).toHaveBeenCalled();
     //   });
     // });
 

--- a/test/Models/Catalog/CatalogItems/ImageryLayerCatalogItemSpec.js
+++ b/test/Models/Catalog/CatalogItems/ImageryLayerCatalogItemSpec.js
@@ -188,38 +188,30 @@ describe("ImageryLayerCatalogItem", function () {
       });
     }
 
-    it("ignores errors in disabled layers", function (done) {
+    it("ignores errors in disabled layers", async function () {
       spyOn(globeOrMap, "isImageryLayerShown").and.returnValue(false);
       const fetchImage = failLoad(503, 10);
 
       imageryLayer._requestImagery(imagery);
 
-      pollToPromise(function () {
+      await pollToPromise(function () {
         return imagery.state === ImageryState.FAILED;
-      })
-        .then(function () {
-          expect(fetchImage.calls.count()).toEqual(1);
-        })
-        .then(done)
-        .catch(done.fail);
+      });
+      expect(fetchImage.calls.count()).toEqual(1);
     });
 
-    it("retries images that fail with a 503 error", function (done) {
+    it("retries images that fail with a 503 error", async function () {
       const fetchImage = failLoad(503, 2);
 
       imageryLayer._requestImagery(imagery);
 
-      pollToPromise(function () {
+      await pollToPromise(function () {
         return imagery.state === ImageryState.RECEIVED;
-      })
-        .then(function () {
-          expect(fetchImage.calls.count()).toEqual(4);
-        })
-        .then(done)
-        .catch(done.fail);
+      });
+      expect(fetchImage.calls.count()).toEqual(4);
     });
 
-    it("eventually gives up on a tile that only succeeds when loaded via blob", function (done) {
+    it("eventually gives up on a tile that only succeeds when loaded via blob", async function () {
       const fetchImage = spyOn(Resource.prototype, "fetchImage").and.callFake(
         function (options) {
           if (options.preferBlob) {
@@ -236,17 +228,13 @@ describe("ImageryLayerCatalogItem", function () {
 
       imageryLayer._requestImagery(imagery);
 
-      pollToPromise(function () {
+      await pollToPromise(function () {
         return imagery.state === ImageryState.FAILED;
-      })
-        .then(function () {
-          expect(fetchImage.calls.count()).toBeGreaterThan(5);
-        })
-        .then(done)
-        .catch(done.fail);
+      });
+      expect(fetchImage.calls.count()).toBeGreaterThan(5);
     });
 
-    it("ignores any number of 404 errors if treat404AsError is false", function (done) {
+    it("ignores any number of 404 errors if treat404AsError is false", async function () {
       const fetchImage = failLoad(404, 100);
       catalogItem.treat404AsError = false;
 
@@ -260,21 +248,17 @@ describe("ImageryLayerCatalogItem", function () {
         imageryLayer._requestImagery(tiles[i]);
       }
 
-      pollToPromise(function () {
+      await pollToPromise(function () {
         let result = true;
         for (let i = 0; i < tiles.length; ++i) {
           result = result && tiles[i].state === ImageryState.FAILED;
         }
         return result;
-      })
-        .then(function () {
-          expect(fetchImage.calls.count()).toEqual(tiles.length * 2);
-        })
-        .then(done)
-        .catch(done.fail);
+      });
+      expect(fetchImage.calls.count()).toEqual(tiles.length * 2);
     });
 
-    it("ignores any number of 403 errors if treat403AsError is false", function (done) {
+    it("ignores any number of 403 errors if treat403AsError is false", async function () {
       const fetchImage = failLoad(403, 100);
       catalogItem.treat403AsError = false;
 
@@ -288,21 +272,17 @@ describe("ImageryLayerCatalogItem", function () {
         imageryLayer._requestImagery(tiles[i]);
       }
 
-      pollToPromise(function () {
+      await pollToPromise(function () {
         let result = true;
         for (let i = 0; i < tiles.length; ++i) {
           result = result && tiles[i].state === ImageryState.FAILED;
         }
         return result;
-      })
-        .then(function () {
-          expect(fetchImage.calls.count()).toEqual(tiles.length * 2);
-        })
-        .then(done)
-        .catch(done.fail);
+      });
+      expect(fetchImage.calls.count()).toEqual(tiles.length * 2);
     });
 
-    it("doesn't disable the layer after only five 404s if treat404AsError is true", function (done) {
+    it("doesn't disable the layer after only five 404s if treat404AsError is true", async function () {
       const fetchImage = failLoad(404, 100);
       catalogItem.treat404AsError = true;
       catalogItem.isShown = true;
@@ -317,22 +297,18 @@ describe("ImageryLayerCatalogItem", function () {
         imageryLayer._requestImagery(tiles[i]);
       }
 
-      pollToPromise(function () {
+      await pollToPromise(function () {
         let result = true;
         for (let i = 0; i < tiles.length; ++i) {
           result = result && tiles[i].state === ImageryState.FAILED;
         }
         return result;
-      })
-        .then(function () {
-          expect(fetchImage.calls.count()).toEqual(tiles.length * 2);
-          expect(catalogItem.isShown).toBe(true);
-        })
-        .then(done)
-        .catch(done.fail);
+      });
+      expect(fetchImage.calls.count()).toEqual(tiles.length * 2);
+      expect(catalogItem.isShown).toBe(true);
     });
 
-    it("disables the layer after six 404s if treat404AsError is true", function (done) {
+    it("disables the layer after six 404s if treat404AsError is true", async function () {
       const fetchImage = failLoad(404, 100);
       catalogItem.treat404AsError = true;
       catalogItem.isShown = true;
@@ -347,19 +323,15 @@ describe("ImageryLayerCatalogItem", function () {
         imageryLayer._requestImagery(tiles[i]);
       }
 
-      pollToPromise(function () {
+      await pollToPromise(function () {
         let result = true;
         for (let i = 0; i < tiles.length; ++i) {
           result = result && tiles[i].state === ImageryState.FAILED;
         }
         return result;
-      })
-        .then(function () {
-          expect(fetchImage.calls.count()).toEqual(tiles.length * 2);
-          expect(catalogItem.isShown).toBe(false);
-        })
-        .then(done)
-        .catch(done.fail);
+      });
+      expect(fetchImage.calls.count()).toEqual(tiles.length * 2);
+      expect(catalogItem.isShown).toBe(false);
     });
   });
 });

--- a/test/Models/Catalog/CatalogItems/KmlCatalogItemSpec.js
+++ b/test/Models/Catalog/CatalogItems/KmlCatalogItemSpec.js
@@ -21,28 +21,18 @@ describeIfSupported("KmlCatalogItem", function () {
     kml = new KmlCatalogItem(terria);
   });
 
-  it("can load a KML file by URL", function (done) {
+  it("can load a KML file by URL", async function () {
     kml.url = "test/KML/vic_police.kml";
-    kml
-      .load()
-      .then(function () {
-        expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-      })
-      .then(done)
-      .catch(done.fail);
+    await kml.load();
+    expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
   });
 
-  it("use provided dataUrl", function (done) {
+  it("use provided dataUrl", async function () {
     kml.url = "test/KML/vic_police.kml";
     kml.dataUrl = "test/test.html";
-    kml
-      .load()
-      .then(function () {
-        expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-        expect(kml.dataUrl).toBe("test/test.html");
-      })
-      .then(done)
-      .catch(done.fail);
+    await kml.load();
+    expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
+    expect(kml.dataUrl).toBe("test/test.html");
   });
 
   it("have default dataUrl and dataUrlType", function () {
@@ -53,118 +43,90 @@ describeIfSupported("KmlCatalogItem", function () {
     expect(kml.dataUrlType).toBe("direct");
   });
 
-  it("can load a KML file by provided XML data", function (done) {
-    loadXML("test/KML/vic_police.kml").then(function (xml) {
+  it("can load a KML file by provided XML data", async function () {
+    await loadXML("test/KML/vic_police.kml").then(function (xml) {
       kml.data = xml;
       kml.dataSourceUrl = "anything.kml";
-      kml
-        .load()
-        .then(function () {
-          expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-        })
-        .then(done)
-        .catch(done.fail);
+      kml.load();
+      expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
     });
   });
 
-  it("can load a KML file by provided Blob", function (done) {
-    loadBlob("test/KML/vic_police.kml").then(function (blob) {
+  it("can load a KML file by provided Blob", async function () {
+    await loadBlob("test/KML/vic_police.kml").then(function (blob) {
       kml.data = blob;
       kml.dataSourceUrl = "anything.kml";
-      kml
-        .load()
-        .then(function () {
-          expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-        })
-        .then(done)
-        .catch(done.fail);
+      kml.load();
+      expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
     });
   });
 
-  it("can load a KML file by provided string", function (done) {
-    loadText("test/KML/vic_police.kml").then(function (s) {
+  it("can load a KML file by provided string", async function () {
+    await loadText("test/KML/vic_police.kml").then(function (s) {
       kml.data = s;
       kml.dataSourceUrl = "anything.kml";
-      kml
-        .load()
-        .then(function () {
-          expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-        })
-        .then(done)
-        .catch(done.fail);
+      kml.load();
+      expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
     });
   });
 
-  it("can load a KMZ file by URL", function (done) {
+  it("can load a KMZ file by URL", async function () {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     kml.url = require("file-loader!../../../../wwwroot/test/KML/vic_police.kmz");
-    kml
-      .load()
-      .then(function () {
-        expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-      })
-      .then(done)
-      .catch(done.fail);
+    await kml.load();
+    expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
   });
 
-  it("can load a KMZ file by provided Blob", function (done) {
-    loadBlob("test/KML/vic_police.kmz").then(function (blob) {
+  it("can load a KMZ file by provided Blob", async function () {
+    await loadBlob("test/KML/vic_police.kmz").then(function (blob) {
       kml.data = blob;
       kml.dataSourceUrl = "anything.kmz";
-      kml
-        .load()
-        .then(function () {
-          expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-        })
-        .then(done)
-        .catch(done.fail);
+      kml.load();
+      expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
     });
   });
 
   describe("error handling", function () {
-    it("fails gracefully when the data at a URL is not XML", function (done) {
+    it("fails gracefully when the data at a URL is not XML", async function () {
       kml.url = "test/CZML/simple.czml";
-      kml
+      await kml
         .load()
         .then(function () {
-          done.fail("Load should not succeed.");
+          throw new Error("Load should not succeed.");
         })
         .catch(function (e) {
           expect(e instanceof TerriaError).toBe(true);
-          done();
         });
     });
 
-    it("fails gracefully when the provided string is not XML", function (done) {
-      loadText("test/CZML/simple.czml").then(function (s) {
+    it("fails gracefully when the provided string is not XML", async function () {
+      await loadText("test/CZML/simple.czml").then(function (s) {
         kml.data = s;
         kml.dataSourceUrl = "anything.czml";
 
         kml
           .load()
           .then(function () {
-            done.fail("Load should not succeed.");
+            throw new Error("Load should not succeed.");
           })
           .catch(function (e) {
             expect(e instanceof TerriaError).toBe(true);
-            done();
           });
       });
     });
 
-    it("fails gracefully when the provided blob is not XML", function (done) {
-      loadBlob("test/CZML/simple.czml").then(function (blob) {
+    it("fails gracefully when the provided blob is not XML", async function () {
+      await loadBlob("test/CZML/simple.czml").then(function (blob) {
         kml.data = blob;
         kml.dataSourceUrl = "anything.czml";
 
         kml
           .load()
           .then(function () {
-            done.fail("Load should not succeed.");
+            throw new Error("Load should not succeed.");
           })
           .catch(function (e) {
             expect(e instanceof TerriaError).toBe(true);
-            done();
           });
       });
     });

--- a/test/Models/Catalog/CatalogItems/KmlCatalogItemSpec.js
+++ b/test/Models/Catalog/CatalogItems/KmlCatalogItemSpec.js
@@ -44,30 +44,27 @@ describeIfSupported("KmlCatalogItem", function () {
   });
 
   it("can load a KML file by provided XML data", async function () {
-    await loadXML("test/KML/vic_police.kml").then(function (xml) {
-      kml.data = xml;
-      kml.dataSourceUrl = "anything.kml";
-      kml.load();
-      expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-    });
+    const xml = await loadXML("test/KML/vic_police.kml");
+    kml.data = xml;
+    kml.dataSourceUrl = "anything.kml";
+    await kml.load();
+    expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
   });
 
   it("can load a KML file by provided Blob", async function () {
-    await loadBlob("test/KML/vic_police.kml").then(function (blob) {
-      kml.data = blob;
-      kml.dataSourceUrl = "anything.kml";
-      kml.load();
-      expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-    });
+    const blob = await loadBlob("test/KML/vic_police.kml");
+    kml.data = blob;
+    kml.dataSourceUrl = "anything.kml";
+    await kml.load();
+    expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
   });
 
   it("can load a KML file by provided string", async function () {
-    await loadText("test/KML/vic_police.kml").then(function (s) {
-      kml.data = s;
-      kml.dataSourceUrl = "anything.kml";
-      kml.load();
-      expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-    });
+    const text = await loadText("test/KML/vic_police.kml");
+    kml.data = text;
+    kml.dataSourceUrl = "anything.kml";
+    await kml.load();
+    expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
   });
 
   it("can load a KMZ file by URL", async function () {
@@ -78,12 +75,11 @@ describeIfSupported("KmlCatalogItem", function () {
   });
 
   it("can load a KMZ file by provided Blob", async function () {
-    await loadBlob("test/KML/vic_police.kmz").then(function (blob) {
-      kml.data = blob;
-      kml.dataSourceUrl = "anything.kmz";
-      kml.load();
-      expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
-    });
+    const blob = await loadBlob("test/KML/vic_police.kmz");
+    kml.data = blob;
+    kml.dataSourceUrl = "anything.kmz";
+    kml.load();
+    expect(kml.dataSource.entities.values.length).toBeGreaterThan(0);
   });
 
   describe("error handling", function () {
@@ -100,35 +96,33 @@ describeIfSupported("KmlCatalogItem", function () {
     });
 
     it("fails gracefully when the provided string is not XML", async function () {
-      await loadText("test/CZML/simple.czml").then(function (s) {
-        kml.data = s;
-        kml.dataSourceUrl = "anything.czml";
+      const text = await loadText("test/CZML/simple.czml");
+      kml.data = text;
+      kml.dataSourceUrl = "anything.czml";
 
-        kml
-          .load()
-          .then(function () {
-            throw new Error("Load should not succeed.");
-          })
-          .catch(function (e) {
-            expect(e instanceof TerriaError).toBe(true);
-          });
-      });
+      await kml
+        .load()
+        .then(function () {
+          throw new Error("Load should not succeed.");
+        })
+        .catch(function (e) {
+          expect(e instanceof TerriaError).toBe(true);
+        });
     });
 
     it("fails gracefully when the provided blob is not XML", async function () {
-      await loadBlob("test/CZML/simple.czml").then(function (blob) {
-        kml.data = blob;
-        kml.dataSourceUrl = "anything.czml";
+      const blob = await loadBlob("test/CZML/simple.czml");
+      kml.data = blob;
+      kml.dataSourceUrl = "anything.czml";
 
-        kml
-          .load()
-          .then(function () {
-            throw new Error("Load should not succeed.");
-          })
-          .catch(function (e) {
-            expect(e instanceof TerriaError).toBe(true);
-          });
-      });
+      await kml
+        .load()
+        .then(function () {
+          throw new Error("Load should not succeed.");
+        })
+        .catch(function (e) {
+          expect(e instanceof TerriaError).toBe(true);
+        });
     });
   });
 });

--- a/test/Models/Catalog/CatalogItems/TerrainCatalogItemSpec.js
+++ b/test/Models/Catalog/CatalogItems/TerrainCatalogItemSpec.js
@@ -15,7 +15,7 @@ describe("TerrainCatalogItem", function () {
     item = new TerrainCatalogItem(terria);
   });
 
-  it("sets terrainProvider on Cesium scene when enabled", function (done) {
+  it("sets terrainProvider on Cesium scene when enabled", async function () {
     var fakeTerrainProvider = {};
     spyOn(item, "_createTerrainProvider").and.returnValue(fakeTerrainProvider);
 
@@ -27,16 +27,11 @@ describe("TerrainCatalogItem", function () {
 
     item.isEnabled = true;
 
-    item
-      .load()
-      .then(function () {
-        expect(terria.cesium.scene.terrainProvider).toBe(fakeTerrainProvider);
-      })
-      .then(done)
-      .catch(done.fail);
+    await item.load();
+    expect(terria.cesium.scene.terrainProvider).toBe(fakeTerrainProvider);
   });
 
-  it("restores previous terrainProvider when disabled", function (done) {
+  it("restores previous terrainProvider when disabled", async function () {
     var fakeTerrainProvider = {};
     spyOn(item, "_createTerrainProvider").and.returnValue(fakeTerrainProvider);
 
@@ -49,21 +44,14 @@ describe("TerrainCatalogItem", function () {
 
     item.isEnabled = true;
 
-    item
-      .load()
-      .then(function () {
-        expect(terria.cesium.scene.terrainProvider).toBe(fakeTerrainProvider);
+    await item.load();
+    expect(terria.cesium.scene.terrainProvider).toBe(fakeTerrainProvider);
 
-        item.isEnabled = false;
-        expect(terria.cesium.scene.terrainProvider).toBe(
-          originalTerrainProvider
-        );
-      })
-      .then(done)
-      .catch(done.fail);
+    item.isEnabled = false;
+    expect(terria.cesium.scene.terrainProvider).toBe(originalTerrainProvider);
   });
 
-  it("hides other terrainProvider catalog items when enabled", function (done) {
+  it("hides other terrainProvider catalog items when enabled", async function () {
     terria.cesium = {
       scene: {
         terrainProvider: undefined
@@ -74,21 +62,15 @@ describe("TerrainCatalogItem", function () {
     spyOn(enabledItem, "_createTerrainProvider").and.returnValue({});
     enabledItem.isEnabled = true;
 
-    enabledItem
-      .load()
-      .then(function () {
-        spyOn(item, "_createTerrainProvider").and.returnValue({});
-        item.isEnabled = true;
+    await enabledItem.load();
+    spyOn(item, "_createTerrainProvider").and.returnValue({});
+    item.isEnabled = true;
 
-        return item.load().then(function () {
-          expect(enabledItem.isShown).toBe(false);
-        });
-      })
-      .then(done)
-      .catch(done.fail);
+    await item.load();
+    expect(enabledItem.isShown).toBe(false);
   });
 
-  it("hides CompositeCatalogItem containing terrain when enabled", function (done) {
+  it("hides CompositeCatalogItem containing terrain when enabled", async function () {
     terria.cesium = {
       scene: {
         terrainProvider: undefined
@@ -102,36 +84,25 @@ describe("TerrainCatalogItem", function () {
 
     composite.isEnabled = true;
 
-    composite
-      .load()
-      .then(function () {
-        spyOn(item, "_createTerrainProvider").and.returnValue({});
-        item.isEnabled = true;
+    await composite.load();
+    spyOn(item, "_createTerrainProvider").and.returnValue({});
+    item.isEnabled = true;
 
-        return item.load().then(function () {
-          expect(composite.isShown).toBe(false);
-        });
-      })
-      .then(done)
-      .catch(done.fail);
+    await item.load();
+    expect(composite.isShown).toBe(false);
   });
 
-  it("throws when shown in 2D", function (done) {
+  it("throws when shown in 2D", async function () {
     terria.leaflet = {};
     spyOn(item, "_createTerrainProvider").and.returnValue({});
     spyOn(terria.error, "raiseEvent");
 
     item.isEnabled = true;
 
-    item
-      .load()
-      .then(function () {
-        expect(terria.raiseErrorToUser).toHaveBeenCalled();
-        expect(item.isShown).toBe(false);
-        item.isShown = true;
-        expect(terria.raiseErrorToUser.calls.count()).toBe(2);
-      })
-      .then(done)
-      .catch(done.fail);
+    await item.load();
+    expect(terria.raiseErrorToUser).toHaveBeenCalled();
+    expect(item.isShown).toBe(false);
+    item.isShown = true;
+    expect(terria.raiseErrorToUser.calls.count()).toBe(2);
   });
 });

--- a/test/Models/Catalog/CatalogMemberSpec.js
+++ b/test/Models/Catalog/CatalogMemberSpec.js
@@ -22,23 +22,19 @@ describe("CatalogMember", function () {
       };
     });
 
-    it("alters isLoading", function (done) {
-      member
-        .load()
-        .then(function () {
-          expect(member.isLoading).toBe(false);
-          done();
-        })
-        .catch(done.fail);
+    it("alters isLoading", async function () {
+      await member.load().then(function () {
+        expect(member.isLoading).toBe(false);
+      });
     });
 
-    it("returns a promise that allows otherwise to be chained", function (done) {
+    it("returns a promise that allows otherwise to be chained", async function () {
       member._load = function () {
         return Promise.reject();
       };
       expect(true).toBe(true); // stop it whinging about no expectations.
 
-      member.load().then(done.fail).catch(done);
+      await expect(member.load()).reject.toBeDefined();
     });
 
     it("returns the same promise for subsequent calls", function () {
@@ -118,8 +114,8 @@ describe("CatalogMember", function () {
   });
 
   describe("updateFromJson", function () {
-    it("merges the info property", function (done) {
-      member
+    it("merges the info property", async function () {
+      await member
         .updateFromJson({
           info: [
             {
@@ -152,9 +148,7 @@ describe("CatalogMember", function () {
           expect(member.info[0].content).toBe("New Value!");
           expect(member.info[1].name).toBe("Another Field");
           expect(member.info[1].content).toBe("Another value");
-        })
-        .then(done)
-        .catch(done.fail);
+        });
     });
   });
 });

--- a/test/Models/Catalog/Ows/WebMapServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapServiceCatalogItemSpec.ts
@@ -646,7 +646,7 @@ describe("WebMapServiceCatalogItem", function () {
     expect(wms.getFeatureInfoFormat.format).toBe("application/vnd.ogc.gml");
   });
 
-  it("uses default time", function (done) {
+  it("uses default time", async function () {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
     runInAction(() => {
@@ -659,13 +659,8 @@ describe("WebMapServiceCatalogItem", function () {
       wmsItem.setTrait(CommonStrata.definition, "layers", "A,B");
     });
 
-    wmsItem
-      .loadMetadata()
-      .then(function () {
-        expect(wmsItem.currentTime).toBe("2016-09-24T00:00:00.000Z");
-      })
-      .then(done)
-      .catch(done.fail);
+    await wmsItem.loadMetadata();
+    expect(wmsItem.currentTime).toBe("2016-09-24T00:00:00.000Z");
   });
 
   it("uses default time=current", async function () {
@@ -768,7 +763,7 @@ describe("WebMapServiceCatalogItem", function () {
     expect(imageryProvider.enablePickFeatures).toBe(false);
   });
 
-  it("dimensions and styles for a 'real' WMS layer", function (done) {
+  it("dimensions and styles for a 'real' WMS layer", async function () {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
     runInAction(() => {
@@ -790,63 +785,50 @@ describe("WebMapServiceCatalogItem", function () {
       );
     });
 
-    wmsItem
-      .loadMetadata()
-      .then(function () {
-        expect(wmsItem.styleSelectableDimensions.length).toBe(2);
+    await wmsItem.loadMetadata();
+    expect(wmsItem.styleSelectableDimensions.length).toBe(2);
 
-        // Check Styles and dimensions
-        expect(wmsItem.styleSelectableDimensions[0].selectedId).toBe(
-          "contour/ferret"
-        );
-        expect(wmsItem.styleSelectableDimensions[0].options!.length).toBe(41);
+    // Check Styles and dimensions
+    expect(wmsItem.styleSelectableDimensions[0].selectedId).toBe(
+      "contour/ferret"
+    );
+    expect(wmsItem.styleSelectableDimensions[0].options!.length).toBe(41);
 
-        expect(wmsItem.styleSelectableDimensions[1].selectedId).toBe(
-          "shadefill/alg2"
-        );
-        expect(wmsItem.styleSelectableDimensions[1].options!.length).toBe(40);
+    expect(wmsItem.styleSelectableDimensions[1].selectedId).toBe(
+      "shadefill/alg2"
+    );
+    expect(wmsItem.styleSelectableDimensions[1].options!.length).toBe(40);
 
-        expect(wmsItem.wmsDimensionSelectableDimensions[0].name).toBe(
-          "elevation"
-        );
-        expect(wmsItem.wmsDimensionSelectableDimensions[0].selectedId).toBe(
-          "-0.59375"
-        );
-        expect(
-          wmsItem.wmsDimensionSelectableDimensions[0].options!.length
-        ).toBe(16);
+    expect(wmsItem.wmsDimensionSelectableDimensions[0].name).toBe("elevation");
+    expect(wmsItem.wmsDimensionSelectableDimensions[0].selectedId).toBe(
+      "-0.59375"
+    );
+    expect(wmsItem.wmsDimensionSelectableDimensions[0].options!.length).toBe(
+      16
+    );
 
-        expect(wmsItem.wmsDimensionSelectableDimensions[1].name).toBe("custom");
-        expect(wmsItem.wmsDimensionSelectableDimensions[1].selectedId).toBe(
-          "Another thing"
-        );
-        expect(
-          wmsItem.wmsDimensionSelectableDimensions[1].options!.length
-        ).toBe(4);
+    expect(wmsItem.wmsDimensionSelectableDimensions[1].name).toBe("custom");
+    expect(wmsItem.wmsDimensionSelectableDimensions[1].selectedId).toBe(
+      "Another thing"
+    );
+    expect(wmsItem.wmsDimensionSelectableDimensions[1].options!.length).toBe(4);
 
-        expect(wmsItem.wmsDimensionSelectableDimensions[2].name).toBe(
-          "another"
-        );
-        expect(wmsItem.wmsDimensionSelectableDimensions[2].selectedId).toBe(
-          "Second"
-        );
-        expect(
-          wmsItem.wmsDimensionSelectableDimensions[2].options!.length
-        ).toBe(3);
+    expect(wmsItem.wmsDimensionSelectableDimensions[2].name).toBe("another");
+    expect(wmsItem.wmsDimensionSelectableDimensions[2].selectedId).toBe(
+      "Second"
+    );
+    expect(wmsItem.wmsDimensionSelectableDimensions[2].options!.length).toBe(3);
 
-        expect(wmsItem.legends.length).toBe(2);
-        expect(wmsItem.legends[0].url).toBe(
-          "http://geoport-dev.whoi.edu/thredds/wms/coawst_4/use/fmrc/coawst_4_use_best.ncd?REQUEST=GetLegendGraphic&LAYER=v&PALETTE=ferret"
-        );
-        expect(wmsItem.legends[1].url).toBe(
-          "http://geoport-dev.whoi.edu/thredds/wms/coawst_4/use/fmrc/coawst_4_use_best.ncd?REQUEST=GetLegendGraphic&LAYER=wetdry_mask_u&PALETTE=alg2"
-        );
-      })
-      .then(done)
-      .catch(done.fail);
+    expect(wmsItem.legends.length).toBe(2);
+    expect(wmsItem.legends[0].url).toBe(
+      "http://geoport-dev.whoi.edu/thredds/wms/coawst_4/use/fmrc/coawst_4_use_best.ncd?REQUEST=GetLegendGraphic&LAYER=v&PALETTE=ferret"
+    );
+    expect(wmsItem.legends[1].url).toBe(
+      "http://geoport-dev.whoi.edu/thredds/wms/coawst_4/use/fmrc/coawst_4_use_best.ncd?REQUEST=GetLegendGraphic&LAYER=wetdry_mask_u&PALETTE=alg2"
+    );
   });
 
-  it("fetches default legend - if supportsGetLegendRequest is false", function (done) {
+  it("fetches default legend - if supportsGetLegendRequest is false", async function () {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
     runInAction(() => {
@@ -859,16 +841,11 @@ describe("WebMapServiceCatalogItem", function () {
       wmsItem.setTrait(CommonStrata.definition, "layers", "A");
     });
 
-    wmsItem
-      .loadMetadata()
-      .then(function () {
-        expect(wmsItem.legends.length).toBe(1);
-        expect(wmsItem.legends[0].url).toBe(
-          "http://geoport-dev.whoi.edu/thredds/wms/coawst_4/use/fmrc/coawst_4_use_best.ncd?REQUEST=GetLegendGraphic&LAYER=v&PALETTE=rainbow"
-        );
-      })
-      .then(done)
-      .catch(done.fail);
+    await wmsItem.loadMetadata();
+    expect(wmsItem.legends.length).toBe(1);
+    expect(wmsItem.legends[0].url).toBe(
+      "http://geoport-dev.whoi.edu/thredds/wms/coawst_4/use/fmrc/coawst_4_use_best.ncd?REQUEST=GetLegendGraphic&LAYER=v&PALETTE=rainbow"
+    );
   });
 
   it("fetches default legend - if supportsGetLegendRequest is true", async () => {
@@ -910,7 +887,7 @@ describe("WebMapServiceCatalogItem", function () {
     );
   });
 
-  it("fetches geoserver legend", function (done) {
+  it("fetches geoserver legend", async function () {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
     runInAction(() => {
@@ -924,24 +901,19 @@ describe("WebMapServiceCatalogItem", function () {
       wmsItem.setTrait(CommonStrata.definition, "isGeoServer", true);
     });
 
-    wmsItem
-      .loadMetadata()
-      .then(function () {
-        expect(wmsItem.legends.length).toBe(1);
+    await wmsItem.loadMetadata();
+    expect(wmsItem.legends.length).toBe(1);
 
-        // Match for fontColour = 0xffffff || 0xfff
-        expect(
-          wmsItem.legends[0].url ===
-            "http://example.com/?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A&LEGEND_OPTIONS=fontName%3ACourier%3BfontStyle%3Abold%3BfontSize%3A12%3BforceLabels%3Aon%3BfontAntiAliasing%3Atrue%3BlabelMargin%3A5%3BfontColor%3A0xffffff%3Bdpi%3A182&transparent=true" ||
-            wmsItem.legends[0].url ===
-              "http://example.com/?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A&LEGEND_OPTIONS=fontName%3ACourier%3BfontStyle%3Abold%3BfontSize%3A12%3BforceLabels%3Aon%3BfontAntiAliasing%3Atrue%3BlabelMargin%3A5%3BfontColor%3A0xfff%3Bdpi%3A182&transparent=true"
-        ).toBeTruthy();
-      })
-      .then(done)
-      .catch(done.fail);
+    // Match for fontColour = 0xffffff || 0xfff
+    expect(
+      wmsItem.legends[0].url ===
+        "http://example.com/?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A&LEGEND_OPTIONS=fontName%3ACourier%3BfontStyle%3Abold%3BfontSize%3A12%3BforceLabels%3Aon%3BfontAntiAliasing%3Atrue%3BlabelMargin%3A5%3BfontColor%3A0xffffff%3Bdpi%3A182&transparent=true" ||
+        wmsItem.legends[0].url ===
+          "http://example.com/?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A&LEGEND_OPTIONS=fontName%3ACourier%3BfontStyle%3Abold%3BfontSize%3A12%3BforceLabels%3Aon%3BfontAntiAliasing%3Atrue%3BlabelMargin%3A5%3BfontColor%3A0xfff%3Bdpi%3A182&transparent=true"
+    ).toBeTruthy();
   });
 
-  it("fetches GetLegendGraphic", function (done) {
+  it("fetches GetLegendGraphic", async function () {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
     runInAction(() => {
@@ -960,19 +932,15 @@ describe("WebMapServiceCatalogItem", function () {
       );
     });
 
-    wmsItem
-      .loadMetadata()
-      .then(function () {
-        expect(wmsItem.legends.length).toBe(1);
-        expect(wmsItem.legends[0].url).toBe(
-          "http://example.com/?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A&style=no-legend"
-        );
-      })
-      .then(done)
-      .catch(done.fail);
+    await wmsItem.loadMetadata();
+
+    expect(wmsItem.legends.length).toBe(1);
+    expect(wmsItem.legends[0].url).toBe(
+      "http://example.com/?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A&style=no-legend"
+    );
   });
 
-  it("supports parameters in a GetLegendGraphic request for a layer without a style configured", function (done) {
+  it("supports parameters in a GetLegendGraphic request for a layer without a style configured", async function () {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
     runInAction(() => {
@@ -994,19 +962,14 @@ describe("WebMapServiceCatalogItem", function () {
       );
     });
 
-    wmsItem
-      .loadMetadata()
-      .then(function () {
-        expect(wmsItem.legends.length).toBe(1);
-        expect(wmsItem.legends[0].url).toBe(
-          "http://example.com/mapserv?map=%2Fmap%2Fexample.map&service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A"
-        );
-      })
-      .then(done)
-      .catch(done.fail);
+    await wmsItem.loadMetadata();
+    expect(wmsItem.legends.length).toBe(1);
+    expect(wmsItem.legends[0].url).toBe(
+      "http://example.com/mapserv?map=%2Fmap%2Fexample.map&service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A"
+    );
   });
 
-  it("fetches legend with colourScaleRange", function (done) {
+  it("fetches legend with colourScaleRange", async function () {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
     runInAction(() => {
@@ -1030,20 +993,15 @@ describe("WebMapServiceCatalogItem", function () {
       wmsItem.setTrait(CommonStrata.definition, "colorScaleMaximum", 1);
     });
 
-    wmsItem
-      .loadMetadata()
-      .then(function () {
-        expect(wmsItem.isThredds).toBeTruthy();
-        expect(wmsItem.legends.length).toBe(1);
-        expect(wmsItem.legends[0].url).toBe(
-          "http://geoport-dev.whoi.edu/thredds/wms/?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A&colorscalerange=0%2C1"
-        );
-      })
-      .then(done)
-      .catch(done.fail);
+    await wmsItem.loadMetadata();
+    expect(wmsItem.isThredds).toBeTruthy();
+    expect(wmsItem.legends.length).toBe(1);
+    expect(wmsItem.legends[0].url).toBe(
+      "http://geoport-dev.whoi.edu/thredds/wms/?service=WMS&version=1.3.0&request=GetLegendGraphic&format=image%2Fpng&sld_version=1.1.0&layer=A&colorscalerange=0%2C1"
+    );
   });
 
-  it("`selectableDimensions` is empty if `disableDimensionSelectors` is true", function (done) {
+  it("`selectableDimensions` is empty if `disableDimensionSelectors` is true", async function () {
     const terria = new Terria();
     const wmsItem = new WebMapServiceCatalogItem("some-layer", terria);
     runInAction(() => {
@@ -1067,13 +1025,8 @@ describe("WebMapServiceCatalogItem", function () {
       wmsItem.setTrait(CommonStrata.user, "disableDimensionSelectors", true);
     });
 
-    wmsItem
-      .loadMetadata()
-      .then(function () {
-        expect(wmsItem.selectableDimensions.length).toBe(0);
-      })
-      .then(done)
-      .catch(done.fail);
+    await wmsItem.loadMetadata();
+    expect(wmsItem.selectableDimensions.length).toBe(0);
   });
 
   it("sets isEsri from URL", async function () {

--- a/test/Models/LeafletSpec.js
+++ b/test/Models/LeafletSpec.js
@@ -340,7 +340,7 @@ describe("Leaflet Model", function () {
           // The reset happens in a runLater, which a second click will always come behind in a browser,
           // but this isn't guaranteed in unit tests because they're just two setTimeouts racing each other,
           // so give this a healthy 50ms delay to make sure it comes in behind the 0ms delay in Leaflet.js.
-          await runLater(50);
+          await runLater(() => {}, 50);
           click({
             latlng: latlng
           });

--- a/test/Models/MagdaReferenceSpec.ts
+++ b/test/Models/MagdaReferenceSpec.ts
@@ -32,7 +32,7 @@ describe("MagdaReference", function () {
     }
   };
 
-  it("can dereference to a group", function (done) {
+  it("can dereference to a group", async function () {
     const terria = new Terria();
 
     const model = new MagdaReference(undefined, terria);
@@ -43,18 +43,13 @@ describe("MagdaReference", function () {
       recordGroupWithOneCsv
     );
 
-    model
-      .loadReference()
-      .then(() => {
-        expect(model.target instanceof CatalogGroup).toBe(true);
-        const group = model.target as CatalogGroup;
-        expect(group.isOpen).toBe(false);
-      })
-      .then(done)
-      .catch(done.fail);
+    await model.loadReference();
+    expect(model.target instanceof CatalogGroup).toBe(true);
+    const group = model.target as CatalogGroup;
+    expect(group.isOpen).toBe(false);
   });
 
-  it("dereferenced group contains expected item", function (done) {
+  it("dereferenced group contains expected item", async function () {
     const terria = new Terria();
 
     const model = new MagdaReference(undefined, terria);
@@ -65,22 +60,17 @@ describe("MagdaReference", function () {
       recordGroupWithOneCsv
     );
 
-    model
-      .loadReference()
-      .then(() => {
-        const group = model.target as CatalogGroup;
-        expect(group.members.length).toBe(1);
-        expect(group.members[0]).toBe(
-          recordGroupWithOneCsv.aspects.group.members[0].id
-        );
-        expect(group.memberModels.length).toBe(1);
-        expect(group.memberModels[0] instanceof CsvCatalogItem).toBe(true);
-      })
-      .then(done)
-      .catch(done.fail);
+    await model.loadReference();
+    const group = model.target as CatalogGroup;
+    expect(group.members.length).toBe(1);
+    expect(group.members[0]).toBe(
+      recordGroupWithOneCsv.aspects.group.members[0].id
+    );
+    expect(group.memberModels.length).toBe(1);
+    expect(group.memberModels[0] instanceof CsvCatalogItem).toBe(true);
   });
 
-  it("definition trait can override traits of dereferenced member", function (done) {
+  it("definition trait can override traits of dereferenced member", async function () {
     const terria = new Terria();
 
     const model = new MagdaReference(undefined, terria);
@@ -94,17 +84,12 @@ describe("MagdaReference", function () {
       isOpen: true
     });
 
-    model
-      .loadReference()
-      .then(() => {
-        const group = model.target as CatalogGroup;
-        expect(group.isOpen).toBe(true);
-      })
-      .then(done)
-      .catch(done.fail);
+    await model.loadReference();
+    const group = model.target as CatalogGroup;
+    expect(group.isOpen).toBe(true);
   });
 
-  it("override trait can override traits of the members of a dereferenced group", function (done) {
+  it("override trait can override traits of the members of a dereferenced group", async function () {
     const terria = new Terria();
 
     const model = new MagdaReference(undefined, terria);
@@ -124,18 +109,13 @@ describe("MagdaReference", function () {
       ]
     });
 
-    model
-      .loadReference()
-      .then(() => {
-        const group = model.target as CatalogGroup;
-        const csv = group.memberModels[0] as CsvCatalogItem;
-        expect(csv.url).toBe("somethingelse.csv");
-      })
-      .then(done)
-      .catch(done.fail);
+    await model.loadReference();
+    const group = model.target as CatalogGroup;
+    const csv = group.memberModels[0] as CsvCatalogItem;
+    expect(csv.url).toBe("somethingelse.csv");
   });
 
-  it("changes to override trait affect members of a dereferenced group", function (done) {
+  it("changes to override trait affect members of a dereferenced group", async function () {
     const terria = new Terria();
 
     const model = new MagdaReference(undefined, terria);
@@ -155,33 +135,26 @@ describe("MagdaReference", function () {
       ]
     });
 
-    Promise.resolve()
-      .then(async () => {
-        await model.loadReference();
+    await Promise.resolve();
+    await model.loadReference();
 
-        const group = model.target as CatalogGroup;
-        const csv = group.memberModels[0] as CsvCatalogItem;
-        expect(csv.url).toBe("first.csv");
+    const group = model.target as CatalogGroup;
+    const csv = group.memberModels[0] as CsvCatalogItem;
+    expect(csv.url).toBe("first.csv");
 
-        runInAction(() => {
-          const override: any = model.getTrait(
-            CommonStrata.definition,
-            "override"
-          );
-          override.members[0].url = "second.csv";
-        });
+    runInAction(() => {
+      const override: any = model.getTrait(CommonStrata.definition, "override");
+      override.members[0].url = "second.csv";
+    });
 
-        await model.loadReference();
+    await model.loadReference();
 
-        const group2 = model.target as CatalogGroup;
-        const csv2 = group2.memberModels[0] as CsvCatalogItem;
-        expect(csv2.url).toBe("second.csv");
-      })
-      .then(done)
-      .catch(done.fail);
+    const group2 = model.target as CatalogGroup;
+    const csv2 = group2.memberModels[0] as CsvCatalogItem;
+    expect(csv2.url).toBe("second.csv");
   });
 
-  it("changes to Magda record affect members of a dereferenced group", function (done) {
+  it("changes to Magda record affect members of a dereferenced group", async function () {
     const terria = new Terria();
 
     const model = new MagdaReference(undefined, terria);
@@ -201,30 +174,26 @@ describe("MagdaReference", function () {
       ]
     });
 
-    Promise.resolve()
-      .then(async () => {
-        await model.loadReference();
+    await Promise.resolve();
+    await model.loadReference();
 
-        const group = model.target as CatalogGroup;
-        const csv = group.memberModels[0] as CsvCatalogItem;
-        expect(csv.name).toContain("A thing");
+    const group = model.target as CatalogGroup;
+    const csv = group.memberModels[0] as CsvCatalogItem;
+    expect(csv.name).toContain("A thing");
 
-        runInAction(() => {
-          const magdaRecord: any = model.getTrait(
-            CommonStrata.definition,
-            "magdaRecord"
-          );
-          magdaRecord.aspects.group.members[0].name = "!!!";
-        });
+    runInAction(() => {
+      const magdaRecord: any = model.getTrait(
+        CommonStrata.definition,
+        "magdaRecord"
+      );
+      magdaRecord.aspects.group.members[0].name = "!!!";
+    });
 
-        await model.loadReference();
+    await model.loadReference();
 
-        const group2 = model.target as CatalogGroup;
-        const csv2 = group2.memberModels[0] as CsvCatalogItem;
-        expect(csv2.name).toBe("!!!");
-      })
-      .then(done)
-      .catch(done.fail);
+    const group2 = model.target as CatalogGroup;
+    const csv2 = group2.memberModels[0] as CsvCatalogItem;
+    expect(csv2.name).toBe("!!!");
   });
 
   it("loads valid items and ignores broken items", async function () {
@@ -315,7 +284,7 @@ describe("MagdaReference", function () {
     expect(unknown.target).toBeUndefined();
   });
 
-  it("can add record aspects by override", function (done) {
+  it("can add record aspects by override", async function () {
     const theMagdaItemId = "a magda item id";
     const theRecordName = "Test Record";
     const theRecordId = "test-record-id";
@@ -392,11 +361,10 @@ describe("MagdaReference", function () {
       theCatalogItemName
     );
     expect(catalogItem!.uniqueId).toBe(theRecordId);
-    done();
   });
 
   describe("UI access type", function () {
-    it("returns 'public' when magda v1 access control says the record is public", function (done) {
+    it("returns 'public' when magda v1 access control says the record is public", async function () {
       const terria = new Terria();
       const reference = new MagdaReference("magda-reference", terria);
       reference.setTrait(CommonStrata.definition, "recordId", "test id");
@@ -410,10 +378,9 @@ describe("MagdaReference", function () {
         }
       });
       expect(reference.accessType === "public").toBeTruthy();
-      done();
     });
 
-    it("does not return 'public' when magda v1 access control does not say the record is public", function (done) {
+    it("does not return 'public' when magda v1 access control does not say the record is public", async function () {
       const terria = new Terria();
       const reference = new MagdaReference("magda-reference", terria);
       reference.setTrait(CommonStrata.definition, "recordId", "test id");
@@ -427,10 +394,9 @@ describe("MagdaReference", function () {
         }
       });
       expect(reference.accessType === "public").toBeFalsy();
-      done();
     });
 
-    it("does not return 'public' when magda v2 access control says the record belongs to an org unit without constraint exemption being set.", function (done) {
+    it("does not return 'public' when magda v2 access control says the record belongs to an org unit without constraint exemption being set.", async function () {
       const terria = new Terria();
       const reference = new MagdaReference("magda-reference", terria);
       reference.setTrait(CommonStrata.definition, "recordId", "test id");
@@ -444,10 +410,9 @@ describe("MagdaReference", function () {
         }
       });
       expect(reference.accessType === "public").toBeFalsy();
-      done();
     });
 
-    it("returns 'public' when magda v2 access control says the record belongs to an org unit with constraint exemption being set to true.", function (done) {
+    it("returns 'public' when magda v2 access control says the record belongs to an org unit with constraint exemption being set to true.", async function () {
       const terria = new Terria();
       const reference = new MagdaReference("magda-reference", terria);
       reference.setTrait(CommonStrata.definition, "recordId", "test id");
@@ -462,10 +427,9 @@ describe("MagdaReference", function () {
         }
       });
       expect(reference.accessType === "public").toBeTruthy();
-      done();
     });
 
-    it("does not return 'public' when magda v2 access control says the record belongs to an org unit with constraint exemption being set to false.", function (done) {
+    it("does not return 'public' when magda v2 access control says the record belongs to an org unit with constraint exemption being set to false.", async function () {
       const terria = new Terria();
       const reference = new MagdaReference("magda-reference", terria);
       reference.setTrait(CommonStrata.definition, "recordId", "test id");
@@ -480,10 +444,9 @@ describe("MagdaReference", function () {
         }
       });
       expect(reference.accessType === "public").toBeFalsy();
-      done();
     });
 
-    it("returns 'public' when magda v2 access control does not say the record belongs to an org unit.", function (done) {
+    it("returns 'public' when magda v2 access control does not say the record belongs to an org unit.", async function () {
       const terria = new Terria();
       const reference = new MagdaReference("magda-reference", terria);
       reference.setTrait(CommonStrata.definition, "recordId", "test id");
@@ -497,10 +460,9 @@ describe("MagdaReference", function () {
         }
       });
       expect(reference.accessType === "public").toBeTruthy();
-      done();
     });
 
-    it("returns value depends on magda v2 access control if magda v1 access control also exists.", function (done) {
+    it("returns value depends on magda v2 access control if magda v1 access control also exists.", async function () {
       const terria = new Terria();
       const reference = new MagdaReference("magda-reference", terria);
       reference.setTrait(CommonStrata.definition, "recordId", "test id");
@@ -545,11 +507,9 @@ describe("MagdaReference", function () {
         }
       });
       expect(reference.accessType === "public").toBeFalsy();
-
-      done();
     });
 
-    it("returns 'public' when there are no any access control aspects.", function (done) {
+    it("returns 'public' when there are no any access control aspects.", async function () {
       const terria = new Terria();
       const reference = new MagdaReference("magda-reference", terria);
       reference.setTrait(CommonStrata.definition, "recordId", "test id");
@@ -561,7 +521,6 @@ describe("MagdaReference", function () {
         }
       });
       expect(reference.accessType === "public").toBeTruthy();
-      done();
     });
 
     it("returns `super.accessType` when magdaRecord is unset", function () {

--- a/test/Models/SearchProviders/AustralianGazetteerSearchProviderSpec.ts
+++ b/test/Models/SearchProviders/AustralianGazetteerSearchProviderSpec.ts
@@ -27,10 +27,10 @@ describe("GazetteerSearchProvider", function () {
       Promise.resolve(wfsResponseXml)
     );
     const results = searchProvider.search("Fred");
-    return results.resultsCompletePromise.then(() => {
-      expect(searchProvider.getXml).toHaveBeenCalledTimes(1);
-      expect(results).toBeDefined();
-      expect(results.results.length > 0).toBeTruthy();
-    });
+    await results.resultsCompletePromise;
+
+    expect(searchProvider.getXml).toHaveBeenCalledTimes(1);
+    expect(results).toBeDefined();
+    expect(results.results.length > 0).toBeTruthy();
   });
 });

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -283,7 +283,7 @@ describe("Terria", function () {
     });
 
     describe("via loadMagdaConfig", function () {
-      it("should dereference uniqueId to `/`", function (done) {
+      it("should dereference uniqueId to `/`", async function () {
         expect(terria.catalog.group.uniqueId).toEqual("/");
 
         jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
@@ -293,21 +293,15 @@ describe("Terria", function () {
         // no init sources before starting
         expect(terria.initSources.length).toEqual(0);
 
-        terria
-          .start({
-            configUrl: "test/Magda/map-config-basic.json",
-            i18nOptions
-          })
-          .then(function () {
-            expect(terria.catalog.group.uniqueId).toEqual("/");
-            done();
-          })
-          .catch((error) => {
-            done.fail(error);
-          });
+        await terria.start({
+          configUrl: "test/Magda/map-config-basic.json",
+          i18nOptions
+        });
+
+        expect(terria.catalog.group.uniqueId).toEqual("/");
       });
 
-      it("works with basic initializationUrls", function (done) {
+      it("works with basic initializationUrls", async function () {
         jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
           // terria's "Magda derived url"
           responseJSON: mapConfigBasicJson
@@ -315,27 +309,20 @@ describe("Terria", function () {
         // no init sources before starting
         expect(terria.initSources.length).toEqual(0);
 
-        terria
-          .start({
-            configUrl: "test/Magda/map-config-basic.json",
-            i18nOptions
-          })
-          .then(function () {
-            expect(terria.initSources.length).toEqual(1);
-            expect(isInitFromUrl(terria.initSources[0])).toEqual(true);
-            if (isInitFromUrl(terria.initSources[0])) {
-              expect(terria.initSources[0].initUrl).toEqual(
-                mapConfigBasicJson.aspects["terria-config"]
-                  .initializationUrls[0]
-              );
-            } else {
-              throw "not init source";
-            }
-            done();
-          })
-          .catch((error) => {
-            done.fail(error);
-          });
+        await terria.start({
+          configUrl: "test/Magda/map-config-basic.json",
+          i18nOptions
+        });
+
+        expect(terria.initSources.length).toEqual(1);
+        expect(isInitFromUrl(terria.initSources[0])).toEqual(true);
+        if (isInitFromUrl(terria.initSources[0])) {
+          expect(terria.initSources[0].initUrl).toEqual(
+            mapConfigBasicJson.aspects["terria-config"].initializationUrls[0]
+          );
+        } else {
+          throw "not init source";
+        }
       });
 
       it("works with v7initializationUrls", async function () {
@@ -410,37 +397,30 @@ describe("Terria", function () {
           throw "not init source";
         }
       });
-      it("parses dereferenced group aspect", async function (done) {
+      it("parses dereferenced group aspect", async function () {
         expect(terria.catalog.group.uniqueId).toEqual("/");
         // dereferenced res
         jasmine.Ajax.stubRequest(/.*api\/v0\/registry.*/).andReturn({
           responseJSON: mapConfigDereferencedJson
         });
-        await terria
-          .start({
-            configUrl: "test/Magda/map-config-dereferenced.json",
-            i18nOptions
-          })
-          .then(function () {
-            const groupAspect = mapConfigDereferencedJson.aspects["group"];
-            const ids = groupAspect.members.map((member: any) => member.id);
-            expect(terria.catalog.group.uniqueId).toEqual("/");
-            // ensure user added data co-exists with dereferenced magda members
-            expect(terria.catalog.group.members.length).toEqual(3);
-            expect(terria.catalog.userAddedDataGroup).toBeDefined();
-            ids.forEach((id: string) => {
-              const model = terria.getModelById(MagdaReference, id);
-              if (!model) {
-                throw "no record id.";
-              }
-              expect(terria.modelIds).toContain(id);
-              expect(model.recordId).toEqual(id);
-            });
-            done();
-          })
-          .catch((error) => {
-            done.fail(error);
-          });
+        await terria.start({
+          configUrl: "test/Magda/map-config-dereferenced.json",
+          i18nOptions
+        });
+        const groupAspect = mapConfigDereferencedJson.aspects["group"];
+        const ids = groupAspect.members.map((member: any) => member.id);
+        expect(terria.catalog.group.uniqueId).toEqual("/");
+        // ensure user added data co-exists with dereferenced magda members
+        expect(terria.catalog.group.members.length).toEqual(3);
+        expect(terria.catalog.userAddedDataGroup).toBeDefined();
+        ids.forEach((id: string) => {
+          const model = terria.getModelById(MagdaReference, id);
+          if (!model) {
+            throw "no record id.";
+          }
+          expect(terria.modelIds).toContain(id);
+          expect(model.recordId).toEqual(id);
+        });
       });
     });
 
@@ -1116,23 +1096,17 @@ describe("Terria", function () {
       jasmine.Ajax.uninstall();
     });
 
-    it("initializes proxy with parameters from config file", function (done) {
-      terria
-        .start({
-          configUrl: "test/init/configProxy.json",
-          i18nOptions
-        })
-        .then(function () {
-          expect(terria.corsProxy.baseProxyUrl).toBe("/myproxy/");
-          expect(terria.corsProxy.proxyDomains).toEqual([
-            "example.com",
-            "csiro.au"
-          ]);
-          done();
-        })
-        .catch((_error) => {
-          done.fail();
-        });
+    it("initializes proxy with parameters from config file", async function () {
+      await terria.start({
+        configUrl: "test/init/configProxy.json",
+        i18nOptions
+      });
+
+      expect(terria.corsProxy.baseProxyUrl).toBe("/myproxy/");
+      expect(terria.corsProxy.proxyDomains).toEqual([
+        "example.com",
+        "csiro.au"
+      ]);
     });
   });
 

--- a/test/ReactViews/DimensionSelectorSectionSpec.tsx
+++ b/test/ReactViews/DimensionSelectorSectionSpec.tsx
@@ -135,22 +135,22 @@ describe("DimensionSelectorSection", function () {
       );
     });
 
-    await wmsItem.loadMetadata().then(function () {
-      const { container } = render(
-        <ThemeProvider theme={terriaTheme}>
-          <SelectableDimensionSection
-            item={wmsItem}
-            placement={DEFAULT_PLACEMENT}
-          />
-        </ThemeProvider>
-      );
+    await wmsItem.loadMetadata();
 
-      // Expect 5 dimensions (elevation, custom, another + 2 styles)
-      const labels = container.querySelectorAll("label");
+    const { container } = render(
+      <ThemeProvider theme={terriaTheme}>
+        <SelectableDimensionSection
+          item={wmsItem}
+          placement={DEFAULT_PLACEMENT}
+        />
+      </ThemeProvider>
+    );
 
-      expect(screen.getAllByRole("combobox").length).toBe(5);
-      expect(labels.length).toBe(5);
-    });
+    // Expect 5 dimensions (elevation, custom, another + 2 styles)
+    const labels = container.querySelectorAll("label");
+
+    expect(screen.getAllByRole("combobox").length).toBe(5);
+    expect(labels.length).toBe(5);
   });
 
   it("shows csv region mapping options", async function () {

--- a/test/ReactViews/Map/Panels/SharePanel/BuildShareLinkSpec.ts
+++ b/test/ReactViews/Map/Panels/SharePanel/BuildShareLinkSpec.ts
@@ -65,54 +65,44 @@ describe("BuildShareLink", function () {
   });
 
   describe("user added model containing local data", function () {
-    it("should not be serialized", function (done) {
+    it("should not be serialized", async function () {
       const modelId = "Test";
       const model = new GeoJsonCatalogItem(modelId, terria);
 
-      loadBlob("test/GeoJSON/bike_racks.geojson", {})
-        .then((blob) => {
-          model.setFileInput(blob as File);
-          terria.addModel(model);
+      const blob = await loadBlob("test/GeoJSON/bike_racks.geojson", {});
+      model.setFileInput(blob as File);
+      terria.addModel(model);
 
-          expect(terria.getModelById(BaseModel, modelId)).toBe(model);
-          expect(isShareable(terria)(modelId)).toBe(false);
-          return addUserCatalogMember(terria, model);
-        })
-        .then(() => {
-          const shareLink = buildShareLink(terria, viewState);
-          const params = decodeAndParseStartHash(shareLink);
-          const initSources = flattenInitSources(params.initSources);
+      expect(terria.getModelById(BaseModel, modelId)).toBe(model);
+      expect(isShareable(terria)(modelId)).toBe(false);
+      await addUserCatalogMember(terria, model);
 
-          expect(
-            initSources.models?.[USER_ADDED_CATEGORY_ID].members
-          ).not.toContain(model.uniqueId);
+      const shareLink = buildShareLink(terria, viewState);
+      const params = decodeAndParseStartHash(shareLink);
+      const initSources = flattenInitSources(params.initSources);
 
-          done();
-        });
+      expect(
+        initSources.models?.[USER_ADDED_CATEGORY_ID].members
+      ).not.toContain(model.uniqueId);
     });
 
-    it("should not be added to workbench in generated url", function (done) {
+    it("should not be added to workbench in generated url", async function () {
       const modelId = "Test";
       const model = new GeoJsonCatalogItem(modelId, terria);
 
-      loadBlob("test/GeoJSON/bike_racks.geojson", {})
-        .then((blob) => {
-          model.setFileInput(blob as File);
-          terria.addModel(model);
-          return addUserCatalogMember(terria, model);
-        })
-        .then(() => {
-          return terria.workbench.add(model);
-        })
-        .then(() => {
-          const shareLink = buildShareLink(terria, viewState);
-          const params = decodeAndParseStartHash(shareLink);
-          const initSources = flattenInitSources(params.initSources);
+      const blob = await loadBlob("test/GeoJSON/bike_racks.geojson", {});
 
-          expect(initSources.workbench).not.toContain(model.uniqueId);
+      model.setFileInput(blob as File);
+      terria.addModel(model);
+      await addUserCatalogMember(terria, model);
 
-          done();
-        });
+      await terria.workbench.add(model);
+
+      const shareLink = buildShareLink(terria, viewState);
+      const params = decodeAndParseStartHash(shareLink);
+      const initSources = flattenInitSources(params.initSources);
+
+      expect(initSources.workbench).not.toContain(model.uniqueId);
     });
   });
 
@@ -131,36 +121,29 @@ describe("BuildShareLink", function () {
       terria.addModel(model);
     });
 
-    it("should be serialized", function (done) {
-      addUserCatalogMember(terria, model).then(() => {
-        const shareLink = buildShareLink(terria, viewState);
-        const params = decodeAndParseStartHash(shareLink);
-        const initSources = flattenInitSources(params.initSources);
+    it("should be serialized", async function () {
+      await addUserCatalogMember(terria, model);
+      const shareLink = buildShareLink(terria, viewState);
+      const params = decodeAndParseStartHash(shareLink);
+      const initSources = flattenInitSources(params.initSources);
 
-        expect(model.uniqueId).toBeDefined();
-        expect(isShareable(terria)(model.uniqueId ?? "")).toBe(true);
-        expect(initSources.models?.[USER_ADDED_CATEGORY_ID].members).toContain(
-          model.uniqueId
-        );
-
-        done();
-      });
+      expect(model.uniqueId).toBeDefined();
+      expect(isShareable(terria)(model.uniqueId ?? "")).toBe(true);
+      expect(initSources.models?.[USER_ADDED_CATEGORY_ID].members).toContain(
+        model.uniqueId
+      );
     });
 
-    it("should be added to workbench in generated url", function (done) {
-      addUserCatalogMember(terria, model)
-        .then(() => {
-          return terria.workbench.add(model);
-        })
-        .then(() => {
-          const shareLink = buildShareLink(terria, viewState);
-          const params = decodeAndParseStartHash(shareLink);
-          const initSources = flattenInitSources(params.initSources);
+    it("should be added to workbench in generated url", async function () {
+      await addUserCatalogMember(terria, model);
 
-          expect(initSources.workbench).toContain(model.uniqueId);
+      await terria.workbench.add(model);
 
-          done();
-        });
+      const shareLink = buildShareLink(terria, viewState);
+      const params = decodeAndParseStartHash(shareLink);
+      const initSources = flattenInitSources(params.initSources);
+
+      expect(initSources.workbench).toContain(model.uniqueId);
     });
   });
 

--- a/test/Table/CsvSpec.ts
+++ b/test/Table/CsvSpec.ts
@@ -9,14 +9,16 @@ describe("Csv", function () {
     expect(dataColumnMajor[1].slice(1)).toEqual(["5", "8", "-3"]);
   }
 
-  it("can read from csv string", function () {
+  it("can read from csv string", async function () {
     const csvString = "x,y\r\n1,5\r\n3,8\r\n4,-3\r\n";
-    return Csv.parseString(csvString, true).then(checkCsvParse);
+    const data = await Csv.parseString(csvString, true);
+    checkCsvParse(data);
   });
 
-  it("can read from csv string that includes comments", function () {
+  it("can read from csv string that includes comments", async function () {
     const csvString =
       "x,y\r\n1,5\r\n3,8\r\n4,-3\r\n# this is a comment\n// and this\n";
-    return Csv.parseString(csvString, true, true).then(checkCsvParse);
+    const data = await Csv.parseString(csvString, true, true);
+    checkCsvParse(data);
   });
 });


### PR DESCRIPTION
### What this PR does

Replace Jasmine `done` callback pattern with `async/await` across 13 test files. This modernises the async test style by replacing `function(done)` / `done()` with `async function()` / `await`, making tests more readable and less error-prone.

### Test me

Run the test suite — no functional changes, only async pattern modernisation

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist) - this PR modifies test files only
- [x] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
