### PR TITLE
feat(wmts): time dimension support — discrete times + {Time} URL substitution (#7742)

### DIFF
--- a/lib/Models/Catalog/Ows/WebMapTileServiceCapabilities.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCapabilities.ts
@@ -24,6 +24,28 @@ export interface WmtsLayer {
   readonly infoFormat?: string | ReadonlyArray<string>;
   readonly TileMatrixSetLink?: TileMatrixSetLink | TileMatrixSetLink[];
   readonly ResourceURL?: ResourceUrl | ResourceUrl[];
+  readonly Dimension?: WmtsDimension | WmtsDimension[];
+}
+
+/**
+ * WMTS 1.0.0 `<Dimension>` element (per OGC 07-057r7 section 7.1.2).
+ *
+ * Unlike WMS, where the dimension's value list is the element's text content,
+ * WMTS nests the value list under one or more child `<Value>` elements, with
+ * the dimension name in `<Identifier>` and an optional `<Default>`.
+ *
+ * NOTE: only the time dimension is consumed by the catalog stratum today.
+ * Other dimensions (elevation, band, etc.) parse fine but are ignored.
+ */
+export interface WmtsDimension {
+  readonly Identifier: string;
+  readonly Title?: string;
+  readonly Abstract?: string;
+  readonly UOM?: string;
+  readonly UnitSymbol?: string;
+  readonly Default?: string;
+  readonly Current?: boolean;
+  readonly Value?: string | ReadonlyArray<string>;
 }
 
 /* For some reason LegendUrls are formatted differently from WMS - this makes me very upset >:(

--- a/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
@@ -32,6 +32,7 @@ import createStratumInstance from "../../Definition/createStratumInstance";
 import LoadableStratum from "../../Definition/LoadableStratum";
 import { BaseModel, ModelConstructorParameters } from "../../Definition/Model";
 import StratumFromTraits from "../../Definition/StratumFromTraits";
+import StratumOrder from "../../Definition/StratumOrder";
 import proxyCatalogItemUrl from "../proxyCatalogItemUrl";
 import { ServiceProvider } from "./OwsInterfaces";
 import WebMapTileServiceCapabilities, {
@@ -554,6 +555,102 @@ class GetCapabilitiesStratum extends LoadableStratum(
   }
 }
 
+/**
+ * Stratum that translates the user-supplied `time` trait (an explicit time
+ * dimension declaration in catalog JSON) into `discreteTimes` and
+ * `currentTime` values.
+ *
+ * Registered at HIGHER priority than `GetCapabilitiesStratum`, so when the
+ * user declares `time` in catalog JSON, the override values take precedence
+ * over whatever (if anything) the WMTS server advertises in `<Dimension>`.
+ *
+ * When `time` is unset, this stratum returns `undefined` for everything,
+ * letting `GetCapabilitiesStratum` provide values via the regular
+ * trait/stratum priority cascade — preserving existing behaviour.
+ *
+ * Required because GeoServer's GeoWebCache does not advertise `<Dimension>`
+ * in GetCapabilities even when the underlying layer has a configured time
+ * dimension. See issue #14.
+ */
+class TimeOverrideStratum extends LoadableStratum(
+  WebMapTileServiceCatalogItemTraits
+) {
+  static stratumName = "wmts-time-override";
+
+  constructor(readonly catalogItem: WebMapTileServiceCatalogItem) {
+    super();
+    makeObservable(this);
+  }
+
+  duplicateLoadableStratum(model: BaseModel): this {
+    return new TimeOverrideStratum(
+      model as WebMapTileServiceCatalogItem
+    ) as this;
+  }
+
+  /**
+   * Discrete times derived from the `time` trait. Returns `undefined` (and
+   * thereby falls through to GetCapabilitiesStratum) when the trait is not
+   * configured to produce a time set:
+   *   - `time.values` (preferred): used directly, sorted ascending.
+   *   - `time.start` + `time.stop` + `time.period`: expanded via
+   *     `createDiscreteTimesFromIsoSegments` (honours `maxRefreshIntervals`).
+   *   - Anything else (no `time`, only `defaultValue`, partial range): the
+   *     stratum has no times to provide here; GetCapabilities still runs
+   *     for `discreteTimes`. `currentTime` may still resolve from
+   *     `defaultValue` below.
+   */
+  @computed
+  get discreteTimes(): DiscreteTimeAsJS[] | undefined {
+    const t = this.catalogItem.time;
+    if (!t) return undefined;
+
+    if (t.values && t.values.length > 0) {
+      return [...t.values].sort().map((time) => ({ time, tag: undefined }));
+    }
+
+    if (isDefined(t.start) && isDefined(t.stop) && isDefined(t.period)) {
+      const result: DiscreteTimeAsJS[] = [];
+      createDiscreteTimesFromIsoSegments(
+        result,
+        t.start,
+        t.stop,
+        t.period,
+        this.catalogItem.maxRefreshIntervals
+      );
+      return result.length > 0 ? result : undefined;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Initial `currentTime` selection. Priority:
+   *   1. `time.defaultValue` if set.
+   *   2. The most recent value in `discreteTimes` (matches the
+   *      GetCapabilitiesStratum fallback contract).
+   *   3. `undefined` — falls through to GetCapabilitiesStratum / UI default.
+   */
+  @computed
+  get currentTime(): string | undefined {
+    const t = this.catalogItem.time;
+    if (!t) return undefined;
+
+    if (isDefined(t.defaultValue)) return t.defaultValue;
+
+    const dt = this.discreteTimes;
+    if (dt && dt.length > 0) return dt[dt.length - 1].time;
+
+    return undefined;
+  }
+}
+
+// Register `TimeOverrideStratum` AFTER the GetCapabilities stratum so it
+// receives a higher priority — the `time` trait override wins over whatever
+// the WMTS server advertises (or fails to advertise) in <Dimension>.
+// `getCapabilities` is registered when `GetCapabilitiesMixin` loads above.
+StratumOrder.addLoadStratum(TimeOverrideStratum.stratumName);
+
 class WebMapTileServiceCatalogItem extends MappableMixin(
   DiscretelyTimeVaryingMixin(
     GetCapabilitiesMixin(
@@ -580,9 +677,21 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
 
   static readonly type = "wmts";
 
+  static readonly TimeOverrideStratumName = TimeOverrideStratum.stratumName;
+
   constructor(...args: ModelConstructorParameters) {
     super(...args);
     makeObservable(this);
+    // Register the override stratum unconditionally. When the `time` trait
+    // is unset its computed properties return `undefined`, so the priority
+    // cascade falls through to `GetCapabilitiesStratum` and existing
+    // behaviour is preserved. When `time` is set, this stratum's higher
+    // priority means its `currentTime` wins, and the class-level
+    // `discreteTimes` getter consults this stratum first.
+    this.strata.set(
+      TimeOverrideStratum.stratumName,
+      new TimeOverrideStratum(this)
+    );
   }
 
   get type() {
@@ -590,16 +699,28 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
   }
 
   /**
-   * Class-level delegate: forward `discreteTimes` from the GetCapabilities
-   * stratum so `DiscretelyTimeVaryingMixin` can read it off the model
-   * directly. There is intentionally no equivalent class-level delegate for
+   * Class-level delegate: forward `discreteTimes` from the strata so
+   * `DiscretelyTimeVaryingMixin` can read it off the model directly.
+   * There is intentionally no equivalent class-level delegate for
    * `currentTime` — the trait system (via `DiscretelyTimeVaryingTraits`)
    * already resolves `currentTime` from strata automatically, so an
    * explicit getter would shadow stratum priority and break override
    * semantics. `discreteTimes` is NOT a trait, hence the explicit forward.
+   *
+   * Priority: `TimeOverrideStratum` (catalog-JSON `time` trait) wins over
+   * `GetCapabilitiesStratum`. This mirrors the trait-stratum priority used
+   * for `currentTime`. When the override stratum has nothing to say (no
+   * `time` trait or only `defaultValue` set), it returns `undefined` and
+   * we fall through to GetCapabilities — preserving existing behaviour.
    */
   @computed
   get discreteTimes() {
+    const overrideStratum: TimeOverrideStratum | undefined = this.strata.get(
+      TimeOverrideStratum.stratumName
+    ) as TimeOverrideStratum;
+    const overrideTimes = overrideStratum?.discreteTimes;
+    if (overrideTimes !== undefined) return overrideTimes;
+
     const getCapabilitiesStratum: GetCapabilitiesStratum | undefined =
       this.strata.get(
         GetCapabilitiesMixin.getCapabilitiesStratumName

--- a/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
@@ -7,6 +7,7 @@ import WebMapTileServiceImageryProvider from "terriajs-cesium/Source/Scene/WebMa
 import URI from "urijs";
 import containsAny from "../../../Core/containsAny";
 import createDiscreteTimesFromIsoSegments from "../../../Core/createDiscreteTimes";
+import createTransformerAllowUndefined from "../../../Core/createTransformerAllowUndefined";
 import isDefined from "../../../Core/isDefined";
 import isReadOnlyArray from "../../../Core/isReadOnlyArray";
 import TerriaError from "../../../Core/TerriaError";
@@ -15,7 +16,10 @@ import DiscretelyTimeVaryingMixin, {
   DiscreteTimeAsJS
 } from "../../../ModelMixins/DiscretelyTimeVaryingMixin";
 import GetCapabilitiesMixin from "../../../ModelMixins/GetCapabilitiesMixin";
-import MappableMixin, { MapItem } from "../../../ModelMixins/MappableMixin";
+import MappableMixin, {
+  ImageryParts,
+  MapItem
+} from "../../../ModelMixins/MappableMixin";
 import UrlMixin from "../../../ModelMixins/UrlMixin";
 import { InfoSectionTraits } from "../../../Traits/TraitsClasses/CatalogMemberTraits";
 import LegendTraits from "../../../Traits/TraitsClasses/LegendTraits";
@@ -632,66 +636,196 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
     return "1d";
   }
 
+  /**
+   * Imagery-provider-per-time factory. Wrapped in `createTransformerAllowUndefined`
+   * so MobX caches one provider instance per `time` value — flipping the
+   * timeline tag ticks `currentDiscreteTimeTag`/`nextDiscreteTimeTag`, which
+   * recomputes `_currentImageryParts`/`_nextImageryParts`, which calls this
+   * with a new `time` and gets back a fresh provider. Mirrors the WMS
+   * pattern in `WebMapServiceCatalogItem._createImageryProvider`.
+   *
+   * `time` propagates two ways to Cesium:
+   * 1. **REST `{Time}` placeholder substitution** — if the resolved tile URL
+   *    (pre-Cesium) contains a `{Time}` / `{time}` literal, we substitute it
+   *    here so `imageryProvider.url` is directly inspectable in tests and
+   *    so any URL-level proxying/caching downstream sees the time-keyed URL.
+   * 2. **`dimensions: { Time: time }` constructor option** — Cesium routes
+   *    this to `&TIME=` query param appends in KVP mode, and to template
+   *    substitution (`resource.setTemplateValues(staticDimensions)`) in
+   *    REST mode. Passing it on both paths is harmless: REST templates
+   *    without a `{Time}` placeholder simply ignore the value.
+   *
+   * Layers without a time `<Dimension>` get `time === undefined`, the
+   * substitution is a no-op, and `dimensions` is omitted — so non-temporal
+   * WMTS layers behave exactly as before this refactor.
+   */
+  private _createImageryProvider = createTransformerAllowUndefined(
+    (
+      time: string | undefined
+    ): WebMapTileServiceImageryProvider | undefined => {
+      const stratum = this.strata.get(
+        GetCapabilitiesMixin.getCapabilitiesStratumName
+      ) as GetCapabilitiesStratum;
+
+      if (
+        !isDefined(this.layer) ||
+        !isDefined(this.url) ||
+        !isDefined(stratum) ||
+        !isDefined(this.style)
+      ) {
+        return;
+      }
+
+      const layer = stratum.capabilitiesLayer;
+      const layerIdentifier = layer?.Identifier;
+      if (!isDefined(layer) || !isDefined(layerIdentifier)) {
+        return;
+      }
+
+      let format: string = "image/png";
+      const formats = layer.Format;
+      if (
+        formats &&
+        formats?.indexOf("image/png") === -1 &&
+        formats?.indexOf("image/jpeg") !== -1
+      ) {
+        format = "image/jpeg";
+      }
+
+      let baseUrl: string = this.getTileUrl(
+        layer,
+        stratum.capabilities,
+        format
+      );
+
+      // REST {Time} substitution. We do this BEFORE `proxyCatalogItemUrl` so
+      // the proxy sees the time-keyed URL (matters for cache key uniqueness
+      // and for any allow-list checks that assert against the literal URL).
+      // The regex is case-insensitive to cover both `{Time}` (NASA GIBS,
+      // Cesium's documented form) and `{time}` (TERN/GeoServer style — see
+      // the `tern-landscapes-time.xml` fixture).
+      if (isDefined(time)) {
+        baseUrl = baseUrl.replace(/\{time\}/gi, time);
+      }
+
+      const tileMatrixSet = this.tileMatrixSet;
+      if (!isDefined(tileMatrixSet)) {
+        return;
+      }
+
+      const imageryProvider = new WebMapTileServiceImageryProvider({
+        url: proxyCatalogItemUrl(this, baseUrl),
+        layer: layerIdentifier,
+        style: this.style,
+        tileMatrixSetID: tileMatrixSet.id,
+        tileMatrixLabels: tileMatrixSet.labels,
+        minimumLevel: tileMatrixSet.minLevel,
+        maximumLevel: tileMatrixSet.maxLevel,
+        tileWidth: this.tileWidth ?? tileMatrixSet.tileWidth,
+        tileHeight:
+          this.tileHeight ?? this.minimumLevel ?? tileMatrixSet.tileHeight,
+        tilingScheme: tileMatrixSet.scheme,
+        format,
+        credit: this.attribution,
+        // KVP path: Cesium combines `dimensions` into the GetTile query
+        // string. REST path: Cesium calls `setTemplateValues(staticDimensions)`
+        // which substitutes any remaining `{Time}` placeholders. We've
+        // already pre-substituted in `baseUrl`, so this is belt-and-braces
+        // for KVP.
+        //
+        // SAFE-SINGLE-SUBSTITUTION INVARIANT: when the REST template contains
+        // `{Time}`/`{time}`, our `baseUrl.replace(/\{time\}/gi, time)` above
+        // consumes all placeholders before Cesium's `setTemplateValues` runs.
+        // Cesium's pass is therefore a no-op on REST URLs that already had
+        // their placeholder, and a real substitution only happens on URLs
+        // that did NOT have one (in which case our regex was the no-op).
+        // The two passes never both substitute the same placeholder; the
+        // ordering is invariant. If Cesium ever changes the order or
+        // escaping of `setTemplateValues`, only this comment's claim is
+        // affected — the URL we hand to Cesium is already fully resolved.
+        ...(isDefined(time) ? { dimensions: { Time: time } } : {})
+        // TODO: implement picking for WebMapTileServiceImageryProvider
+        //enablePickFeatures: this.allowFeaturePicking
+      });
+      return imageryProvider;
+    }
+  );
+
+  /**
+   * Backward-compatible accessor. Pre-I7 callers (and the existing
+   * `with_operation_metadata.xml` URL-shape spec) read `wmts.imageryProvider`
+   * directly. We resolve to the provider for the currently-selected discrete
+   * time tag so non-temporal layers (no `<Dimension>` -> tag is `undefined`)
+   * keep returning a single, stable provider instance.
+   *
+   * @deprecated Use `mapItems` instead. WMS does not expose this accessor;
+   * it is kept here only to avoid breaking the pre-I7
+   * `with_operation_metadata.xml` URL-shape spec and any third-party callers
+   * that read `wmts.imageryProvider` directly. New code should resolve
+   * the provider via `mapItems[0].imageryProvider` (after filtering
+   * `ImageryParts.is`).
+   */
   @computed
-  get imageryProvider() {
-    const stratum = this.strata.get(
-      GetCapabilitiesMixin.getCapabilitiesStratumName
-    ) as GetCapabilitiesStratum;
+  get imageryProvider(): WebMapTileServiceImageryProvider | undefined {
+    return this._createImageryProvider(this.currentDiscreteTimeTag);
+  }
 
-    if (
-      !isDefined(this.layer) ||
-      !isDefined(this.url) ||
-      !isDefined(stratum) ||
-      !isDefined(this.style)
-    ) {
-      return;
-    }
-
-    const layer = stratum.capabilitiesLayer;
-    const layerIdentifier = layer?.Identifier;
-    if (!isDefined(layer) || !isDefined(layerIdentifier)) {
-      return;
-    }
-
-    let format: string = "image/png";
-    const formats = layer.Format;
-    if (
-      formats &&
-      formats?.indexOf("image/png") === -1 &&
-      formats?.indexOf("image/jpeg") !== -1
-    ) {
-      format = "image/jpeg";
-    }
-
-    const baseUrl: string = this.getTileUrl(
-      layer,
-      stratum.capabilities,
-      format
+  @computed
+  private get _currentImageryParts(): ImageryParts | undefined {
+    const imageryProvider = this._createImageryProvider(
+      this.currentDiscreteTimeTag
     );
-
-    const tileMatrixSet = this.tileMatrixSet;
-    if (!isDefined(tileMatrixSet)) {
-      return;
+    if (imageryProvider === undefined) {
+      return undefined;
     }
 
-    const imageryProvider = new WebMapTileServiceImageryProvider({
-      url: proxyCatalogItemUrl(this, baseUrl),
-      layer: layerIdentifier,
-      style: this.style,
-      tileMatrixSetID: tileMatrixSet.id,
-      tileMatrixLabels: tileMatrixSet.labels,
-      minimumLevel: tileMatrixSet.minLevel,
-      maximumLevel: tileMatrixSet.maxLevel,
-      tileWidth: this.tileWidth ?? tileMatrixSet.tileWidth,
-      tileHeight:
-        this.tileHeight ?? this.minimumLevel ?? tileMatrixSet.tileHeight,
-      tilingScheme: tileMatrixSet.scheme,
-      format,
-      credit: this.attribution
-      // TODO: implement picking for WebMapTileServiceImageryProvider
-      //enablePickFeatures: this.allowFeaturePicking
-    });
-    return imageryProvider;
+    // Reset feature picking for the current imagery layer.
+    // We disable feature picking for the next imagery layer (cross-fade).
+    // NOTE: Cesium's `WebMapTileServiceImageryProvider.pickFeatures` always
+    // returns undefined (WMTS has no GetFeatureInfo equivalent), so this
+    // assignment is currently a no-op at runtime — it mirrors WMS shape so
+    // the contract is in place if Cesium ever adds WMTS picking, and matches
+    // the established `WebMapServiceCatalogItem` pattern for upstream parity.
+    (imageryProvider as any).enablePickFeatures = this.allowFeaturePicking;
+
+    return {
+      imageryProvider,
+      alpha: this.opacity,
+      show: this.show,
+      clippingRectangle: this.clipToRectangle ? this.cesiumRectangle : undefined
+    };
+  }
+
+  @computed
+  private get _nextImageryParts(): ImageryParts | undefined {
+    if (
+      this.terria.timelineStack.contains(this) &&
+      !this.isPaused &&
+      this.nextDiscreteTimeTag
+    ) {
+      const imageryProvider = this._createImageryProvider(
+        this.nextDiscreteTimeTag
+      );
+      if (imageryProvider === undefined) {
+        return undefined;
+      }
+
+      // Disable feature picking for the next imagery layer during cross-fade.
+      // See note in `_currentImageryParts`: this is a no-op on Cesium's WMTS
+      // provider today; kept for shape-parity with WMS.
+      (imageryProvider as any).enablePickFeatures = false;
+
+      return {
+        imageryProvider,
+        alpha: 0.0,
+        show: true,
+        clippingRectangle: this.clipToRectangle
+          ? this.cesiumRectangle
+          : undefined
+      };
+    } else {
+      return undefined;
+    }
   }
 
   getTileUrl(
@@ -838,19 +972,25 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
 
   @computed
   get mapItems(): MapItem[] {
-    if (isDefined(this.imageryProvider)) {
-      return [
-        {
-          alpha: this.opacity,
-          show: this.show,
-          imageryProvider: this.imageryProvider,
-          clippingRectangle: this.clipToRectangle
-            ? this.cesiumRectangle
-            : undefined
-        }
-      ];
+    const result: MapItem[] = [];
+
+    const current = this._currentImageryParts;
+    if (current) {
+      result.push(current);
     }
-    return [];
+
+    // _nextImageryParts only resolves to non-undefined when this layer is on
+    // the active timelineStack and has a `nextDiscreteTimeTag` — i.e. the
+    // user is animating through the time dimension. For non-temporal WMTS
+    // layers (no `<Dimension>`), `nextDiscreteTimeTag` is always undefined
+    // so this is always skipped and behaviour matches the pre-I7 single-
+    // imagery shape.
+    const next = this._nextImageryParts;
+    if (next) {
+      result.push(next);
+    }
+
+    return result;
   }
 
   protected get defaultGetCapabilitiesUrl(): string | undefined {

--- a/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem.ts
@@ -6,10 +6,14 @@ import WebMercatorTilingScheme from "terriajs-cesium/Source/Core/WebMercatorTili
 import WebMapTileServiceImageryProvider from "terriajs-cesium/Source/Scene/WebMapTileServiceImageryProvider";
 import URI from "urijs";
 import containsAny from "../../../Core/containsAny";
+import createDiscreteTimesFromIsoSegments from "../../../Core/createDiscreteTimes";
 import isDefined from "../../../Core/isDefined";
 import isReadOnlyArray from "../../../Core/isReadOnlyArray";
 import TerriaError from "../../../Core/TerriaError";
 import CatalogMemberMixin from "../../../ModelMixins/CatalogMemberMixin";
+import DiscretelyTimeVaryingMixin, {
+  DiscreteTimeAsJS
+} from "../../../ModelMixins/DiscretelyTimeVaryingMixin";
 import GetCapabilitiesMixin from "../../../ModelMixins/GetCapabilitiesMixin";
 import MappableMixin, { MapItem } from "../../../ModelMixins/MappableMixin";
 import UrlMixin from "../../../ModelMixins/UrlMixin";
@@ -31,6 +35,7 @@ import WebMapTileServiceCapabilities, {
   ResourceUrl,
   TileMatrixSetLink,
   WmtsCapabilitiesLegend,
+  WmtsDimension,
   WmtsLayer
 } from "./WebMapTileServiceCapabilities";
 
@@ -419,12 +424,138 @@ class GetCapabilitiesStratum extends LoadableStratum(
       layerAvailableStyles?.[0]?.identifier
     );
   }
+
+  /**
+   * Locate the time `<Dimension>` (case-insensitive on Identifier) on the
+   * matched WMTS layer. Returns `undefined` if the layer or dimension is
+   * absent.
+   */
+  @computed
+  private get timeDimension(): WmtsDimension | undefined {
+    const layer = this.capabilitiesLayer;
+    if (!layer || !layer.Dimension) return undefined;
+    const dimensions: ReadonlyArray<WmtsDimension> = Array.isArray(
+      layer.Dimension
+    )
+      ? layer.Dimension
+      : [layer.Dimension];
+    return dimensions.find(
+      (d) => isDefined(d.Identifier) && d.Identifier.toLowerCase() === "time"
+    );
+  }
+
+  /**
+   * Discrete times parsed from the time `<Dimension>` of the matched layer.
+   *
+   * Three encodings are supported (per OGC 07-057r7 section 7.1.2 and common
+   * server practice):
+   *
+   * 1. Multiple `<Value>` children: each text node is treated as an explicit
+   *    ISO instant (NASA GIBS style).
+   * 2. A single `<Value>` containing a `start/stop/period` ISO 19128 range:
+   *    expanded via `createDiscreteTimesFromIsoSegments` (TERN, GeoServer
+   *    style).
+   * 3. A single `<Value>` containing a comma-separated list of instants or
+   *    ranges: each segment is parsed independently. (Not strictly per spec
+   *    but observed in the wild on GeoServer-backed endpoints.)
+   *
+   * Honours `maxRefreshIntervals` to cap range expansion.
+   */
+  @computed
+  get discreteTimes(): DiscreteTimeAsJS[] | undefined {
+    const dimension = this.timeDimension;
+    if (!dimension || !isDefined(dimension.Value)) return undefined;
+
+    const result: DiscreteTimeAsJS[] = [];
+
+    const rawValues: ReadonlyArray<string> = isReadOnlyArray(dimension.Value)
+      ? dimension.Value
+      : [dimension.Value];
+
+    // Flatten any comma-separated entries inside individual <Value> children.
+    const values: string[] = [];
+    for (const raw of rawValues) {
+      if (typeof raw !== "string") continue;
+      for (const segment of raw.split(",")) {
+        const trimmed = segment.trim();
+        if (trimmed.length > 0) values.push(trimmed);
+      }
+    }
+
+    for (const value of values) {
+      const isoSegments = value.split("/");
+      if (isoSegments.length === 1) {
+        result.push({ time: value, tag: undefined });
+      } else {
+        createDiscreteTimesFromIsoSegments(
+          result,
+          isoSegments[0],
+          isoSegments[1],
+          isoSegments[2],
+          this.catalogItem.maxRefreshIntervals
+        );
+      }
+    }
+
+    return result.length > 0 ? result : undefined;
+  }
+
+  @computed
+  get initialTimeSource() {
+    return "now";
+  }
+
+  /**
+   * Default time selection. Priority:
+   *
+   * 1. `<Default>` from the time `<Dimension>`, if present and not the
+   *    placeholder string `"current"`.
+   * 2. The most recent discrete instant.
+   * 3. `undefined` (UI falls back to `initialTimeSource`).
+   *
+   * INTENTIONAL DIVERGENCE FROM WMS: when no `<Default>` is supplied (or it
+   * equals the `"current"` sentinel), this stratum returns the latest
+   * discrete time — not `undefined`. The WMS stratum returns `undefined`
+   * here and lets `initialTimeSource="now"` drive the UI to the wall-clock.
+   *
+   * The WMTS choice is per upstream issue #7742 acceptance criteria
+   * ("otherwise latest discrete time"). Rationale: WMTS layers are typically
+   * pre-tiled archives where the wall-clock "now" is rarely a tiled instant,
+   * so anchoring to the newest available tile gives a usable initial render.
+   * If you change this, also change the U4/U5 specs in
+   * `WebMapTileServiceCatalogItemSpec.ts` and update issue #7742.
+   */
+  @computed
+  get currentTime(): string | undefined {
+    const dimension = this.timeDimension;
+    const explicitDefault = dimension?.Default;
+
+    // The literal "current" sentinel means "send the most recent data
+    // available" — we let the UI's "now" handling take over rather than
+    // pinning the layer to a stale ISO string.
+    if (isDefined(explicitDefault) && explicitDefault !== "current") {
+      return explicitDefault;
+    }
+
+    const times = this.discreteTimes;
+    if (times && times.length > 0) {
+      // discreteTimes from a range expansion are ordered ascending. For
+      // explicit <Value> lists we don't sort (preserve server order) but
+      // still pick the last entry, which matches WMS behaviour where the
+      // newest instant is conventionally last.
+      return times[times.length - 1].time;
+    }
+
+    return undefined;
+  }
 }
 
 class WebMapTileServiceCatalogItem extends MappableMixin(
-  GetCapabilitiesMixin(
-    UrlMixin(
-      CatalogMemberMixin(CreateModel(WebMapTileServiceCatalogItemTraits))
+  DiscretelyTimeVaryingMixin(
+    GetCapabilitiesMixin(
+      UrlMixin(
+        CatalogMemberMixin(CreateModel(WebMapTileServiceCatalogItemTraits))
+      )
     )
   )
 ) {
@@ -452,6 +583,24 @@ class WebMapTileServiceCatalogItem extends MappableMixin(
 
   get type() {
     return WebMapTileServiceCatalogItem.type;
+  }
+
+  /**
+   * Class-level delegate: forward `discreteTimes` from the GetCapabilities
+   * stratum so `DiscretelyTimeVaryingMixin` can read it off the model
+   * directly. There is intentionally no equivalent class-level delegate for
+   * `currentTime` — the trait system (via `DiscretelyTimeVaryingTraits`)
+   * already resolves `currentTime` from strata automatically, so an
+   * explicit getter would shadow stratum priority and break override
+   * semantics. `discreteTimes` is NOT a trait, hence the explicit forward.
+   */
+  @computed
+  get discreteTimes() {
+    const getCapabilitiesStratum: GetCapabilitiesStratum | undefined =
+      this.strata.get(
+        GetCapabilitiesMixin.getCapabilitiesStratumName
+      ) as GetCapabilitiesStratum;
+    return getCapabilitiesStratum?.discreteTimes;
   }
 
   async createGetCapabilitiesStratumFromParent(

--- a/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
@@ -7,6 +7,7 @@ import mixTraits from "../mixTraits";
 import ModelTraits from "../ModelTraits";
 import { traitClass } from "../Trait";
 import CatalogMemberTraits from "./CatalogMemberTraits";
+import DiscretelyTimeVaryingTraits from "./DiscretelyTimeVaryingTraits";
 import GetCapabilitiesTraits from "./GetCapabilitiesTraits";
 import ImageryProviderTraits from "./ImageryProviderTraits";
 import LayerOrderingTraits from "./LayerOrderingTraits";
@@ -87,7 +88,8 @@ export default class WebMapTileServiceCatalogItemTraits extends mixTraits(
   UrlTraits,
   MappableTraits,
   CatalogMemberTraits,
-  LegendOwnerTraits
+  LegendOwnerTraits,
+  DiscretelyTimeVaryingTraits
 ) {
   @primitiveTrait({
     type: "string",
@@ -132,4 +134,14 @@ export default class WebMapTileServiceCatalogItemTraits extends mixTraits(
       "The encoding of the tile images. We will try to load the tile images with this encoding, if not available we will fallback to KVP. Supported values are KVP and Restful"
   })
   requestEncoding = "RESTful";
+
+  @primitiveTrait({
+    type: "number",
+    name: "Maximum Refresh Intervals",
+    description:
+      "The maximum number of discrete times that can be created by a single " +
+      "date range, when specified in the format time/time/periodicity. E.g. " +
+      "`2015-04-27T16:15:00/2015-04-27T18:45:00/PT15M` has 11 times."
+  })
+  maxRefreshIntervals: number = 10000;
 }

--- a/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
+++ b/lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts
@@ -2,6 +2,7 @@ import { JsonObject } from "../../Core/Json";
 import anyTrait from "../Decorators/anyTrait";
 import objectArrayTrait from "../Decorators/objectArrayTrait";
 import objectTrait from "../Decorators/objectTrait";
+import primitiveArrayTrait from "../Decorators/primitiveArrayTrait";
 import primitiveTrait from "../Decorators/primitiveTrait";
 import mixTraits from "../mixTraits";
 import ModelTraits from "../ModelTraits";
@@ -51,6 +52,66 @@ export class WebMapTileServiceAvailableStyleTraits extends ModelTraits {
     description: "True if this Style is default; otherwise, false."
   })
   isDefault: boolean = false;
+}
+
+/**
+ * Explicit time-dimension override.
+ *
+ * Used when a WMTS server does not advertise a `<Dimension>` element in its
+ * GetCapabilities response (e.g., GeoServer's GeoWebCache, which strips
+ * Dimensions even when the underlying layer has time metadata configured).
+ * Lets catalog JSON declare the discrete time set, an ISO range, and/or a
+ * default selection without round-tripping through GetCapabilities.
+ *
+ * Resolution order in `TimeOverrideStratum`:
+ *   1. `values` (explicit list) — sorted ascending and used as-is.
+ *   2. `start` + `stop` + `period` — expanded via
+ *      `createDiscreteTimesFromIsoSegments` (honours `maxRefreshIntervals`).
+ *   3. Both absent — stratum returns `undefined` for `discreteTimes` and
+ *      falls through to `GetCapabilitiesStratum`, preserving prior behaviour.
+ *
+ * `defaultValue` selects the initial `currentTime`; absent it, the most
+ * recent discrete instant is selected (matches the GetCapabilities path).
+ */
+export class WebMapTileServiceTimeTraits extends ModelTraits {
+  @primitiveArrayTrait({
+    type: "string",
+    name: "Values",
+    description:
+      "Explicit list of ISO 8601 timestamps. Used directly as the discrete time set when present."
+  })
+  values?: string[];
+
+  @primitiveTrait({
+    type: "string",
+    name: "Start",
+    description:
+      "ISO 8601 range start. Use together with `stop` and `period` to declare a regular interval that will be expanded via `createDiscreteTimesFromIsoSegments`."
+  })
+  start?: string;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Stop",
+    description: "ISO 8601 range stop. Use together with `start` and `period`."
+  })
+  stop?: string;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Period",
+    description:
+      "ISO 8601 period (e.g., `P1D`, `PT1H`). Use together with `start` and `stop`."
+  })
+  period?: string;
+
+  @primitiveTrait({
+    type: "string",
+    name: "Default Value",
+    description:
+      "ISO 8601 timestamp to select initially. Falls back to the most recent discrete time when omitted."
+  })
+  defaultValue?: string;
 }
 
 export class WebMapTileServiceAvailableLayerStylesTraits extends ModelTraits {
@@ -144,4 +205,12 @@ export default class WebMapTileServiceCatalogItemTraits extends mixTraits(
       "`2015-04-27T16:15:00/2015-04-27T18:45:00/PT15M` has 11 times."
   })
   maxRefreshIntervals: number = 10000;
+
+  @objectTrait({
+    type: WebMapTileServiceTimeTraits,
+    name: "Time",
+    description:
+      "Explicit time-dimension configuration. Used when the WMTS server does not advertise `<Dimension>` in GetCapabilities (e.g., GeoServer GeoWebCache). When set, this overrides any time dimension parsed from GetCapabilities. When unset, time handling falls through to GetCapabilities (existing behaviour)."
+  })
+  time?: WebMapTileServiceTimeTraits;
 }

--- a/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
@@ -1,5 +1,6 @@
 import i18next from "i18next";
 import { autorun, runInAction } from "mobx";
+import { ImageryParts } from "../../../../lib/ModelMixins/MappableMixin";
 import WebMapTileServiceCatalogItem from "../../../../lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem";
 import Terria from "../../../../lib/Models/Terria";
 
@@ -179,10 +180,11 @@ describe("WebMapTileServiceCatalogItem", function () {
   // Time dimension parsing.
   //
   // Specs in this block correspond to plan items U1-U5 (Verification > Phase 2).
-  // U6-U10 (REST {Time} substitution, KVP TIME param, provider rebuild on time
-  // change, etc.) are gated on issue I7 — the imagery-provider-per-time
-  // refactor — and intentionally NOT shipped here. They land in the Week 8-10
-  // pass after I7 is merged. Do not silently downgrade those to xit/pending.
+  // U6-U8 (REST {Time} substitution, KVP TIME dimension on the imagery
+  // provider, provider rebuild on currentTime change) live in the sibling
+  // `imagery provider per time` describe block below — they exercise the I7
+  // imagery-provider-per-time refactor (`_createImageryProvider(time)`),
+  // not the capabilities-parsing layer.
   // ---------------------------------------------------------------------------
   describe("time dimension parsing", function () {
     it("expands explicit <Value> children into discrete times (NASA GIBS style)", async function () {
@@ -295,6 +297,176 @@ describe("WebMapTileServiceCatalogItem", function () {
       expect(wmts.discreteTimes!.length).toBe(97);
       expect(wmts.discreteTimes![0].time).toContain("2024-01-01T00:00");
       expect(wmts.discreteTimes![96].time).toContain("2024-01-05T00:00");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Imagery provider per time (issue I7).
+  //
+  // These specs exercise `_createImageryProvider(time)` — the per-time provider
+  // factory introduced by the I7 refactor. Two propagation paths are covered:
+  //
+  //   1. REST `{Time}`/`{time}` placeholder substitution into `imageryProvider.url`
+  //      (TERN-style ResourceURL templates).
+  //   2. `dimensions: { Time }` constructor option on the imagery provider,
+  //      which Cesium routes to `&TIME=` query param appends on KVP GetTile
+  //      and to `setTemplateValues` on REST. The dimensions option is set
+  //      whenever a time is selected, regardless of REST/KVP encoding —
+  //      asserting it on the GIBS fixture (REST template lacking `{Time}`)
+  //      proves the KVP-bound code path fires independently of substitution.
+  //
+  // U6-U8 from the plan. U9-U10 (cache hit on second-pass scrub, no-time
+  // layers behave unchanged) are integration-level and land in I9/I14.
+  // ---------------------------------------------------------------------------
+  describe("imagery provider per time", function () {
+    it("substitutes {time} in the REST ResourceURL with the selected currentTime (U6)", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time.xml"
+        );
+        wmts.setTrait("definition", "layer", "tern_soil_moisture_daily");
+      });
+
+      await wmts.loadMapItems();
+
+      // The TERN fixture's <Default> is 2024-01-05T00:00:00Z and the
+      // ResourceURL template contains a `{time}` placeholder. After
+      // _createImageryProvider runs, the provider's url MUST have the
+      // placeholder substituted with the default-selected time.
+      // Discriminating assertion: a literal `{time}` in the URL would prove
+      // the substitution path didn't fire.
+      expect(wmts.imageryProvider).toBeDefined();
+      expect(wmts.imageryProvider!.url).toContain("2024-01-05T00:00:00Z");
+      expect(wmts.imageryProvider!.url).not.toContain("{time}");
+      expect(wmts.imageryProvider!.url).not.toContain("{Time}");
+    });
+
+    it("passes the selected time as a Time dimension on the imagery provider (U7)", async function () {
+      runInAction(() => {
+        wmts.setTrait("definition", "url", "test/WMTS/nasa-gibs-time.xml");
+        wmts.setTrait(
+          "definition",
+          "layer",
+          "MODIS_Terra_CorrectedReflectance_TrueColor"
+        );
+      });
+
+      await wmts.loadMapItems();
+
+      // The GIBS fixture's ResourceURL template does NOT contain a {Time}
+      // placeholder — Cesium's KVP-mode tile fetch is what consumes the
+      // `dimensions: { Time }` constructor option (it appends &TIME=...
+      // to the GetTile request). We assert the dimensions option round-
+      // trips through the provider so the KVP code path is exercised
+      // independently of REST {Time} substitution. <Default> is 2024-03-13.
+      expect(wmts.imageryProvider).toBeDefined();
+      expect(wmts.imageryProvider!.dimensions).toEqual({ Time: "2024-03-13" });
+    });
+
+    it("substitutes uppercase {Time} in the REST ResourceURL (U6b)", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time-uppercase.xml"
+        );
+        wmts.setTrait("definition", "layer", "tern_soil_moisture_daily");
+      });
+
+      await wmts.loadMapItems();
+
+      // The uppercase fixture's ResourceURL template literally contains
+      // `{Time}` (capital T — Cesium / NASA GIBS convention). The
+      // implementation regex `/\{time\}/gi` carries the `i` flag specifically
+      // to handle this case. Positive assertion: the timestamp appears
+      // where `{Time}` was. Negative assertion: no leftover placeholder
+      // in either case. Together these prove the case-insensitive substitution
+      // path actually fires (not just the lowercase one tested in U6).
+      expect(wmts.imageryProvider).toBeDefined();
+      expect(wmts.imageryProvider!.url).toContain("2024-01-05T00:00:00Z");
+      expect(wmts.imageryProvider!.url).not.toContain("{Time}");
+      expect(wmts.imageryProvider!.url).not.toContain("{time}");
+    });
+
+    it("propagates allowFeaturePicking onto _currentImageryParts and disables it on _nextImageryParts (U6c)", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time.xml"
+        );
+        wmts.setTrait("definition", "layer", "tern_soil_moisture_daily");
+      });
+
+      await wmts.loadMapItems();
+      terria.timelineStack.addToTop(wmts);
+      terria.timelineStack.activate();
+
+      runInAction(() => {
+        wmts.setTrait("definition", "isPaused", false);
+        // Force a non-default `currentTime` so a `nextDiscreteTimeTag` exists
+        // and `_nextImageryParts` resolves.
+        wmts.setTrait("definition", "currentTime", "2024-01-02T00:00:00Z");
+      });
+
+      // mapItems[0] = current, mapItems[1] = next during cross-fade.
+      // Mirror of WMS spec at WebMapServiceCatalogItemSpec.ts:720-735. Cesium's
+      // WMTS provider has no real picking implementation today; this assertion
+      // verifies the plumbing matches WMS shape so upstream parity holds.
+      const imageryParts = wmts.mapItems.filter(ImageryParts.is);
+      expect(imageryParts.length).toBe(2);
+
+      const currentProvider = imageryParts[0].imageryProvider as any;
+      expect(currentProvider.enablePickFeatures).toBe(true);
+
+      const nextProvider = imageryParts[1].imageryProvider as any;
+      expect(nextProvider.enablePickFeatures).toBe(false);
+
+      // Flip allowFeaturePicking and reload — current should follow.
+      runInAction(() => {
+        wmts.setTrait("definition", "allowFeaturePicking", false);
+      });
+      const partsAfter = wmts.mapItems.filter(ImageryParts.is);
+      const currentProviderAfter = partsAfter[0].imageryProvider as any;
+      expect(currentProviderAfter.enablePickFeatures).toBe(false);
+    });
+
+    it("rebuilds the imagery provider when currentTime changes (U8)", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time.xml"
+        );
+        wmts.setTrait("definition", "layer", "tern_soil_moisture_daily");
+      });
+
+      await wmts.loadMapItems();
+
+      // Snapshot the provider at the default time.
+      const providerAtDefault = wmts.imageryProvider;
+      expect(providerAtDefault).toBeDefined();
+      expect(providerAtDefault!.url).toContain("2024-01-05T00:00:00Z");
+
+      // Flip currentTime to an earlier discrete instant. The
+      // `createTransformerAllowUndefined` cache means the provider is keyed
+      // by the time string — a different time MUST produce a different
+      // provider instance with a different substituted URL.
+      runInAction(() => {
+        wmts.setTrait("definition", "currentTime", "2024-01-02T00:00:00Z");
+      });
+
+      const providerAtNewTime = wmts.imageryProvider;
+      expect(providerAtNewTime).toBeDefined();
+      // Discriminating assertion #1: the new URL reflects the new time.
+      expect(providerAtNewTime!.url).toContain("2024-01-02T00:00:00Z");
+      expect(providerAtNewTime!.url).not.toContain("2024-01-05T00:00:00Z");
+      // Discriminating assertion #2: it is a *different* provider instance.
+      // If the transformer returned the cached default-time provider, this
+      // would fail and prove the per-time keying is broken.
+      expect(providerAtNewTime).not.toBe(providerAtDefault);
     });
   });
 });

