### PR TITLE
Fix analytics events skipped when keepCatalogOpen is true

### DIFF
--- a/lib/ReactViews/DataCatalog/toggleItemOnMapFromCatalog.ts
+++ b/lib/ReactViews/DataCatalog/toggleItemOnMapFromCatalog.ts
@@ -64,12 +64,13 @@ export default async function toggleItemOnMapFromCatalog(
 
   addOrRemoveFromTimelineStack(viewState.terria, item, op);
 
+  viewState.terria.analytics?.logEvent(
+    Category.dataSource,
+    analyticsEvents[op],
+    getPath(item)
+  );
+
   if (viewState.terria.workbench.contains(item) && !keepCatalogOpen) {
     viewState.closeCatalog();
-    viewState.terria.analytics?.logEvent(
-      Category.dataSource,
-      analyticsEvents[op],
-      getPath(item)
-    );
   }
 }


### PR DESCRIPTION
Small bugfix for analytics tracking. Events were not firing when users added data to the workbench from the catalogue preview view.

Here's an example from the Terria open demo catalogue -- clicking on this button did not fire the expected event.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/9a244da4-e215-437b-b8cf-cfbb19a7c651" />


### What this PR does

`logEvent` for **addFromPreviewButton** / **removeFromPreviewButton** was inside the `!keepCatalogOpen` guard in `toggleItemOnMapFromCatalog.ts`, so analytics events did not happen whenever `keepCatalogOpen` was true (e.g. Shift/Ctrl held, or `configParameters.keepCatalogOpen` set).

This PR moves the `logEvent` call outside that branch so it always fires when an item is added to or removed from the workbench, independent of whether the catalog stays open.

### How to test

- Ensure `enableConsoleAnalytics` is enabled in Terria config
- Open the browser dev console
- Add an item to the map from the preview panel — confirm a **dataSource / addFromPreviewButton** log appears
- Remove the item — confirm a **dataSource / removeFromPreviewButton** log appears

Previously, neither event was logged when keepCatalogOpen was true (....so says the AI overlord....)
