### PR TITLE
UI update: Underline "link" button text 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Capture default timeline state in share links including current time,
   playback etc.
 - Added support for draping imagery on 3D tilesets. This can be enabled per-tileset by setting the [drapeImagery](https://github.com/TerriaJS/terriajs/blob/23a2bb2b9c1058e1c7141b5e678de51af58da82b/lib/Traits/TraitsClasses/Cesium3dTilesTraits.ts#L195-L201) trait to `true`. Then from the workbench, drag the imagery layers that need to be draped, above the tileset item.
+- Underline text buttons
 - [The next improvement]
 
 #### 8.11.3 - 2026-02-02

--- a/lib/ReactViews/Custom/FeedbackLinkCustomComponent.tsx
+++ b/lib/ReactViews/Custom/FeedbackLinkCustomComponent.tsx
@@ -33,7 +33,7 @@ export const FeedbackLink = (props: {
         text-align: left;
       `}
     >
-      <Text bold>
+      <Text bold isLink>
         {parseCustomMarkdownToReact(
           props.feedbackMessage
             ? props.feedbackMessage

--- a/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/my-data-tab.scss
+++ b/lib/ReactViews/ExplorerWindow/Tabs/MyDataTab/my-data-tab.scss
@@ -74,6 +74,7 @@
 
     font-size: variables.$font-size-small;
     font-weight: variables.$font-weight-medium;
+    text-decoration: underline;
     width: 100%;
     padding: variables.$padding 0;
 

--- a/lib/ReactViews/Map/Panels/LangPanel/LangPanel.tsx
+++ b/lib/ReactViews/Map/Panels/LangPanel/LangPanel.tsx
@@ -3,6 +3,7 @@ import Terria from "../../../../Models/Terria";
 import Box from "../../../../Styled/Box";
 import { RawButton } from "../../../../Styled/Button";
 import Icon from "../../../../Styled/Icon";
+import { TextSpan } from "../../../../Styled/Text";
 import Ul, { Li } from "../../../../Styled/List";
 import MenuPanel from "../../../StandardUserInterface/customizable/MenuPanel";
 import Styles from "../../MenuBar/menu-bar.scss";
@@ -51,7 +52,7 @@ const LangPanel = (props: Props) => {
           ).map(([key, value]) => (
             <Li key={key}>
               <RawButton onClick={() => i18n.changeLanguage(key)}>
-                {value}
+                <TextSpan isLink>{value}</TextSpan>
               </RawButton>
             </Li>
           ))}

--- a/lib/ReactViews/Map/Panels/SharePanel/AdvancedOptions/AdvancedOptions.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/AdvancedOptions/AdvancedOptions.tsx
@@ -50,6 +50,7 @@ export const AdvancedOptions: FC<IAdvancedOptionsProps> = ({
         <TextSpan
           fullWidth
           medium
+          isLink
           css={`
             display: flex;
           `}

--- a/lib/ReactViews/Notification/shareConvertNotification.tsx
+++ b/lib/ReactViews/Notification/shareConvertNotification.tsx
@@ -55,7 +55,7 @@ export const shareConvertNotification = (
             text-align: left;
           `}
         >
-          <TextSpan textLight bold medium>
+          <TextSpan textLight bold medium isLink>
             {parseCustomMarkdownToReact(
               i18next.t("share.convertNotificationHelp")
             )}
@@ -69,7 +69,7 @@ export const shareConvertNotification = (
             text-align: left;
           `}
         >
-          <TextSpan textLight bold medium>
+          <TextSpan textLight bold medium isLink>
             {parseCustomMarkdownToReact(
               i18next.t("share.convertNotificationFeedback")
             )}

--- a/lib/ReactViews/Preview/WarningBox.tsx
+++ b/lib/ReactViews/Preview/WarningBox.tsx
@@ -63,7 +63,9 @@ const WarningBox: FC<{
                     showErrorNotification(props.viewState!, props.error!)
                   }
                 >
-                  <TextSpan primary>See details</TextSpan>
+                  <TextSpan primary isLink>
+                    See details
+                  </TextSpan>
                 </RawButton>
               </div>
             ) : null}

--- a/lib/ReactViews/Search/Breadcrumbs.jsx
+++ b/lib/ReactViews/Search/Breadcrumbs.jsx
@@ -9,18 +9,12 @@ import Text, { TextSpan } from "../../Styled/Text";
 import Icon, { StyledIcon } from "../../Styled/Icon";
 import Spacing from "../../Styled/Spacing";
 import { RawButton } from "../../Styled/Button";
-import styled from "styled-components";
 import getAncestors from "../../Models/getAncestors";
 import getDereferencedIfExists from "../../Core/getDereferencedIfExists";
 import { runInAction } from "mobx";
 import CommonStrata from "../../Models/Definition/CommonStrata";
 
-const RawButtonAndUnderline = styled(RawButton)`
-  ${(props) => `
-  &:hover, &:focus {
-    text-decoration: underline ${props.theme.textDark};
-  }`}
-`;
+const RawButtonAndUnderline = RawButton;
 
 @observer
 class Breadcrumbs extends Component {
@@ -63,7 +57,7 @@ class Breadcrumbs extends Component {
           type="button"
           onClick={() => this.openInCatalog(ancestors.slice(i, i + 1))}
         >
-          <TextSpan small textDark>
+          <TextSpan small textDark isLink>
             {parent}
           </TextSpan>
         </RawButtonAndUnderline>
@@ -102,7 +96,7 @@ class Breadcrumbs extends Component {
           glyph={Icon.GLYPHS.globe}
         />
         <Spacing right={1.2} />
-        <Box flexWrap>
+        <Box flexWrap alignItemsFlexEnd>
           {parentGroups &&
             parentGroups.map((parent, i) => (
               <Fragment key={i}>

--- a/lib/ReactViews/Story/StoryBuilder.tsx
+++ b/lib/ReactViews/Story/StoryBuilder.tsx
@@ -406,7 +406,8 @@ class StoryBuilder extends Component<
             textLight
             className={Styles.removeButton}
           >
-            <Icon glyph={Icon.GLYPHS.remove} /> {t("story.removeAllStories")}
+            <Icon glyph={Icon.GLYPHS.remove} />{" "}
+            <TextSpan isLink>{t("story.removeAllStories")}</TextSpan>
           </RawButton>
         </Box>
         <Spacing bottom={2} />

--- a/lib/ReactViews/Workbench/Workbench.tsx
+++ b/lib/ReactViews/Workbench/Workbench.tsx
@@ -100,7 +100,7 @@ class Workbench extends Component<IProps> {
                 styledWidth={"12px"}
                 displayInline
               />
-              <TextSpan textLight small>
+              <TextSpan textLight small isLink>
                 {t("workbench.enableAll")}
               </TextSpan>
             </RawButton>
@@ -121,7 +121,7 @@ class Workbench extends Component<IProps> {
                 styledWidth={"12px"}
                 displayInline
               />
-              <TextSpan textLight small>
+              <TextSpan textLight small isLink>
                 {t("workbench.disableAll")}
               </TextSpan>
             </RawButton>
@@ -143,7 +143,7 @@ class Workbench extends Component<IProps> {
                 styledWidth={"12px"}
                 displayInline
               />
-              <TextSpan textLight small>
+              <TextSpan textLight small isLink>
                 {t("workbench.expandAll")}
               </TextSpan>
             </RawButton>
@@ -164,7 +164,7 @@ class Workbench extends Component<IProps> {
                 styledWidth={"12px"}
                 displayInline
               />
-              <TextSpan textLight small>
+              <TextSpan textLight small isLink>
                 {t("workbench.collapseAll")}
               </TextSpan>
             </RawButton>
@@ -189,7 +189,7 @@ class Workbench extends Component<IProps> {
               styledWidth={"12px"}
               displayInline
             />
-            <TextSpan textLight small>
+            <TextSpan textLight small isLink>
               {t("workbench.removeAll")}
             </TextSpan>
           </RawButton>


### PR DESCRIPTION
### What this PR does
For buttons that are plain text or text + icon, underline so it's more obviously clickable. 
Fix Breadcrumbs alignment

Ideally this would be done via a prop on `RawButton` but a) We don't wanter to underline the icon, b) the color is typically set on the text element rather than the button itself

<img width="540" height="231" alt="Screenshot 2026-02-19 at 3 27 07 pm" src="https://github.com/user-attachments/assets/1d65de2f-0d28-49b4-833a-fd0c4a47dc1f" />
<img width="1243" height="371" alt="Screenshot 2026-02-19 at 3 14 05 pm" src="https://github.com/user-attachments/assets/7aa4ee9c-aff7-4b11-8f7f-b7086a00f722" />
<img width="812" height="308" alt="Screenshot 2026-02-19 at 3 13 42 pm" src="https://github.com/user-attachments/assets/b3dc21f9-a185-4743-9dd5-7c473efc8d14" />
<img width="764" height="541" alt="Screenshot 2026-02-19 at 2 58 34 pm" src="https://github.com/user-attachments/assets/ca92de34-4a5b-49fb-a18d-042bc5da4a19" />
<img width="530" height="429" alt="Screenshot 2026-02-19 at 2 57 03 pm" src="https://github.com/user-attachments/assets/a647be5c-7f65-47c3-a164-cd6483ded9a2" />
<img width="745" height="304" alt="Screenshot 2026-02-19 at 2 50 06 pm" src="https://github.com/user-attachments/assets/0af9e0cc-a14c-4824-8478-21a32574bc54" />
<img width="485" height="155" alt="Screenshot 2026-02-19 at 2 49 26 pm" src="https://github.com/user-attachments/assets/723937b6-e91d-4198-9901-bd1e20a7fd5c" />
<img width="506" height="168" alt="Screenshot 2026-02-19 at 2 46 57 pm" src="https://github.com/user-attachments/assets/35dd7505-8c1f-4995-909a-99c4dcbbbf27" />
<img width="341" height="466" alt="Screenshot 2026-02-19 at 2 46 09 pm" src="https://github.com/user-attachments/assets/5b29132e-a43b-4c1e-b959-5779014c732d" />
<img width="458" height="385" alt="Screenshot 2026-02-19 at 2 46 06 pm" src="https://github.com/user-attachments/assets/3bc046c5-83c1-4db3-9218-9e23cba0fabd" />


### Test me

Navigate http://ci.terria.io/underline-link-buttons and see style changes

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist) N/A
- [ ] I've updated relevant documentation in `doc/`. N/A
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
