### PR TITLE
Set default `refreshInterval` in traits instead of method override.

### DIFF
--- a/packages/terriajs/lib/ModelMixins/CatalogFunctionJobMixin.ts
+++ b/packages/terriajs/lib/ModelMixins/CatalogFunctionJobMixin.ts
@@ -154,10 +154,6 @@ function CatalogFunctionJobMixin<
       }
     }
 
-    get refreshInterval() {
-      return 2;
-    }
-
     private pollingForResults = false;
 
     /**

--- a/packages/terriajs/lib/Traits/TraitsClasses/CatalogFunctionJobTraits.ts
+++ b/packages/terriajs/lib/Traits/TraitsClasses/CatalogFunctionJobTraits.ts
@@ -49,5 +49,5 @@ export default class CatalogFunctionJobTraits extends mixTraits(
       "How often the job will poll for results, in seconds. (This overrides `AutoRefreshingTraits`)",
     type: "number"
   })
-  refreshInterval = 1;
+  refreshInterval = 2;
 }


### PR DESCRIPTION
### What this PR does

Set the default value in traits instead of method override.  This is so that the mixin implementations can override the value from a loadable stratum.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
