### PR TITLE
Publish config

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,24 +23,26 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
 
-      - name: Detect a version change and tag the new version
-        uses: steve9164/action-detect-and-tag-new-version@v1
+      - name: Detect a version change
         id: detect
-        with:
-          tag-template: "{VERSION}"
-          use-annotated-tag: "true"
-          tagger-name: Terria Bot via GitHub Actions
-          tagger-email: TerriaBot@users.noreply.github.com
+        run: |
+          LOCAL_VERSION=$(node -p "require('./package.json').version")
+          echo "Current version in package.json: $LOCAL_VERSION"
 
-      - name: Version update detected
-        if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
-        run: 'echo "Version change from ${{steps.detect.outputs.previous-version}} to ${{steps.detect.outputs.current-version}} detected"'
+          IS_ALREADY_PUBLISHED=$(npm view terriajs@$LOCAL_VERSION version 2>/dev/null || echo 'false')
+
+          if [ "$IS_ALREADY_PUBLISHED" != "false" ]; then
+            echo "terriajs@$LOCAL_VERSION is already published"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else 
+            echo "TerriaJS $LOCAL_VERSION is not published yet, proceeding with publish"
+            echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Node.js for NPM
-        if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
+        if: steps.detect.outputs.should_publish == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -48,44 +50,51 @@ jobs:
           node-version-file: ".nvmrc"
 
       - name: Install yarn
-        if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
+        if: steps.detect.outputs.should_publish == 'true'
         run: npm install -g yarn@^1.22.22
 
       - name: Install dependencies
-        if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
+        if: steps.detect.outputs.should_publish == 'true'
         run: yarn install --ignore-engines
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
 
       # - name: Update attributions.md
-      #   if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
       #   run: |
-      #     git config --global user.email "info@terria.io"
-      #     git config --global user.name "GitHub Actions"
+      #     git config --global user.email "TerriaBot@users.noreply.github.com"
+      #     git config --global user.name "Terria Bot via GitHub Actions"
       #     yarn gulp code-attribution
       #     git add doc/acknowledgements/attributions.md
       #     if ! git diff --cached --quiet; then
-      #       git commit -m "Update attributions.md for v${{ steps.detect.outputs.current-version }}"
+      #       git commit -m "Update attributions.md for v${{ steps.detect.outputs.version }}"
       #       git push origin HEAD:${{ github.ref_name }}
       #     fi
 
       - name: Lint and build terriajs
-        if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
+        if: steps.detect.outputs.should_publish == 'true'
         run: npx gulp lint release
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
 
       - name: Publish package to NPM
-        if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
+        if: steps.detect.outputs.should_publish == 'true'
         run: npm publish --tag ${NPM_TAG}
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
           NODE_AUTH_TOKEN: ""
 
+      - name: Tag and push the new version to GitHub
+        if: steps.detect.outputs.should_publish == 'true'
+        run: |
+          git config user.name "Terria Bot via GitHub Actions"
+          git config user.email "TerriaBot@users.noreply.github.com"
+          git tag "${{ steps.detect.outputs.version }}"
+          git push origin "${{ steps.detect.outputs.version }}"
+
       # These slack success and failure message actions can be combined but it means there'll be no notification on a failed
       #  action-detect-and-tag-new-version. It also allows for a bit better message customisation
       - name: Send success notification on Slack
-        if: steps.detect.outputs.previous-version != steps.detect.outputs.current-version
+        if: steps.detect.outputs.should_publish == 'true'
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
@@ -93,7 +102,7 @@ jobs:
           author_name: ${{ github.workflow }}
           mention: here
           if_mention: always
-          text: ":white_check_mark: Published v${{ steps.detect.outputs.current-version }} to https://www.npmjs.com/package/terriajs"
+          text: ":white_check_mark: Published v${{ steps.detect.outputs.version }} to https://www.npmjs.com/package/terriajs"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - main
 
-env:
-  NPM_TAG: latest
-
 concurrency:
   group: npm-publish
   cancel-in-progress: false
@@ -39,6 +36,14 @@ jobs:
             echo "TerriaJS $LOCAL_VERSION is not published yet, proceeding with publish"
             echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
+
+            if [[ "$LOCAL_VERSION" == *"-"* ]]; then
+              NPM_TAG=$(echo "$LOCAL_VERSION" | sed 's/[^-]*-\([^.]*\).*/\1/')
+            else
+              NPM_TAG="latest"
+            fi
+            echo "NPM tag to use: $NPM_TAG"
+            echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Node.js for NPM
@@ -78,7 +83,7 @@ jobs:
 
       - name: Publish package to NPM
         if: steps.detect.outputs.should_publish == 'true'
-        run: npm publish --tag ${NPM_TAG}
+        run: npm publish --tag ${{ steps.detect.outputs.npm_tag }}
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"
           NODE_AUTH_TOKEN: ""

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -6,6 +6,8 @@
 
 - Checkout and pull `main` branch of `terriajs`, run `yarn install` if necessary.
 - Bump the version number in `package.json`.
+  - Release will happen only if that version number is not already published to npm.
+  - For a pre-release, add a pre-release tag to the version number, e.g. `8.12.3-alpha.0`. The pre-release tag can be any string, but it's common to use `alpha`, `beta`, `rc` (release candidate) etc. followed by a number that is incremented for each pre-release.
 - Review and edit CHANGES.md.
   - Ensure that entries for new changes are written in the right section by diffing against the last version. Make sure the section name matches the version you set in `package.json` above.
   - e.g. `git diff 8.2.25 HEAD -- CHANGES.md` (where `8.2.25` is the previous published version)


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

The last few releases had issues publishing to npm, and we had to do multiple releases because the version-detection script detected a change only in the last 2 commits. It is more error-prone to check if the version is actually published to npm and, if not, try publishing it (if publishing fails, every merge to main after that will trigger the publish).
Also, we now detect the NPM_TAG from the actual version, so we can publish prereleases by just bumping the version in `package.json`. 

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
