### PR TITLE
POC: Add splitter support for vector data in leaflet

### DIFF
--- a/lib/Map/Leaflet/ImageryProviderLeafletGridLayer.ts
+++ b/lib/Map/Leaflet/ImageryProviderLeafletGridLayer.ts
@@ -1,17 +1,12 @@
 import L from "leaflet";
-import {
-  autorun,
-  computed,
-  IReactionDisposer,
-  observable,
-  makeObservable
-} from "mobx";
+import { autorun, IReactionDisposer, observable, makeObservable } from "mobx";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
 import CesiumEvent from "terriajs-cesium/Source/Core/Event";
 import CesiumMath from "terriajs-cesium/Source/Core/Math";
 import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
 import Leaflet from "../../Models/Leaflet";
 import ImageryProvider from "terriajs-cesium/Source/Scene/ImageryProvider";
+import getClipsForSplitter from "./getClipsForSplitter";
 
 export interface ImageryProviderWithGridLayerSupport extends ImageryProvider {
   requestImageForCanvas: (
@@ -70,48 +65,29 @@ export default class ImageryProviderLeafletGridLayer extends L.GridLayer {
         return;
       }
 
+      if (
+        this.splitDirection === SplitDirection.NONE ||
+        !this.leaflet.size ||
+        !this.leaflet.nw ||
+        !this.leaflet.se
+      ) {
+        container.style.clipPath = "none";
+        return;
+      }
+
+      const clips = getClipsForSplitter({
+        size: this.leaflet.size,
+        nw: this.leaflet.nw,
+        se: this.leaflet.se,
+        splitPosition: this.splitPosition
+      });
+
       if (this.splitDirection === SplitDirection.LEFT) {
-        const { left: clipLeft } = this._clipsForSplitter;
-        container.style.clip = clipLeft;
-      } else if (this.splitDirection === SplitDirection.RIGHT) {
-        const { right: clipRight } = this._clipsForSplitter;
-        container.style.clip = clipRight;
+        container.style.clipPath = clips.left;
       } else {
-        container.style.clip = "auto";
+        container.style.clipPath = clips.right;
       }
     });
-  }
-
-  @computed
-  get _clipsForSplitter() {
-    let clipLeft = "";
-    let clipRight = "";
-    let clipPositionWithinMap;
-    let clipX;
-
-    if (this.leaflet.size && this.leaflet.nw && this.leaflet.se) {
-      clipPositionWithinMap = this.leaflet.size.x * this.splitPosition;
-      clipX = Math.round(this.leaflet.nw.x + clipPositionWithinMap);
-      clipLeft =
-        "rect(" +
-        [this.leaflet.nw.y, clipX, this.leaflet.se.y, this.leaflet.nw.x].join(
-          "px,"
-        ) +
-        "px)";
-      clipRight =
-        "rect(" +
-        [this.leaflet.nw.y, this.leaflet.se.x, this.leaflet.se.y, clipX].join(
-          "px,"
-        ) +
-        "px)";
-    }
-
-    return {
-      left: clipLeft,
-      right: clipRight,
-      clipPositionWithinMap: clipPositionWithinMap,
-      clipX: clipX
-    };
   }
 
   createTile(tilePoint: L.Coords, done: L.DoneCallback) {

--- a/lib/Map/Leaflet/ImageryProviderLeafletTileLayer.ts
+++ b/lib/Map/Leaflet/ImageryProviderLeafletTileLayer.ts
@@ -1,12 +1,6 @@
 import i18next from "i18next";
 import L, { TileEvent } from "leaflet";
-import {
-  autorun,
-  computed,
-  IReactionDisposer,
-  observable,
-  makeObservable
-} from "mobx";
+import { autorun, IReactionDisposer, observable, makeObservable } from "mobx";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartographic from "terriajs-cesium/Source/Core/Cartographic";
 import CesiumCredit from "terriajs-cesium/Source/Core/Credit";
@@ -21,6 +15,7 @@ import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
 import isDefined from "../../Core/isDefined";
 import TerriaError from "../../Core/TerriaError";
 import Leaflet from "../../Models/Leaflet";
+import getClipsForSplitter from "./getClipsForSplitter";
 import getUrlForImageryTile from "../ImageryProvider/getUrlForImageryTile";
 import { ProviderCoords } from "../PickedFeatures/PickedFeatures";
 
@@ -97,47 +92,29 @@ export default class ImageryProviderLeafletTileLayer extends L.TileLayer {
         return;
       }
 
+      if (
+        this.splitDirection === SplitDirection.NONE ||
+        !this.leaflet.size ||
+        !this.leaflet.nw ||
+        !this.leaflet.se
+      ) {
+        container.style.clipPath = "none";
+        return;
+      }
+
+      const clips = getClipsForSplitter({
+        size: this.leaflet.size,
+        nw: this.leaflet.nw,
+        se: this.leaflet.se,
+        splitPosition: this.splitPosition
+      });
+
       if (this.splitDirection === SplitDirection.LEFT) {
-        const { left: clipLeft } = this._clipsForSplitter;
-        container.style.clip = clipLeft;
-      } else if (this.splitDirection === SplitDirection.RIGHT) {
-        const { right: clipRight } = this._clipsForSplitter;
-        container.style.clip = clipRight;
+        container.style.clipPath = clips.left;
       } else {
-        container.style.clip = "auto";
+        container.style.clipPath = clips.right;
       }
     });
