### PR TITLE
gaussian splat fix in order to visualize them properly

### DIFF
--- a/packages/terriajs/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/packages/terriajs/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -47,6 +47,58 @@ import ClippingMixin from "./ClippingMixin";
 import MappableMixin from "./MappableMixin";
 import ShadowMixin from "./ShadowMixin";
 
+/**
+ * terriajs-cesium 23.0.2 references `Cesium3DTileset#isGltfExtensionRequired` in its
+ * Gaussian splat content routing (see Cesium's Cesium3DTileContentFactory +
+ * GaussianSplat3DTileContent.tilesetRequiresGaussianSplattingExt) but never defines the
+ * method. The routing guard `tileset.isGltfExtensionRequired instanceof Function` is
+ * therefore always false, so every Gaussian splat (.glb) tile falls back to the regular
+ * model loader: the tileset loads but renders nothing. Upstream CesiumJS defines these
+ * methods, which is why the same Cesium ion asset renders in stock Cesium but is invisible
+ * in Terria.
+ *
+ * We define the missing methods here, reading the glTF extension lists that Cesium ion
+ * stores under the tileset's `3DTILES_content_gltf` extension. This runs once when the
+ * module is imported (before any tileset instance is created) and is a no-op if a future
+ * terriajs-cesium version provides the methods itself.
+ */
+function ensureGltfExtensionDetection(): void {
+  const proto = Cesium3DTileset.prototype as unknown as {
+    isGltfExtensionUsed?: (extensionName: string) => boolean;
+    isGltfExtensionRequired?: (extensionName: string) => boolean;
+  };
+
+  const hasGltfExtension = (
+    tileset: { extensions?: Record<string, any> },
+    list: "extensionsUsed" | "extensionsRequired",
+    extensionName: string
+  ): boolean => {
+    const contentGltf = tileset.extensions?.["3DTILES_content_gltf"];
+    const extensions = contentGltf?.[list];
+    return Array.isArray(extensions) && extensions.indexOf(extensionName) > -1;
+  };
+
+  if (typeof proto.isGltfExtensionUsed !== "function") {
+    proto.isGltfExtensionUsed = function (
+      this: { extensions?: Record<string, any> },
+      extensionName: string
+    ): boolean {
+      return hasGltfExtension(this, "extensionsUsed", extensionName);
+    };
+  }
+
+  if (typeof proto.isGltfExtensionRequired !== "function") {
+    proto.isGltfExtensionRequired = function (
+      this: { extensions?: Record<string, any> },
+      extensionName: string
+    ): boolean {
+      return hasGltfExtension(this, "extensionsRequired", extensionName);
+    };
+  }
+}
+
+ensureGltfExtensionDetection();
+
 interface Cesium3DTilesCatalogItemIface extends InstanceType<
   ReturnType<typeof Cesium3dTilesMixin>
 > {}
@@ -215,7 +267,41 @@ function Cesium3dTilesMixin<T extends AbstractConstructor<BaseType>>(Base: T) {
               if (observableTileset.root !== undefined) {
                 this.originalRootTransform =
                   observableTileset.root.transform.clone();
-                observableTileset.root.transform = Matrix4.IDENTITY.clone();
+                // Normally we move the root transform into `tileset.modelMatrix`
+                // and reset the root transform to identity, so the origin/rotation/
+                // scale traits can drive the whole tileset.
+                //
+                // Gaussian splat tilesets must NOT be treated this way. Cesium's
+                // GaussianSplatPrimitive bakes splat positions into a local frame
+                // derived from `tileset.modelMatrix * ENU(boundingSphere.center)`.
+                // If the full ECEF root transform lives in modelMatrix, that local
+                // frame ends up ~6,371 km from the splats (the Earth's translation is
+                // effectively counted twice), so the baked float32 positions lose all
+                // precision and the splats render as oversized "fog".
+                //
+                // So when this is a Gaussian splat tileset and no transformation
+                // traits are set, we leave the root transform in place and keep
+                // modelMatrix identity (originalRootTransform = identity).
+                const isGaussianSplat =
+                  typeof (observableTileset as any).isGltfExtensionRequired ===
+                    "function" &&
+                  (observableTileset as any).isGltfExtensionRequired(
+                    "KHR_gaussian_splatting"
+                  );
+                const hasTransformTraits =
+                  this.origin?.latitude !== undefined ||
+                  this.origin?.longitude !== undefined ||
+                  this.origin?.height !== undefined ||
+                  this.rotation?.heading !== undefined ||
+                  this.rotation?.pitch !== undefined ||
+                  this.rotation?.roll !== undefined ||
+                  this.scale !== undefined;
+
+                if (isGaussianSplat && !hasTransformTraits) {
+                  this.originalRootTransform = Matrix4.IDENTITY.clone();
+                } else {
+                  observableTileset.root.transform = Matrix4.IDENTITY.clone();
+                }
               }
             }
           });