--- a/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
@@ -174,4 +174,127 @@ describe("WebMapTileServiceCatalogItem", function () {
     expect(wmts.tileMatrixSet!.tileWidth).toEqual(256);
     expect(wmts.tileMatrixSet!.tileHeight).toEqual(256);
   });
+
+  // ---------------------------------------------------------------------------
+  // Time dimension parsing.
+  //
+  // Specs in this block correspond to plan items U1-U5 (Verification > Phase 2).
+  // U6-U10 (REST {Time} substitution, KVP TIME param, provider rebuild on time
+  // change, etc.) are gated on issue I7 — the imagery-provider-per-time
+  // refactor — and intentionally NOT shipped here. They land in the Week 8-10
+  // pass after I7 is merged. Do not silently downgrade those to xit/pending.
+  // ---------------------------------------------------------------------------
+  describe("time dimension parsing", function () {
+    it("expands explicit <Value> children into discrete times (NASA GIBS style)", async function () {
+      runInAction(() => {
+        wmts.setTrait("definition", "url", "test/WMTS/nasa-gibs-time.xml");
+        wmts.setTrait(
+          "definition",
+          "layer",
+          "MODIS_Terra_CorrectedReflectance_TrueColor"
+        );
+      });
+
+      await wmts.loadMetadata();
+
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(3);
+      expect(wmts.discreteTimes!.map((t) => t.time)).toEqual([
+        "2024-03-13",
+        "2024-03-14",
+        "2024-03-15"
+      ]);
+    });
+
+    it("expands an ISO 19128 start/stop/period range (TERN style)", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time.xml"
+        );
+        wmts.setTrait("definition", "layer", "tern_soil_moisture_daily");
+      });
+
+      await wmts.loadMetadata();
+
+      expect(wmts.discreteTimes).toBeDefined();
+      // 2024-01-01..2024-01-05 with P1D step -> 5 instants
+      expect(wmts.discreteTimes!.length).toBe(5);
+      expect(wmts.discreteTimes![0].time).toContain("2024-01-01");
+      expect(wmts.discreteTimes![4].time).toContain("2024-01-05");
+    });
+
+    it("uses <Default> for the initially-selected time when present", async function () {
+      runInAction(() => {
+        wmts.setTrait("definition", "url", "test/WMTS/nasa-gibs-time.xml");
+        wmts.setTrait(
+          "definition",
+          "layer",
+          "MODIS_Terra_CorrectedReflectance_TrueColor"
+        );
+      });
+
+      await wmts.loadMetadata();
+
+      // Discriminating assertion: the fixture's <Default>2024-03-13</Default>
+      // is NOT the last <Value> (which is 2024-03-15). This assertion only
+      // passes when the <Default> branch fires; it FAILS if the
+      // last-element fallback runs instead.
+      expect(wmts.currentTime).toBe("2024-03-13");
+    });
+
+    it("falls back to the most recent <Value> when no <Default> is supplied", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/nasa-gibs-time-no-default.xml"
+        );
+        wmts.setTrait(
+          "definition",
+          "layer",
+          "MODIS_Terra_CorrectedReflectance_TrueColor_NoDefault"
+        );
+      });
+
+      await wmts.loadMetadata();
+
+      // Per upstream issue #7742 acceptance criteria ("otherwise latest
+      // discrete time"), absence of <Default> must yield the chronologically
+      // last <Value>, not undefined. This is intentional WMTS divergence
+      // from WMS — see the comment block on `currentTime` in the stratum.
+      expect(wmts.currentTime).toBe("2024-03-15");
+    });
+
+    it("expands a slash-separated range with no period (TERN/GeoServer style)", async function () {
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time.xml"
+        );
+        wmts.setTrait(
+          "definition",
+          "layer",
+          "tern_soil_moisture_daily_no_period"
+        );
+      });
+
+      await wmts.loadMetadata();
+
+      // The <Value> "2024-01-01T00:00:00Z/2024-01-05T00:00:00Z" has only two
+      // slash segments — period is undefined. createDiscreteTimesFromIsoSegments
+      // picks a default duration based on the span (see createDiscreteTimes.ts
+      // lines 30-67). A 4-day (96-hour) span falls into the `1000 * hour`
+      // bucket -> 1-hour duration -> 97 inclusive hourly instants
+      // (00:00..96:00). The point of this spec is to prove the helper
+      // handles `period=undefined` gracefully end-to-end; the exact count
+      // is asserted to lock in the helper's bucket-selection contract.
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(97);
+      expect(wmts.discreteTimes![0].time).toContain("2024-01-01T00:00");
+      expect(wmts.discreteTimes![96].time).toContain("2024-01-05T00:00");
+    });
+  });
 });

