### PR TITLE
add check for workbench

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.12.3)
 
+- Search result IDs are checked against workbench IDs to determine `add` or `remove` status.
 - [The next improvement]
 
 #### 8.12.2 - 2026-03-27

--- a/lib/ReactViews/DataCatalog/DataCatalogReference.tsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogReference.tsx
@@ -77,6 +77,12 @@ export default observer(function DataCatalogReference({
     btnState = ButtonState.Preview;
   } else if (reference.isFunction) {
     btnState = ButtonState.Stats;
+  } else if (
+    reference.terria.workbench.contains(reference) ||
+    (reference.uniqueId !== undefined &&
+      reference.terria.workbench.itemIds.includes(reference.uniqueId))
+  ) {
+    btnState = ButtonState.Remove;
   } else {
     btnState = ButtonState.Add;
   }


### PR DESCRIPTION
### What this PR does
Currently search results are always in the `add` state, which leads to confusing behaviour. 

This change checks if a dataset from the search results is already in the workbench. If so, change the button state to `remove`.

Fixes #<insert issue number here if relevant>

This is a description of what I've done in this PR, especially explaining choices made to make the reviewer's job easier. If I don't replace this paragraph with an actual description, my PR will probably be ignored.

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
