### PR TITLE
saas-next prep (2/3): pluggable config loading + nested strata (Node-ready)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 #### next release (8.12.3)
 
 - Add `disablePostRequests` config parameter (default `false`) to optionally forbid non-GET requests made through `loadWithXhr`, allowing a deployment to lock down to GET-only requests.
+- **Breaking:** `Terria.start()` now takes a `loadConfig` callback (`() => Promise<{ config, baseUri, configUrl? }>`) instead of `configUrl`/`configUrlHeaders`. Use the exported `defaultLoadConfig(configUrl)` helper to preserve existing behaviour (including Magda config support). This allows hosting Terria in a non-browser environment (e.g. server-side rendering).
+- Add support for nested `strata` in model JSON: `updateModelFromJson` now recurses into a `strata` object, and `combineModelStrata` is exported from `createCombinedModel`.
+- Improve non-browser (Node) compatibility: guard `window`/`localStorage` access, fall back to the raw key in `TerriaError` when i18next is not initialised, allow injecting a `CorsProxy` via `TerriaOptions`, and make SDMX structure loading use `fetchText`.
 - Refactor analytics into `lib/Core/analytics/` module, make `analytics` always defined using `NoopAnalytics` default, and remove auto-detection logic from `Terria`. Analytics instance must now be supplied via `TerriaOptions` or defaults to no-op. ([7817](https://github.com/TerriaJS/terriajs/pull/7817))
 - Upgrade dev dependencies
   - Upgrade dompurify to version 3.3.3 to resolve security vulnerabilities.

--- a/buildprocess/generateCatalogIndex.ts
+++ b/buildprocess/generateCatalogIndex.ts
@@ -18,7 +18,7 @@ import { BaseModel } from "../lib/Models/Definition/Model";
 import hasTraits from "../lib/Models/Definition/hasTraits";
 import { CatalogIndexFile } from "../lib/Models/SearchProviders/CatalogIndex";
 import registerSearchProviders from "../lib/Models/SearchProviders/registerSearchProviders";
-import Terria from "../lib/Models/Terria";
+import Terria, { defaultLoadConfig } from "../lib/Models/Terria";
 import CatalogMemberReferenceTraits from "../lib/Traits/TraitsClasses/CatalogMemberReferenceTraits";
 import patchNetworkRequests from "./patchNetworkRequests";
 import { program } from "commander";
@@ -326,7 +326,7 @@ export default async function generateCatalogIndex(
   try {
     terria.configParameters.serverConfigUrl = `${baseUrl}serverconfig`;
     terria.configParameters.corsProxyBaseUrl = `${baseUrl}proxy/`;
-    await terria.start({ configUrl });
+    await terria.start({ loadConfig: () => defaultLoadConfig(configUrl) });
 
     await terria.loadInitSources();
   } catch (e) {

--- a/buildprocess/patchNetworkRequests.ts
+++ b/buildprocess/patchNetworkRequests.ts
@@ -1,118 +1,213 @@
 /* eslint-disable prefer-rest-params */
 import Resource from "terriajs-cesium/Source/Core/Resource";
+import URI from "urijs";
+/** Cached lightweight JSDOM window reused across calls to avoid leaking instances. */
+let _cachedJsdomWindow: { XMLHttpRequest: any; DOMParser: any } | undefined;
+
+export type PatchNetworkRequestsOptions = {
+  /** Patch window.XMLHttpRequest.prototype.open for URL rewriting and basic auth. Default: true */
+  xhr?: boolean;
+  /** Patch Cesium Resource._Implementations.loadWithXhr for URL rewriting. Default: true */
+  cesiumResource?: boolean;
+  /** Replace global.fetch with a URL-rewriting/auth version. Default: true */
+  fetch?: boolean;
+  assignXmlHttpRequestToGlobal?: boolean;
+  assignDomParserToGlobal?: boolean;
+  jsDomGlobal?: boolean;
+};
 
 /** Patch XMLHttpRequest and Fetch so they work correctly in Node.js
  * Also supports `basicAuth` token, which will be added to all requests which use `baseUrl` or start with `/proxy`
+ *
+ * When running inside a shared process (e.g. Next.js), use `options` to limit
+ * which patches are applied to avoid polluting the host process globals.
  */
 export default function patchNetworkRequests(
   baseUrl: string,
   basicAuth: string | undefined,
-  logFailedRequest: boolean = false
+  logFailedRequest: boolean = false,
+  logTag?: string,
+  options?: PatchNetworkRequestsOptions
 ) {
+  const tag = logTag ? `[${logTag}] ` : "";
+  const opts = {
+    xhr: true,
+    cesiumResource: true,
+    fetch: true,
+    assignXmlHttpRequestToGlobal: true,
+    assignDomParserToGlobal: true,
+    jsDomGlobal: true,
+    ...options
+  };
+
   // Overwrite browser APIs (eg XMLHttpRequest and fetch)
-  require("global-jsdom")(undefined, {
-    url: baseUrl
-  });
+  if (opts.jsDomGlobal) {
+    console.log(`${tag}Applying global-jsdom to ${baseUrl}`);
+    require("global-jsdom")(undefined, {
+      url: baseUrl
+    });
+  }
 
   // Add basic auth token for all XMLHttpRequest/fetch that use baseUrl hostname
 
   const baseHostname = new URL(baseUrl).hostname;
 
-  // Adapted from https://stackoverflow.com/a/43875390
-  const open = window.XMLHttpRequest.prototype.open;
-  window.XMLHttpRequest.prototype.open = function (
-    _method: string,
-    url: string
-  ) {
-    // All URLs need to be absolute - so add the base URL if it's not already there
-    if (url.indexOf("http://") !== 0 && url.indexOf("https://") !== 0) {
-      console.log(`Rewrite relative URL: \`${url}\` to \`${arguments[1]}\``);
-      arguments[1] = `${baseUrl}${url}`;
-      url = `${baseUrl}${url}`;
-    }
-
-    open.apply(this, arguments as any);
-
-    console.log("\x1b[35m%s\x1b[0m", `Making XHR: ${url}`);
-
-    if (basicAuth) {
-      if (new URL(url).hostname === baseHostname || url.startsWith("proxy/")) {
-        this.setRequestHeader("authorization", `Basic ${basicAuth}`);
-      }
-    }
-
-    if (logFailedRequest) {
-      this.onloadend = (req) => {
-        if (this.status < 200 || this.status >= 300) {
-          console.log("\n\n\n");
-          console.log(this.responseURL);
-          console.log(new URL(this.responseURL).hostname === baseHostname);
-          console.log("\n\n\n");
-        }
-      };
-    }
-  };
-
-  const load = (Resource as any)._Implementations.loadWithXhr;
-  (Resource as any)._Implementations.loadWithXhr = function (...args: any) {
-    // Note we don't need to patch the loadWithXhr for basic auth, as it uses XMLHttpRequest
-    // if (URI(args[0]).hostname() === baseHostname) {
-    //   if (!args[4]) {
-    //     args[4] = {};
-    //   }
-    //   args[4]["authorization"] = `Basic ${basicAuth}`;
-    // }
-
-    console.log("\x1b[35m%s\x1b[0m", `Loading resource request: ${args[0]}`);
-
-    // All URLs need to be absolute - so add the base URL if it's not already there
-    if (args[0].indexOf("http://") !== 0 && args[0].indexOf("https://") !== 0) {
-      console.log(
-        `Rewrite relative URL: \`${args[0]}\` to \`${baseUrl}${args[0]}\``
-      );
-      args[0] = `${baseUrl}${args[0]}`;
-    }
-
-    load.apply(this, args);
-  };
-
-  // A fun method to add Auth headers to all requests with baseUrl
-  const originalFetch = globalThis.fetch;
-  const newFetch = (
-    input: RequestInfo | URL,
-    init?: RequestInit
-  ): Promise<Response> => {
-    let url =
-      typeof input === "string"
-        ? input
-        : input instanceof URL
-          ? input.href
-          : input.url;
-
-    console.log("\x1b[35m%s\x1b[0m", `Making fetch request: ${url}`);
-
-    // All URLs need to be absolute - so add the base URL if it's not already there
-    if (url.indexOf("http://") !== 0 && url.indexOf("https://") !== 0) {
-      console.log(`Rewrite relative URL: \`${url}\` to \`${baseUrl}${url}\``);
-      url = `${baseUrl}${url}`;
-    }
-
-    if (
-      (basicAuth && new URL(url).hostname === baseHostname) ||
-      url.startsWith("proxy/")
+  if (opts.xhr) {
+    console.log(`${tag}Applying XMLHttpRequest patch to ${baseUrl}`);
+    // Adapted from https://stackoverflow.com/a/43875390
+    const open = window.XMLHttpRequest.prototype.open;
+    window.XMLHttpRequest.prototype.open = function (
+      _method: string,
+      url: string
     ) {
-      if (!init) {
-        init = {};
+      // All URLs need to be absolute - so add the base URL if it's not already there
+      if (url.indexOf("http://") !== 0 && url.indexOf("https://") !== 0) {
+        console.log(
+          `${tag}Rewrite relative URL: \`${url}\` to \`${baseUrl}${url}\``
+        );
+        arguments[1] = `${baseUrl}${url}`;
+        url = `${baseUrl}${url}`;
       }
-      const headers = new Headers(init.headers);
-      headers.set("authorization", `Basic ${basicAuth}`);
-      init.headers = headers;
+
+      open.apply(this, arguments as any);
+
+      console.log("\x1b[35m%s\x1b[0m", `${tag}Making XHR: ${url}`);
+
+      if (basicAuth) {
+        if (URI(url).hostname() === baseHostname || url.startsWith("proxy/")) {
+          this.setRequestHeader("authorization", `Basic ${basicAuth}`);
+        }
+      }
+
+      if (logFailedRequest) {
+        this.onloadend = (_req) => {
+          if (this.status < 200 || this.status >= 300) {
+            console.log(tag, "\n\n\n");
+            console.log(tag, this.responseURL);
+            console.log(tag, URI(this.responseURL).hostname() === baseHostname);
+            console.log(tag, "\n\n\n");
+          }
+        };
+      }
+    };
+  }
+
+  if (opts.cesiumResource) {
+    const impl = (Resource as any)._Implementations;
+    // Store the original so repeated calls don't stack wrappers
+    if (!impl._originalLoadWithXhr) {
+      impl._originalLoadWithXhr = impl.loadWithXhr;
     }
+    console.log(`${tag}Applying Cesium Resource patch to ${baseUrl}`);
+    const load = impl._originalLoadWithXhr;
+    impl.loadWithXhr = function (...args: any) {
+      console.log(
+        "\x1b[35m%s\x1b[0m",
+        `${tag}Loading resource request: ${args[0]}`
+      );
 
-    return originalFetch(input, init as RequestInit);
-  };
-  globalThis.fetch = newFetch;
+      // All URLs need to be absolute - so add the base URL if it's not already there
+      if (
+        args[0].indexOf("http://") !== 0 &&
+        args[0].indexOf("https://") !== 0
+      ) {
+        console.log(
+          `${tag}Rewrite relative URL: \`${args[0]}\` to \`${baseUrl}${args[0]}\``
+        );
+        args[0] = `${baseUrl}${args[0]}`;
+      }
 
-  global.XMLHttpRequest = window.XMLHttpRequest;
-  global.DOMParser = window.DOMParser;
+      load.apply(this, args);
+    };
+  }
+
+  if (opts.fetch) {
+    console.log(`${tag}Applying fetch patch to ${baseUrl}`);
+    // A fun method to add Auth headers to all requests with baseUrl
+    const newFetch = (
+      input: RequestInfo,
+      init?: RequestInit
+    ): Promise<Response> => {
+      let url = typeof input === "string" ? input : input.url;
+
+      console.log("\x1b[35m%s\x1b[0m", `${tag}Making fetch request: ${url}`);
+
+      // All URLs need to be absolute - so add the base URL if it's not already there
+      if (url.indexOf("http://") !== 0 && url.indexOf("https://") !== 0) {
+        console.log(
+          `${tag}Rewrite relative URL: \`${url}\` to \`${baseUrl}${url}\``
+        );
+        url = `${baseUrl}${url}`;
+      }
+
+      if (
+        (basicAuth && URI(url).hostname() === baseHostname) ||
+        url.startsWith("proxy/")
+      ) {
+        if (!init) {
+          init = {};
+        }
+        if (init.headers) {
+          if (Array.isArray(init.headers)) {
+            init.headers.push(["authorization", `Basic ${basicAuth}`]);
+          } else if (init.headers instanceof Headers) {
+            init.headers = [
+              ...Array.from(init.headers.entries()),
+              ["authorization", `Basic ${basicAuth}`]
+            ];
+          } else {
+            init.headers = [
+              ...Object.entries(init.headers),
+              ["authorization", `Basic ${basicAuth}`]
+            ];
+          }
+        } else {
+          init.headers = [["authorization", `Basic ${basicAuth}`]];
+        }
+      }
+
+      return fetch(input as any, init as any) as any;
+    };
+    global.fetch = newFetch as any;
+
+    // Set global fetch objects from node-fetch
+    global.Headers = Headers as any;
+    global.Request = Request as any;
+    global.Response = Response as any;
+  }
+
+  // When jsdom-global is not used, create a lightweight JSDOM instance
+  // to pull browser APIs from (XMLHttpRequest, DOMParser).
+  // Reuse across calls to avoid creating multiple JSDOM instances.
+  const needsJsdomInstance =
+    !opts.jsDomGlobal &&
+    (opts.assignXmlHttpRequestToGlobal || opts.assignDomParserToGlobal);
+  if (needsJsdomInstance && !_cachedJsdomWindow) {
+    _cachedJsdomWindow = new (require("jsdom").JSDOM)("", {
+      url: baseUrl
+    }).window;
+  }
+  const jsdomWindow = needsJsdomInstance ? _cachedJsdomWindow : undefined;
+
+  if (opts.assignXmlHttpRequestToGlobal) {
+    if (!opts.jsDomGlobal && !jsdomWindow) {
+      throw new Error(
+        "Cannot assign XMLHttpRequest: JSDOM window not available"
+      );
+    }
+    console.log(`${tag}Assigning XMLHttpRequest to global`);
+    global.XMLHttpRequest = opts.jsDomGlobal
+      ? window.XMLHttpRequest
+      : jsdomWindow!.XMLHttpRequest;
+  }
+
+  if (opts.assignDomParserToGlobal) {
+    if (!opts.jsDomGlobal && !jsdomWindow) {
+      throw new Error("Cannot assign DOMParser: JSDOM window not available");
+    }
+    console.log(`${tag}Assigning DOMParser to global`);
+    global.DOMParser = opts.jsDomGlobal
+      ? window.DOMParser
+      : jsdomWindow!.DOMParser;
+  }
 }

--- a/lib/Core/TerriaError.ts
+++ b/lib/Core/TerriaError.ts
@@ -16,8 +16,13 @@ export interface I18nTranslateString {
   parameters?: Record<string, string>;
 }
 
-function resolveI18n(i: I18nTranslateString | string) {
-  return typeof i === "string" ? i : i18next.t(i.key, i.parameters);
+function resolveI18n(i: I18nTranslateString | string): string {
+  if (typeof i === "string") return i;
+
+  // When i18next isn't initialized (e.g. Node environment), t() may return
+  // the key object or a non-string value. Fall back to the raw key.
+  const result = i18next.isInitialized ? i18next.t(i.key, i.parameters) : i.key;
+  return typeof result === "string" ? result : i.key;
 }
 
 /** `TerriaErrorSeverity` can be `Error` or `Warning`.

--- a/lib/Models/Catalog/SdmxJson/SdmxJsonCatalogItem.ts
+++ b/lib/Models/Catalog/SdmxJson/SdmxJsonCatalogItem.ts
@@ -151,7 +151,7 @@ export default class SdmxJsonCatalogItem
         headers: {
           Accept: "application/vnd.sdmx.data+csv; version=1.0.0"
         }
-      }).fetch();
+      }).fetchText();
 
       if (!isDefined(csvString)) {
         throw new TerriaError({

--- a/lib/Models/Catalog/SdmxJson/SdmxJsonServerStratum.ts
+++ b/lib/Models/Catalog/SdmxJson/SdmxJsonServerStratum.ts
@@ -431,53 +431,64 @@ export function parseSdmxUrn(urn?: string) {
 
 export async function loadSdmxJsonStructure(
   url: string,
-  allowNotImplemeted: false
+  allowNotImplemented: false
 ): Promise<SdmxJsonStructureMessage>;
 export async function loadSdmxJsonStructure(
   url: string,
-  allowNotImplemeted: true
+  allowNotImplemented: true
 ): Promise<SdmxJsonStructureMessage | undefined>;
 export async function loadSdmxJsonStructure(
   url: string,
-  allowNotImplemeted: boolean
+  allowNotImplemented: boolean
 ) {
   try {
-    return JSON.parse(
-      await new Resource({
-        url,
-        headers: {
-          Accept:
-            "application/vnd.sdmx.structure+json; charset=utf-8; version=1.0"
-        }
-      }).fetch()
-    ) as SdmxJsonStructureMessage;
-  } catch (error) {
-    // If SDMX server has returned an error message
-    if (error instanceof RequestErrorEvent && isDefined(error.response)) {
-      if (!allowNotImplemeted) {
-        throw new TerriaError({
-          title: i18next.t(
-            "models.sdmxServerStratum.sdmxStructureLoadErrorTitle"
-          ),
-          message: sdmxErrorString.has(error.statusCode)
-            ? `${sdmxErrorString.get(error.statusCode)}: ${error.response}`
-            : `${error.response}`
-        });
+    const response = await new Resource({
+      url,
+      headers: {
+        Accept:
+          "application/vnd.sdmx.structure+json; charset=utf-8; version=1.0"
       }
-      // Not sure what happened (maybe CORS)
-    } else if (!allowNotImplemeted) {
+    }).fetchText();
+
+    if (response === undefined) {
       throw new TerriaError({
         title: i18next.t(
           "models.sdmxServerStratum.sdmxStructureLoadErrorTitle"
         ),
-        message: `Unkown error occurred${
-          isDefined(error)
-            ? typeof error === "string"
-              ? `: ${error}`
-              : `: ${JSON.stringify(error)}`
-            : ""
-        }`
+        message: `Failed to fetch SDMX structure from ${url}`
       });
+    }
+
+    return JSON.parse(response) as SdmxJsonStructureMessage;
+  } catch (error) {
+    // If SDMX server has returned an error message
+    if (error instanceof RequestErrorEvent && isDefined(error.response)) {
+      const terriaError = new TerriaError({
+        title: i18next.t(
+          "models.sdmxServerStratum.sdmxStructureLoadErrorTitle"
+        ),
+        message: sdmxErrorString.has(error.statusCode)
+          ? `${sdmxErrorString.get(error.statusCode)}: ${error.response}`
+          : `${error.response}`
+      });
+
+      if (!allowNotImplemented) {
+        throw terriaError;
+      } else {
+        terriaError.log();
+      }
+
+      // Not sure what happened (maybe CORS)
+    } else {
+      const terriaError = TerriaError.from(error, {
+        title: i18next.t("models.sdmxServerStratum.sdmxStructureLoadErrorTitle")
+      });
+
+      if (!allowNotImplemented) {
+        throw terriaError;
+      } else {
+        terriaError.log();
+      }
     }
   }
 }

--- a/lib/Models/Definition/createCombinedModel.ts
+++ b/lib/Models/Definition/createCombinedModel.ts
@@ -73,6 +73,26 @@ export function extractBottomModel(model: BaseModel): BaseModel | undefined {
   return undefined;
 }
 
+/** Combines the strata of a model into a single stratum. */
+export function combineModelStrata(
+  model: BaseModel,
+  strataTopToBottom: readonly string[]
+): StratumFromTraits<ModelTraits> | undefined {
+  let combined: StratumFromTraits<ModelTraits> | undefined;
+
+  for (const stratumId of strataTopToBottom) {
+    const stratum = model.strata.get(stratumId);
+    if (stratum === undefined) continue;
+
+    combined =
+      combined === undefined
+        ? stratum
+        : createCombinedStratum(model.TraitsClass, combined, stratum);
+  }
+
+  return combined;
+}
+
 class CombinedStrata implements Map<string, StratumFromTraits<ModelTraits>> {
   constructor(
     readonly top: BaseModel,

--- a/lib/Models/Definition/updateModelFromJson.ts
+++ b/lib/Models/Definition/updateModelFromJson.ts
@@ -1,5 +1,6 @@
 import { uniq } from "lodash-es";
 import { isObservableArray, runInAction } from "mobx";
+import { isJsonObject } from "../../Core/Json";
 import isDefined from "../../Core/isDefined";
 import Result from "../../Core/Result";
 import TerriaError from "../../Core/TerriaError";
@@ -9,17 +10,41 @@ import { BaseModel } from "./Model";
 
 export default function updateModelFromJson(
   model: BaseModel,
-  stratumName: string,
+  defaultStratumName: string,
   json: Partial<ModelJson>,
   replaceStratum: boolean = false
 ): Result<undefined> {
-  const traits = model.traits;
-
   const errors: TerriaError[] = [];
+
+  updateModelFromJsonInternal(
+    model,
+    defaultStratumName,
+    json,
+    errors,
+    replaceStratum
+  );
+
+  return new Result(
+    undefined,
+    TerriaError.combine(
+      errors,
+      `Error updating model \`${model.uniqueId}\` from JSON for stratum \`${defaultStratumName}\``
+    )
+  );
+}
+
+function updateModelFromJsonInternal(
+  model: BaseModel,
+  currentStratumName: string,
+  json: Partial<ModelJson>,
+  errors: TerriaError[],
+  replaceStratum: boolean = false
+) {
+  const traits = model.traits;
 
   runInAction(() => {
     if (replaceStratum) {
-      model.strata.set(stratumName, createStratumInstance(model));
+      model.strata.set(currentStratumName, createStratumInstance(model));
     }
 
     Object.keys(json).forEach((propertyName) => {
@@ -27,14 +52,17 @@ export default function updateModelFromJson(
         propertyName === "id" ||
         propertyName === "type" ||
         propertyName === "localId" ||
-        propertyName === "shareKeys"
+        propertyName === "shareKeys" ||
+        propertyName === "strata"
       ) {
         return;
       }
 
       const trait = traits[propertyName];
       if (trait === undefined) {
-        errors.push(
+        pushStratumError(
+          errors,
+          currentStratumName,
           new TerriaError({
             title: "Unknown property",
             message: `The property \`${propertyName}\` is not valid for type \`${
@@ -47,34 +75,80 @@ export default function updateModelFromJson(
 
       const jsonValue = json[propertyName];
       if (jsonValue === undefined) {
-        model.setTrait(stratumName, propertyName, undefined);
+        model.setTrait(currentStratumName, propertyName, undefined);
       } else {
         let newTrait = trait
-          .fromJson(model, stratumName, jsonValue)
-          .pushErrorTo(errors);
+          .fromJson(model, currentStratumName, jsonValue)
+          .pushErrorTo(
+            errors,
+            `Error updating stratum \`${currentStratumName}\``
+          );
 
         if (isDefined(newTrait)) {
           // We want to merge members of groups with the same name/id
           if (propertyName === "members") {
             newTrait = mergeWithExistingMembers(
               model,
-              stratumName,
+              currentStratumName,
               propertyName,
               newTrait
             );
           }
-          model.setTrait(stratumName, propertyName, newTrait);
+          model.setTrait(currentStratumName, propertyName, newTrait);
         }
       }
     });
   });
 
-  return new Result(
-    undefined,
-    TerriaError.combine(
+  updateNestedStrataFromJson(model, currentStratumName, json.strata, errors);
+}
+
+function updateNestedStrataFromJson(
+  model: BaseModel,
+  currentStratumName: string,
+  strata: ModelJson["strata"],
+  errors: TerriaError[]
+) {
+  if (strata === undefined) {
+    return;
+  }
+
+  if (!isJsonObject(strata, false)) {
+    pushStratumError(
       errors,
-      `Error updating model \`${model.uniqueId}\` from JSON`
-    )
+      currentStratumName,
+      new TerriaError({
+        title: "Invalid strata",
+        message: "The property `strata` must be a JSON object."
+      })
+    );
+    return;
+  }
+
+  Object.entries(strata).forEach(([nestedStratumName, nestedJson]) => {
+    if (!isJsonObject(nestedJson, false)) {
+      pushStratumError(
+        errors,
+        nestedStratumName,
+        new TerriaError({
+          title: "Invalid strata",
+          message: `The value for stratum \`${nestedStratumName}\` must be a JSON object.`
+        })
+      );
+      return;
+    }
+
+    updateModelFromJsonInternal(model, nestedStratumName, nestedJson, errors);
+  });
+}
+
+function pushStratumError(
+  errors: TerriaError[],
+  stratumName: string,
+  error: unknown
+) {
+  errors.push(
+    TerriaError.from(error, `Error updating stratum \`${stratumName}\``)
   );
 }
 

--- a/lib/Models/InitSource.ts
+++ b/lib/Models/InitSource.ts
@@ -32,6 +32,7 @@ export interface ModelJson extends JsonObject {
   type?: string;
   shareKeys?: string[];
   members?: (string | JsonObject)[];
+  strata?: { [stratumName: string]: Partial<ModelJson> };
 }
 
 export interface StoryData {

--- a/lib/Models/Terria.ts
+++ b/lib/Models/Terria.ts
@@ -25,7 +25,7 @@ import AsyncLoader from "../Core/AsyncLoader";
 import Class from "../Core/Class";
 import CorsProxy from "../Core/CorsProxy";
 import { setPostRequestsDisabled } from "../Core/loadWithXhr";
-import {
+import JsonValue, {
   JsonArray,
   JsonObject,
   isJsonBoolean,
@@ -78,7 +78,7 @@ import SearchProviderTraits from "../Traits/SearchProviders/SearchProviderTraits
 import MappableTraits from "../Traits/TraitsClasses/MappableTraits";
 import MapNavigationModel from "../ViewModels/MapNavigation/MapNavigationModel";
 import TerriaViewer from "../ViewModels/TerriaViewer";
-import { BaseMapsModel } from "./BaseMaps/BaseMapsModel";
+import { BaseMapItem, BaseMapsModel } from "./BaseMaps/BaseMapsModel";
 import CameraView from "./CameraView";
 import Catalog from "./Catalog/Catalog";
 import CatalogGroup from "./Catalog/CatalogGroup";
@@ -389,11 +389,44 @@ export interface ConfigParameters {
   keepCatalogOpen: boolean;
 }
 
-interface StartOptions {
-  configUrl: string;
-  configUrlHeaders?: {
-    [key: string]: string;
+const IS_DEVELOPMENT = process.env.NODE_ENV === "development";
+
+/**
+ * Default {@link StartOptions.loadConfig} implementation: fetches and parses
+ * the config (JSON5) at `configUrl` and derives the base URI. Returns the raw
+ * `configUrl` as well so Magda configs can still be resolved (see
+ * {@link Terria.loadMagdaConfig}).
+ */
+export const defaultLoadConfig = async (configUrl: string) => {
+  const hashProperties =
+    typeof window !== "undefined"
+      ? queryToObject(new URI(window.location).fragment())
+      : {};
+
+  // If in development environment, allow usage of #configUrl to set Terria config URL
+  if (IS_DEVELOPMENT) {
+    if (hashProperties["configUrl"] && hashProperties["configUrl"] !== "")
+      configUrl = hashProperties["configUrl"];
+  }
+
+  const baseUri = new URI(configUrl).filename("");
+
+  const config = await loadJson5(configUrl);
+
+  return {
+    config,
+    baseUri,
+    configUrl
   };
+};
+
+interface StartOptions {
+  loadConfig: (cb?: () => void) => Promise<{
+    config: JsonValue;
+    baseUri: URI;
+    /** The URL the config was loaded from, if known. Required for Magda configs. */
+    configUrl?: string;
+  }>;
   applicationUrl?: Location;
   shareDataService?: ShareDataService;
   errorService?: ErrorServiceProvider;
@@ -430,6 +463,8 @@ interface TerriaOptions {
   cesiumBaseUrl?: string;
 
   analytics?: Analytics;
+
+  corsProxy?: CorsProxy;
 }
 
 interface HomeCameraInit {
@@ -500,7 +535,7 @@ export default class Terria {
    * Gets or sets the {@link this.corsProxy} used to determine if a URL needs to be proxied and to proxy it if necessary.
    * @type {CorsProxy}
    */
-  corsProxy: CorsProxy = new CorsProxy();
+  corsProxy: CorsProxy;
 
   /**
    * Gets or sets the instance to which to report Google Analytics-style log
@@ -755,6 +790,8 @@ export default class Terria {
     (buildModuleUrl as any).setBaseUrl(this.cesiumBaseUrl);
 
     this.analytics = options.analytics ?? new NoopAnalytics();
+
+    this.corsProxy = options.corsProxy ?? new CorsProxy();
   }
 
   /** Raise error to user.
@@ -995,7 +1032,10 @@ export default class Terria {
 
   async start(options: StartOptions): Promise<void> {
     // Some hashProperties need to be set before anything else happens
-    const hashProperties = queryToObject(new URI(window.location).fragment());
+    const hashProperties =
+      typeof window !== "undefined"
+        ? queryToObject(new URI(window.location).fragment())
+        : {};
 
     if (isDefined(hashProperties["ignoreErrors"])) {
       this.userProperties.set("ignoreErrors", hashProperties["ignoreErrors"]);
@@ -1003,30 +1043,16 @@ export default class Terria {
 
     this.shareDataService = options.shareDataService;
 
-    // If in development environment, allow usage of #configUrl to set Terria config URL
-    if (this.developmentEnv) {
-      if (
-        isDefined(hashProperties["configUrl"]) &&
-        hashProperties["configUrl"] !== ""
-      )
-        options.configUrl = hashProperties["configUrl"];
-    }
-
-    const baseUri = new URI(options.configUrl).filename("");
-
-    const launchUrlForAnalytics =
-      options.applicationUrl?.href || getUriWithoutPath(baseUri);
+    let launchUrlForAnalytics = options.applicationUrl?.href;
 
     try {
-      const config = await loadJson5(
-        options.configUrl,
-        options.configUrlHeaders
-      );
+      const { config, baseUri, configUrl } = await options.loadConfig();
+      launchUrlForAnalytics ||= getUriWithoutPath(baseUri);
 
       // If it's a magda config, we only load magda config and parameters should never be a property on the direct
       // config aspect (it would be under the `terria-config` aspect)
-      if (isJsonObject(config) && config.aspects) {
-        await this.loadMagdaConfig(options.configUrl, config, baseUri);
+      if (isJsonObject(config) && config.aspects && configUrl) {
+        await this.loadMagdaConfig(configUrl, config, baseUri);
       }
       runInAction(() => {
         if (isJsonObject(config) && isJsonObject(config.parameters)) {
@@ -1038,7 +1064,7 @@ export default class Terria {
       this.raiseErrorToUser(error, {
         sender: this,
         title: { key: "models.terria.loadConfigErrorTitle" },
-        message: `Couldn't load ${options.configUrl}`,
+        message: `Couldn't load configuration`,
         severity: TerriaErrorSeverity.Error
       });
     } finally {
@@ -1198,7 +1224,7 @@ export default class Terria {
   async loadPersistedOrInitBaseMap(): Promise<void> {
     const baseMapItems = this.baseMapsModel.baseMapItems;
     // Set baseMap fallback to first option
-    let baseMap = baseMapItems[0];
+    let baseMap = baseMapItems[0] as BaseMapItem | undefined;
     const persistedBaseMapId = this.getLocalProperty("basemap");
     const baseMapSearch = baseMapItems.find(
       (baseMapItem) => baseMapItem.item?.uniqueId === persistedBaseMapId
@@ -2176,7 +2202,7 @@ export default class Terria {
 
   getLocalProperty(key: string): string | boolean | null {
     try {
-      if (!defined(window.localStorage)) {
+      if (typeof window === "undefined" || !defined(window.localStorage)) {
         return null;
       }
     } catch (_e) {
@@ -2194,7 +2220,7 @@ export default class Terria {
 
   setLocalProperty(key: string, value: string | boolean): boolean {
     try {
-      if (!defined(window.localStorage)) {
+      if (typeof window === "undefined" || !defined(window.localStorage)) {
         return false;
       }
     } catch (_e) {

--- a/test/Models/Definition/updateModelFromJsonSpec.ts
+++ b/test/Models/Definition/updateModelFromJsonSpec.ts
@@ -41,6 +41,108 @@ describe("updateModelFromJson", function () {
       expect(model.getTrait(CommonStrata.definition, "name")).toBe("B");
       expect(model.getTrait(CommonStrata.user, "name")).toBe("C");
     });
+
+    it("true only replaces the default stratum when nested strata are provided", function () {
+      updateModelFromJson(
+        model,
+        CommonStrata.definition,
+        {
+          url: "Z",
+          strata: {
+            [CommonStrata.user]: {
+              url: "Y"
+            }
+          }
+        },
+        true
+      );
+
+      expect(model.getTrait(CommonStrata.definition, "url")).toBe("Z");
+      expect(model.getTrait(CommonStrata.definition, "name")).toBeUndefined();
+      expect(model.getTrait(CommonStrata.user, "name")).toBe("C");
+      expect(model.getTrait(CommonStrata.user, "url")).toBe("Y");
+    });
+  });
+
+  describe("when json contains nested strata", function () {
+    beforeEach(function () {
+      model = new WebMapServiceCatalogItem("Test", new Terria());
+    });
+
+    it("updates the default and nested strata recursively", function () {
+      updateModelFromJson(model, CommonStrata.definition, {
+        url: "test/WMS/single_metadata_url.xml",
+        strata: {
+          [CommonStrata.user]: {
+            name: "User name",
+            strata: {
+              [CommonStrata.override]: {
+                description: "Override description"
+              }
+            }
+          }
+        }
+      });
+
+      expect(model.getTrait(CommonStrata.definition, "url")).toBe(
+        "test/WMS/single_metadata_url.xml"
+      );
+      expect(model.getTrait(CommonStrata.user, "name")).toBe("User name");
+      expect(model.getTrait(CommonStrata.override, "description")).toBe(
+        "Override description"
+      );
+    });
+
+    it("includes the nested stratum name in unknown property errors", function () {
+      const result = updateModelFromJson(model, CommonStrata.definition, {
+        strata: {
+          [CommonStrata.user]: {
+            someTrait: "What what"
+          }
+        }
+      });
+      const flattenedErrors = result.error?.flatten() ?? [];
+
+      expect(
+        flattenedErrors.find(
+          (error) =>
+            error.message === `Error updating stratum \`${CommonStrata.user}\``
+        )
+      ).toBeDefined();
+      expect(
+        flattenedErrors.find(
+          (error) =>
+            error.message ===
+            "The property `someTrait` is not valid for type `wms`."
+        )
+      ).toBeDefined();
+    });
+
+    it("reports invalid nested strata payloads with stratum context", function () {
+      const invalidJson = JSON.parse(
+        `{"strata":{"${CommonStrata.user}":"not-an-object"}}`
+      );
+      const result = updateModelFromJson(
+        model,
+        CommonStrata.definition,
+        invalidJson
+      );
+      const flattenedErrors = result.error?.flatten() ?? [];
+
+      expect(
+        flattenedErrors.find(
+          (error) =>
+            error.message === `Error updating stratum \`${CommonStrata.user}\``
+        )
+      ).toBeDefined();
+      expect(
+        flattenedErrors.find(
+          (error) =>
+            error.message ===
+            `The value for stratum \`${CommonStrata.user}\` must be a JSON object.`
+        )
+      ).toBeDefined();
+    });
   });
 
   describe("when id of group already exists", function () {

--- a/test/Models/ErrorServiceSpec.ts
+++ b/test/Models/ErrorServiceSpec.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from "msw";
 import TerriaError from "../../lib/Core/TerriaError";
 import { ErrorServiceProvider } from "../../lib/Models/ErrorServiceProviders/ErrorService";
 import StubErrorServiceProvider from "../../lib/Models/ErrorServiceProviders/StubErrorServiceProvider";
-import Terria from "../../lib/Models/Terria";
+import Terria, { defaultLoadConfig } from "../../lib/Models/Terria";
 import { worker } from "../mocks/browser";
 
 describe("ErrorService", function () {
@@ -33,7 +33,7 @@ describe("ErrorService", function () {
   it("Initializes an error service, passing in config", async function () {
     const initSpy = spyOn(mockErrorServiceProvider, "init");
     await terria.start({
-      configUrl: "test-config.json",
+      loadConfig: () => defaultLoadConfig("test-config.json"),
       errorService: mockErrorServiceProvider
     });
     expect(initSpy).toHaveBeenCalledTimes(1);
@@ -42,7 +42,7 @@ describe("ErrorService", function () {
   it("Gets called with error", async function () {
     const errorSpy = spyOn(mockErrorServiceProvider, "error").and.callThrough();
     await terria.start({
-      configUrl: "test-config.json",
+      loadConfig: () => defaultLoadConfig("test-config.json"),
       errorService: mockErrorServiceProvider
     });
     const error = new TerriaError({
@@ -54,7 +54,7 @@ describe("ErrorService", function () {
 
   it("Falls back to stub provider", async () => {
     await terria.start({
-      configUrl: "test-config.json"
+      loadConfig: () => defaultLoadConfig("test-config.json")
     });
     expect(terria.errorService).toEqual(jasmine.any(StubErrorServiceProvider));
   });

--- a/test/Models/TerriaSpec.ts
+++ b/test/Models/TerriaSpec.ts
@@ -29,7 +29,7 @@ import {
   isInitFromOptions,
   isInitFromUrl
 } from "../../lib/Models/InitSource";
-import Terria from "../../lib/Models/Terria";
+import Terria, { defaultLoadConfig } from "../../lib/Models/Terria";
 import ViewerMode from "../../lib/Models/ViewerMode";
 import ViewState from "../../lib/ReactViewModels/ViewState";
 import { buildShareLink } from "../../lib/ReactViews/Map/Panels/SharePanel/BuildShareLink";
@@ -138,7 +138,8 @@ describe("TerriaSpec", function () {
       }
 
       await terria.start({
-        configUrl: "test/Magda/map-config-dereferenced.json",
+        loadConfig: async () =>
+          await defaultLoadConfig("test/Magda/map-config-dereferenced.json"),
         i18nOptions
       });
       verifyGroups(mapConfigDereferencedJson.aspects["group"], 3);
@@ -218,7 +219,7 @@ describe("TerriaSpec", function () {
         )
       );
       await terria.start({
-        configUrl: `config.json`,
+        loadConfig: async () => await defaultLoadConfig("config.json"),
         i18nOptions
       });
 
@@ -257,7 +258,8 @@ describe("TerriaSpec", function () {
       );
 
       await terria.start({
-        configUrl: `path/to/config/configUrl.json`,
+        loadConfig: async () =>
+          await defaultLoadConfig("path/to/config/configUrl.json"),
         i18nOptions
       });
 
@@ -294,7 +296,8 @@ describe("TerriaSpec", function () {
         expect(terria.initSources.length).toEqual(0);
 
         await terria.start({
-          configUrl: "test/Magda/map-config-basic.json",
+          loadConfig: async () =>
+            await defaultLoadConfig("test/Magda/map-config-basic.json"),
           i18nOptions
         });
 
@@ -312,7 +315,8 @@ describe("TerriaSpec", function () {
         expect(terria.initSources.length).toEqual(0);
 
         await terria.start({
-          configUrl: "test/Magda/map-config-basic.json",
+          loadConfig: async () =>
+            await defaultLoadConfig("test/Magda/map-config-basic.json"),
           i18nOptions
         });
 
@@ -345,7 +349,8 @@ describe("TerriaSpec", function () {
         expect(terria.initSources.length).toBe(0);
 
         await terria.start({
-          configUrl: "test/Magda/map-config-v7.json",
+          loadConfig: async () =>
+            await defaultLoadConfig("test/Magda/map-config-v7.json"),
           i18nOptions
         });
 
@@ -379,7 +384,8 @@ describe("TerriaSpec", function () {
         // no init sources before starting
         expect(terria.initSources.length).toEqual(0);
         await terria.start({
-          configUrl: "test/Magda/map-config-inline-init.json",
+          loadConfig: async () =>
+            await defaultLoadConfig("test/Magda/map-config-inline-init.json"),
           i18nOptions
         });
 
@@ -411,7 +417,8 @@ describe("TerriaSpec", function () {
         );
 
         await terria.start({
-          configUrl: "test/Magda/map-config-dereferenced.json",
+          loadConfig: async () =>
+            await defaultLoadConfig("test/Magda/map-config-dereferenced.json"),
           i18nOptions
         });
 
@@ -450,7 +457,7 @@ describe("TerriaSpec", function () {
 
       expect(terria.mainViewer.viewerMode).toBe(ViewerMode.Cesium);
       await terria.start({
-        configUrl: "test-config.json",
+        loadConfig: async () => await defaultLoadConfig(""),
         applicationUrl: {
           href: "http://test.com/#map=2d"
         } as Location,
@@ -489,7 +496,8 @@ describe("TerriaSpec", function () {
       );
 
       await terria.start({
-        configUrl: `path/to/config/configUrl.json`,
+        loadConfig: async () =>
+          await defaultLoadConfig(`path/to/config/configUrl.json`),
         i18nOptions
       });
 
@@ -526,7 +534,7 @@ describe("TerriaSpec", function () {
       );
 
       await terria.start({
-        configUrl: `configUrl.json`,
+        loadConfig: async () => await defaultLoadConfig(`configUrl.json`),
         i18nOptions
       });
 
@@ -798,7 +806,12 @@ describe("TerriaSpec", function () {
         });
 
         await Promise.all(
-          [terria, newTerria].map((t) => t.start({ configUrl, i18nOptions }))
+          [terria, newTerria].map((t) =>
+            t.start({
+              loadConfig: async () => await defaultLoadConfig(configUrl),
+              i18nOptions
+            })
+          )
         );
 
         terria.catalog.group.addMembersFromJson(CommonStrata.definition, [
@@ -943,12 +956,12 @@ describe("TerriaSpec", function () {
         );
 
         await terria.start({
-          configUrl,
+          loadConfig: async () => await defaultLoadConfig(configUrl),
           i18nOptions
         });
 
         await newTerria.start({
-          configUrl,
+          loadConfig: async () => await defaultLoadConfig(configUrl),
           i18nOptions
         });
       });
@@ -1095,7 +1108,8 @@ describe("TerriaSpec", function () {
 
     it("initializes proxy with parameters from config file", async function () {
       await terria.start({
-        configUrl: "test/init/configProxy.json",
+        loadConfig: async () =>
+          await defaultLoadConfig("test/init/configProxy.json"),
         i18nOptions
       });
 
@@ -1467,7 +1481,7 @@ describe("TerriaSpec", function () {
         href: "http://test.com/#map=2d"
       } as Location;
       await terria.start({
-        configUrl: "test-config.json",
+        loadConfig: async () => await defaultLoadConfig(""),
         applicationUrl: location
       });
       terria.loadPersistedMapSettings();
@@ -1480,7 +1494,9 @@ describe("TerriaSpec", function () {
         terria,
         "getLocalProperty"
       ).and.returnValue("2d");
-      await terria.start({ configUrl: "test-config.json" });
+      await terria.start({
+        loadConfig: async () => await defaultLoadConfig("")
+      });
       terria.loadPersistedMapSettings();
       expect(terria.mainViewer.viewerMode).toBe(ViewerMode.Leaflet);
       expect(getLocalPropertySpy).toHaveBeenCalledWith("viewermode");
@@ -1495,7 +1511,7 @@ describe("TerriaSpec", function () {
         href: "http://test.com/#map=4d"
       } as Location;
       await terria.start({
-        configUrl: "test-config.json",
+        loadConfig: async () => await defaultLoadConfig(""),
         applicationUrl: location
       });
       terria.loadPersistedMapSettings();
@@ -1507,7 +1523,9 @@ describe("TerriaSpec", function () {
     it("uses `settings` in initsource", async () => {
       const setBaseMapSpy = spyOn(terria.mainViewer, "setBaseMap");
 
-      await terria.start({ configUrl: "test-config.json" });
+      await terria.start({
+        loadConfig: async () => await defaultLoadConfig("")
+      });
 
       await terria.applyInitData({
         initData: {
@@ -1540,8 +1558,10 @@ describe("TerriaSpec", function () {
 
   describe("basemaps", function () {
     it("when no base maps are specified load defaultBaseMaps", async function () {
-      await terria.start({ configUrl: "test-config.json" });
-      await terria.applyInitData({
+      await terria.start({
+        loadConfig: async () => await defaultLoadConfig("")
+      });
+      terria.applyInitData({
         initData: {}
       });
       await terria.loadInitSources();
@@ -1553,7 +1573,9 @@ describe("TerriaSpec", function () {
     });
 
     it("correctly loads the base maps", async function () {
-      await terria.start({ configUrl: "test-config.json" });
+      await terria.start({
+        loadConfig: async () => await defaultLoadConfig("")
+      });
       await (
         await terria._applyInitData({
           initData: {
@@ -1681,7 +1703,10 @@ describe("TerriaSpec", function () {
         }
       })
     )}`;
-    await terria.start({ configUrl, i18nOptions });
+    await terria.start({
+      loadConfig: async () => await defaultLoadConfig(configUrl),
+      i18nOptions
+    });
     expect(RequestScheduler.requestsByServer["test.domain:333"]).toBe(12);
   });
 
@@ -1757,7 +1782,9 @@ describe("TerriaSpec", function () {
       });
 
       it("zooms the map to focus on the workbench items", async function () {
-        await terria.start({ configUrl: "test-config.json" });
+        await terria.start({
+          loadConfig: async () => await defaultLoadConfig("test-config.json")
+        });
         await terria.loadInitSources();
         await when(() => terria.currentViewer.type === "Cesium");
 
@@ -1774,7 +1801,9 @@ describe("TerriaSpec", function () {
         runInAction(() => {
           terria.mainViewer.viewerMode = undefined;
         });
-        await terria.start({ configUrl: "test-config.json" });
+        await terria.start({
+          loadConfig: async () => await defaultLoadConfig("test-config.json")
+        });
         await terria.loadInitSources();
         expect(terria.currentViewer.type).toEqual("none");
         // Switch to Cesium viewer
@@ -1792,7 +1821,9 @@ describe("TerriaSpec", function () {
       });
 
       it("is not applied if subsequent init sources override the initialCamera settings", async function () {
-        await terria.start({ configUrl: "test-config.json" });
+        await terria.start({
+          loadConfig: async () => await defaultLoadConfig("test-config.json")
+        });
         terria.initSources.push({
           data: {
             initialCamera: {
@@ -1837,7 +1868,7 @@ describe("TerriaSpec", function () {
           originalZoomTo(target, 0.0);
 
         await terria.start({
-          configUrl: "test-config.json",
+          loadConfig: async () => await defaultLoadConfig("test-config.json"),
           applicationUrl: {
             // A share URL with a different `initialCamera` setting
             href: "http://localhost:3001/#start=%7B%22version%22%3A%228.0.0%22%2C%22initSources%22%3A%5B%7B%22stratum%22%3A%22user%22%2C%22initialCamera%22%3A%7B%22east%22%3A80.48324442836365%2C%22west%22%3A74.16912021554141%2C%22north%22%3A10.82936711956377%2C%22south%22%3A7.882086009700934%7D%2C%22workbench%22%3A%5B%22points%22%5D%7D%5D%7D"

--- a/test/ReactViews/Map/Panels/LangPanel/LangPanelSpec.tsx
+++ b/test/ReactViews/Map/Panels/LangPanel/LangPanelSpec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
-import Terria from "../../../../../lib/Models/Terria";
+import { HttpResponse, http } from "msw";
+import Terria, { defaultLoadConfig } from "../../../../../lib/Models/Terria";
 import LangPanel from "../../../../../lib/ReactViews/Map/Panels/LangPanel/LangPanel";
 import { worker } from "../../../../mocks/browser";
 
@@ -41,7 +41,9 @@ describe("LangPanel", function () {
         })
       )
     );
-    await terria.start({ configUrl: "test-config.json" });
+    await terria.start({
+      loadConfig: async () => await defaultLoadConfig("./")
+    });
 
     render(<LangPanel terria={terria} smallScreen={false} />);
 


### PR DESCRIPTION
## What this PR does

Second of three stacked PRs landing `saas-next` onto `main` (2/3). **Stacked on #7846** — review/merge that first (base is `who/saas-prep-post-restore`).

Core init / model-loading changes, plus Node (non-browser) compatibility:

- **Breaking:** `Terria.start()` now takes a `loadConfig` callback (`() => Promise<{ config, baseUri, configUrl? }>`) instead of `configUrl` / `configUrlHeaders`. Use the exported **`defaultLoadConfig(configUrl)`** helper to preserve existing behaviour. (TerriaMap callers will need a one-line update.)
- **Magda preserved:** `defaultLoadConfig` returns `configUrl` so `loadMagdaConfig()` still runs for Magda configs. The Magda `TerriaSpec` describes that `saas-next` had disabled (`xdescribe`) are **re-enabled** here.
- Nested `strata`: `updateModelFromJson` recurses into a `strata` object on model JSON; `combineModelStrata` is exported from `createCombinedModel`.
- Non-browser compatibility: guard `window`/`localStorage`, fall back to the raw i18n key in `TerriaError` when i18next isn't initialised, allow injecting a `CorsProxy` via `TerriaOptions`, SDMX structure loading uses `fetchText`, and `patchNetworkRequests` gains per-patch options for shared (e.g. Next.js) processes.

> Scope note: the broader `TerriaError.toError()` rewrite from `saas-next` is intentionally left out (no OSS consumer); only the i18next-init guard is included.

## Test me

`yarn gulp test` — Magda config specs (`TerriaSpec`) and `updateModelFromJsonSpec` should pass. Existing maps load unchanged via `defaultLoadConfig`.

## Checklist
- [x] `tsc` and `eslint` (max-warnings 0) pass
- [x] Re-enabled the disabled Magda specs; added `updateModelFromJsonSpec`
- [x] CHANGES.md updated (incl. breaking-change note)
