### PR TITLE
chore: replace 8398a7/action-slack with slackapi/slack-github-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,4 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
 
       - name: Run tests using xvfb
-        uses: GabrielBB/xvfb-action@b706e4e27b14669b486812790492dc50ca16b465 # v1.7
-        with:
-          run: yarn workspace terriajs gulp test-firefox
+        run: xvfb-run --auto-servernum yarn workspace terriajs gulp test-firefox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
       - run: npm install -g yarn@^1.22.22 && yarn install
@@ -46,6 +46,6 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
 
       - name: Run tests using xvfb
-        uses: GabrielBB/xvfb-action@v1
+        uses: GabrielBB/xvfb-action@b706e4e27b14669b486812790492dc50ca16b465 # v1.7
         with:
           run: yarn workspace terriajs gulp test-firefox

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,19 +17,19 @@ jobs:
     if: github.repository_owner == 'TerriaJS'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
-      - uses: google-github-actions/auth@v3
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
-      - uses: google-github-actions/setup-gcloud@v3.0.1
-      - uses: google-github-actions/get-gke-credentials@v3.0.0
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+      - uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_LOCATION }}
-      - uses: azure/setup-helm@v5
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: "v3.3.1"
       # Builds and deploys TerriaMap from the local monorepo copy (apps/terriamap,
@@ -42,7 +42,7 @@ jobs:
           FEEDBACK_GITHUB_TOKEN: ${{ secrets.FEEDBACK_GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Upload the resolved root yarn.lock for inspection.
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: yarn.lock

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository_owner == 'TerriaJS'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
@@ -29,7 +29,7 @@ jobs:
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER }}
           location: ${{ secrets.GKE_LOCATION }}
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
         with:
           version: "v3.3.1"
       # Builds and deploys TerriaMap from the local monorepo copy (apps/terriamap,

--- a/.github/workflows/find-region-mapping-alias-duplicates.yml
+++ b/.github/workflows/find-region-mapping-alias-duplicates.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Check out only 2 files
       # Use without cone mode as no git operations are executed past checkout
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           sparse-checkout: |
             packages/terriajs/wwwroot/data/regionMapping.json

--- a/.github/workflows/find-region-mapping-alias-duplicates.yml
+++ b/.github/workflows/find-region-mapping-alias-duplicates.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Check out only 2 files
       # Use without cone mode as no git operations are executed past checkout
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           sparse-checkout: |
             packages/terriajs/wwwroot/data/regionMapping.json

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Detect a version change
         id: detect
@@ -48,7 +48,7 @@ jobs:
 
       - name: Set up Node.js for NPM
         if: steps.detect.outputs.should_publish == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -101,25 +101,36 @@ jobs:
       #  action-detect-and-tag-new-version. It also allows for a bit better message customisation
       - name: Send success notification on Slack
         if: steps.detect.outputs.should_publish == 'true'
-        uses: 8398a7/action-slack@v3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          status: ${{ job.status }}
-          fields: repo,commit,action,ref
-          author_name: ${{ github.workflow }}
-          mention: here
-          if_mention: always
-          text: ":white_check_mark: Published v${{ steps.detect.outputs.version }} to https://www.npmjs.com/package/terriajs"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "<!here> :white_check_mark: Published v${{ steps.detect.outputs.version }} to https://www.npmjs.com/package/terriajs"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "<!here> :white_check_mark: Published v${{ steps.detect.outputs.version }} to <https://www.npmjs.com/package/terriajs|npmjs>"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "*Repo:* ${{ github.repository }} | *Ref:* ${{ github.ref }} | *Commit:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
 
       - name: Send failure or cancellation notification on Slack
         if: failure() || cancelled() # Pick up events even if the job fails or is canceled.
-        uses: 8398a7/action-slack@v3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          status: ${{ job.status }}
-          fields: repo,commit,action,ref
-          author_name: ${{ github.workflow }}
-          mention: here
-          if_mention: always
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "<!here> :x: ${{ github.workflow }} ${{ job.status }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "<!here> :x: *${{ github.workflow }}* ${{ job.status }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "*Repo:* ${{ github.repository }} | *Ref:* ${{ github.ref }} | *Commit:* <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}> | <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Detect a version change
         id: detect

--- a/apps/terriamap/.github/workflows/ci.yml
+++ b/apps/terriamap/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         node-version: [22.x, 24.x, 25.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: rm -rf node_modules && yarn install --frozen-lockfile

--- a/apps/terriamap/.github/workflows/ci.yml
+++ b/apps/terriamap/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         node-version: [22.x, 24.x, 25.x]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: rm -rf node_modules && yarn install --frozen-lockfile

--- a/apps/terriamap/.github/workflows/release.yml
+++ b/apps/terriamap/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/apps/terriamap/.github/workflows/release.yml
+++ b/apps/terriamap/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Migrates to the official Slack-maintained action (v3.0.3, SHA-pinned). Uses Block Kit instead of deprecated attachments. Reproduces repo, commit, action, and ref context with @here mention on both success and failure/cancellation notifications.
The replacement was generated by Claude.

Visual comparison of old and new messages, setting line with colour is possible only with attachments, which are deprecated
<img width="785" height="219" alt="image" src="https://github.com/user-attachments/assets/3b1a5414-bd84-4540-af3a-439606d7ef50" />
<img width="798" height="218" alt="image" src="https://github.com/user-attachments/assets/9e600e16-fa82-441f-82ae-b6d98e24989b" />

### Test me

How should reviewers test this? (Hint: If you want to provide a test catalog item, [create a Gist](https://gist.github.com/) of its catalog JSON, add its url and your branch name to this url: `http://ci.terria.io/<branch name>/#clean&<raw url of your gist>` , and then paste that in the body of this PR)

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
