### PR TITLE
Fix story editor regression

### DIFF
--- a/packages/terriajs/CHANGES.md
+++ b/packages/terriajs/CHANGES.md
@@ -1,6 +1,10 @@
 # Change Log
 
-#### next release (8.12.4)
+#### next release (8.x.x)
+
+#### 8.12.4 - 2026-06-19
+
+- Fix story editor rich-text toolbar dropdowns (paragraph style, alignment, table, text colour) and dialogs (image/media/link) being rendered invisibly behind the editor modal due to z-index stacking context. Add `underline` and `subscript` buttons to the toolbar.
 
 #### 8.12.3 - 2026-06-17
 

--- a/packages/terriajs/lib/ReactViews/Generic/Editor.tsx
+++ b/packages/terriajs/lib/ReactViews/Generic/Editor.tsx
@@ -11,6 +11,7 @@ import "tinymce/models/dom";
 /* Import a skin (can be a custom skin instead of the default) */
 // import "!!style-loader!css-loader!tinymce/skins/ui/oxide/skin.min.css";
 import "!!style-loader!css-loader!./editor.skin.min.css"; // Custom borderless skin
+import "!!style-loader!css-loader!sass-loader!./editor.skin.overrides.scss"; // lift TinyMCE popups above the story modal
 
 /* Import TinyMCE plugins */
 import "tinymce/plugins/media";
@@ -54,7 +55,7 @@ export default function TinyEditor({
         statusbar: false,
         plugins: ["link", "image", "media", "table", "lists", "autolink"],
         toolbar:
-          "blocks | bold italic forecolor | align |" +
+          "blocks | bold italic underline subscript forecolor | align |" +
           " bullist numlist table |" +
           "image media link |" +
           "undo redo | removeformat",

--- a/packages/terriajs/lib/ReactViews/Generic/editor.skin.overrides.scss
+++ b/packages/terriajs/lib/ReactViews/Generic/editor.skin.overrides.scss
@@ -1,0 +1,9 @@
+@use "../../Sass/common/_variables";
+
+/* TinyMCE 7 mounts every menu/dialog in a body-level .tox-tinymce-aux portal,
+   which the skin caps at z-index 1300. The story editor modal sits far higher,
+   so the popups rendered behind it (invisible). Keep the portal one step above
+   the modal via the shared variable instead of a hardcoded number. */
+.tox-tinymce-aux {
+  z-index: variables.$editor-popup-z-index;
+}

--- a/packages/terriajs/lib/Sass/common/_default_variables.scss
+++ b/packages/terriajs/lib/Sass/common/_default_variables.scss
@@ -201,6 +201,9 @@ $lg: 1300px !default;
 
 $front-component-z-index: 99 !default;
 $notification-window-z-index: 99999 !default;
+// TinyMCE editor popups (menus/dialogs) mount on document.body, outside the
+// story editor modal, so they must sit just above $notification-window-z-index.
+$editor-popup-z-index: $notification-window-z-index + 1 !default;
 
 $chart-area-color: rgba(#fff, 0.075) !default;
 $chart-axis-color: #fff !default;

--- a/packages/terriajs/lib/ThirdParty/global.d.ts
+++ b/packages/terriajs/lib/ThirdParty/global.d.ts
@@ -1,5 +1,6 @@
 declare module "*.DAC";
 declare module "*.css";
+declare module "*.scss"; // for side-effect/inline-loader scss imports (per-file css-module typings cover the rest)
 declare module "*.csv";
 declare module "*.xml";
 declare module "*.svg";

--- a/packages/terriajs/package.json
+++ b/packages/terriajs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs",
-  "version": "8.12.3",
+  "version": "8.12.4",
   "description": "Geospatial data visualization platform.",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
### What this PR does

[Fixes this story editor bug](https://github.com/TerriaJS/saas-settings/issues/1263) + releases terria w/ th efix

### Test me

1. Open a story and edit a story page so the rich-text editor shows.
2. Click each toolbar control and confirm the popup now appears above the editor modal:
  - paragraph style (blocks), alignment, table, text colour (forecolor) → dropdowns open
  - image, media, link → dialogs open and are interactive (not just a faded background)
3. Confirm the new underline and subscript buttons are present and apply formatting.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
  - n/a. We'd need a full smoke test to properly assert this.
- [x] I've updated relevant documentation in doc/.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.