--- a/packages/terriajs/lib/ModelMixins/Cesium3dTilesMixin.ts
+++ b/packages/terriajs/lib/ModelMixins/Cesium3dTilesMixin.ts
@@ -47,58 +47,6 @@ import ClippingMixin from "./ClippingMixin";
 import MappableMixin from "./MappableMixin";
 import ShadowMixin from "./ShadowMixin";
 
-/**
- * terriajs-cesium 23.0.2 references `Cesium3DTileset#isGltfExtensionRequired` in its
- * Gaussian splat content routing (see Cesium's Cesium3DTileContentFactory +
- * GaussianSplat3DTileContent.tilesetRequiresGaussianSplattingExt) but never defines the
- * method. The routing guard `tileset.isGltfExtensionRequired instanceof Function` is
- * therefore always false, so every Gaussian splat (.glb) tile falls back to the regular
- * model loader: the tileset loads but renders nothing. Upstream CesiumJS defines these
- * methods, which is why the same Cesium ion asset renders in stock Cesium but is invisible
- * in Terria.
- *
- * We define the missing methods here, reading the glTF extension lists that Cesium ion
- * stores under the tileset's `3DTILES_content_gltf` extension. This runs once when the
- * module is imported (before any tileset instance is created) and is a no-op if a future
- * terriajs-cesium version provides the methods itself.
- */
-function ensureGltfExtensionDetection(): void {
-  const proto = Cesium3DTileset.prototype as unknown as {
-    isGltfExtensionUsed?: (extensionName: string) => boolean;
-    isGltfExtensionRequired?: (extensionName: string) => boolean;
-  };
-
-  const hasGltfExtension = (
-    tileset: { extensions?: Record<string, any> },
-    list: "extensionsUsed" | "extensionsRequired",
-    extensionName: string
-  ): boolean => {
-    const contentGltf = tileset.extensions?.["3DTILES_content_gltf"];
-    const extensions = contentGltf?.[list];
-    return Array.isArray(extensions) && extensions.indexOf(extensionName) > -1;
-  };
-
-  if (typeof proto.isGltfExtensionUsed !== "function") {
-    proto.isGltfExtensionUsed = function (
-      this: { extensions?: Record<string, any> },
-      extensionName: string
-    ): boolean {
-      return hasGltfExtension(this, "extensionsUsed", extensionName);
-    };
-  }
-
-  if (typeof proto.isGltfExtensionRequired !== "function") {
-    proto.isGltfExtensionRequired = function (
-      this: { extensions?: Record<string, any> },
-      extensionName: string
-    ): boolean {
-      return hasGltfExtension(this, "extensionsRequired", extensionName);
-    };
-  }
-}
-
-ensureGltfExtensionDetection();
-
 interface Cesium3DTilesCatalogItemIface extends InstanceType<
   ReturnType<typeof Cesium3dTilesMixin>
 > {}

--- a/packages/terriajs/lib/Models/Cesium.ts
+++ b/packages/terriajs/lib/Models/Cesium.ts
@@ -265,6 +265,8 @@ export default class Cesium extends GlobeOrMap {
 
     this.scene.globe.depthTestAgainstTerrain = false;
 
+    (this.scene as any).pickTranslucentDepth = true;
+
     this.scene.renderError.addEventListener(this.onRenderError.bind(this));
 
     const inputHandler = this.cesiumWidget.screenSpaceEventHandler;


### PR DESCRIPTION
### What this PR does

Before this change, gaussian splat loaded but was not able to visualize inside. 

You could see some data but it looked corrupted. 
But because how the splat renderer is treated different, the splat builds an ENU frame on top of the modelMatrix, and cesium treat it as modelMatrix x ENU, so it was taking it in account a second time, so the splat looked like corrupted or zoomed in.

So the fix is: for splats, don't put the big transform in modelMatrix, so Cesium's ENU frame lands where it's supposed to.

I added the pickTranslucentDepth in order to move the splat easily.

All the other parts should work as previously.

### Test me

How should reviewers test this? 

Just apply the fix and add any gaussian splat you want, you should be able to visualize it correctly. 

Before the change the GS loads but was not able to visualize it.

### Checklist


<img width="1806" height="960" alt="gaussianAfter" src="https://github.com/user-attachments/assets/6039baa2-b7b2-4207-b533-68e5a1516573" />
<img width="1797" height="943" alt="GSBefore" src="https://github.com/user-attachments/assets/a2a649b1-370f-459c-8e81-a60ce81af7fc" />