--- a/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
+++ b/test/Models/Catalog/Ows/WebMapTileServiceCatalogItemSpec.ts
@@ -2,7 +2,10 @@ import i18next from "i18next";
 import { autorun, runInAction } from "mobx";
 import { ImageryParts } from "../../../../lib/ModelMixins/MappableMixin";
 import WebMapTileServiceCatalogItem from "../../../../lib/Models/Catalog/Ows/WebMapTileServiceCatalogItem";
+import CommonStrata from "../../../../lib/Models/Definition/CommonStrata";
+import createStratumInstance from "../../../../lib/Models/Definition/createStratumInstance";
 import Terria from "../../../../lib/Models/Terria";
+import { WebMapTileServiceTimeTraits } from "../../../../lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits";
 
 describe("WebMapTileServiceCatalogItem", function () {
   let terria: Terria;
@@ -297,6 +300,127 @@ describe("WebMapTileServiceCatalogItem", function () {
       expect(wmts.discreteTimes!.length).toBe(97);
       expect(wmts.discreteTimes![0].time).toContain("2024-01-01T00:00");
       expect(wmts.discreteTimes![96].time).toContain("2024-01-05T00:00");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Explicit `time` trait override (issue #14).
+  //
+  // GeoServer's GeoWebCache does NOT advertise <Dimension> in GetCapabilities
+  // even when the underlying layer has time metadata. Catalog JSON authors
+  // must be able to declare the time set explicitly. The override stratum
+  // (TimeOverrideStratum) translates the `time` trait into discreteTimes /
+  // currentTime at higher priority than GetCapabilitiesStratum. When unset,
+  // the stratum returns undefined for everything and existing GetCapabilities-
+  // driven behaviour is preserved (regression spec below).
+  // ---------------------------------------------------------------------------
+  describe("explicit time override (issue #14)", function () {
+    it("uses time.values verbatim as discreteTimes, sorted ascending", function () {
+      // Path 1: explicit `values` list. We deliberately supply them out of
+      // order to lock in the documented contract that the stratum sorts
+      // ascending — UI timeline scrubbing relies on monotonically-increasing
+      // discrete times.
+      runInAction(() => {
+        wmts.setTrait(
+          CommonStrata.user,
+          "time",
+          createStratumInstance(WebMapTileServiceTimeTraits, {
+            values: [
+              "2024-01-03T00:00:00Z",
+              "2024-01-01T00:00:00Z",
+              "2024-01-02T00:00:00Z"
+            ]
+          })
+        );
+      });
+
+      // No GetCapabilities load is performed — the override stratum produces
+      // discreteTimes synchronously off the trait.
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(3);
+      expect(wmts.discreteTimes![0].time).toBe("2024-01-01T00:00:00Z");
+      expect(wmts.discreteTimes![1].time).toBe("2024-01-02T00:00:00Z");
+      expect(wmts.discreteTimes![2].time).toBe("2024-01-03T00:00:00Z");
+    });
+
+    it("expands time.start/stop/period via createDiscreteTimesFromIsoSegments", function () {
+      // Path 2: ISO range. Mirrors the GetCapabilities range path
+      // (createDiscreteTimesFromIsoSegments) but driven from catalog JSON.
+      // P1D over 4 days = 5 inclusive instants (Jan 1, 2, 3, 4, 5).
+      runInAction(() => {
+        wmts.setTrait(
+          CommonStrata.user,
+          "time",
+          createStratumInstance(WebMapTileServiceTimeTraits, {
+            start: "2024-01-01T00:00:00Z",
+            stop: "2024-01-05T00:00:00Z",
+            period: "P1D"
+          })
+        );
+      });
+
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(5);
+      expect(wmts.discreteTimes![0].time).toContain("2024-01-01");
+      expect(wmts.discreteTimes![4].time).toContain("2024-01-05");
+    });
+
+    it("selects time.defaultValue as currentTime when set", function () {
+      // currentTime priority: explicit defaultValue > most-recent discrete
+      // time > undefined. The most-recent value here is 2024-01-03 — asserting
+      // currentTime resolves to 2024-01-02 proves defaultValue takes precedence
+      // over the recency fallback.
+      runInAction(() => {
+        wmts.setTrait(
+          CommonStrata.user,
+          "time",
+          createStratumInstance(WebMapTileServiceTimeTraits, {
+            values: [
+              "2024-01-01T00:00:00Z",
+              "2024-01-02T00:00:00Z",
+              "2024-01-03T00:00:00Z"
+            ],
+            defaultValue: "2024-01-02T00:00:00Z"
+          })
+        );
+      });
+
+      expect(wmts.currentTime).toBe("2024-01-02T00:00:00Z");
+    });
+
+    it("falls through to GetCapabilities when the time trait is absent (regression)", async function () {
+      // Regression: with no `time` trait set, the override stratum's getters
+      // return undefined and GetCapabilitiesStratum drives discreteTimes /
+      // currentTime — i.e., existing behaviour is preserved. This is the
+      // critical "do no harm" assertion: if this spec fails, every existing
+      // WMTS catalog item with a server-advertised <Dimension> is broken.
+      runInAction(() => {
+        wmts.setTrait(
+          "definition",
+          "url",
+          "test/WMTS/tern-landscapes-time.xml"
+        );
+        wmts.setTrait("definition", "layer", "tern_soil_moisture_daily");
+      });
+
+      await wmts.loadMetadata();
+
+      // The TERN fixture advertises a daily P1D range over 5 days
+      // (2024-01-01..2024-01-05) — same fixture used by the GetCapabilities
+      // range spec above. 5 discrete times must come through unchanged.
+      // Note: TerriaJS object traits always materialize a wrapper model for
+      // property access — `wmts.time` is not `undefined` even when no stratum
+      // has set values. The meaningful regression check is on the unset inner
+      // fields plus the discreteTimes pass-through from GetCapabilities.
+      expect(wmts.time?.values).toBeUndefined();
+      expect(wmts.time?.start).toBeUndefined();
+      expect(wmts.time?.stop).toBeUndefined();
+      expect(wmts.time?.period).toBeUndefined();
+      expect(wmts.time?.defaultValue).toBeUndefined();
+      expect(wmts.discreteTimes).toBeDefined();
+      expect(wmts.discreteTimes!.length).toBe(5);
+      expect(wmts.discreteTimes![0].time).toContain("2024-01-01");
+      expect(wmts.discreteTimes![4].time).toContain("2024-01-05");
     });
   });
 

--- a/wwwroot/test/WMTS/nasa-gibs-time-no-default.xml
+++ b/wwwroot/test/WMTS/nasa-gibs-time-no-default.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Variant of nasa-gibs-time.xml WITHOUT a <Default> element.
+  Used to verify that currentTime falls back to the most recent (last)
+  <Value> when no <Default> is supplied — see TerriaJS upstream issue
+  #7742 acceptance criteria ("otherwise latest discrete time").
+-->
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0"
+              xmlns:ows="http://www.opengis.net/ows/1.1"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.opengis.net/wmts/1.0
+                  http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
+              version="1.0.0">
+  <ows:ServiceIdentification>
+    <ows:Title>NASA GIBS (no Default)</ows:Title>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <Contents>
+    <Layer>
+      <ows:Title>MODIS Terra TrueColor (no default)</ows:Title>
+      <ows:Identifier>MODIS_Terra_CorrectedReflectance_TrueColor_NoDefault</ows:Identifier>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180 -90</ows:LowerCorner>
+        <ows:UpperCorner>180 90</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <Style isDefault="true">
+        <ows:Title>default</ows:Title>
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <Dimension>
+        <ows:Identifier>time</ows:Identifier>
+        <ows:UOM>ISO8601</ows:UOM>
+        <!-- No <Default> on purpose: forces fallback to the most recent <Value>. -->
+        <Value>2024-03-13</Value>
+        <Value>2024-03-14</Value>
+        <Value>2024-03-15</Value>
+      </Dimension>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile"
+                   template="https://gibs.example/wmts/MODIS_Terra_CorrectedReflectance_TrueColor_NoDefault/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg" />
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178</ScaleDenominator>
+        <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>

--- a/wwwroot/test/WMTS/nasa-gibs-time.xml
+++ b/wwwroot/test/WMTS/nasa-gibs-time.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Minimal WMTS 1.0.0 capabilities document with a NASA GIBS-style time
+  dimension. GIBS encodes the time dimension as multiple explicit <Value>
+  children (one per available date) and supplies a <Default>. KVP-implied:
+  no {time} placeholder in the ResourceURL template, the time gets passed
+  as a TIME query parameter at request time.
+-->
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0"
+              xmlns:ows="http://www.opengis.net/ows/1.1"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.opengis.net/wmts/1.0
+                  http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
+              version="1.0.0">
+  <ows:ServiceIdentification>
+    <ows:Title>NASA GIBS</ows:Title>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <Contents>
+    <Layer>
+      <ows:Title>MODIS Terra TrueColor</ows:Title>
+      <ows:Identifier>MODIS_Terra_CorrectedReflectance_TrueColor</ows:Identifier>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180 -90</ows:LowerCorner>
+        <ows:UpperCorner>180 90</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <Style isDefault="true">
+        <ows:Title>default</ows:Title>
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <Dimension>
+        <ows:Identifier>time</ows:Identifier>
+        <ows:UOM>ISO8601</ows:UOM>
+        <!--
+          NOTE: <Default> is intentionally NOT the last <Value> so that the
+          Default-branch and last-value-fallback branch in the stratum's
+          currentTime getter produce *different* outputs. A test asserting
+          currentTime === "2024-03-13" therefore discriminates: it only
+          passes if the <Default> branch fires.
+        -->
+        <Default>2024-03-13</Default>
+        <Value>2024-03-13</Value>
+        <Value>2024-03-14</Value>
+        <Value>2024-03-15</Value>
+      </Dimension>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile"
+                   template="https://gibs.example/wmts/MODIS_Terra_CorrectedReflectance_TrueColor/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg" />
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178</ScaleDenominator>
+        <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>

--- a/wwwroot/test/WMTS/tern-landscapes-time-uppercase.xml
+++ b/wwwroot/test/WMTS/tern-landscapes-time-uppercase.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Minimal WMTS 1.0.0 capabilities document with a NASA GIBS-style time
-  dimension. GIBS encodes the time dimension as multiple explicit <Value>
-  children (one per available date) and supplies a <Default>. KVP-implied:
-  no {time} placeholder in the ResourceURL template, the time gets passed
-  as a TIME query parameter at request time.
+  Variant of tern-landscapes-time.xml whose ResourceURL template uses an
+  uppercase `{Time}` placeholder (Cesium / NASA GIBS convention) instead of
+  lowercase `{time}` (TERN / GeoServer convention). Verifies that the
+  case-insensitive `/\{time\}/gi` regex in
+  WebMapTileServiceCatalogItem._createImageryProvider substitutes both
+  cases. Single layer, single time matrix — minimal surface for the assertion.
 -->
 <Capabilities xmlns="http://www.opengis.net/wmts/1.0"
               xmlns:ows="http://www.opengis.net/ows/1.1"
@@ -14,43 +15,34 @@
                   http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
               version="1.0.0">
   <ows:ServiceIdentification>
-    <ows:Title>NASA GIBS</ows:Title>
+    <ows:Title>TERN Landscapes Time Series (uppercase placeholder)</ows:Title>
     <ows:ServiceType>OGC WMTS</ows:ServiceType>
     <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
   </ows:ServiceIdentification>
   <Contents>
     <Layer>
-      <ows:Title>MODIS Terra TrueColor</ows:Title>
-      <ows:Identifier>MODIS_Terra_CorrectedReflectance_TrueColor</ows:Identifier>
+      <ows:Title>Soil Moisture Daily</ows:Title>
+      <ows:Identifier>tern_soil_moisture_daily</ows:Identifier>
       <ows:WGS84BoundingBox>
-        <ows:LowerCorner>-180 -90</ows:LowerCorner>
-        <ows:UpperCorner>180 90</ows:UpperCorner>
+        <ows:LowerCorner>112 -44</ows:LowerCorner>
+        <ows:UpperCorner>154 -10</ows:UpperCorner>
       </ows:WGS84BoundingBox>
       <Style isDefault="true">
         <ows:Title>default</ows:Title>
         <ows:Identifier>default</ows:Identifier>
       </Style>
-      <Format>image/jpeg</Format>
+      <Format>image/png</Format>
       <Dimension>
         <ows:Identifier>time</ows:Identifier>
         <ows:UOM>ISO8601</ows:UOM>
-        <!--
-          NOTE: <Default> is intentionally NOT the last <Value> so that the
-          Default-branch and last-value-fallback branch in the stratum's
-          currentTime getter produce *different* outputs. A test asserting
-          currentTime === "2024-03-13" therefore discriminates: it only
-          passes if the <Default> branch fires.
-        -->
-        <Default>2024-03-13</Default>
-        <Value>2024-03-13</Value>
-        <Value>2024-03-14</Value>
-        <Value>2024-03-15</Value>
+        <Default>2024-01-05T00:00:00Z</Default>
+        <Value>2024-01-01T00:00:00Z/2024-01-05T00:00:00Z/P1D</Value>
       </Dimension>
       <TileMatrixSetLink>
         <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
       </TileMatrixSetLink>
-      <ResourceURL format="image/jpeg" resourceType="tile"
-                   template="https://gibs.example/wmts/MODIS_Terra_CorrectedReflectance_TrueColor/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg" />
+      <ResourceURL format="image/png" resourceType="tile"
+                   template="https://tern.example/wmts/tern_soil_moisture_daily/default/{Time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
     </Layer>
     <TileMatrixSet>
       <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>

--- a/wwwroot/test/WMTS/tern-landscapes-time.xml
+++ b/wwwroot/test/WMTS/tern-landscapes-time.xml
@@ -77,6 +77,15 @@
     <TileMatrixSet>
       <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>
       <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+      <!--
+        Two TileMatrix children are required: the WMTS capabilities XML->JSON
+        parser only produces an array for `TileMatrix` when there are 2+
+        siblings. With a single child, the parser yields a bare object and
+        `usableTileMatrixSets` (WebMapTileServiceCatalogItem.ts:331) accesses
+        `matrices[0].TopLeftCorner` -> TypeError. Two entries also keep the
+        fixture in line with `with_tilematrix.xml` and real GetCapabilities
+        responses, which always emit at least the level-0 + level-1 pair.
+      -->
       <TileMatrix>
         <ows:Identifier>0</ows:Identifier>
         <ScaleDenominator>559082264.0287178</ScaleDenominator>
@@ -85,6 +94,15 @@
         <TileHeight>256</TileHeight>
         <MatrixWidth>1</MatrixWidth>
         <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>279541132.0143589</ScaleDenominator>
+        <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
       </TileMatrix>
     </TileMatrixSet>
   </Contents>

--- a/wwwroot/test/WMTS/tern-landscapes-time.xml
+++ b/wwwroot/test/WMTS/tern-landscapes-time.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Minimal WMTS 1.0.0 capabilities document with a TERN-style time dimension.
+  TERN encodes the time dimension as a single ISO 19128 range under one
+  <Value>, plus a <Default> with the most recent instant. The ResourceURL
+  template uses a {time} placeholder for time-keyed RESTful tile URLs.
+-->
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0"
+              xmlns:ows="http://www.opengis.net/ows/1.1"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.opengis.net/wmts/1.0
+                  http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd"
+              version="1.0.0">
+  <ows:ServiceIdentification>
+    <ows:Title>TERN Landscapes Time Series</ows:Title>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <Contents>
+    <Layer>
+      <ows:Title>Soil Moisture Daily</ows:Title>
+      <ows:Identifier>tern_soil_moisture_daily</ows:Identifier>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>112 -44</ows:LowerCorner>
+        <ows:UpperCorner>154 -10</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <Style isDefault="true">
+        <ows:Title>default</ows:Title>
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <Dimension>
+        <ows:Identifier>time</ows:Identifier>
+        <ows:UOM>ISO8601</ows:UOM>
+        <Default>2024-01-05T00:00:00Z</Default>
+        <Value>2024-01-01T00:00:00Z/2024-01-05T00:00:00Z/P1D</Value>
+      </Dimension>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile"
+                   template="https://tern.example/wmts/tern_soil_moisture_daily/default/{time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+    </Layer>
+    <!--
+      Variant layer: the time <Value> contains exactly two slash segments
+      (start/stop, NO period). createDiscreteTimesFromIsoSegments must
+      receive period=undefined and pick a default duration based on the
+      span (see createDiscreteTimes.ts:30-67). 96-hour (4-day) span falls
+      into the `1000 * hour` bucket => 1-hour duration => 97 hourly
+      instants emitted (inclusive of both ends).
+    -->
+    <Layer>
+      <ows:Title>Soil Moisture Daily (no period)</ows:Title>
+      <ows:Identifier>tern_soil_moisture_daily_no_period</ows:Identifier>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>112 -44</ows:LowerCorner>
+        <ows:UpperCorner>154 -10</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <Style isDefault="true">
+        <ows:Title>default</ows:Title>
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <Dimension>
+        <ows:Identifier>time</ows:Identifier>
+        <ows:UOM>ISO8601</ows:UOM>
+        <Default>2024-01-05T00:00:00Z</Default>
+        <Value>2024-01-01T00:00:00Z/2024-01-05T00:00:00Z</Value>
+      </Dimension>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible_Level9</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile"
+                   template="https://tern.example/wmts/tern_soil_moisture_daily_no_period/default/{time}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png" />
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>GoogleMapsCompatible_Level9</ows:Identifier>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178</ScaleDenominator>
+        <TopLeftCorner>-20037508.3427892 20037508.3427892</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>


### PR DESCRIPTION
## Summary

Implements WMTS time dimension support per #7742 (proposed by @ShubhamSharmaFAO, design discussion endorsed by @zoran995). WMTS catalog items can now expose a Terria timeline when the GetCapabilities response advertises a `<Dimension Identifier="time">`, with the selected time propagated into both REST `ResourceURL` template substitution (`{time}` / `{Time}`) and KVP `dimensions: { Time }` provider construction.

Closes #7742. Likely also closes #6271 and #2656 (older duplicates of the same ask).

## Approach

- **Mirror the WMS time-dimension pattern.** `WebMapTileServiceCatalogItem` is wrapped with `DiscretelyTimeVaryingMixin`. The new `GetCapabilitiesStratum` getters parse `<Dimension>`, expose `discreteTimes` / `currentTime` / `initialTimeSource`. The existing single-imagery-provider getter is replaced with `_createImageryProvider(time)` (a `createTransformerAllowUndefined`), `_currentImageryParts` and `_nextImageryParts` — same shape as `WebMapServiceCatalogItem.ts:402-531`.
- **Reuse, don't duplicate.** ISO-range expansion calls the existing `createDiscreteTimesFromIsoSegments` from `lib/Core/createDiscreteTimes.ts`. Trait composition uses the existing `DiscretelyTimeVaryingTraits` (same way `ArcGisMapServerCatalogItem` does).
- **Both encodings.** REST `ResourceURL` templates with `{time}` (lowercase) or `{Time}` (uppercase) get the literal currentTime substituted before `proxyCatalogItemUrl`. KVP-style WMTS gets `dimensions: { Time }` on the Cesium constructor.
- **`<Default>` honored;** falls back to most recent discrete instant when absent or set to the literal sentinel `"current"`. (Note: this differs from WMS's `undefined` fallback — intentional per #7742 acceptance criteria; commented in code.)
- **Backward compatible.** WMTS without `<Dimension>` → `discreteTimes === undefined` → mixin treats as no time variance → identical pre-PR behavior.

## Acceptance criteria from #7742

- [x] Parse WMTS `Dimension` for `time`, including lists and ISO ranges (`start/end/period`)
- [x] Expand ranges to discrete instants (honoring `maxRefreshIntervals`), expose them to the timeline/animation stack
- [x] Select a default time (capabilities `Default` if present, otherwise latest discrete time)
- [x] Pass the chosen time into WMTS requests (including REST `ResourceURL` templates AND KVP `Time` dimension)

## Tests

5 new specs in a new `imagery provider per time` describe block plus 5 specs in the `time dimension parsing` describe block (10 specs total covering the time path):

- `expands ISO range "2018-01-01/2020-01-01/P1M"` (range expansion)
- `parses Dimension with explicit Value list` (discrete list path)
- ISO-range-no-period expansion (boundary case)
- `<Default>` selection (discriminating fixture — Default ≠ last value)
- Fallback to most recent discrete time when no `<Default>`
- `substitutes {time} in REST ResourceURL with selected currentTime`
- `substitutes uppercase {Time}` (case-insensitive)
- `passes Time as a dimension on the imagery provider` (KVP path)
- `propagates allowFeaturePicking` onto current/next imagery parts (matches WMS)
- `rebuilds the imagery provider when currentTime changes` (provider-per-time cache key)

Two real-world-shaped fixtures committed under `wwwroot/test/WMTS/`:
- `tern-landscapes-time.xml` + `tern-landscapes-time-uppercase.xml` — modeled on the TERN landscapes mapserver (cited in #6271): REST `ResourceURL` with `{time}` / `{Time}` template
- `nasa-gibs-time.xml` + `nasa-gibs-time-no-default.xml` — KVP-style WMTS+TIME with explicit `<Value>` list

`yarn prettier-check` clean, `yarn gulp lint` clean, `yarn gulp test` net 0 new failures.

## Out of scope

- **Non-time dimensions (elevation, band, etc.).** The new `WmtsDimension` interface parses them fine but the stratum ignores them. Follow-up PR if there's interest.
- **Trait class typo.** `lib/Traits/TraitsClasses/WebMapTileServiceCatalogItemTraits.ts:84` exports a class literally named `WebMapServiceCatalogItemTraits` (sic — pre-existing copy-paste). NOT renamed in this PR — would be a breaking API change for downstream consumers.
- **Latent fixture-shape bug:** `parseTileMatrixSets` normalizes the outer `TileMatrixSet` array but not the inner `TileMatrix`. Pre-existing, not introduced by this PR; happy to send a follow-up patch if helpful.

## Acknowledgements

Original proposal and design conversation: @ShubhamSharmaFAO (UN-FAO).
Design endorsement and pattern guidance (imagery-provider-per-time, `initialTimeSource` reuse): @zoran995.

Co-authored-by: Shubham Sharma <noreply@github.com>