### PR TITLE
Fix compass.

### DIFF
--- a/packages/terriajs/lib/ReactViews/Map/MapNavigation/Items/Compass/Compass.tsx
+++ b/packages/terriajs/lib/ReactViews/Map/MapNavigation/Items/Compass/Compass.tsx
@@ -70,6 +70,17 @@ const getCompassScaleRatio = (compassWidth: string) =>
   (Number(compassWidth) + 10) / Number(compassWidth);
 
 /**
+ * Width of the inner side of the ring. This encircles the arrows icon.
+ */
+const gyroWidth = ({
+  compassWidth,
+  ringWidth
+}: {
+  compassWidth: string;
+  ringWidth: string;
+}) => Number(compassWidth) - Number(ringWidth) - 10;
+
+/**
  * You think 0.9999 is a joke but I kid you not, it's the root of all evil in
  * bandaging these related issues:
  * https://github.com/TerriaJS/terriajs/issues/4261
@@ -231,7 +242,7 @@ class Compass extends PureComponent<PropTypes, IStateTypes> {
 
     const compassElement = e.currentTarget;
     const compassRectangle = e.currentTarget.getBoundingClientRect();
-    const maxDistance = compassRectangle.width / 2.0;
+    const maxDistance = gyroWidth(this.props.theme) / 2;
     const center = new Cartesian2(
       (compassRectangle.right - compassRectangle.left) / 2.0,
       (compassRectangle.bottom - compassRectangle.top) / 2.0
@@ -243,10 +254,14 @@ class Compass extends PureComponent<PropTypes, IStateTypes> {
     const vector = Cartesian2.subtract(clickLocation, center, vectorScratch);
     const distanceFromCenter = Cartesian2.magnitude(vector);
 
-    const distanceFraction = distanceFromCenter / maxDistance;
+    const distanceFraction = distanceFromCenter / (maxDistance + 10);
 
-    const nominalTotalRadius = 145;
-    const nominalGyroRadius = 50;
+    // width of the StyledCompass component
+    const nominalTotalRadius = compassRectangle.width;
+
+    // width of the inner side of the ring (encircling the arrows icon)
+    // when user drags this part we need to trigger rotate()
+    const nominalGyroRadius = gyroWidth(this.props.theme);
 
     if (distanceFraction < nominalGyroRadius / nominalTotalRadius) {
       orbit(this, compassElement, vector);
@@ -535,7 +550,7 @@ function rotate(
     camera.rotateRight(newCameraAngle - currentCameraAngle);
     camera.lookAtTransform(oldTransform);
 
-    // viewModel.props.terria.cesium.notifyRepaintRequired();
+    viewModel.props.terria.cesium?.notifyRepaintRequired();
   };
 
   viewModel.rotateMouseUpFunction = function (_e) {
@@ -654,7 +669,7 @@ function orbit(
 
     camera.lookAtTransform(oldTransform);
 
-    // viewModel.props.terria.cesium.notifyRepaintRequired();
+    viewModel.props.terria.cesium?.notifyRepaintRequired();
 
     viewModel.orbitLastTimestamp = timestamp;
   };
@@ -673,7 +688,7 @@ function orbit(
       orbitCursorOpacity: easedOpacity
     });
 
-    // viewModel.props.terria.cesium.notifyRepaintRequired();
+    viewModel.props.terria.cesium?.notifyRepaintRequired();
   }
 
   viewModel.orbitMouseMoveFunction = function (e) {

--- a/packages/terriajs/lib/ReactViews/Map/MapNavigation/Items/Compass/Compass.tsx
+++ b/packages/terriajs/lib/ReactViews/Map/MapNavigation/Items/Compass/Compass.tsx
@@ -260,12 +260,12 @@ class Compass extends PureComponent<PropTypes, IStateTypes> {
     const nominalTotalRadius = compassRectangle.width;
 
     // width of the inner side of the ring (encircling the arrows icon)
-    // when user drags this part we need to trigger rotate()
+    // when user drags this part we need to trigger orbit
     const nominalGyroRadius = gyroWidth(this.props.theme);
 
     if (distanceFraction < nominalGyroRadius / nominalTotalRadius) {
       orbit(this, compassElement, vector);
-    } else if (distanceFraction < 1.0) {
+    } else if (distanceFraction < 1.4) {
       rotate(this, compassElement, vector);
     } else {
       return true;


### PR DESCRIPTION
### What this PR does

Previously:
- Camera changes were rendered only on mouse up event (or a network event) that woke up the [CesiumRendererLoopPauser](https://github.com/TerriaJS/terriajs/blob/main/packages/terriajs/lib/Map/Cesium/CesiumRenderLoopPauser.ts).
- There were some hardcoded magic values that were sensitive to CSS changes and got out of sync when styles changed. Have replaced them with values derived from the style.

### Test me

Before:
- Open CI from main branch - http://ci.terria.io/main
- Interact with the compass
- Notice that the updates are not instant - sometimes the updates render only once you have lifted or moved the mouse

After:
- Try this branch - http://ci.terria.io/fix-compass
- It should react to the changes instantly

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
