### PR TITLE
SaaS-next: Show Share button on group preview when sharing is enabled

### DIFF
--- a/lib/ReactViews/Preview/GroupPreview.jsx
+++ b/lib/ReactViews/Preview/GroupPreview.jsx
@@ -66,7 +66,7 @@ class GroupPreview extends Component {
                   : t("models.catalog.addAll")}
               </button>
             )}
-            {this.props.terria.configParameters.disableSharePanel && (
+            {!this.props.terria.configParameters.disableSharePanel && (
               <SharePanel
                 catalogShare
                 modalWidth={this.props.widthFromMeasureElementHOC}


### PR DESCRIPTION
### What this PR does

Fixes an inverted boolean in `GroupPreview.jsx`that hid the Share button on catalog groups.

The condition guarding `<SharePanel>` was `disableSharePanel && ...` — so the button only rendered when sharing was disabled, and was hidden whenever sharing was enabled. Negated the check to `!disableSharePanel && ...` so the button appears when sharing is enabled, matching the behavior on individual items.

### How to test

- [ ] Open a group in the catalog preview with `disableSharePanel: false` (default) — Share button appears
- [ ] Set `disableSharePanel: true` in config — Share button is hidden

### Checklist

- [x] There are unit tests to verify my changes are correct or **unit tests aren't applicable** (No existing test coverage for `GroupPreview.jsx` )
- [ ] I've updated relevant documentation in `doc/`- n/a
- [ ] I've updated CHANGES.md with what I changed - n/a I think?
- [x] I've provided instructions in the PR description on how to test this PR.