-  }
-
-  @computed
-  get _clipsForSplitter() {
-    let clipLeft = "";
-    let clipRight = "";
-    let clipPositionWithinMap;
-    let clipX;
-
-    if (this.leaflet.size && this.leaflet.nw && this.leaflet.se) {
-      clipPositionWithinMap = this.leaflet.size.x * this.splitPosition;
-      clipX = Math.round(this.leaflet.nw.x + clipPositionWithinMap);
-      clipLeft =
-        "rect(" +
-        [this.leaflet.nw.y, clipX, this.leaflet.se.y, this.leaflet.nw.x].join(
-          "px,"
-        ) +
-        "px)";
-      clipRight =
-        "rect(" +
-        [this.leaflet.nw.y, this.leaflet.se.x, this.leaflet.se.y, clipX].join(
-          "px,"
-        ) +
-        "px)";
-    }
-    return {
-      left: clipLeft,
-      right: clipRight,
-      clipPositionWithinMap: clipPositionWithinMap,
-      clipX: clipX
-    };
   }
 
   _tileOnError(_done: unknown, _tile: unknown, _e: unknown) {

--- a/lib/Map/Leaflet/LeafletVisualizer.ts
+++ b/lib/Map/Leaflet/LeafletVisualizer.ts
@@ -1,4 +1,5 @@
 import L, { LatLngBounds, LatLngBoundsLiteral, PolylineOptions } from "leaflet";
+import { autorun, IReactionDisposer, makeObservable, observable } from "mobx";
 import AssociativeArray from "terriajs-cesium/Source/Core/AssociativeArray";
 import Cartesian2 from "terriajs-cesium/Source/Core/Cartesian2";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
@@ -17,8 +18,10 @@ import EntityCollection from "terriajs-cesium/Source/DataSources/EntityCollectio
 import PolylineDashMaterialProperty from "terriajs-cesium/Source/DataSources/PolylineDashMaterialProperty";
 import PolylineGlowMaterialProperty from "terriajs-cesium/Source/DataSources/PolylineGlowMaterialProperty";
 import Property from "terriajs-cesium/Source/DataSources/Property";
+import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
 import isDefined from "../../Core/isDefined";
 import { convertCesiumDashNumberToDashArray } from "../../Models/Catalog/Esri/esriStyleToTableStyle";
+import getClipsForSplitter from "./getClipsForSplitter";
 import LeafletScene from "./LeafletScene";
 
 interface PointDetails {
@@ -98,25 +101,44 @@ const tmpImage =
  */
 let prevBoundsType = 0;
 
+let paneCounter = 0;
+
 /**
  * A {@link Visualizer} which maps {@link Entity#point} to Leaflet primitives.
  **/
-class LeafletGeomVisualizer {
+export class LeafletGeomVisualizer {
   private readonly _featureGroup: L.FeatureGroup;
   private readonly _entitiesToVisualize: AssociativeArray;
   private readonly _entityHash: EntityHash;
+  private readonly _disposeSplitterReaction: IReactionDisposer;
+
+  readonly paneName: string;
+  readonly paneElement: HTMLElement;
+
+  @observable splitDirection: SplitDirection = SplitDirection.NONE;
+  @observable splitPosition: number = 0.5;
 
   constructor(
     readonly leafletScene: LeafletScene,
     readonly entityCollection: EntityCollection
   ) {
+    makeObservable(this);
+
+    this.paneName = `terriajs-geom-visualizer-${paneCounter++}`;
+    this.paneElement = leafletScene.map.createPane(this.paneName);
+    this.paneElement.style.zIndex = "500";
+
     entityCollection.collectionChanged.addEventListener(
       this._onCollectionChanged,
       this
     );
-    this._featureGroup = L.featureGroup().addTo(leafletScene.map);
+    this._featureGroup = L.featureGroup([], { pane: this.paneName }).addTo(
+      leafletScene.map
+    );
     this._entitiesToVisualize = new AssociativeArray();
     this._entityHash = {};
+
+    this._disposeSplitterReaction = this._reactToSplitterChange();
 
     this._onCollectionChanged(
       entityCollection,
@@ -124,6 +146,33 @@ class LeafletGeomVisualizer {
       [],
       []
     );
+  }
+
+  private _reactToSplitterChange(): IReactionDisposer {
+    return autorun(() => {
+      if (this.splitDirection === SplitDirection.NONE) {
+        this.paneElement.style.clipPath = "none";
+        return;
+      }
+
+      const map = this.leafletScene.map;
+      const size = map.getSize();
+      const nw = map.containerPointToLayerPoint([0, 0]);
+      const se = map.containerPointToLayerPoint(size);
+
+      const clips = getClipsForSplitter({
+        size,
+        nw,
+        se,
+        splitPosition: this.splitPosition
+      });
+
+      if (this.splitDirection === SplitDirection.LEFT) {
+        this.paneElement.style.clipPath = clips.left;
+      } else {
+        this.paneElement.style.clipPath = clips.right;
+      }
+    });
   }
 
   private _onCollectionChanged(
@@ -302,7 +351,8 @@ class LeafletGeomVisualizer {
         fillOpacity: color.alpha,
         color: outlineColor.toCssColorString(),
         weight: outlineWidth,
-        opacity: outlineColor.alpha
+        opacity: outlineColor.alpha,
+        pane: this.paneName
       };
 
       layer = details.layer = L.circleMarker(
@@ -445,7 +495,10 @@ class LeafletGeomVisualizer {
 
     let redrawIcon = false;
     if (!isDefined(geomLayer)) {
-      const markerOptions = { icon: L.icon({ iconUrl: tmpImage }) };
+      const markerOptions = {
+        icon: L.icon({ iconUrl: tmpImage }),
+        pane: this.paneName
+      };
       marker = L.marker(latlng, markerOptions);
       marker.on("click", featureClicked.bind(undefined, this, entity));
       marker.on("mousedown", featureMousedown.bind(undefined, this, entity));
@@ -574,7 +627,10 @@ class LeafletGeomVisualizer {
 
     let redrawLabel = false;
     if (!isDefined(geomLayer)) {
-      const markerOptions = { icon: L.icon({ iconUrl: tmpImage }) };
+      const markerOptions = {
+        icon: L.icon({ iconUrl: tmpImage }),
+        pane: this.paneName
+      };
       marker = L.marker(latlng, markerOptions);
       marker.on("click", featureClicked.bind(undefined, this, entity));
       marker.on("mousedown", featureMousedown.bind(undefined, this, entity));
@@ -719,7 +775,8 @@ class LeafletGeomVisualizer {
         fillOpacity: fillColor.alpha,
         weight: outline ? outlineWidth : 0.0,
         color: outlineColor.toCssColorString(),
-        opacity: outlineColor.alpha
+        opacity: outlineColor.alpha,
+        pane: this.paneName
       };
 
       if (outline && dashArray) {
@@ -857,7 +914,8 @@ class LeafletGeomVisualizer {
         fillOpacity: fillColor.alpha,
         weight: outline ? outlineWidth : 0.0,
         color: outlineColor.toCssColorString(),
-        opacity: outlineColor.alpha
+        opacity: outlineColor.alpha,
+        pane: this.paneName
       };
 
       if (outline && dashArray) {
@@ -989,7 +1047,8 @@ class LeafletGeomVisualizer {
     const polylineOptions: PolylineOptions = {
       color: color.toCssColorString(),
       weight: width,
-      opacity: color.alpha
+      opacity: color.alpha,
+      pane: this.paneName
     };
 
     if (dashArray) {
@@ -1044,6 +1103,8 @@ class LeafletGeomVisualizer {
    * Removes and destroys all primitives created by this instance.
    */
   destroy() {
+    this._disposeSplitterReaction();
+
     const entities = this._entitiesToVisualize.values;
     const entityHash = this._entityHash;
 
@@ -1056,6 +1117,11 @@ class LeafletGeomVisualizer {
       this
     );
     this.leafletScene.map.removeLayer(this._featureGroup);
+
+    if (this.paneElement.parentNode) {
+      this.paneElement.parentNode.removeChild(this.paneElement);
+    }
+
     return destroyObject(this);
   }
 

--- a/lib/Map/Leaflet/getClipsForSplitter.ts
+++ b/lib/Map/Leaflet/getClipsForSplitter.ts
@@ -1,0 +1,31 @@
+type Point = { readonly x: number; readonly y: number };
+
+type ClipInputs = {
+  readonly size: Point;
+  readonly nw: Point;
+  readonly se: Point;
+  readonly splitPosition: number;
+};
+
+type ClipResult = {
+  readonly left: string;
+  readonly right: string;
+  readonly clipX: number;
+};
+
+export default function getClipsForSplitter({
+  size,
+  nw,
+  se,
+  splitPosition
+}: ClipInputs): ClipResult {
+  const clipX = Math.round(nw.x + size.x * splitPosition);
+  const left =
+    `polygon(${nw.x}px ${nw.y}px, ${clipX}px ${nw.y}px, ` +
+    `${clipX}px ${se.y}px, ${nw.x}px ${se.y}px)`;
+  const right =
+    `polygon(${clipX}px ${nw.y}px, ${se.x}px ${nw.y}px, ` +
+    `${se.x}px ${se.y}px, ${clipX}px ${se.y}px)`;
+
+  return { left, right, clipX };
+}

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -37,7 +37,9 @@ import LeafletDataSourceDisplay from "../Map/Leaflet/LeafletDataSourceDisplay";
 import LeafletScene from "../Map/Leaflet/LeafletScene";
 import LeafletSelectionIndicator from "../Map/Leaflet/LeafletSelectionIndicator";
 import getClipsForSplitter from "../Map/Leaflet/getClipsForSplitter";
-import LeafletVisualizer from "../Map/Leaflet/LeafletVisualizer";
+import LeafletVisualizer, {
+  LeafletGeomVisualizer
+} from "../Map/Leaflet/LeafletVisualizer";
 import L from "../Map/LeafletPatched";
 import PickedFeatures, {
   ProviderCoords,
@@ -181,6 +183,10 @@ export default class Leaflet extends GlobeOrMap {
     this._eventHelper.add(this.terria.timelineClock.onTick, ((clock: Clock) => {
       this.dataSourceDisplay.update(clock.currentTime);
     }) as any);
+
+    this._eventHelper.add(this.dataSources.dataSourceAdded, () => {
+      this._applySplitterToDataSources();
+    });
 
     const ticker = () => {
       if (!this._stopRequestAnimationFrame) {
@@ -890,9 +896,9 @@ export default class Leaflet extends GlobeOrMap {
           MappableMixin.isMixedInto(item) &&
           hasTraits(item, SplitterTraits, "splitDirection")
         ) {
-          const layers = this.getImageryLayersForItem(item);
           const splitDirection = item.splitDirection;
 
+          const layers = this.getImageryLayersForItem(item);
           layers.forEach(
             action((layer) => {
               if (showSplitter) {
@@ -906,8 +912,57 @@ export default class Leaflet extends GlobeOrMap {
           );
         }
       });
+      this._applySplitterToDataSources();
       this.notifyRepaintRequired();
     });
+  }
+
+  _applySplitterToDataSources() {
+    const items = this.terria.mainViewer.items.get();
+    const showSplitter = this.terria.showSplitter;
+    const splitPosition = this.terria.splitPosition;
+
+    items.forEach((item) => {
+      if (
+        !MappableMixin.isMixedInto(item) ||
+        !hasTraits(item, SplitterTraits, "splitDirection")
+      ) {
+        return;
+      }
+
+      const splitDirection = item.splitDirection;
+      const visualizers = this.getVisualizersForItem(item);
+      visualizers.forEach(
+        action((visualizer) => {
+          if (showSplitter) {
+            visualizer.splitDirection = splitDirection;
+            visualizer.splitPosition = splitPosition;
+          } else {
+            visualizer.splitDirection = SplitDirection.NONE;
+            visualizer.splitPosition = splitPosition;
+          }
+        })
+      );
+    });
+  }
+
+  getVisualizersForItem(item: MappableMixin.Instance): LeafletGeomVisualizer[] {
+    const result: LeafletGeomVisualizer[] = [];
+    const dataSources = item.mapItems.filter(isDataSource);
+    for (const ds of dataSources) {
+      if (!this.dataSources.contains(ds)) {
+        continue;
+      }
+      const visualizers = (ds as any).visualizers;
+      if (Array.isArray(visualizers)) {
+        for (const v of visualizers) {
+          if (v instanceof LeafletGeomVisualizer) {
+            result.push(v);
+          }
+        }
+      }
+    }
+    return result;
   }
 
   getImageryLayersForItem(

--- a/lib/Models/Leaflet.ts
+++ b/lib/Models/Leaflet.ts
@@ -36,6 +36,7 @@ import ImageryProviderLeafletTileLayer from "../Map/Leaflet/ImageryProviderLeafl
 import LeafletDataSourceDisplay from "../Map/Leaflet/LeafletDataSourceDisplay";
 import LeafletScene from "../Map/Leaflet/LeafletScene";
 import LeafletSelectionIndicator from "../Map/Leaflet/LeafletSelectionIndicator";
+import getClipsForSplitter from "../Map/Leaflet/getClipsForSplitter";
 import LeafletVisualizer from "../Map/Leaflet/LeafletVisualizer";
 import L from "../Map/LeafletPatched";
 import PickedFeatures, {
@@ -984,27 +985,20 @@ export default class Leaflet extends GlobeOrMap {
     }
   }
 
-  getClipsForSplitter(): any {
-    let clipLeft: string = "";
-    let clipRight: string = "";
-    let clipPositionWithinMap: number = 0;
-    let clipX: number = 0;
-    if (this.terria.showSplitter) {
-      const map = this.map;
-      const size = map.getSize();
-      const nw = map.containerPointToLayerPoint([0, 0]);
-      const se = map.containerPointToLayerPoint(size);
-      clipPositionWithinMap = size.x * this.terria.splitPosition;
-      clipX = Math.round(nw.x + clipPositionWithinMap);
-      clipLeft = "rect(" + [nw.y, clipX, se.y, nw.x].join("px,") + "px)";
-      clipRight = "rect(" + [nw.y, se.x, se.y, clipX].join("px,") + "px)";
+  getClipsForSplitter() {
+    if (!this.terria.showSplitter) {
+      return { left: "", right: "", clipPositionWithinMap: 0, clipX: 0 };
     }
 
+    const size = this.map.getSize();
+    const nw = this.map.containerPointToLayerPoint([0, 0]);
+    const se = this.map.containerPointToLayerPoint(size);
+    const splitPosition = this.terria.splitPosition;
+    const clips = getClipsForSplitter({ size, nw, se, splitPosition });
+
     return {
-      left: clipLeft,
-      right: clipRight,
-      clipPositionWithinMap: clipPositionWithinMap,
-      clipX: clipX
+      ...clips,
+      clipPositionWithinMap: size.x * splitPosition
     };
   }
 
@@ -1021,7 +1015,7 @@ export default class Leaflet extends GlobeOrMap {
     this._attributionControl.remove();
 
     try {
-      // html2canvas can't handle the clip style which is used for the splitter. So if the splitter is active, we render
+      // html2canvas can't handle the clip-path style which is used for the splitter. So if the splitter is active, we render
       // a left image and a right image and compose them. Also remove the splitter drag thumb.
       let promise: any;
       if (this.terria.showSplitter) {
@@ -1031,17 +1025,17 @@ export default class Leaflet extends GlobeOrMap {
         promise = html2canvas(this.map.getContainer(), {
           useCORS: true,
           ignoreElements: (element: HTMLElement) =>
-            (element.style.clip !== undefined &&
-              element.style.clip !== null &&
-              element.style.clip.replace(/ /g, "") === clipRight) ||
+            (element.style.clipPath !== undefined &&
+              element.style.clipPath !== null &&
+              element.style.clipPath.replace(/ /g, "") === clipRight) ||
             this.isSplitterDragThumb(element)
         }).then((leftCanvas: HTMLCanvasElement) => {
           return html2canvas(this.map.getContainer(), {
             useCORS: true,
             ignoreElements: (element: HTMLElement) =>
-              (element.style.clip !== undefined &&
-                element.style.clip !== null &&
-                element.style.clip.replace(/ /g, "") === clipLeft) ||
+              (element.style.clipPath !== undefined &&
+                element.style.clipPath !== null &&
+                element.style.clipPath.replace(/ /g, "") === clipLeft) ||
               this.isSplitterDragThumb(element)
           }).then((rightCanvas: HTMLCanvasElement) => {
             const combined = document.createElement("canvas");

--- a/test/Map/Leaflet/LeafletGeomVisualizerSpec.ts
+++ b/test/Map/Leaflet/LeafletGeomVisualizerSpec.ts
@@ -1,0 +1,119 @@
+import L from "leaflet";
+import { runInAction } from "mobx";
+import SplitDirection from "terriajs-cesium/Source/Scene/SplitDirection";
+import EntityCollection from "terriajs-cesium/Source/DataSources/EntityCollection";
+import LeafletScene from "../../../lib/Map/Leaflet/LeafletScene";
+import { LeafletGeomVisualizer } from "../../../lib/Map/Leaflet/LeafletVisualizer";
+
+function createMap(): L.Map {
+  const container = document.createElement("div");
+  container.style.width = "1000px";
+  container.style.height = "600px";
+  document.body.appendChild(container);
+  return L.map(container, { zoomControl: false }).setView([0, 0], 2);
+}
+
+describe("LeafletGeomVisualizer", function () {
+  let map: L.Map;
+  let scene: LeafletScene;
+  let entities: EntityCollection;
+
+  beforeEach(function () {
+    map = createMap();
+    scene = new LeafletScene(map);
+    entities = new EntityCollection();
+  });
+
+  afterEach(function () {
+    map.remove();
+    const container = map.getContainer();
+    if (container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+  });
+
+  it("creates a custom pane on construction", function () {
+    const visualizer = new LeafletGeomVisualizer(scene, entities);
+    const paneElement = visualizer.paneElement;
+    expect(paneElement).toBeDefined();
+    expect(paneElement.parentNode).toBe(map.getPane("mapPane")!);
+    visualizer.destroy();
+  });
+
+  it("generates unique pane names across instances", function () {
+    const v1 = new LeafletGeomVisualizer(scene, entities);
+    const v2 = new LeafletGeomVisualizer(scene, entities);
+    expect(v1.paneName).not.toBe(v2.paneName);
+    v1.destroy();
+    v2.destroy();
+  });
+
+  describe("splitter clipping", function () {
+    it("applies no clip-path when splitDirection is NONE", function () {
+      const visualizer = new LeafletGeomVisualizer(scene, entities);
+      runInAction(() => {
+        visualizer.splitDirection = SplitDirection.NONE;
+      });
+
+      expect(
+        visualizer.paneElement.style.clipPath === "none" ||
+          visualizer.paneElement.style.clipPath === ""
+      ).toBe(true);
+      visualizer.destroy();
+    });
+
+    it("applies left clip-path polygon when splitDirection is LEFT", function () {
+      const visualizer = new LeafletGeomVisualizer(scene, entities);
+      runInAction(() => {
+        visualizer.splitDirection = SplitDirection.LEFT;
+        visualizer.splitPosition = 0.5;
+      });
+
+      const clipPath = visualizer.paneElement.style.clipPath;
+      expect(clipPath).not.toBe("none");
+      expect(clipPath).not.toBe("");
+      expect(clipPath).toMatch(/^polygon\(/);
+      visualizer.destroy();
+    });
+
+    it("applies right clip-path polygon when splitDirection is RIGHT", function () {
+      const visualizer = new LeafletGeomVisualizer(scene, entities);
+      runInAction(() => {
+        visualizer.splitDirection = SplitDirection.RIGHT;
+        visualizer.splitPosition = 0.5;
+      });
+
+      const clipPath = visualizer.paneElement.style.clipPath;
+      expect(clipPath).not.toBe("none");
+      expect(clipPath).not.toBe("");
+      expect(clipPath).toMatch(/^polygon\(/);
+      visualizer.destroy();
+    });
+
+    it("produces different clip-paths for LEFT vs RIGHT at the same position", function () {
+      const v1 = new LeafletGeomVisualizer(scene, entities);
+      const v2 = new LeafletGeomVisualizer(scene, entities);
+
+      runInAction(() => {
+        v1.splitDirection = SplitDirection.LEFT;
+        v1.splitPosition = 0.5;
+        v2.splitDirection = SplitDirection.RIGHT;
+        v2.splitPosition = 0.5;
+      });
+
+      expect(v1.paneElement.style.clipPath).not.toBe(
+        v2.paneElement.style.clipPath
+      );
+      v1.destroy();
+      v2.destroy();
+    });
+  });
+
+  it("removes the pane element from DOM on destroy", function () {
+    const visualizer = new LeafletGeomVisualizer(scene, entities);
+    const paneElement = visualizer.paneElement;
+    expect(paneElement.parentNode).not.toBeNull();
+    visualizer.destroy();
+    expect(paneElement.parentNode).toBeNull();
+  });
+});

--- a/test/Map/Leaflet/getClipsForSplitterSpec.ts
+++ b/test/Map/Leaflet/getClipsForSplitterSpec.ts
@@ -1,0 +1,83 @@
+import getClipsForSplitter from "../../../lib/Map/Leaflet/getClipsForSplitter";
+
+describe("getClipsForSplitter", function () {
+  it("returns correct left and right clip-path polygons for a given split position", function () {
+    const result = getClipsForSplitter({
+      size: { x: 1000, y: 600 },
+      nw: { x: 0, y: 0 },
+      se: { x: 1000, y: 600 },
+      splitPosition: 0.5
+    });
+
+    expect(result.left).toBe(
+      "polygon(0px 0px, 500px 0px, 500px 600px, 0px 600px)"
+    );
+    expect(result.right).toBe(
+      "polygon(500px 0px, 1000px 0px, 1000px 600px, 500px 600px)"
+    );
+    expect(result.clipX).toBe(500);
+  });
+
+  it("rounds clipX to the nearest integer", function () {
+    const result = getClipsForSplitter({
+      size: { x: 1001, y: 600 },
+      nw: { x: 0, y: 0 },
+      se: { x: 1001, y: 600 },
+      splitPosition: 0.5
+    });
+
+    expect(result.clipX).toBe(501);
+    expect(result.left).toBe(
+      "polygon(0px 0px, 501px 0px, 501px 600px, 0px 600px)"
+    );
+  });
+
+  it("handles non-zero nw offset (scrolled/panned map)", function () {
+    const result = getClipsForSplitter({
+      size: { x: 800, y: 400 },
+      nw: { x: -100, y: -50 },
+      se: { x: 700, y: 350 },
+      splitPosition: 0.25
+    });
+
+    expect(result.clipX).toBe(Math.round(-100 + 800 * 0.25));
+    expect(result.left).toBe(
+      "polygon(-100px -50px, 100px -50px, 100px 350px, -100px 350px)"
+    );
+    expect(result.right).toBe(
+      "polygon(100px -50px, 700px -50px, 700px 350px, 100px 350px)"
+    );
+  });
+
+  it("handles split position at 0 (fully left)", function () {
+    const result = getClipsForSplitter({
+      size: { x: 1000, y: 600 },
+      nw: { x: 0, y: 0 },
+      se: { x: 1000, y: 600 },
+      splitPosition: 0
+    });
+
+    expect(result.clipX).toBe(0);
+    expect(result.left).toBe("polygon(0px 0px, 0px 0px, 0px 600px, 0px 600px)");
+    expect(result.right).toBe(
+      "polygon(0px 0px, 1000px 0px, 1000px 600px, 0px 600px)"
+    );
+  });
+
+  it("handles split position at 1 (fully right)", function () {
+    const result = getClipsForSplitter({
+      size: { x: 1000, y: 600 },
+      nw: { x: 0, y: 0 },
+      se: { x: 1000, y: 600 },
+      splitPosition: 1
+    });
+
+    expect(result.clipX).toBe(1000);
+    expect(result.left).toBe(
+      "polygon(0px 0px, 1000px 0px, 1000px 600px, 0px 600px)"
+    );
+    expect(result.right).toBe(
+      "polygon(1000px 0px, 1000px 0px, 1000px 600px, 1000px 600px)"
+    );
+  });
+});


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Adds splitter support for points and billboards in Leaflet (2D mode). #7673 adds support for the splitter only in Cesium and this PR extends this support to Leaflet. 

Approach: Each LeafletGeomVisualizer creates a dedicated Leaflet pane. All its layers (markers, circle markers, polylines, polygons) render into that pane. When splitting is active, CSS clip-path: polygon() is applied to the pane element — the same technique used for imagery tile layers.

Changes:
- Extracted shared getClipsForSplitter utility from duplicated code in ImageryProviderLeafletTileLayer and ImageryProviderLeafletGridLayer
- Modernised from deprecated CSS clip: rect() to clip-path: polygon() across all splitter consumers
- Added per-visualizer custom panes with @observable splitDirection / splitPosition and MobX autorun to LeafletGeomVisualizer
- Extended Leaflet._reactToSplitterChanges() to propagate split state to data source visualizers

### Test me

1. Add a CSV or GeoJSON point dataset
2. Switch to 2D (Leaflet) mode
3. Enable the splitter
4. Set the dataset to LEFT or RIGHT split direction
5. Verify points/billboards clip at the split line
6. Drag the splitter — verify clipping updates in real time
7. Verify imagery layer splitting still works (no regressions)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
