### PR TITLE
Fix minmap marker in pedestrian mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
   - Fixed a crash when searching for strings containing regex special characters (e.g. `mel\`) by escaping the search string before using it in the keyword highlight regex.
   - Nominatim default URL updated to `https://`.
 - Move catalog-search-provider instance from SearchBarModel to Catalog class. Setting catalog search provider from ViewState is now deprecated.
+- Fix to improve marker rotation rendering in pedestrian mode minimap [7860](https://github.com/TerriaJS/terriajs/pull/7860)
 
 #### 8.12.2 - 2026-03-27
 

--- a/lib/Map/Leaflet/LeafletVisualizer.ts
+++ b/lib/Map/Leaflet/LeafletVisualizer.ts
@@ -1287,7 +1287,7 @@ function recolorBillboard(
  * Use CSS transform to rotate the billboard icon
  */
 function rotateBillboardIcon(marker: L.Marker, rotation: number) {
-  const el: HTMLElement | undefined = (marker as any)._icon;
+  const el: HTMLElement | undefined = marker.getElement();
   if (!isDefined(el)) {
     return;
   }

--- a/lib/Map/Leaflet/LeafletVisualizer.ts
+++ b/lib/Map/Leaflet/LeafletVisualizer.ts
@@ -500,6 +500,16 @@ class LeafletGeomVisualizer {
         }
       }
     }
+
+    const rotation = getValueOrDefault(
+      markerGraphics.rotation,
+      time,
+      undefined
+    );
+
+    if (rotation !== undefined) {
+      rotateBillboardIcon(marker, rotation);
+    }
   }
 
   private _updateLabel(
@@ -1271,6 +1281,25 @@ function recolorBillboard(
 
   context.putImageData(image, 0, 0);
   return canvas.toDataURL();
+}
+
+/**
+ * Use CSS transform to rotate the billboard icon
+ */
+function rotateBillboardIcon(marker: L.Marker, rotation: number) {
+  const el: HTMLElement | undefined = (marker as any)._icon;
+  if (!isDefined(el)) {
+    return;
+  }
+
+  // Rotate w.r.t to center point of the element
+  el.style.transformOrigin = "center center";
+
+  const pos = L.DomUtil.getPosition(el);
+  const translate = isDefined(pos)
+    ? `translate3d(${pos.x}px, ${pos.y}px, 0)`
+    : "";
+  el.style.transform = `${translate} rotateZ(${rotation}rad)`;
 }
 
 function featureClicked(

--- a/lib/ReactViews/Tools/PedestrianMode/Marker.ts
+++ b/lib/ReactViews/Tools/PedestrianMode/Marker.ts
@@ -1,3 +1,4 @@
+import { makeObservable } from "mobx";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
 import BillboardGraphics from "terriajs-cesium/Source/DataSources/BillboardGraphics";
 import CallbackProperty from "terriajs-cesium/Source/DataSources/CallbackProperty";
@@ -5,132 +6,48 @@ import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSourc
 import Entity from "terriajs-cesium/Source/DataSources/Entity";
 import MappableMixin from "../../../ModelMixins/MappableMixin";
 import CreateModel from "../../../Models/Definition/CreateModel";
-import Terria from "../../../Models/Terria";
+import { ModelConstructorParameters } from "../../../Models/Definition/Model";
 import MappableTraits from "../../../Traits/TraitsClasses/MappableTraits";
 
 export default class Marker extends MappableMixin(CreateModel(MappableTraits)) {
   private dataSource: CustomDataSource;
-  private icon: RotatableIcon;
-
-  private currentRotation = 0;
-  position: Cartesian3;
 
   /**
-   * @param terria Terria instance
-   * @param iconUrl An HTML image element to use as the marker icon
-   * @param position Initial position of the marker icon
-   * @param rotation Initial rotation of the marker icon
+   * Marker rotation in radians
    */
-  constructor(
-    readonly terria: Terria,
-    readonly iconUrl: string,
-    position: Cartesian3,
-    rotation: number
-  ) {
-    super(undefined, terria);
-    this.position = position;
+  public rotation: number | undefined;
+
+  /**
+   * Marker position
+   */
+  public position: Cartesian3 | undefined;
+
+  /**
+   * Marker URL
+   */
+  public iconUrl: string | undefined;
+
+  constructor(...args: ModelConstructorParameters) {
+    super(...args);
+    makeObservable(this);
+
     this.dataSource = new CustomDataSource();
-
-    this.icon = new RotatableIcon(iconUrl, 24, 24);
-    this.icon.loadPromise.then(() => this.icon.rotate(rotation));
-
-    const entity = new Entity({
-      billboard: new BillboardGraphics({
-        image: this.icon.canvas
-      }),
-      position: new CallbackProperty(() => this.position, false) as any
-    });
-
-    this.dataSource.entities.add(entity);
-  }
-
-  /**
-   * Set marker rotation in radians
-   */
-  set rotation(rotation: number) {
-    // round to 2 decimal places to minimize rotation updates
-    const newRotation = Math.round(rotation * 100) / 100;
-    if (this.currentRotation !== newRotation) {
-      this.icon.rotate(newRotation);
-      this.currentRotation = newRotation;
-    }
+    this.dataSource.entities.add(
+      new Entity({
+        billboard: new BillboardGraphics({
+          width: 24,
+          height: 24,
+          image: new CallbackProperty(() => this.iconUrl, false),
+          rotation: new CallbackProperty(() => this.rotation, false)
+        }),
+        position: new CallbackProperty(() => this.position, false) as any
+      })
+    );
   }
 
   async forceLoadMapItems() {}
 
   get mapItems() {
     return [this.dataSource];
-  }
-}
-
-/**
- * A dynamically rotatable icon
- *
- * This class provides a {@canvas} instance with the rotated image drawn on it.
- * The canvas instance can be used as an image parameter in Billboard graphics
- * or other entities drawn by Cesium/Leaflet instances.
- */
-class RotatableIcon {
-  private image: HTMLImageElement;
-  private ctx: CanvasRenderingContext2D | undefined;
-
-  // The canvas on which the icon is drawn and transformed
-  public canvas: HTMLCanvasElement;
-
-  // Resolves when the icon image is loaded and ready to be drawn
-  public loadPromise: Promise<void>;
-
-  /**
-   * @param iconUrl The url of the icon image
-   * @param width Optional icon width.
-   *              If given, the image will be scaled to this width
-   *              otherwise we use the image width.
-   * @param height Optional icon height.
-   *              If given, the image will be scaled to this height
-   *              otherwise we use the image height.
-   */
-  constructor(iconUrl: string, width?: number, height?: number) {
-    this.image = new Image();
-    this.canvas = document.createElement("canvas");
-    this.ctx = this.canvas.getContext("2d") ?? undefined;
-    this.image.src = iconUrl;
-    this.loadPromise = new Promise((resolve) => {
-      this.image.addEventListener("load", () => {
-        this.canvas.width = width ?? this.image.width;
-        this.canvas.height = height ?? this.image.height;
-        resolve();
-      });
-    });
-  }
-
-  /**
-   * Rotate the icon by the given angle
-   *
-   * @param rotation Angle in radians
-   */
-  rotate(rotation: number) {
-    if (this.ctx === undefined || this.image.complete === false) {
-      return;
-    }
-
-    const image = this.image;
-    const ctx = this.ctx;
-    const canvas = this.canvas;
-
-    ctx.save();
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    // translate so that we rotate about the image center
-    ctx.translate(canvas.width / 2, canvas.height / 2);
-    ctx.rotate(rotation);
-    ctx.drawImage(
-      image,
-      // x & y coordinate to draw the image relative to the translated center
-      -canvas.width / 2,
-      -canvas.height / 2,
-      // scales the image to fit the canvas width & height
-      canvas.width,
-      canvas.height
-    );
-    ctx.restore();
   }
 }

--- a/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
@@ -1,4 +1,5 @@
 import { action, autorun, computed } from "mobx";
+import { observer } from "mobx-react";
 import { FC, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
@@ -26,7 +27,7 @@ export type MiniMapView = {
   rotation: number;
 };
 
-const MiniMap: FC<MiniMapProps> = (props) => {
+const MiniMap: FC<MiniMapProps> = observer((props) => {
   const { terria, baseMap, view } = props;
   const container = useRef<HTMLDivElement>(null);
   const [miniMapViewer, setMiniMapViewer] = useState<
@@ -37,12 +38,9 @@ const MiniMap: FC<MiniMapProps> = (props) => {
   /* eslint-disable-next-line react-hooks/exhaustive-deps */
   useEffect(
     action(() => {
-      const marker = new Marker(
-        terria,
-        minimapNavIcon,
-        view.position,
-        view.rotation
-      );
+      const marker = new Marker(undefined, terria);
+      marker.iconUrl = minimapNavIcon;
+
       const viewer = new TerriaViewer(
         terria,
         computed(() => [marker])
@@ -74,7 +72,7 @@ const MiniMap: FC<MiniMapProps> = (props) => {
   }, [miniMapViewer, locationMarker, view]);
 
   return <MapContainer ref={container} />;
-};
+});
 
 const MapContainer = styled.div`
   height: 180px;

--- a/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
@@ -35,7 +35,6 @@ const MiniMap: FC<MiniMapProps> = observer((props) => {
   >();
   const [locationMarker, setLocationMarker] = useState<Marker | undefined>();
 
-  /* eslint-disable-next-line react-hooks/exhaustive-deps */
   useEffect(
     action(() => {
       const marker = new Marker(undefined, terria);

--- a/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MiniMap.tsx
@@ -1,4 +1,4 @@
-import { action, autorun, computed } from "mobx";
+import { autorun, computed, runInAction } from "mobx";
 import { observer } from "mobx-react";
 import { FC, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
@@ -35,29 +35,28 @@ const MiniMap: FC<MiniMapProps> = observer((props) => {
   >();
   const [locationMarker, setLocationMarker] = useState<Marker | undefined>();
 
-  useEffect(
-    action(() => {
-      const marker = new Marker(undefined, terria);
-      marker.iconUrl = minimapNavIcon;
+  useEffect(() => {
+    const marker = new Marker(undefined, terria);
+    marker.iconUrl = minimapNavIcon;
 
-      const viewer = new TerriaViewer(
-        terria,
-        computed(() => [marker])
-      );
+    const viewer = new TerriaViewer(
+      terria,
+      computed(() => [marker])
+    );
 
+    runInAction(() => {
       viewer.viewerMode = ViewerMode.Leaflet;
       viewer.disableInteraction = true;
-      if (container.current) viewer.attach(container.current);
+    });
+    if (container.current) viewer.attach(container.current);
 
-      viewer.setBaseMap(baseMap);
+    viewer.setBaseMap(baseMap);
 
-      setMiniMapViewer(viewer);
-      setLocationMarker(marker);
+    setMiniMapViewer(viewer);
+    setLocationMarker(marker);
 
-      return () => viewer.destroy();
-    }),
-    [terria, baseMap]
-  );
+    return () => viewer.destroy();
+  }, [terria, baseMap]);
 
   useEffect(() => {
     const disposer = autorun(() => {

--- a/lib/ReactViews/Tools/PedestrianMode/MovementControls.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/MovementControls.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import heightControlsImage from "../../../../wwwroot/images/height-controls.svg";
@@ -25,10 +25,15 @@ const MovementControls: FC<MovementControlsProps> = (props) => {
 
   const toggleMaximized = () => setIsMaximized(!isMaximized);
 
+  // onMove could change on each render but we want to pass a stable callbac to
+  // MovementsController
+  const onMoveRef = useRef<() => void>();
+  onMoveRef.current = () => props.onMove();
+
   useEffect(() => {
     const movementsController = new MovementsController(
       props.cesium,
-      props.onMove,
+      () => onMoveRef.current?.(),
       props.pedestrianHeight,
       props.maxVerticalLookAngle
     );

--- a/lib/ReactViews/Tools/PedestrianMode/PedestrianMode.tsx
+++ b/lib/ReactViews/Tools/PedestrianMode/PedestrianMode.tsx
@@ -1,14 +1,14 @@
-import { reaction } from "mobx";
+import { observable, reaction, runInAction } from "mobx";
 import { observer } from "mobx-react";
 import { FC, useEffect, useState } from "react";
 import styled from "styled-components";
 import Cesium from "../../../Models/Cesium";
 import ViewState from "../../../ReactViewModels/ViewState";
+import { MeasureTool } from "../../Map/MapNavigation/Items";
 import PositionRightOfWorkbench from "../../Workbench/PositionRightOfWorkbench";
 import DropPedestrianToGround from "./DropPedestrianToGround";
-import MiniMap, { getViewFromScene, MiniMapView } from "./MiniMap";
+import MiniMap, { MiniMapView, getViewFromScene } from "./MiniMap";
 import MovementControls from "./MovementControls";
-import { MeasureTool } from "../../Map/MapNavigation/Items";
 
 // The desired camera height measured from the surface in metres
 export const PEDESTRIAN_HEIGHT = 1.7;
@@ -34,7 +34,16 @@ const PedestrianMode: FC<PedestrianModeProps> = observer((props) => {
     viewState.closeTool();
     return null;
   }
-  const updateView = () => setView(getViewFromScene(cesium.scene));
+
+  const updateView = () => {
+    if (!view) {
+      setView(observable(getViewFromScene(cesium.scene)));
+    } else {
+      runInAction(() => {
+        Object.assign(view, getViewFromScene(cesium.scene));
+      });
+    }
+  };
 
   useEffect(() => {
     const item = viewState.terria.mapNavigationModel.findItem(

--- a/test/Map/Leaflet/LeafletVisualizerSpec.ts
+++ b/test/Map/Leaflet/LeafletVisualizerSpec.ts
@@ -1,0 +1,65 @@
+import L from "leaflet";
+import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import JulianDate from "terriajs-cesium/Source/Core/JulianDate";
+import CesiumMath from "terriajs-cesium/Source/Core/Math";
+import BillboardGraphics from "terriajs-cesium/Source/DataSources/BillboardGraphics";
+import CustomDataSource from "terriajs-cesium/Source/DataSources/CustomDataSource";
+import Entity from "terriajs-cesium/Source/DataSources/Entity";
+import LeafletScene from "../../../lib/Map/Leaflet/LeafletScene";
+import LeafletVisualizer from "../../../lib/Map/Leaflet/LeafletVisualizer";
+
+describe("LeafletVisualizer", function () {
+  let container: HTMLElement;
+  let map: L.Map;
+  let scene: LeafletScene;
+  let dataSource: CustomDataSource;
+
+  beforeEach(function () {
+    container = document.createElement("div");
+    container.style.width = "200px";
+    container.style.height = "200px";
+    document.body.appendChild(container);
+    map = L.map(container, { center: [0, 0], zoom: 3 });
+    scene = new LeafletScene(map);
+    dataSource = new CustomDataSource();
+  });
+
+  afterEach(function () {
+    map.remove();
+    document.body.removeChild(container);
+  });
+
+  function visualize() {
+    const visualizer = new LeafletVisualizer().visualizersCallback(
+      scene,
+      undefined,
+      dataSource
+    )[0];
+    visualizer.update(JulianDate.now());
+  }
+
+  describe("billboard", function () {
+    it("applies a CSS rotate transform when the billboard defines a rotation", function () {
+      const rotation = CesiumMath.toRadians(42);
+      dataSource.entities.add(
+        new Entity({
+          position: Cartesian3.fromDegrees(0, 0) as any,
+          billboard: new BillboardGraphics({
+            // single pixel dot
+            image:
+              "data:image/gif;base64,R0lGODlhAQABAPAAAAAAAP///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==",
+            width: 24,
+            height: 24,
+            rotation
+          })
+        })
+      );
+      visualize();
+
+      const icon = container.querySelector<HTMLElement>(".leaflet-marker-icon");
+      expect(icon).not.toBeNull();
+      expect(icon!.style.transform).toMatch(/rotateZ\(0\.73\d*rad\)/);
+      expect(icon!.style.transformOrigin).toBe("center center");
+    });
+  });
+});

--- a/test/Map/Leaflet/LeafletVisualizerSpec.ts
+++ b/test/Map/Leaflet/LeafletVisualizerSpec.ts
@@ -59,7 +59,9 @@ describe("LeafletVisualizer", function () {
       const icon = container.querySelector<HTMLElement>(".leaflet-marker-icon");
       expect(icon).not.toBeNull();
       expect(icon!.style.transform).toMatch(/rotateZ\(0\.73\d*rad\)/);
-      expect(icon!.style.transformOrigin).toBe("center center");
+      expect(icon!.style.transformOrigin.startsWith("center center")).toBe(
+        true
+      );
     });
   });
 });

--- a/test/ReactViews/Tools/PedestrianMode/MarkerSpec.ts
+++ b/test/ReactViews/Tools/PedestrianMode/MarkerSpec.ts
@@ -1,0 +1,36 @@
+import Cartesian3 from "terriajs-cesium/Source/Core/Cartesian3";
+import BillboardGraphics from "terriajs-cesium/Source/DataSources/BillboardGraphics";
+import Entity from "terriajs-cesium/Source/DataSources/Entity";
+import Terria from "../../../../lib/Models/Terria";
+import Marker from "../../../../lib/ReactViews/Tools/PedestrianMode/Marker";
+
+describe("Marker", function () {
+  let terria: Terria;
+  let marker: Marker;
+  let entity: Entity;
+  let billboard: BillboardGraphics;
+
+  beforeEach(function () {
+    terria = new Terria();
+    marker = new Marker(undefined, terria);
+    entity = marker.mapItems[0].entities.values[0];
+    billboard = marker.mapItems[0].entities.values[0].billboard!;
+  });
+
+  it("correctly sets the billboard image from the icon URL", function () {
+    const url = "data:image/gif;base64,ABC";
+    marker.iconUrl = url;
+    expect(billboard.image?.getValue()).toBe(url);
+  });
+
+  it("correctly sets the billboard rotation", function () {
+    marker.rotation = Math.PI;
+    expect(billboard.rotation?.getValue()).toBe(Math.PI);
+  });
+
+  it("correctly sets the billboard position", function () {
+    const position = Cartesian3.fromDegrees(144.9631, -37.8136);
+    marker.position = position;
+    expect(entity.position?.getValue()).toEqual(position);
+  });
+});


### PR DESCRIPTION
### What this PR does

Main change is to use CSS transform to rotate billboard images in Leaflet view.

Currently, we update billboard rotation by generating a new image every frame. 

This is:
   a. less performant
   b. isn't responsive enough because we draw the new image asynchronously in [onload](https://github.com/TerriaJS/terriajs/blob/fa2a741bb71cb2ac8d8958c38409204bcc0dd105/lib/Map/Leaflet/LeafletVisualizer.ts#L493-L495) callbacks which maybe deferred when there is continuous user input.

### Test me

Before:
- Enter pedestrian mode in main branch - http://ci.terria.io/main
- Simultaneously move forward and rotate the view by pressing `W` key and dragging the mouse to a side
- Note how the marker in the minimap does not rotate until you release `W` key

After:
- Repeat the same steps from this branch - http://ci.terria.io/fix-minmap-marker
- See how the minmap marker updates smoothly

### Checklist

- [X] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [X] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
