### PR TITLE
Fix TypeScript errors from terriajs-cesium workspace package 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
       "../../../node_modules/",
       "../../../node_modules/@types/"
     ],
+    "preserveSymlinks": true,
     "types": ["terriajs-cesium", "@testing-library/jasmine-dom"]
   },
   "include": ["./lib/**/*", "./test/**/*", "./buildprocess/**/*"]


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Cesium started adding `@ts-check` to their JS source files. Because terriajs-cesium can be a yarn workspace package symlinked into node_modules, TypeScript resolves the symlink to the real path outside node_modules and reports errors from those files. In the previous release of cesium there were only 3 errors, but in `v1.140`, there is over 150.

`preserveSymlinks: true` keeps the symlink path intact, treats the cesium source as library code, and suppresses error reporting.

### Test me

- Try linking the terriajs-cesium package in the TerriaMap repo and observe that no type errors are reported. 
- Confirm that terriajs type errors are still reported.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
