### PR TITLE
fix branch name parsing in deploy scrip

### DIFF
--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-GITHUB_BRANCH=${GITHUB_REF##*/}
+GITHUB_BRANCH=${GITHUB_REF_NAME}
 
 # Don't run for greenkeeper branches; there are too many!
 if [[ $GITHUB_BRANCH =~ ^greenkeeper/ ]]; then
@@ -10,7 +10,9 @@ if [[ $GITHUB_BRANCH =~ ^greenkeeper/ ]]; then
 fi
 
 # A version of the branch name that can be used as a DNS name once we prepend and append some stuff.
-SAFE_BRANCH_NAME=$(printf '%s' "${GITHUB_BRANCH:0:32}" | sed -e 's/./\L&/g' -e 's/[^-a-z0-9]/-/g' -e 's/-*$//')
+SAFE_BRANCH_NAME=$(printf '%s' "${GITHUB_BRANCH:0:32}" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^-a-z0-9]/-/g' -e 's/-*$//')
+echo $SAFE_BRANCH_NAME
+echo $GITHUB_BRANCH
 
 [[ $SAFE_BRANCH_NAME != $GITHUB_BRANCH ]] && echo "::warning file=buildprocess/ci-deploy.sh::Branch name sanitised to '${SAFE_BRANCH_NAME}' for kubernetes resources. This may work, however using branch names less than 32 characters long with [a-z0-9] and hyphen separators are preferred"
 

--- a/buildprocess/ci-deploy.sh
+++ b/buildprocess/ci-deploy.sh
@@ -11,8 +11,6 @@ fi
 
 # A version of the branch name that can be used as a DNS name once we prepend and append some stuff.
 SAFE_BRANCH_NAME=$(printf '%s' "${GITHUB_BRANCH:0:32}" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^-a-z0-9]/-/g' -e 's/-*$//')
-echo $SAFE_BRANCH_NAME
-echo $GITHUB_BRANCH
 
 [[ $SAFE_BRANCH_NAME != $GITHUB_BRANCH ]] && echo "::warning file=buildprocess/ci-deploy.sh::Branch name sanitised to '${SAFE_BRANCH_NAME}' for kubernetes resources. This may work, however using branch names less than 32 characters long with [a-z0-9] and hyphen separators are preferred"
 


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

When the branch name contains `/`, it is parsed incorrectly, and deployment fails because the dependency sync isn't able to resolve the branch in terriajs repo. `GITHUB_REF_NAME` only contains short ref name of the branch or tag that triggered the workflow run (see https://docs.github.com/en/actions/reference/workflows-and-actions/variables for more details. 

### Test me

CI deployment is passing on this branch.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- ~[ ] I've updated relevant documentation in `doc/`.~
- ~[ ] I've updated CHANGES.md with what I changed.~
- [x] I've provided instructions in the PR description on how to test this PR.
