### PR TITLE
experimental components DI to support easy components override

### DIFF
--- a/packages/terriajs/lib/ReactViewModels/SearchState.ts
+++ b/packages/terriajs/lib/ReactViewModels/SearchState.ts
@@ -19,9 +19,6 @@ export default class SearchState {
 
   @observable private _locationSearchText: string = "";
 
-  @observable unifiedSearchText: string = "";
-  @observable isWaitingToStartUnifiedSearch: boolean = false;
-
   @observable showLocationSearchResults: boolean = false;
   @observable showMobileLocationSearch: boolean = false;
   @observable showMobileCatalogSearch: boolean = false;

--- a/packages/terriajs/lib/ReactViews/DataCatalog/DataCatalog.tsx
+++ b/packages/terriajs/lib/ReactViews/DataCatalog/DataCatalog.tsx
@@ -1,27 +1,32 @@
-import { Component } from "react";
-import { observer } from "mobx-react";
-import PropTypes from "prop-types";
-import { withTranslation } from "react-i18next";
+import { useTranslation, withTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
+import CatalogMemberMixin from "../../ModelMixins/CatalogMemberMixin";
+import { BaseModel } from "../../Models/Definition/Model";
+import { useViewState } from "../Context";
 import SearchHeader from "../Search/SearchHeader";
 import Styles from "./data-catalog.scss";
 import DataCatalogMember from "./DataCatalogMember";
+import { observer } from "mobx-react";
 
-// Displays the data catalog.
-@observer
-class DataCatalog extends Component {
-  static propTypes = {
-    terria: PropTypes.object,
-    viewState: PropTypes.object,
-    items: PropTypes.array,
-    hideActionButton: PropTypes.bool,
-    onActionButtonClicked: PropTypes.func,
-    removable: PropTypes.bool,
-    t: PropTypes.func.isRequired
-  };
+interface DataCatalogProps {
+  items?: readonly BaseModel[];
+  hideActionButton?: boolean;
+  onActionButtonClicked?: (item: CatalogMemberMixin.Instance) => void;
+  removable?: boolean;
+}
 
-  render() {
-    const searchState = this.props.viewState.searchState;
+export const DataCatalog = observer(
+  ({
+    items,
+    hideActionButton,
+    onActionButtonClicked,
+    removable
+  }: DataCatalogProps) => {
+    const viewState = useViewState();
+    const { t } = useTranslation();
+
+    const { terria } = viewState;
+    const searchState = viewState.searchState;
     const isSearching = searchState.catalogSearchText.length > 0;
     const catalogSearchProvider = searchState.catalogSearchProvider;
     const unfilteredItems =
@@ -31,9 +36,9 @@ class DataCatalog extends Component {
         ? searchState.catalogSearchProvider.searchResult.results.map(
             (result) => result.catalogItem
           )
-        : this.props.items;
-    const items = (unfilteredItems || []).filter(defined);
-    const { t } = this.props;
+        : items;
+
+    const filteredItems = (unfilteredItems || []).filter(defined);
 
     return (
       <ul className={Styles.dataCatalog}>
@@ -43,22 +48,22 @@ class DataCatalog extends Component {
             <SearchHeader searchResult={catalogSearchProvider.searchResult} />
           </>
         )}
-        {items.map(
+        {filteredItems.map(
           (item) =>
-            item !== this.props.terria.catalog.userAddedDataGroup && (
+            item !== terria.catalog.userAddedDataGroup && (
               <DataCatalogMember
-                viewState={this.props.viewState}
+                viewState={viewState}
                 member={item}
                 // manage group `isOpen` flag locally if searching through models dynamically (i.e. not using catalog index)
                 // This must be false if resultsAreReferences - so group references open correctly in the search
                 manageIsOpenLocally={
-                  isSearching && !catalogSearchProvider.resultsAreReferences
+                  isSearching && !catalogSearchProvider?.resultsAreReferences
                 }
                 key={item.uniqueId}
-                hideActionButton={this.props.hideActionButton}
-                onActionButtonClicked={this.props.onActionButtonClicked}
-                removable={this.props.removable}
-                terria={this.props.terria}
+                hideActionButton={hideActionButton}
+                onActionButtonClicked={onActionButtonClicked}
+                removable={removable}
+                terria={terria}
                 isTopLevel
               />
             )
@@ -66,6 +71,6 @@ class DataCatalog extends Component {
       </ul>
     );
   }
-}
+);
 
 export default withTranslation()(DataCatalog);

--- a/packages/terriajs/lib/ReactViews/DataCatalog/DataCatalogSearch.tsx
+++ b/packages/terriajs/lib/ReactViews/DataCatalog/DataCatalogSearch.tsx
@@ -1,0 +1,20 @@
+import { observer } from "mobx-react";
+import SearchBox from "../Search/SearchBox";
+
+type DataCatalogSearchProps = {
+  searchPlaceholder: string;
+  searchText: string;
+  onSearchTextChanged: (text: string) => void;
+  onDoSearch: () => void;
+};
+
+export const DataCatalogSearch = observer((props: DataCatalogSearchProps) => {
+  return (
+    <SearchBox
+      searchText={props.searchText}
+      onSearchTextChanged={props.onSearchTextChanged}
+      onDoSearch={props.onDoSearch}
+      placeholder={props.searchPlaceholder}
+    />
+  );
+});

--- a/packages/terriajs/lib/ReactViews/ExplorerWindow/ExplorerWindowComponents.ts
+++ b/packages/terriajs/lib/ReactViews/ExplorerWindow/ExplorerWindowComponents.ts
@@ -1,0 +1,11 @@
+import { observable } from "mobx";
+
+import { DataCatalog } from "../DataCatalog/DataCatalog";
+import { DataCatalogSearch } from "../DataCatalog/DataCatalogSearch";
+import ExplorerWindow from "./ExplorerWindow";
+
+export const ExplorerWindowComponents = observable({
+  DataCatalog: DataCatalog,
+  DataCatalogSearch: DataCatalogSearch,
+  ExplorerWindow: ExplorerWindow
+});

--- a/packages/terriajs/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.tsx
+++ b/packages/terriajs/lib/ReactViews/ExplorerWindow/Tabs/DataCatalogTab.tsx
@@ -2,17 +2,17 @@ import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import { useTranslation } from "react-i18next";
 import type CatalogMemberMixin from "../../../ModelMixins/CatalogMemberMixin";
+import MappableMixin from "../../../ModelMixins/MappableMixin";
+import { BaseModel } from "../../../Models/Definition/Model";
 import Box from "../../../Styled/Box";
 import { useViewState } from "../../Context";
-import DataCatalog from "../../DataCatalog/DataCatalog";
 import DataPreview from "../../Preview/DataPreview";
 import Breadcrumbs from "../../Search/Breadcrumbs";
-import SearchBox from "../../Search/SearchBox";
+import { ExplorerWindowComponents } from "../ExplorerWindowComponents";
 import Styles from "./data-catalog-tab.scss";
-import MappableMixin from "../../../ModelMixins/MappableMixin";
 
 interface DataCatalogTabProps {
-  items?: unknown[];
+  items?: readonly BaseModel[];
   searchPlaceholder?: string;
   onActionButtonClicked?: (item: CatalogMemberMixin.Instance) => void;
   /** Override the default toggleItemOnMap behavior (when "add/remove from map" button is clicked in the data preview panel) */
@@ -36,7 +36,7 @@ const DataCatalogTab = observer(function DataCatalogTab(
     terria
   } = viewState;
 
-  const searchPlaceholder =
+  const searchPlaceholder: string =
     props.searchPlaceholder || t("addData.searchPlaceholder");
 
   const changeSearchText = (newText: string) => {
@@ -55,16 +55,14 @@ const DataCatalogTab = observer(function DataCatalogTab(
         <Box fullHeight overflow="hidden">
           <Box className={Styles.dataExplorer} styledWidth="40%">
             {!props.hideSearch && searchState.catalogSearchProvider && (
-              <SearchBox
+              <ExplorerWindowComponents.DataCatalogSearch
                 searchText={searchState.catalogSearchText}
                 onSearchTextChanged={changeSearchText}
                 onDoSearch={search}
-                placeholder={searchPlaceholder}
+                searchPlaceholder={searchPlaceholder}
               />
             )}
-            <DataCatalog
-              terria={terria}
-              viewState={viewState}
+            <ExplorerWindowComponents.DataCatalog
               hideActionButton={props.hideActionButton}
               onActionButtonClicked={props.onActionButtonClicked}
               items={props.items}

--- a/packages/terriajs/lib/ReactViews/Mobile/MobileModalWindow.jsx
+++ b/packages/terriajs/lib/ReactViews/Mobile/MobileModalWindow.jsx
@@ -6,7 +6,7 @@ import { Component } from "react";
 import { withTranslation } from "react-i18next";
 import Box from "../../Styled/Box";
 import Icon from "../../Styled/Icon";
-import DataCatalog from "../DataCatalog/DataCatalog";
+import { ExplorerWindowComponents } from "../ExplorerWindow/ExplorerWindowComponents";
 import DataPreview from "../Preview/DataPreview";
 import WorkbenchList from "../Workbench/WorkbenchList";
 import Styles from "./mobile-modal-window.scss";
@@ -42,9 +42,7 @@ class MobileModalWindow extends Component {
       case viewState.mobileViewOptions.data:
         // No multiple catalogue tabs in mobile
         return (
-          <DataCatalog
-            terria={this.props.terria}
-            viewState={this.props.viewState}
+          <ExplorerWindowComponents.DataCatalog
             items={this.props.terria.catalog.group.memberModels}
           />
         );

--- a/packages/terriajs/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
+++ b/packages/terriajs/lib/ReactViews/StandardUserInterface/StandardUserInterface.tsx
@@ -9,7 +9,7 @@ import combine from "terriajs-cesium/Source/Core/combine";
 import ViewState from "../../ReactViewModels/ViewState";
 import Disclaimer from "../Disclaimer";
 import DragDropFile from "../DragDropFile";
-import ExplorerWindow from "../ExplorerWindow/ExplorerWindow";
+import { ExplorerWindowComponents } from "../ExplorerWindow/ExplorerWindowComponents";
 import FeatureInfoPanel from "../FeatureInfo/FeatureInfoPanel";
 import FeedbackForm from "../Feedback/FeedbackForm";
 import { Medium, Small } from "../Generic/Responsive";
@@ -240,7 +240,7 @@ const StandardUserInterfaceBase: FC<StandardUserInterfaceProps> = observer(
                   />
                   <div id="map-data-attribution" />
                   <main>
-                    <ExplorerWindow />
+                    <ExplorerWindowComponents.ExplorerWindow />
                     {props.terria.configParameters.experimentalFeatures &&
                       !props.viewState.hideMapUi && (
                         <ExperimentalFeatures

--- a/packages/terriajs/test/ReactViews/DataCatalogSpec.tsx
+++ b/packages/terriajs/test/ReactViews/DataCatalogSpec.tsx
@@ -1,11 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import i18next from "i18next";
 import CatalogGroup from "../../lib/Models/Catalog/CatalogGroup";
 import CommonStrata from "../../lib/Models/Definition/CommonStrata";
 import Terria from "../../lib/Models/Terria";
 import ViewState from "../../lib/ReactViewModels/ViewState";
-import DataCatalog from "../../lib/ReactViews/DataCatalog/DataCatalog";
-import { withThemeContext } from "./withContext";
+import { ExplorerWindowComponents } from "../../lib/ReactViews/ExplorerWindow/ExplorerWindowComponents";
+import { renderWithContexts } from "./withContext";
 
 describe("DataCatalog", function () {
   let terria: Terria;
@@ -34,14 +34,11 @@ describe("DataCatalog", function () {
     terria.addModel(anotherGroup);
     terria.catalog.group.add(CommonStrata.definition, anotherGroup);
 
-    render(
-      withThemeContext(
-        <DataCatalog
-          terria={terria}
-          viewState={viewState}
-          items={terria.catalog.group.memberModels}
-        />
-      )
+    renderWithContexts(
+      <ExplorerWindowComponents.DataCatalog
+        items={terria.catalog.group.memberModels}
+      />,
+      viewState
     );
 
     expect(screen.getByText("Another Group")).toBeInTheDocument();


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

This is a **proof of concept for a "components dependency injection container"** for the Explorer Window area of TerriaJS.

The idea: instead of importing UI components directly, the components that make up the Explorer Window (Data Catalog, Data Catalog search box, and the Explorer Window itself) are exposed through a single object — `ExplorerWindowComponents` — that can have its entries replaced from outside TerriaJS.

This gives us a way to swap out individual components quickly without rebuilding the entire interface, or having to polute terriajs interface with functionality that won't be actually used by the community. The motivation is to support faster iteration on the SaaS side: when we need a custom version of one of these components for a SaaS feature, we can override it in place rather than maintaining a parallel copy of the surrounding code. If a customisation proves generally useful, it's also much easier to backport into the OSS version later, since the override sits alongside the original component rather than diverging from it.

#### Example

```ts
import { ExplorerWindowComponents } from "terriajs/lib/ReactViews/ExplorerWindow/ExplorerWindowComponents";
import MyCustomSearch from "./MyCustomSearch";

// Replace TerriaJS's default Data Catalog with our own component
ExplorerWindowComponents.DataCatalogSearch = MyCustomSearch;
```

**note**: The team needed this to implement custom functionality on the SaaS side, and this is an experiment to make it possible. If it proves useful, we may extend it to other parts of the codebase.

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
