### PR TITLE
Add i18n support across the catalog and map layers

### DIFF
--- a/lib/Core/getPath.ts
+++ b/lib/Core/getPath.ts
@@ -1,22 +1,37 @@
+import i18next, { i18n } from "i18next";
+import { applyTranslationIfExists } from "../Language/languageHelpers";
 import CatalogMemberMixin from "../ModelMixins/CatalogMemberMixin";
 import getAncestors from "../Models/getAncestors";
 import { BaseModel } from "../Models/Definition/Model";
 import getDereferencedIfExists from "./getDereferencedIfExists";
 import isDefined from "./isDefined";
 
-export default function getPath(item: BaseModel, separator?: string) {
+// Pass the reactive i18n from useTranslation() in React components so the result
+// updates when the user switches language. The global i18next fallback is fine for
+// analytics/non-UI code where re-rendering is irrelevant.
+export default function getPath(
+  item: BaseModel,
+  separator?: string,
+  i18nInstance: i18n = i18next
+) {
   const sep = isDefined(separator) ? separator : "/";
-  return getParentGroups(item).join(sep);
+  return getParentGroups(item, i18nInstance).join(sep);
 }
 
-export function getParentGroups(item: BaseModel) {
+export function getParentGroups(item: BaseModel, i18nInstance: i18n = i18next) {
   const dereferenced = getDereferencedIfExists(item);
   return [
     ...getAncestors(dereferenced).map(getDereferencedIfExists),
     dereferenced
-  ].map(
-    (ancestor) =>
-      (CatalogMemberMixin.isMixedInto(ancestor) && ancestor.nameInCatalog) ||
-      ancestor.uniqueId
-  );
+  ].map((ancestor) => {
+    if (CatalogMemberMixin.isMixedInto(ancestor)) {
+      const name = ancestor.nameInCatalog || "";
+      return (
+        (i18nInstance && applyTranslationIfExists(name, i18nInstance)) ||
+        name ||
+        ancestor.uniqueId
+      );
+    }
+    return ancestor.uniqueId;
+  });
 }

--- a/lib/ModelMixins/CatalogMemberMixin.ts
+++ b/lib/ModelMixins/CatalogMemberMixin.ts
@@ -7,8 +7,10 @@ import {
   makeObservable,
   override
 } from "mobx";
+import i18next, { i18n as i18nType } from "i18next";
 import Mustache from "mustache";
 import AbstractConstructor from "../Core/AbstractConstructor";
+import { applyTranslationIfExists } from "../Language/languageHelpers";
 import AsyncLoader from "../Core/AsyncLoader";
 import isDefined from "../Core/isDefined";
 import { isJsonObject, isJsonString, JsonObject } from "../Core/Json";
@@ -236,9 +238,8 @@ function CatalogMemberMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
 const descriptionRegex = /description/i;
 
 namespace CatalogMemberMixin {
-  export interface Instance extends InstanceType<
-    ReturnType<typeof CatalogMemberMixin>
-  > {}
+  export interface Instance
+    extends InstanceType<ReturnType<typeof CatalogMemberMixin>> {}
   export function isMixedInto(model: any): model is Instance {
     return model && model.hasCatalogMemberMixin;
   }
@@ -247,16 +248,18 @@ namespace CatalogMemberMixin {
 export default CatalogMemberMixin;
 
 /** Convenience function to get user readable name of a BaseModel */
-export const getName = action((model: BaseModel | undefined) => {
-  return (
-    (CatalogMemberMixin.isMixedInto(model) ? model.name : undefined) ??
-    (hasTraits(model, CatalogMemberReferenceTraits, "name")
-      ? model.name
-      : undefined) ??
-    model?.uniqueId ??
-    "Unknown model"
-  );
-});
+export const getName = action(
+  (model: BaseModel | undefined, i18nInstance: i18nType = i18next) => {
+    const name =
+      (CatalogMemberMixin.isMixedInto(model) ? model.name : undefined) ??
+      (hasTraits(model, CatalogMemberReferenceTraits, "name")
+        ? model.name
+        : undefined) ??
+      model?.uniqueId ??
+      "Unknown model";
+    return applyTranslationIfExists(name, i18nInstance) || name;
+  }
+);
 
 /** Recursively apply mustache template to all nested string properties in a JSON Object */
 function mustacheNestedJsonObject(obj: JsonObject, view: any) {

--- a/lib/Models/Catalog/Ows/WebMapServiceCapabilities.ts
+++ b/lib/Models/Catalog/Ows/WebMapServiceCapabilities.ts
@@ -164,6 +164,24 @@ export default class WebMapServiceCapabilities {
       return Promise.resolve(loadXML(url)).then(function (capabilitiesXml) {
         const json = xml2json(capabilitiesXml);
         if (!capabilitiesXml || !defined(json.Capability)) {
+          // The server may answer with a ServiceExceptionReport instead of a
+          // Capabilities document (e.g. GeoServer rejecting `AcceptLanguages`
+          // when no internationalized content is defined). Surface its text so
+          // the cause is visible rather than the generic message below.
+          const serviceException =
+            json?.ServiceExceptionReport?.ServiceException ??
+            json?.ServiceException;
+          if (defined(serviceException)) {
+            const message =
+              typeof serviceException === "string"
+                ? serviceException
+                : serviceException?.toString?.() ??
+                  JSON.stringify(serviceException);
+            throw networkRequestError({
+              title: "Server refused the request",
+              message: `The URL ${url} returned a WMS ServiceException:\n\n${message}`
+            });
+          }
           throw networkRequestError({
             title: "Invalid GetCapabilities",
             message:
@@ -190,10 +208,7 @@ export default class WebMapServiceCapabilities {
     readonly [name: string]: CapabilitiesLayer;
   };
 
-  private constructor(
-    readonly xml: XMLDocument,
-    readonly json: any
-  ) {
+  private constructor(readonly xml: XMLDocument, readonly json: any) {
     this.allLayers = [];
     this.rootLayers = [];
     this.topLevelNamedLayers = [];

--- a/lib/Models/Catalog/Ows/WebMapServiceCapabilitiesStratum.ts
+++ b/lib/Models/Catalog/Ows/WebMapServiceCapabilitiesStratum.ts
@@ -61,14 +61,36 @@ export default class WebMapServiceCapabilitiesStratum extends LoadableStratum(
       });
     }
 
-    if (!isDefined(capabilities))
-      capabilities = await WebMapServiceCapabilities.fromUrl(
-        proxyCatalogItemUrl(
-          catalogItem,
-          catalogItem.getCapabilitiesUrl,
-          catalogItem.getCapabilitiesCacheDuration
-        )
-      );
+    if (!isDefined(capabilities)) {
+      const getCapabilitiesUrl = catalogItem.getCapabilitiesUrl;
+      try {
+        capabilities = await WebMapServiceCapabilities.fromUrl(
+          proxyCatalogItemUrl(
+            catalogItem,
+            getCapabilitiesUrl,
+            catalogItem.getCapabilitiesCacheDuration
+          )
+        );
+      } catch (e) {
+        // Some WMS servers reject the `AcceptLanguages` parameter with a
+        // ServiceException when no internationalized content is defined for the
+        // requested language(s). Retry once without it before giving up.
+        const urlWithoutLanguage = new URI(getCapabilitiesUrl)
+          .removeQuery("AcceptLanguages")
+          .toString();
+        // Param wasn't present, so there's nothing to retry - rethrow original error.
+        if (urlWithoutLanguage === getCapabilitiesUrl) {
+          throw e;
+        }
+        capabilities = await WebMapServiceCapabilities.fromUrl(
+          proxyCatalogItemUrl(
+            catalogItem,
+            urlWithoutLanguage,
+            catalogItem.getCapabilitiesCacheDuration
+          )
+        );
+      }
+    }
 
     return new WebMapServiceCapabilitiesStratum(catalogItem, capabilities);
   }
@@ -876,8 +898,8 @@ export default class WebMapServiceCapabilitiesStratum extends LoadableStratum(
     const formatsArray = isJsonArray(formats)
       ? formats
       : isJsonString(formats)
-        ? [formats]
-        : [];
+      ? [formats]
+      : [];
 
     if (this.catalogItem.supportsGetTimeseries) {
       return { format: "text/csv", type: "text" };

--- a/lib/Models/Catalog/Ows/WebMapServiceCatalogItem.ts
+++ b/lib/Models/Catalog/Ows/WebMapServiceCatalogItem.ts
@@ -321,11 +321,16 @@ class WebMapServiceCatalogItem
         this.uri.clone()
       );
 
+      const lng = i18next.resolvedLanguage ?? i18next.language;
+      const fallbackLng = Array.isArray(i18next.options.fallbackLng)
+        ? i18next.options.fallbackLng[0]
+        : (i18next.options.fallbackLng as string);
       return baseUrl
         .setSearch({
           service: "WMS",
           version: this.useWmsVersion130 ? "1.3.0" : "1.1.1",
-          request: "GetCapabilities"
+          request: "GetCapabilities",
+          ...(lng ? { AcceptLanguages: `${lng} ${fallbackLng} *` } : {})
         })
         .toString();
     } else {
@@ -379,6 +384,9 @@ class WebMapServiceCatalogItem
       new URI(this.url)
     );
 
+    if (i18next.language) {
+      baseUrl.addSearch("LANGUAGE", i18next.language);
+    }
     return baseUrl.toString();
   }
 
@@ -400,6 +408,9 @@ class WebMapServiceCatalogItem
       .addQuery("styles", encodeURIComponent(styleId));
     if (time) {
       uri.addQuery("time", time);
+    }
+    if (i18next.language) {
+      uri.addQuery("LANGUAGE", i18next.language);
     }
     return uri.toString();
   }

--- a/lib/ReactViews/Custom/FeedbackLinkCustomComponent.tsx
+++ b/lib/ReactViews/Custom/FeedbackLinkCustomComponent.tsx
@@ -8,7 +8,7 @@ import CustomComponent, {
   DomElement,
   ProcessNodeContext
 } from "./CustomComponent";
-import parseCustomMarkdownToReact from "./parseCustomMarkdownToReact";
+import { parseCustomMarkdownToReactWithOptions } from "./parseCustomMarkdownToReact";
 
 function showFeedback(viewState: ViewState) {
   runInAction(() => {
@@ -34,22 +34,24 @@ export const FeedbackLink = (props: {
       `}
     >
       <Text bold isLink>
-        {parseCustomMarkdownToReact(
+        {parseCustomMarkdownToReactWithOptions(
           props.feedbackMessage
             ? props.feedbackMessage
-            : i18next.t("models.raiseError.notificationFeedback")
+            : i18next.t("models.raiseError.notificationFeedback"),
+          { inline: true }
         )}
       </Text>
     </RawButton>
   ) : (
     // If we only have supportEmail - show message and the email address
     <>
-      {parseCustomMarkdownToReact(
+      {parseCustomMarkdownToReactWithOptions(
         props.emailMessage
           ? `${props.emailMessage} ${props.viewState.terria.supportEmail}`
           : i18next.t("models.raiseError.notificationFeedbackEmail", {
               email: props.viewState.terria.supportEmail
-            })
+            }),
+        { inline: true }
       )}
     </>
   );

--- a/lib/ReactViews/DataCatalog/DataCatalogGroup.tsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogGroup.tsx
@@ -4,8 +4,10 @@ import { observer } from "mobx-react";
 import { useTranslation } from "react-i18next";
 import addedByUser from "../../Core/addedByUser";
 import getPath from "../../Core/getPath";
+import { applyTranslationIfExists } from "../../Language/languageHelpers";
 import removeUserAddedData from "../../Models/Catalog/removeUserAddedData";
 import ViewState from "../../ReactViewModels/ViewState";
+import Result from "../../Core/Result";
 import { BaseModel } from "../../Models/Definition/Model";
 import CatalogGroup from "./CatalogGroup";
 import DataCatalogMember from "./DataCatalogMember";
@@ -23,7 +25,7 @@ interface GroupModel extends BaseModel {
   displayGroup?: boolean;
   members: any[];
   memberModels: any[];
-  loadMembers: () => void;
+  loadMembers: () => Promise<Result<void>>;
   nameInCatalog?: string;
   url?: string;
   uniqueId: string;
@@ -55,7 +57,7 @@ const DataCatalogGroup: React.FC<PropsType> = observer((props) => {
     isTopLevel
   } = props;
 
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [isOpenLocal, setIsOpenLocal] = useState(false);
 
   const isOpen = useCallback(() => {
@@ -83,7 +85,10 @@ const DataCatalogGroup: React.FC<PropsType> = observer((props) => {
 
   const getNameOrPrettyUrl = useCallback(() => {
     // Grab a name via nameInCatalog, if it's a blank string, try and generate one from the url
-    const nameInCatalog = group.nameInCatalog || "";
+    const nameInCatalog = applyTranslationIfExists(
+      group.nameInCatalog || "",
+      i18n
+    );
     if (nameInCatalog !== "") {
       return nameInCatalog;
     }
@@ -98,20 +103,24 @@ const DataCatalogGroup: React.FC<PropsType> = observer((props) => {
       () => [group, isOpen()],
       ([currentGroup, isCurrentlyOpen]) => {
         if (isCurrentlyOpen && currentGroup) {
-          (currentGroup as GroupModel).loadMembers();
+          // Surface load failures (e.g. WMS GetCapabilities ServiceException) to
+          // the user instead of letting them fail silently in the console.
+          (currentGroup as GroupModel).loadMembers().then((result) => {
+            result.raiseError(viewState.terria);
+          });
         }
       },
       { equals: comparer.shallow, fireImmediately: true }
     );
 
     return () => cleanupLoadMembersReaction();
-  }, [group, isOpen]);
+  }, [group, isOpen, viewState]);
 
   return (
     <CatalogGroup
       text={getNameOrPrettyUrl()}
       isPrivate={group.isPrivate}
-      title={getPath(group, " → ")}
+      title={getPath(group, " → ", i18n)}
       topLevel={isTopLevel}
       open={isOpen()}
       loading={group.isLoading || group.isLoadingMembers}

--- a/lib/ReactViews/DataCatalog/DataCatalogItem.tsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogItem.tsx
@@ -4,6 +4,7 @@ import { MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
 import addedByUser from "../../Core/addedByUser";
+import { applyTranslationIfExists } from "../../Language/languageHelpers";
 import { DataSourceAction } from "../../Core/Analytics/analyticEvents";
 import getPath from "../../Core/getPath";
 import CatalogFunctionMixin from "../../ModelMixins/CatalogFunctionMixin";
@@ -34,7 +35,7 @@ export default observer(function DataCatalogItem({
   removable,
   hideActionButton
 }: Props) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const STATE_TO_TITLE = {
     [ButtonState.Loading]: t("catalogItem.loading"),
     [ButtonState.Remove]: t("catalogItem.removeFromMap"),
@@ -102,9 +103,9 @@ export default observer(function DataCatalogItem({
     <CatalogItem
       onTextClick={setPreviewedItem}
       selected={isSelected}
-      text={item.nameInCatalog!}
+      text={applyTranslationIfExists(item.nameInCatalog!, i18n)}
       isPrivate={item.isPrivate}
-      title={getPath(item, " -> ")}
+      title={getPath(item, " -> ", i18n)}
       btnState={btnState}
       onBtnClick={onBtnClicked}
       hideBtn={hideActionButton}

--- a/lib/ReactViews/DataCatalog/DataCatalogReference.tsx
+++ b/lib/ReactViews/DataCatalog/DataCatalogReference.tsx
@@ -1,6 +1,7 @@
 import { runInAction } from "mobx";
 import { observer } from "mobx-react";
 import { MouseEvent } from "react";
+import { useTranslation } from "react-i18next";
 import defined from "terriajs-cesium/Source/Core/defined";
 import addedByUser from "../../Core/addedByUser";
 import { DataSourceAction } from "../../Core/Analytics/analyticEvents";
@@ -35,6 +36,8 @@ export default observer(function DataCatalogReference({
   isTopLevel,
   hideActionButton
 }: Props) {
+  const { i18n } = useTranslation();
+
   const setPreviewedItem = () =>
     viewState
       .viewCatalogMember(reference)
@@ -68,7 +71,7 @@ export default observer(function DataCatalogReference({
     ? viewState.userDataPreviewedItem === reference
     : viewState.previewedItem === reference;
 
-  const path = getPath(reference, " -> ");
+  const path = getPath(reference, " -> ", i18n);
 
   let btnState: ButtonState;
   if (reference.isLoading) {

--- a/lib/ReactViews/Map/Panels/SharePanel/Print/PrintWorkbench.tsx
+++ b/lib/ReactViews/Map/Panels/SharePanel/Print/PrintWorkbench.tsx
@@ -4,6 +4,7 @@ import CatalogMemberMixin, {
 import DiscretelyTimeVaryingMixin from "../../../../../ModelMixins/DiscretelyTimeVaryingMixin";
 import MappableMixin from "../../../../../ModelMixins/MappableMixin";
 import { BaseModel } from "../../../../../Models/Definition/Model";
+import { useTranslation } from "react-i18next";
 import SelectableDimensions, {
   DEFAULT_PLACEMENT,
   filterSelectableDimensions,
@@ -51,9 +52,10 @@ const renderLegend = (catalogItem: BaseModel) => {
 };
 
 const WorkbenchItem = ({ item }: { item: BaseModel }) => {
+  const { i18n } = useTranslation();
   return (
     <div className="WorkbenchItem">
-      <h3>{getName(item)}</h3>
+      <h3>{getName(item, i18n)}</h3>
       {renderDisplayVariables(item)}
       <div>{renderLegend(item)}</div>
     </div>

--- a/lib/ReactViews/Preview/DataPreview.jsx
+++ b/lib/ReactViews/Preview/DataPreview.jsx
@@ -7,6 +7,7 @@ import { Component } from "react";
 import { Trans, withTranslation } from "react-i18next";
 import CatalogFunctionMixin from "../../ModelMixins/CatalogFunctionMixin";
 import ReferenceMixin from "../../ModelMixins/ReferenceMixin";
+import { applyTranslationIfExists } from "../../Language/languageHelpers";
 import InvokeFunction from "../Analytics/InvokeFunction";
 import Loader from "../Loader";
 import Description from "./Description";
@@ -37,7 +38,7 @@ class DataPreview extends Component {
   }
 
   renderInner() {
-    const { t } = this.props;
+    const { t, i18n } = this.props;
     let previewed = this.props.previewed;
     if (previewed !== undefined && ReferenceMixin.isMixedInto(previewed)) {
       // We are loading the nested target because we could be dealing with a nested reference here
@@ -56,7 +57,9 @@ class DataPreview extends Component {
     if (previewed && previewed.isLoadingMetadata) {
       return (
         <div className={Styles.previewInner}>
-          <h3 className={Styles.h3}>{previewed.name}</h3>
+          <h3 className={Styles.h3}>
+            {applyTranslationIfExists(previewed.name || "", i18n)}
+          </h3>
           <Loader />
         </div>
       );
@@ -75,7 +78,9 @@ class DataPreview extends Component {
     } else if (chartData) {
       return (
         <div className={Styles.previewInner}>
-          <h3 className={Styles.h3}>{previewed.name}</h3>
+          <h3 className={Styles.h3}>
+            {applyTranslationIfExists(previewed.name || "", i18n)}
+          </h3>
           <p>{t("preview.doesNotContainGeospatialData")}</p>
           <div className={Styles.previewChart}>
             {/* TODO: Show a preview chart

--- a/lib/ReactViews/Preview/Description.jsx
+++ b/lib/ReactViews/Preview/Description.jsx
@@ -7,6 +7,7 @@ import Box from "../../Styled/Box";
 import Button from "../../Styled/Button";
 import Collapsible from "../Custom/Collapsible/Collapsible";
 import parseCustomMarkdownToReact from "../Custom/parseCustomMarkdownToReact";
+import { applyTranslationIfExists } from "../../Language/languageHelpers";
 import DataPreviewSections from "./DataPreviewSections";
 import ExportData from "./ExportData";
 import Styles from "./mappable-preview.scss";
@@ -88,9 +89,15 @@ class Description extends Component {
         {catalogItem.description && catalogItem.description.length > 0 && (
           <div>
             <h4 className={Styles.h4}>{t("description.name")}</h4>
-            {parseCustomMarkdownToReact(catalogItem.description, {
-              catalogItem: catalogItem
-            })}
+            {parseCustomMarkdownToReact(
+              applyTranslationIfExists(
+                catalogItem.description,
+                this.props.i18n
+              ),
+              {
+                catalogItem: catalogItem
+              }
+            )}
           </div>
         )}
 

--- a/lib/ReactViews/Preview/GroupPreview.jsx
+++ b/lib/ReactViews/Preview/GroupPreview.jsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react";
 import PropTypes from "prop-types";
 import { Component } from "react";
 import { withTranslation } from "react-i18next";
+import { applyTranslationIfExists } from "../../Language/languageHelpers";
 import parseCustomMarkdownToReact from "../Custom/parseCustomMarkdownToReact";
 import {
   addRemoveButtonClicked,
@@ -34,14 +35,16 @@ class GroupPreview extends Component {
   render() {
     const metadataItem =
       this.props.previewed.nowViewingCatalogItem || this.props.previewed;
-    const { t } = this.props;
+    const { t, i18n } = this.props;
     return (
       <div>
         <div
           className={Styles.titleAndShareWrapper}
           ref={(component) => (this.refToMeasure = component)}
         >
-          <h3>{this.props.previewed.name}</h3>
+          <h3>
+            {applyTranslationIfExists(this.props.previewed.name || "", i18n)}
+          </h3>
 
           <div className={Styles.shareLinkWrapper}>
             {/* If this is a display group, show the "Add/Remove All" button next to the shareLink */}
@@ -95,7 +98,10 @@ class GroupPreview extends Component {
                 <div>
                   <h4 className={Styles.h4}>{t("description.name")}</h4>
                   {parseCustomMarkdownToReact(
-                    this.props.previewed.description,
+                    applyTranslationIfExists(
+                      this.props.previewed.description || "",
+                      i18n
+                    ),
                     { catalogItem: this.props.previewed }
                   )}
                 </div>

--- a/lib/ReactViews/Preview/MappablePreview.jsx
+++ b/lib/ReactViews/Preview/MappablePreview.jsx
@@ -15,6 +15,7 @@ import DataPreviewMap from "./DataPreviewMap";
 import Description from "./Description";
 import Styles from "./mappable-preview.scss";
 import WarningBox from "./WarningBox";
+import { applyTranslationIfExists } from "../../Language/languageHelpers";
 
 /**
  * @typedef {object} Props
@@ -72,7 +73,7 @@ class MappablePreview extends Component {
   }
 
   render() {
-    const { t } = this.props;
+    const { t, i18n } = this.props;
     const catalogItem = this.props.previewed;
     return (
       <div className={Styles.root}>
@@ -100,7 +101,9 @@ class MappablePreview extends Component {
             className={Styles.titleAndShareWrapper}
             ref={(component) => (this.refToMeasure = component)}
           >
-            <h3 className={Styles.h3}>{catalogItem.name}</h3>
+            <h3 className={Styles.h3}>
+              {applyTranslationIfExists(catalogItem.name || "", i18n)}
+            </h3>
             {!catalogItem.hasLocalData &&
               !this.props.viewState.useSmallScreenInterface && (
                 <div className={Styles.shareLinkWrapper}>

--- a/lib/ReactViews/Search/Breadcrumbs.jsx
+++ b/lib/ReactViews/Search/Breadcrumbs.jsx
@@ -13,6 +13,7 @@ import getAncestors from "../../Models/getAncestors";
 import getDereferencedIfExists from "../../Core/getDereferencedIfExists";
 import { runInAction } from "mobx";
 import CommonStrata from "../../Models/Definition/CommonStrata";
+import { applyTranslationIfExists } from "../../Language/languageHelpers";
 
 const RawButtonAndUnderline = RawButton;
 
@@ -39,6 +40,7 @@ class Breadcrumbs extends Component {
   }
 
   renderCrumb(parent, i, parentGroups) {
+    const { i18n } = this.props;
     const ancestors = getAncestors(this.props.previewed).map((ancestor) =>
       getDereferencedIfExists(ancestor)
     );
@@ -47,7 +49,7 @@ class Breadcrumbs extends Component {
     if (i === parentGroups.length - 1) {
       return (
         <Text small textDark>
-          {parent}
+          {applyTranslationIfExists(parent || "", i18n)}
         </Text>
       );
       /* The first and last two groups use the full name */
@@ -58,7 +60,7 @@ class Breadcrumbs extends Component {
           onClick={() => this.openInCatalog(ancestors.slice(i, i + 1))}
         >
           <TextSpan small textDark isLink>
-            {parent}
+            {applyTranslationIfExists(parent || "", i18n)}
           </TextSpan>
         </RawButtonAndUnderline>
       );
@@ -76,7 +78,7 @@ class Breadcrumbs extends Component {
 
   render() {
     const parentGroups = this.props.previewed
-      ? getParentGroups(this.props.previewed)
+      ? getParentGroups(this.props.previewed, this.props.i18n)
       : undefined;
 
     return (

--- a/lib/ReactViews/Workbench/WorkbenchItem.tsx
+++ b/lib/ReactViews/Workbench/WorkbenchItem.tsx
@@ -36,7 +36,7 @@ const WorkbenchItemRaw: React.FC<IProps> = observer((props) => {
   const { item, style, className, viewState, onMouseDown, onTouchStart } =
     props;
 
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const theme = useTheme();
 
   const toggleDisplay = action(() => {
@@ -72,7 +72,7 @@ const WorkbenchItemRaw: React.FC<IProps> = observer((props) => {
             <DraggableBox
               onMouseDown={onMouseDown}
               onTouchStart={onTouchStart}
-              title={getPath(item, " → ")}
+              title={getPath(item, " → ", i18n)}
               fullWidth
             >
               {!(item as any).isMappable && !isLoading && (


### PR DESCRIPTION
### What this PR does

- Query GeoServer using the user's selected language to load i18n layer info and legends.
- Translate translate#-prefixed strings found in the catalog JSON when rendering the catalog UI.
- Improve WMS language handling, attempting to serve languages by:
  A) the user's language, B) the fallback language, C) any other available.
- Add i18n support to the titles and descriptions of data catalog items shown in the right-hand preview panel.
- Translate catalog names in getPath using a reactive i18n instance.
- Improve handling of server exceptions, specifically ServiceExceptionReport, to surface the concrete error (e.g. when adding data from a URL with AcceptLanguages against a server that does not support i18n).
- Retry requests without the AcceptLanguages parameter when the server fails to serve a request that includes it.
- Fix invalid `<p>` nesting in FeedbackLinkCustomComponent: since FeedbackLink renders inside a markdown-generated `<p>`, calling parseCustomMarkdownToReact added another `<p>`. Use { inline: true } so md.renderInline emits only inline elements.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
