### PR TITLE
Catalog search provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
   - Fixed a crash when searching for strings containing regex special characters (e.g. `mel\`) by escaping the search string before using it in the keyword highlight regex.
   - Nominatim default URL updated to `https://`.
 - We no longer start terriajs-server when running `yarn gulp dev` as it is not needed for running tests in the browser with jasmine-browser-runner. If you need terriajs-server, you can start it separately by running `yarn gulp terriajs-server` in another terminal.
+- Move catalog-search-provider instance from SearchBarModel to Catalog class.
 
 #### 8.12.2 - 2026-03-27
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
   - Added `autocompleteEnabled` trait to `LocationSearchProviderTraits`, replacing the previous `supportsAutocomplete()` method. When any provider has `autocompleteEnabled: false` (e.g. Nominatim), that provider displays a "Press Enter to start searching" message and only searches on manual submission. This changes behavior introduced in 8.11.0 where autocomplete was disabled globally when Nominatim was used, which was not ideal for other providers that support autocomplete.
   - Fixed a crash when searching for strings containing regex special characters (e.g. `mel\`) by escaping the search string before using it in the keyword highlight regex.
   - Nominatim default URL updated to `https://`.
+- We no longer start terriajs-server when running `yarn gulp dev` as it is not needed for running tests in the browser with jasmine-browser-runner. If you need terriajs-server, you can start it separately by running `yarn gulp terriajs-server` in another terminal.
 
 #### 8.12.2 - 2026-03-27
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,8 +27,7 @@
   - Added `autocompleteEnabled` trait to `LocationSearchProviderTraits`, replacing the previous `supportsAutocomplete()` method. When any provider has `autocompleteEnabled: false` (e.g. Nominatim), that provider displays a "Press Enter to start searching" message and only searches on manual submission. This changes behavior introduced in 8.11.0 where autocomplete was disabled globally when Nominatim was used, which was not ideal for other providers that support autocomplete.
   - Fixed a crash when searching for strings containing regex special characters (e.g. `mel\`) by escaping the search string before using it in the keyword highlight regex.
   - Nominatim default URL updated to `https://`.
-- We no longer start terriajs-server when running `yarn gulp dev` as it is not needed for running tests in the browser with jasmine-browser-runner. If you need terriajs-server, you can start it separately by running `yarn gulp terriajs-server` in another terminal.
-- Move catalog-search-provider instance from SearchBarModel to Catalog class.
+- Move catalog-search-provider instance from SearchBarModel to Catalog class. Setting catalog search provider from ViewState is now deprecated.
 
 #### 8.12.2 - 2026-03-27
 

--- a/lib/ModelMixins/SearchProviders/LocationSearchProviderMixin.ts
+++ b/lib/ModelMixins/SearchProviders/LocationSearchProviderMixin.ts
@@ -50,6 +50,21 @@ function LocationSearchProviderMixin<
     get autocompleteEnabled() {
       return super.autocompleteEnabled ?? true;
     }
+
+    @override
+    get flightDurationSeconds() {
+      return (
+        super.flightDurationSeconds ??
+        this.terria.searchBarModel.flightDurationSeconds
+      );
+    }
+
+    get recommendedListLength() {
+      return (
+        super.recommendedListLength ??
+        this.terria.searchBarModel.recommendedListLength
+      );
+    }
   }
 
   return LocationSearchProviderMixin;

--- a/lib/ModelMixins/SearchProviders/SearchProviderMixin.ts
+++ b/lib/ModelMixins/SearchProviders/SearchProviderMixin.ts
@@ -1,5 +1,5 @@
 import { debounce } from "lodash-es";
-import { action, makeObservable, observable } from "mobx";
+import { action, makeObservable, observable, override } from "mobx";
 import AbstractConstructor from "../../Core/AbstractConstructor";
 import Model from "../../Models/Definition/Model";
 import SearchProviderResult from "../../Models/SearchProviders/SearchProviderResults";
@@ -24,6 +24,11 @@ function SearchProviderMixin<
       this._debouncedSearch = debounce((searchText: string) => {
         this.performSearch(searchText);
       }, this.debounceTime);
+    }
+
+    @override
+    get minCharacters() {
+      return super.minCharacters ?? this.terria.searchBarModel.minCharacters;
     }
 
     @observable

--- a/lib/Models/Catalog/Catalog.ts
+++ b/lib/Models/Catalog/Catalog.ts
@@ -7,18 +7,33 @@ import Terria from "../Terria";
 import Group from "./Group";
 import { BaseModel } from "../Definition/Model";
 import isDefined from "../../Core/isDefined";
+import CatalogSearchProviderMixin from "../../ModelMixins/SearchProviders/CatalogSearchProviderMixin";
+import CatalogSearchProvider from "../SearchProviders/CatalogSearchProvider";
 
 export default class Catalog {
   @observable
   group: Group & BaseModel;
 
+  @observable
+  searchProvider: CatalogSearchProviderMixin.Instance | undefined;
+
   readonly terria: Terria;
 
   private _disposeCreateUserAddedGroup: () => void;
 
-  constructor(terria: Terria) {
+  constructor(
+    terria: Terria,
+    searchProvider?: CatalogSearchProviderMixin.Instance
+  ) {
     makeObservable(this);
     this.terria = terria;
+    this.searchProvider =
+      searchProvider ??
+      new CatalogSearchProvider(
+        "catalog-search-provider",
+        terria,
+        terria.searchBarModel.minCharacters
+      );
     this.group = new CatalogGroup("/", this.terria);
     this.terria.addModel(this.group);
 

--- a/lib/Models/Catalog/Catalog.ts
+++ b/lib/Models/Catalog/Catalog.ts
@@ -23,17 +23,20 @@ export default class Catalog {
 
   constructor(
     terria: Terria,
-    searchProvider?: CatalogSearchProviderMixin.Instance
+    options: { searchProvider?: CatalogSearchProviderMixin.Instance } = {}
   ) {
     makeObservable(this);
     this.terria = terria;
-    this.searchProvider =
-      searchProvider ??
-      new CatalogSearchProvider(
-        "catalog-search-provider",
+    if ("searchProvider" in options) {
+      this.searchProvider = options.searchProvider;
+    } else {
+      this.searchProvider = CatalogSearchProvider.fromOptions({
+        id: "catalog-search-provider",
         terria,
-        terria.searchBarModel.minCharacters
-      );
+        minCharacters: this.terria.searchBarModel.minCharacters
+      });
+    }
+
     this.group = new CatalogGroup("/", this.terria);
     this.terria.addModel(this.group);
 

--- a/lib/Models/Catalog/Catalog.ts
+++ b/lib/Models/Catalog/Catalog.ts
@@ -30,11 +30,10 @@ export default class Catalog {
     if ("searchProvider" in options) {
       this.searchProvider = options.searchProvider;
     } else {
-      this.searchProvider = CatalogSearchProvider.fromOptions({
-        id: "catalog-search-provider",
-        terria,
-        minCharacters: this.terria.searchBarModel.minCharacters
-      });
+      this.searchProvider = new CatalogSearchProvider(
+        "catalog-search-provider",
+        terria
+      );
     }
 
     this.group = new CatalogGroup("/", this.terria);

--- a/lib/Models/SearchProviders/CatalogSearchProvider.ts
+++ b/lib/Models/SearchProviders/CatalogSearchProvider.ts
@@ -107,7 +107,7 @@ export default class CatalogSearchProvider extends CatalogSearchProviderMixin(
   CreateModel(CatalogSearchProviderTraits)
 ) {
   static readonly type = "catalog-search-provider";
-  debounceTime = 300;
+  override debounceTime = 300;
 
   constructor(id: string | undefined, terria: Terria) {
     super(id, terria);

--- a/lib/Models/SearchProviders/CatalogSearchProvider.ts
+++ b/lib/Models/SearchProviders/CatalogSearchProvider.ts
@@ -1,4 +1,4 @@
-import { autorun, makeObservable, runInAction } from "mobx";
+import { autorun, computed, makeObservable, override, runInAction } from "mobx";
 import { Category, SearchAction } from "../../Core/Analytics/analyticEvents";
 import { TerriaErrorSeverity } from "../../Core/TerriaError";
 import GroupMixin from "../../ModelMixins/GroupMixin";
@@ -115,30 +115,13 @@ export default class CatalogSearchProvider extends CatalogSearchProviderMixin(
     makeObservable(this);
   }
 
-  static fromOptions({
-    id,
-    terria,
-    minCharacters
-  }: {
-    id: string | undefined;
-    terria: Terria;
-    minCharacters?: number;
-  }) {
-    const searchProvider = new CatalogSearchProvider(id, terria);
-
-    if (minCharacters !== undefined) {
-      searchProvider.setTrait(
-        CommonStrata.defaults,
-        "minCharacters",
-        minCharacters
-      );
-    }
-
-    return searchProvider;
-  }
-
   get type() {
     return CatalogSearchProvider.type;
+  }
+
+  @override
+  get minCharacters(): number | undefined {
+    return super.minCharacters ?? this.terria.searchBarModel.minCharacters;
   }
 
   protected logEvent(searchText: string) {

--- a/lib/Models/SearchProviders/CatalogSearchProvider.ts
+++ b/lib/Models/SearchProviders/CatalogSearchProvider.ts
@@ -1,4 +1,4 @@
-import { autorun, makeObservable, override, runInAction } from "mobx";
+import { autorun, makeObservable, runInAction } from "mobx";
 import { Category, SearchAction } from "../../Core/Analytics/analyticEvents";
 import { TerriaErrorSeverity } from "../../Core/TerriaError";
 import GroupMixin from "../../ModelMixins/GroupMixin";
@@ -116,11 +116,6 @@ export default class CatalogSearchProvider extends CatalogSearchProviderMixin(
 
   get type() {
     return CatalogSearchProvider.type;
-  }
-
-  @override
-  get minCharacters(): number | undefined {
-    return super.minCharacters ?? this.terria.searchBarModel.minCharacters;
   }
 
   protected logEvent(searchText: string) {

--- a/lib/Models/SearchProviders/CatalogSearchProvider.ts
+++ b/lib/Models/SearchProviders/CatalogSearchProvider.ts
@@ -1,11 +1,10 @@
-import { autorun, computed, makeObservable, override, runInAction } from "mobx";
+import { autorun, makeObservable, override, runInAction } from "mobx";
 import { Category, SearchAction } from "../../Core/Analytics/analyticEvents";
 import { TerriaErrorSeverity } from "../../Core/TerriaError";
 import GroupMixin from "../../ModelMixins/GroupMixin";
 import ReferenceMixin from "../../ModelMixins/ReferenceMixin";
 import CatalogSearchProviderMixin from "../../ModelMixins/SearchProviders/CatalogSearchProviderMixin";
 import CatalogSearchProviderTraits from "../../Traits/SearchProviders/CatalogSearchProviderTraits";
-import CommonStrata from "../Definition/CommonStrata";
 import CreateModel from "../Definition/CreateModel";
 import { BaseModel } from "../Definition/Model";
 import Terria from "../Terria";

--- a/lib/Models/SearchProviders/CatalogSearchProvider.ts
+++ b/lib/Models/SearchProviders/CatalogSearchProvider.ts
@@ -109,16 +109,12 @@ export default class CatalogSearchProvider extends CatalogSearchProviderMixin(
   static readonly type = "catalog-search-provider";
   debounceTime = 300;
 
-  constructor(id: string | undefined, terria: Terria) {
+  constructor(id: string | undefined, terria: Terria, minCharacters?: number) {
     super(id, terria);
 
     makeObservable(this);
 
-    this.setTrait(
-      CommonStrata.defaults,
-      "minCharacters",
-      terria.searchBarModel.minCharacters
-    );
+    this.setTrait(CommonStrata.defaults, "minCharacters", minCharacters);
   }
 
   get type() {

--- a/lib/Models/SearchProviders/CatalogSearchProvider.ts
+++ b/lib/Models/SearchProviders/CatalogSearchProvider.ts
@@ -109,12 +109,32 @@ export default class CatalogSearchProvider extends CatalogSearchProviderMixin(
   static readonly type = "catalog-search-provider";
   debounceTime = 300;
 
-  constructor(id: string | undefined, terria: Terria, minCharacters?: number) {
+  constructor(id: string | undefined, terria: Terria) {
     super(id, terria);
 
     makeObservable(this);
+  }
 
-    this.setTrait(CommonStrata.defaults, "minCharacters", minCharacters);
+  static fromOptions({
+    id,
+    terria,
+    minCharacters
+  }: {
+    id: string | undefined;
+    terria: Terria;
+    minCharacters?: number;
+  }) {
+    const searchProvider = new CatalogSearchProvider(id, terria);
+
+    if (minCharacters !== undefined) {
+      searchProvider.setTrait(
+        CommonStrata.defaults,
+        "minCharacters",
+        minCharacters
+      );
+    }
+
+    return searchProvider;
   }
 
   get type() {

--- a/lib/Models/SearchProviders/SearchBarModel.ts
+++ b/lib/Models/SearchProviders/SearchBarModel.ts
@@ -3,7 +3,8 @@ import {
   computed,
   isObservableArray,
   makeObservable,
-  observable
+  observable,
+  reaction
 } from "mobx";
 import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import RuntimeError from "terriajs-cesium/Source/Core/RuntimeError";
@@ -27,6 +28,17 @@ export class SearchBarModel extends CreateModel(SearchBarTraits) {
 
   constructor(readonly terria: Terria) {
     super("search-bar-model", terria);
+
+    reaction(
+      () => this.minCharacters,
+      (minCharacters) => {
+        this.terria.catalog.searchProvider?.setTrait(
+          CommonStrata.defaults,
+          "minCharacters",
+          minCharacters
+        );
+      }
+    );
 
     makeObservable(this);
   }

--- a/lib/Models/SearchProviders/SearchBarModel.ts
+++ b/lib/Models/SearchProviders/SearchBarModel.ts
@@ -10,7 +10,6 @@ import RuntimeError from "terriajs-cesium/Source/Core/RuntimeError";
 import { JsonObject } from "../../Core/Json";
 import Result from "../../Core/Result";
 import TerriaError from "../../Core/TerriaError";
-import CatalogSearchProviderMixin from "../../ModelMixins/SearchProviders/CatalogSearchProviderMixin";
 import LocationSearchProviderMixin from "../../ModelMixins/SearchProviders/LocationSearchProviderMixin";
 import { SearchBarTraits } from "../../Traits/SearchProviders/SearchBarTraits";
 import SearchProviderTraits from "../../Traits/SearchProviders/SearchProviderTraits";
@@ -25,9 +24,6 @@ import upsertSearchProviderFromJson from "./upsertSearchProviderFromJson";
 
 export class SearchBarModel extends CreateModel(SearchBarTraits) {
   private locationSearchProviders = observable.map<string, BaseModel>();
-
-  @observable
-  catalogSearchProvider: CatalogSearchProviderMixin.Instance | undefined;
 
   constructor(readonly terria: Terria) {
     super("search-bar-model", terria);

--- a/lib/Models/SearchProviders/SearchBarModel.ts
+++ b/lib/Models/SearchProviders/SearchBarModel.ts
@@ -29,17 +29,6 @@ export class SearchBarModel extends CreateModel(SearchBarTraits) {
   constructor(readonly terria: Terria) {
     super("search-bar-model", terria);
 
-    reaction(
-      () => this.minCharacters,
-      (minCharacters) => {
-        this.terria.catalog.searchProvider?.setTrait(
-          CommonStrata.defaults,
-          "minCharacters",
-          minCharacters
-        );
-      }
-    );
-
     makeObservable(this);
   }
 

--- a/lib/Models/SearchProviders/SearchBarModel.ts
+++ b/lib/Models/SearchProviders/SearchBarModel.ts
@@ -3,8 +3,7 @@ import {
   computed,
   isObservableArray,
   makeObservable,
-  observable,
-  reaction
+  observable
 } from "mobx";
 import DeveloperError from "terriajs-cesium/Source/Core/DeveloperError";
 import RuntimeError from "terriajs-cesium/Source/Core/RuntimeError";

--- a/lib/Models/SearchProviders/upsertSearchProviderFromJson.ts
+++ b/lib/Models/SearchProviders/upsertSearchProviderFromJson.ts
@@ -1,5 +1,4 @@
 import i18next from "i18next";
-import { runInAction } from "mobx";
 import Result from "../../Core/Result";
 import TerriaError from "../../Core/TerriaError";
 import { applyTranslationIfExists } from "../../Language/languageHelpers";
@@ -61,8 +60,6 @@ export default function upsertSearchProviderFromJson(
     }
   }
 
-  setDefaultTraits(model);
-
   updateModelFromJson(model, stratumName, json).catchError((error) => {
     errors.push(error);
     model!.setTrait(CommonStrata.underride, "isExperiencingIssues", true);
@@ -78,28 +75,4 @@ export default function upsertSearchProviderFromJson(
       )}\``
     )
   );
-}
-
-function setDefaultTraits(model: BaseModel) {
-  const terria = model.terria;
-
-  runInAction(() => {
-    model.setTrait(
-      CommonStrata.defaults,
-      "flightDurationSeconds",
-      terria.searchBarModel.flightDurationSeconds
-    );
-
-    model.setTrait(
-      CommonStrata.defaults,
-      "minCharacters",
-      terria.searchBarModel.minCharacters
-    );
-
-    model.setTrait(
-      CommonStrata.defaults,
-      "recommendedListLength",
-      terria.searchBarModel.recommendedListLength
-    );
-  });
 }

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -531,9 +531,9 @@ export default class Terria {
   readonly indeterminateTileLoadProgressEvent = new CesiumEvent();
   readonly workbench = new Workbench();
   readonly overlays = new Workbench();
-  readonly catalog = new Catalog(this);
   readonly baseMapsModel = new BaseMapsModel("basemaps", this);
   readonly searchBarModel = new SearchBarModel(this);
+  readonly catalog = new Catalog(this);
   readonly timelineClock = new Clock({ shouldAnimate: false });
   // readonly overrides: any = overrides; // TODO: add options.functionOverrides like in master
 

--- a/lib/ReactViewModels/SearchState.ts
+++ b/lib/ReactViewModels/SearchState.ts
@@ -4,17 +4,14 @@ import {
   IReactionDisposer,
   makeObservable,
   observable,
-  reaction,
-  runInAction
+  reaction
 } from "mobx";
 import CatalogSearchProviderMixin from "../ModelMixins/SearchProviders/CatalogSearchProviderMixin";
 import LocationSearchProviderMixin from "../ModelMixins/SearchProviders/LocationSearchProviderMixin";
-import CatalogSearchProvider from "../Models/SearchProviders/CatalogSearchProvider";
 import Terria from "../Models/Terria";
 
 interface SearchStateOptions {
   terria: Terria;
-  catalogSearchProvider?: CatalogSearchProviderMixin.Instance;
 }
 
 export default class SearchState {
@@ -37,12 +34,6 @@ export default class SearchState {
     makeObservable(this);
 
     this.terria = options.terria;
-
-    runInAction(() => {
-      this.terria.searchBarModel.catalogSearchProvider =
-        options.catalogSearchProvider ||
-        new CatalogSearchProvider("catalog-search-provider", options.terria);
-    });
 
     this._workbenchItemsSubscription = reaction(
       () => this.terria.workbench.items,
@@ -89,7 +80,7 @@ export default class SearchState {
 
   @computed
   get catalogSearchProvider(): CatalogSearchProviderMixin.Instance | undefined {
-    return this.terria.searchBarModel.catalogSearchProvider;
+    return this.terria.catalog.searchProvider;
   }
 
   @action

--- a/lib/ReactViewModels/ViewState.ts
+++ b/lib/ReactViewModels/ViewState.ts
@@ -2,12 +2,12 @@ import {
   action,
   computed,
   IReactionDisposer,
+  makeObservable,
   observable,
   reaction,
-  runInAction,
-  makeObservable
+  runInAction
 } from "mobx";
-import { ReactNode, MouseEvent, ComponentType, Ref } from "react";
+import { ComponentType, MouseEvent, ReactNode, Ref } from "react";
 import defined from "terriajs-cesium/Source/Core/defined";
 import addedByUser from "../Core/addedByUser";
 import {
@@ -22,9 +22,12 @@ import CatalogMemberMixin, { getName } from "../ModelMixins/CatalogMemberMixin";
 import GroupMixin from "../ModelMixins/GroupMixin";
 import MappableMixin from "../ModelMixins/MappableMixin";
 import ReferenceMixin from "../ModelMixins/ReferenceMixin";
+import CatalogSearchProviderMixin from "../ModelMixins/SearchProviders/CatalogSearchProviderMixin";
+import CzmlCatalogItem from "../Models/Catalog/CatalogItems/CzmlCatalogItem";
 import CommonStrata from "../Models/Definition/CommonStrata";
 import { BaseModel } from "../Models/Definition/Model";
 import getAncestors from "../Models/getAncestors";
+import { getMarkerCatalogItem } from "../Models/LocationMarkerUtils";
 import { SelectableDimension } from "../Models/SelectableDimensions/SelectableDimensions";
 import Terria from "../Models/Terria";
 import { ViewingControl } from "../Models/ViewingControls";
@@ -37,9 +40,6 @@ import {
   TourPoint
 } from "./defaultTourPoints";
 import SearchState from "./SearchState";
-import CatalogSearchProviderMixin from "../ModelMixins/SearchProviders/CatalogSearchProviderMixin";
-import { getMarkerCatalogItem } from "../Models/LocationMarkerUtils";
-import CzmlCatalogItem from "../Models/Catalog/CatalogItems/CzmlCatalogItem";
 
 export const DATA_CATALOG_NAME = "data-catalog";
 export const USER_DATA_NAME = "my-data";
@@ -50,8 +50,10 @@ export const WORKBENCH_RESIZE_ANIMATION_DURATION = 500;
 
 interface ViewStateOptions {
   terria: Terria;
-  catalogSearchProvider: CatalogSearchProviderMixin.Instance | undefined;
-  errorHandlingProvider?: any;
+  /**
+   * @deprecated
+   */
+  catalogSearchProvider?: CatalogSearchProviderMixin.Instance;
 }
 
 /**
@@ -202,8 +204,6 @@ export default class ViewState {
       this.bottomDockHeight = height;
     }
   }
-
-  errorProvider: any | null = null;
 
   // default value is null, because user has not made decision to show or
   // not show story
@@ -391,13 +391,14 @@ export default class ViewState {
     makeObservable(this);
     const terria = options.terria;
     this.searchState = new SearchState({
-      terria,
-      catalogSearchProvider: options.catalogSearchProvider
+      terria
     });
+    if (options.catalogSearchProvider) {
+      runInAction(() => {
+        this.terria.catalog.searchProvider = options.catalogSearchProvider;
+      });
+    }
 
-    this.errorProvider = options.errorHandlingProvider
-      ? options.errorHandlingProvider
-      : null;
     this.terria = terria;
 
     // When features are picked, show the feature info panel.

--- a/lib/Traits/SearchProviders/LocationSearchProviderTraits.ts
+++ b/lib/Traits/SearchProviders/LocationSearchProviderTraits.ts
@@ -16,17 +16,23 @@ class LocationSearchProviderTraits extends mixTraits(SearchProviderTraits) {
   @primitiveTrait({
     type: "number",
     name: "recommendedListLength",
-    description: "Maximum amount of entries in the suggestion list."
+    description:
+      "Maximum amount of entries in the suggestion list. If not defined fallbacks to recommendedListLength value defined as part of searchBarConfig."
   })
-  recommendedListLength: number = 5;
+  get recommendedListLength(): number | undefined {
+    return undefined;
+  }
 
   @primitiveTrait({
     type: "number",
-    name: "URL",
-    description: "Time to move to the result location.",
+    name: "flightDurationSeconds",
+    description:
+      "Time to move to the result location. If not defined fallbacks to flightDurationSeconds value defined as part of searchBarConfig.",
     isNullable: true
   })
-  flightDurationSeconds?: number = 1.5;
+  get flightDurationSeconds(): number | undefined {
+    return undefined;
+  }
 
   @primitiveTrait({
     type: "boolean",

--- a/lib/Traits/SearchProviders/SearchProviderTraits.ts
+++ b/lib/Traits/SearchProviders/SearchProviderTraits.ts
@@ -13,7 +13,8 @@ class SearchProviderTraits extends ModelTraits {
   @primitiveTrait({
     type: "number",
     name: "Minimum characters",
-    description: "Minimum number of characters required for search to start",
+    description:
+      "Minimum number of characters required for search to start. If not defined fallbacks to minCharacters value defined as part of searchBarConfig.",
     isNullable: true
   })
   get minCharacters(): number | undefined {

--- a/lib/Traits/SearchProviders/SearchProviderTraits.ts
+++ b/lib/Traits/SearchProviders/SearchProviderTraits.ts
@@ -1,6 +1,7 @@
 import ModelTraits from "../ModelTraits";
 import primitiveTrait from "../Decorators/primitiveTrait";
 
+/* eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging */
 class SearchProviderTraits extends ModelTraits {
   @primitiveTrait({
     type: "string",

--- a/lib/Traits/SearchProviders/SearchProviderTraits.ts
+++ b/lib/Traits/SearchProviders/SearchProviderTraits.ts
@@ -1,7 +1,7 @@
 import ModelTraits from "../ModelTraits";
 import primitiveTrait from "../Decorators/primitiveTrait";
 
-export default class SearchProviderTraits extends ModelTraits {
+class SearchProviderTraits extends ModelTraits {
   @primitiveTrait({
     type: "string",
     name: "Name",
@@ -15,5 +15,17 @@ export default class SearchProviderTraits extends ModelTraits {
     description: "Minimum number of characters required for search to start",
     isNullable: true
   })
-  minCharacters?: number;
+  get minCharacters(): number | undefined {
+    return;
+  }
 }
+
+/* eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging */
+interface SearchProviderTraits {
+  // Add traits here that you want to override from some Mixin or Model class
+  // without generating TS2611 type error.
+  name: SearchProviderTraits["name"];
+  minCharacters: SearchProviderTraits["minCharacters"];
+}
+
+export default SearchProviderTraits;

--- a/test/Map/StyledHtmlSpec.tsx
+++ b/test/Map/StyledHtmlSpec.tsx
@@ -16,8 +16,7 @@ describe("StyledHtml", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ModelMixins/SearchProviders/SearchProviderMixinSpec.ts
+++ b/test/ModelMixins/SearchProviders/SearchProviderMixinSpec.ts
@@ -68,4 +68,44 @@ describe("SearchProviderMixin", () => {
     expect(searchProvider.logEvent).toHaveBeenCalled();
     expect(searchProvider.doSearch).toHaveBeenCalled();
   });
+
+  describe("searchBarModel minCharacters fallback", () => {
+    let freshProvider: TestSearchProvider;
+
+    beforeEach(() => {
+      freshProvider = new TestSearchProvider("fresh", terria);
+      freshProvider.logEvent.calls.reset();
+      freshProvider.doSearch.calls.reset();
+    });
+
+    it(" - uses searchBarModel minCharacters when provider trait is not set", () => {
+      terria.searchBarModel.setTrait(
+        CommonStrata.definition,
+        "minCharacters",
+        7
+      );
+      expect(freshProvider.minCharacters).toEqual(7);
+    });
+
+    it(" - provider minCharacters takes precedence over searchBarModel", () => {
+      terria.searchBarModel.setTrait(
+        CommonStrata.definition,
+        "minCharacters",
+        7
+      );
+      freshProvider.setTrait(CommonStrata.definition, "minCharacters", 2);
+      expect(freshProvider.minCharacters).toEqual(2);
+    });
+
+    it(" - does not search when text is shorter than searchBarModel minCharacters", () => {
+      terria.searchBarModel.setTrait(
+        CommonStrata.definition,
+        "minCharacters",
+        7
+      );
+      freshProvider.search("abc", true);
+      expect(freshProvider.searchResult.isSearching).toBeFalsy();
+      expect(freshProvider.doSearch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/test/Models/SearchProviders/LocationSearchProviderSpec.ts
+++ b/test/Models/SearchProviders/LocationSearchProviderSpec.ts
@@ -1,4 +1,5 @@
 import LocationSearchProviderMixin from "../../../lib/ModelMixins/SearchProviders/LocationSearchProviderMixin";
+import CommonStrata from "../../../lib/Models/Definition/CommonStrata";
 import BingMapsSearchProvider from "../../../lib/Models/SearchProviders/BingMapsSearchProvider";
 import Terria from "../../../lib/Models/Terria";
 
@@ -28,5 +29,53 @@ describe("LocationSearchProvider", function () {
 
   it(" - propperly defines default isOpen", function () {
     expect(bingMapsSearchProvider.isOpen).toEqual(true);
+  });
+
+  describe("searchBarModel fallback", function () {
+    it(" - reads recommendedListLength from searchBarModel when not set on provider", function () {
+      terria.searchBarModel.setTrait(
+        CommonStrata.definition,
+        "recommendedListLength",
+        10
+      );
+      expect(bingMapsSearchProvider.recommendedListLength).toEqual(10);
+    });
+
+    it(" - reads flightDurationSeconds from searchBarModel when not set on provider", function () {
+      terria.searchBarModel.setTrait(
+        CommonStrata.definition,
+        "flightDurationSeconds",
+        3.0
+      );
+      expect(bingMapsSearchProvider.flightDurationSeconds).toEqual(3.0);
+    });
+
+    it(" - provider recommendedListLength takes precedence over searchBarModel", function () {
+      terria.searchBarModel.setTrait(
+        CommonStrata.definition,
+        "recommendedListLength",
+        10
+      );
+      bingMapsSearchProvider.setTrait(
+        CommonStrata.definition,
+        "recommendedListLength",
+        3
+      );
+      expect(bingMapsSearchProvider.recommendedListLength).toEqual(3);
+    });
+
+    it(" - provider flightDurationSeconds takes precedence over searchBarModel", function () {
+      terria.searchBarModel.setTrait(
+        CommonStrata.definition,
+        "flightDurationSeconds",
+        3.0
+      );
+      bingMapsSearchProvider.setTrait(
+        CommonStrata.definition,
+        "flightDurationSeconds",
+        0.5
+      );
+      expect(bingMapsSearchProvider.flightDurationSeconds).toEqual(0.5);
+    });
   });
 });

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -565,8 +565,7 @@ describe("TerriaSpec", function () {
       beforeEach(function () {
         newTerria = new Terria({ appBaseHref: "/", baseUrl: "./" });
         viewState = new ViewState({
-          terria: terria,
-          catalogSearchProvider: undefined
+          terria: terria
         });
 
         UrlToCatalogMemberMapping.register(
@@ -793,8 +792,7 @@ describe("TerriaSpec", function () {
         )}`;
         newTerria = new Terria({ baseUrl: "./" });
         viewState = new ViewState({
-          terria: terria,
-          catalogSearchProvider: undefined
+          terria: terria
         });
 
         await Promise.all(
@@ -904,8 +902,7 @@ describe("TerriaSpec", function () {
           "https://magda.example.com/api/v0/registry/records/map-config-example?optionalAspect=terria-config&optionalAspect=terria-init&optionalAspect=group&dereference=true";
 
         viewState = new ViewState({
-          terria: terria,
-          catalogSearchProvider: undefined
+          terria: terria
         });
         newTerria = new Terria({ baseUrl: "./" });
 

--- a/test/Models/Workflows/SelectableDimensionWorkflowSpec.ts
+++ b/test/Models/Workflows/SelectableDimensionWorkflowSpec.ts
@@ -13,8 +13,7 @@ describe("SelectableDimensionWorkflow", function () {
   beforeEach(function () {
     terria = new Terria();
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
   });
 

--- a/test/ReactViewModels/ViewStateSpec.ts
+++ b/test/ReactViewModels/ViewStateSpec.ts
@@ -16,8 +16,7 @@ describe("ViewState", function () {
   beforeEach(function () {
     terria = new Terria();
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
   });
 
@@ -58,12 +57,6 @@ describe("ViewState", function () {
       viewState.userDataPreviewedItem = item;
       viewState.removeModelReferences(item);
       expect(viewState.userDataPreviewedItem).toBeUndefined();
-    });
-  });
-
-  describe("error provider", function () {
-    it("creates an empty error provider by default", function () {
-      expect(viewState.errorProvider).toBeNull();
     });
   });
 

--- a/test/ReactViews/BottomDock/BottomDockSpec.tsx
+++ b/test/ReactViews/BottomDock/BottomDockSpec.tsx
@@ -12,8 +12,7 @@ describe("BottomDock", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/BottomDock/MapDataCountSpec.tsx
+++ b/test/ReactViews/BottomDock/MapDataCountSpec.tsx
@@ -14,8 +14,7 @@ describe("MapDataCount", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Custom/Chart/BottomDockChartSpec.tsx
+++ b/test/ReactViews/Custom/Chart/BottomDockChartSpec.tsx
@@ -15,8 +15,7 @@ describe("BottomDockChart", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
     chartItems = [
       {

--- a/test/ReactViews/Custom/Chart/FeatureInfoPanelChartSpec.tsx
+++ b/test/ReactViews/Custom/Chart/FeatureInfoPanelChartSpec.tsx
@@ -33,7 +33,7 @@ describe("FeatureInfoPanelChart", function () {
 
     context = {
       terria: new Terria(),
-      viewState: new ViewState({ terria, catalogSearchProvider: undefined }),
+      viewState: new ViewState({ terria }),
       feature: new TerriaFeature({}),
       catalogItem
     };

--- a/test/ReactViews/Custom/Chart/PointOnMapSpec.tsx
+++ b/test/ReactViews/Custom/Chart/PointOnMapSpec.tsx
@@ -13,8 +13,7 @@ describe("PointOnMap", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
   });
 

--- a/test/ReactViews/Custom/SettingsPanelCustomComponentSpec.ts
+++ b/test/ReactViews/Custom/SettingsPanelCustomComponentSpec.ts
@@ -12,8 +12,7 @@ describe("SettingsPanelCustomComponent", function () {
 
   beforeEach(function () {
     viewState = new ViewState({
-      terria: new Terria(),
-      catalogSearchProvider: undefined
+      terria: new Terria()
     });
 
     registerCustomComponentTypes(viewState.terria);

--- a/test/ReactViews/DataCatalog/DataCatalogItemSpec.tsx
+++ b/test/ReactViews/DataCatalog/DataCatalogItemSpec.tsx
@@ -27,8 +27,7 @@ describe("DataCatalogItem", () => {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
     wmsItem = new WebMapServiceCatalogItem("test", terria);
 

--- a/test/ReactViews/DataCatalogSpec.tsx
+++ b/test/ReactViews/DataCatalogSpec.tsx
@@ -24,8 +24,7 @@ describe("DataCatalog", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/DisclaimerSpec.tsx
+++ b/test/ReactViews/DisclaimerSpec.tsx
@@ -14,8 +14,7 @@ describe("Disclaimer", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/FeatureInfoPanelSpec.tsx
+++ b/test/ReactViews/FeatureInfoPanelSpec.tsx
@@ -24,8 +24,7 @@ describe("FeatureInfoPanel", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/FeatureInfoSectionSpec.tsx
+++ b/test/ReactViews/FeatureInfoSectionSpec.tsx
@@ -64,8 +64,7 @@ describe("FeatureInfoSection", function () {
     catalogItem = new TestModel("teststrata", terria);
 
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
     const properties = {
       name: "Kay",

--- a/test/ReactViews/Generic/PromptSpec.tsx
+++ b/test/ReactViews/Generic/PromptSpec.tsx
@@ -13,8 +13,7 @@ describe("HelpPrompt", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Map/Navigation/Compass/CompassSpec.tsx
+++ b/test/ReactViews/Map/Navigation/Compass/CompassSpec.tsx
@@ -14,8 +14,7 @@ describe("Compass", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Map/Navigation/Compass/GyroscopeGuidanceSpec.tsx
+++ b/test/ReactViews/Map/Navigation/Compass/GyroscopeGuidanceSpec.tsx
@@ -13,8 +13,7 @@ describe("GyroscopeGuidance", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Map/Panels/HelpPanel/HelpPanelSpec.tsx
+++ b/test/ReactViews/Map/Panels/HelpPanel/HelpPanelSpec.tsx
@@ -14,8 +14,7 @@ describe("HelpPanel", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Map/Panels/HelpPanel/VideoGuideSpec.tsx
+++ b/test/ReactViews/Map/Panels/HelpPanel/VideoGuideSpec.tsx
@@ -17,8 +17,7 @@ describe("VideoGuide", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Map/Panels/SharePanel/BuildShareLinkSpec.ts
+++ b/test/ReactViews/Map/Panels/SharePanel/BuildShareLinkSpec.ts
@@ -36,8 +36,7 @@ beforeEach(function () {
   // };
 
   viewState = new ViewState({
-    terria: terria,
-    catalogSearchProvider: undefined
+    terria: terria
   });
 });
 

--- a/test/ReactViews/Map/TerriaViewerWrapper/TerriaViewerWrapperSpec.tsx
+++ b/test/ReactViews/Map/TerriaViewerWrapper/TerriaViewerWrapperSpec.tsx
@@ -13,7 +13,7 @@ describe("TerriaViewerWrapper", function () {
 
   beforeEach(function () {
     terria = new Terria();
-    viewState = new ViewState({ terria, catalogSearchProvider: undefined });
+    viewState = new ViewState({ terria });
   });
 
   describe("when main viewer is in leaflet mode", function () {

--- a/test/ReactViews/Mobile/MobileHeaderSpec.tsx
+++ b/test/ReactViews/Mobile/MobileHeaderSpec.tsx
@@ -18,8 +18,7 @@ describe("MobileHeader", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Notification/NotificationSpec.tsx
+++ b/test/ReactViews/Notification/NotificationSpec.tsx
@@ -14,8 +14,7 @@ describe("Notification", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Search/BreadcrumbsSpec.tsx
+++ b/test/ReactViews/Search/BreadcrumbsSpec.tsx
@@ -15,8 +15,7 @@ describe("Breadcrumbs", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
     catalogGroup = new CatalogGroup("group-of-geospatial-cats", terria);
     terria.addModel(catalogGroup);

--- a/test/ReactViews/Search/SearchBoxAndResultsSpec.tsx
+++ b/test/ReactViews/Search/SearchBoxAndResultsSpec.tsx
@@ -27,9 +27,12 @@ describe("SearchBoxAndResults", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: new CatalogSearchProvider("catalog", terria)
+      terria: terria
     });
+    terria.catalog.searchProvider = new CatalogSearchProvider(
+      "catalog-search-provider",
+      terria
+    );
   });
 
   it("renders with an input(SearchBox), but no SearchInDataCatalog without showLocationSearchResults", function () {
@@ -81,7 +84,7 @@ describe("SearchBoxAndResults", function () {
       viewState.searchState.locationSearchText = searchText;
       viewState.searchState.showLocationSearchResults = true;
 
-      viewState.terria.searchBarModel.catalogSearchProvider = undefined;
+      viewState.terria.catalog.searchProvider = undefined;
     });
     renderWithContexts(
       <ThemeProvider theme={terriaTheme}>

--- a/test/ReactViews/Search/SearchBoxSpec.tsx
+++ b/test/ReactViews/Search/SearchBoxSpec.tsx
@@ -14,8 +14,7 @@ describe("SearchBox", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/SidePanel/BrandingSpec.tsx
+++ b/test/ReactViews/SidePanel/BrandingSpec.tsx
@@ -11,8 +11,7 @@ describe("Branding", function () {
   beforeEach(function () {
     terria = new Terria();
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
   });
 

--- a/test/ReactViews/StandardUserInterface/TrainerBar/TrainerBarSpec.tsx
+++ b/test/ReactViews/StandardUserInterface/TrainerBar/TrainerBarSpec.tsx
@@ -15,8 +15,7 @@ describe("TrainerBar", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/StandardUserInterfaceSpec.tsx
+++ b/test/ReactViews/StandardUserInterfaceSpec.tsx
@@ -22,8 +22,7 @@ describe("StandardUserInterface", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Story/StoryBuilderSpec.tsx
+++ b/test/ReactViews/Story/StoryBuilderSpec.tsx
@@ -14,8 +14,7 @@ describe("StoryBuilder", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
     runInAction(() => {
       viewState.storyBuilderShown = true;

--- a/test/ReactViews/ToolSpec.tsx
+++ b/test/ReactViews/ToolSpec.tsx
@@ -12,8 +12,7 @@ describe("Tool", function () {
   beforeEach(function () {
     const terria = new Terria();
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
   });
 

--- a/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
+++ b/test/ReactViews/Tools/ItemSearchTool/ItemSearchToolSpec.tsx
@@ -47,8 +47,7 @@ describe("ItemSearchTool", function () {
     registerItemSearchProvider("testProvider", TestItemSearchProvider);
     const terria: Terria = new Terria();
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
     item = new MockSearchableItem("test", terria);
     item.setTrait(CommonStrata.user, "search", {

--- a/test/ReactViews/Tour/TourPortalSpec.tsx
+++ b/test/ReactViews/Tour/TourPortalSpec.tsx
@@ -16,8 +16,7 @@ describe("TourPortal", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/WelcomeMessageSpec.tsx
+++ b/test/ReactViews/WelcomeMessageSpec.tsx
@@ -14,8 +14,7 @@ describe("WelcomeMessage", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
   });
 

--- a/test/ReactViews/Workbench/Controls/IdealZoomSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/IdealZoomSpec.tsx
@@ -25,11 +25,9 @@ describe("Ideal Zoom", function () {
     theItem = new Cesium3DTilesCatalogItem("my3dtiles", terria);
     theItem.setTrait("definition", "url", "/test/Cesium3DTiles/tileset.json");
 
-    const options = {
-      terria: terria,
-      catalogSearchProvider: undefined
-    };
-    viewState = new ViewState(options);
+    viewState = new ViewState({
+      terria: terria
+    });
   });
 
   it("should use default camera view if no parameters are given.", async function () {

--- a/test/ReactViews/Workbench/Controls/ViewingControlsSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/ViewingControlsSpec.tsx
@@ -15,8 +15,7 @@ describe("ViewingControls", function () {
   beforeEach(function () {
     terria = new Terria();
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
   });
 

--- a/test/ReactViews/Workbench/Controls/WorkbenchItemControlsSpec.tsx
+++ b/test/ReactViews/Workbench/Controls/WorkbenchItemControlsSpec.tsx
@@ -19,8 +19,7 @@ describe("WorkbenchItemControls", function () {
       baseUrl: "./"
     });
     viewState = new ViewState({
-      terria: terria,
-      catalogSearchProvider: undefined
+      terria: terria
     });
 
     item = new WebMapServiceCatalogItem("test-item", terria);

--- a/test/ReactViews/Workflows/WorkflowPanelSpec.tsx
+++ b/test/ReactViews/Workflows/WorkflowPanelSpec.tsx
@@ -14,8 +14,7 @@ describe("WorkflowPanel", function () {
     terria.configParameters.regionMappingDefinitionsUrl =
       "./data/regionMapping.json";
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
   });
 

--- a/test/ViewModels/FeatureInfoPanelSpec.ts
+++ b/test/ViewModels/FeatureInfoPanelSpec.ts
@@ -11,8 +11,7 @@ describe("FeatureInfoPanelViewModel", function () {
   beforeEach(function () {
     terria = new Terria();
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
   });
 

--- a/test/ViewModels/MapNavigation/MapToolbarSpec.ts
+++ b/test/ViewModels/MapNavigation/MapToolbarSpec.ts
@@ -10,8 +10,7 @@ describe("MapToolbar", function () {
   beforeEach(function () {
     terria = new Terria();
     viewState = new ViewState({
-      terria,
-      catalogSearchProvider: undefined
+      terria
     });
   });
 

--- a/test/ViewModels/ViewingControlsMenuSpec.ts
+++ b/test/ViewModels/ViewingControlsMenuSpec.ts
@@ -9,8 +9,7 @@ describe("ViewingControlsMenu", function () {
     it("adds the menu item generator function to `viewState.globalViewingControlOptions` array", function () {
       const terria = new Terria();
       const viewState = new ViewState({
-        terria,
-        catalogSearchProvider: undefined
+        terria
       });
       expect(viewState.globalViewingControlOptions.length).toEqual(0);
       const generateFunction = () => ({


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Move the catalogue search provider from `SearchBarModel` to the `Catalog` class. I always felt that the catalogue search provider doesn't belong in SearchBarModel, but at the time I was writing it, I wasn't aware of `Catalog`, so it stayed in the model.

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
