### PR TITLE
loadJson should pass on all extra options.

### DIFF
--- a/packages/terriajs/lib/Core/loadJson.ts
+++ b/packages/terriajs/lib/Core/loadJson.ts
@@ -33,9 +33,7 @@ export default function loadJson<T = any>(
 
     jsonPromise =
       urlOrResource instanceof Resource
-        ? urlOrResource.post(body, {
-            responseType: responseType
-          })!
+        ? urlOrResource.post(params.data, params)!
         : Resource.post(params)!;
   } else {
     // Make a GET instead


### PR DESCRIPTION
### What this PR does

Currently when given a `Resource` type, `loadJson` will silently ignore the extra options like `headers`. This PR changes `loadJson` to pass on those extra params to the `post` method.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
