### PR TITLE
remove ts-essentials from dependencies and replace pick properties with custom utility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Update gulpfile.js to gulp V4 syntax, which provides task descriptions in `yarn gulp --tasks`.
 - Fix splitter failing for local file catalog items by storing file data as blob URLs in the `url` trait instead of private instance fields, ensuring `duplicateModel()` preserves the data. [#7762](https://github.com/TerriaJS/terriajs/pull/7762)
 - Replace react-uid with react useId hook for generating unique ids.
+- Remove ts-essentials dependency and replace with custom type utility.
 - [The next improvement]
 
 #### 8.11.3 - 2026-02-02

--- a/lib/Table/TableStyleMap.ts
+++ b/lib/Table/TableStyleMap.ts
@@ -1,5 +1,4 @@
 import { computed, makeObservable } from "mobx";
-import { PickProperties } from "ts-essentials";
 import JsonValue from "../Core/Json";
 import { NotUndefined } from "../Core/TypeModifiers";
 import TableMixin from "../ModelMixins/TableMixin";
@@ -11,6 +10,10 @@ import {
   TableStyleMapTraits
 } from "../Traits/TraitsClasses/Table/StyleMapTraits";
 import TableStyleTraits from "../Traits/TraitsClasses/Table/StyleTraits";
+
+type PickProperties<Type, Value> = {
+  [Key in keyof Type as Type[Key] extends Value ? Key : never]: Type[Key];
+};
 
 export interface TableStyleMapModel<T extends TableStyleMapSymbolTraits> {
   enabled?: boolean;

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "terriajs-tiff-imagery-provider": "2.13.3-webpack5-3",
     "terriajs-typings-for-css-modules-loader": "^2.5.2",
     "thredds-catalog-crawler": "0.0.7",
-    "ts-essentials": "^5.0.0",
     "typescript": "^5.9.2",
     "urijs": "^1.18.12",
     "webpack": "^5.96.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9499,11 +9499,6 @@ ts-api-utils@^2.0.1:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.0.1.tgz#660729385b625b939aaa58054f45c058f33f10cd"
   integrity sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==
 
-ts-essentials@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-5.0.0.tgz#531d590c9cd62652c9d96284904cbdb2a1dd5ca8"
-  integrity sha512-ftKWOm6Jq+/UCBekDfxUjLODEd5XGN2EM/+TIQV9LJ5xSV12je4GqdRyv7pXXGGYmEt/nQa6F00xTWYJ5PMjIQ==
-
 tslib@^2.3.0, tslib@^2.3.1, tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

`ts-essentials` is used in only one place, and the type used is super simple, so it is not worth the maintenance overhead of tracking versions and upgrading

### Test me

Build is passing

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
