### PR TITLE
Add `edit` stratum.

### DIFF
--- a/packages/terriajs/CHANGES.md
+++ b/packages/terriajs/CHANGES.md
@@ -5,6 +5,7 @@
 - Upgraded `terriajs-cesium` to `26.0.0` and `terriajs-cesium-widgets` to `16.0.0`. We are now using cesium 1.142.
 - Upgraded terriajs-server to v5.0.0-alpha.3
 - Upgraded to i18next v26 and migrated to i18next select pattern `(t($ => translation.key))` #7882
+- Add `edit` stratum for tracking temporary user changes that shouldn't be captured in share link - example form edits.
 
 #### 8.12.4 - 2026-06-19
 

--- a/packages/terriajs/lib/Models/Definition/CommonStrata.ts
+++ b/packages/terriajs/lib/Models/Definition/CommonStrata.ts
@@ -3,7 +3,10 @@ enum CommonStrata {
   underride = "underride",
   definition = "definition",
   override = "override",
-  user = "user"
+  user = "user",
+
+  // Stratum for temporary user changes that shouldn't be captured in share links, example: form inputs
+  edit = "edit"
 }
 
 export default CommonStrata;

--- a/packages/terriajs/lib/Models/Definition/StratumOrder.ts
+++ b/packages/terriajs/lib/Models/Definition/StratumOrder.ts
@@ -40,6 +40,7 @@ export default class StratumOrder {
     this.addDefinitionStratum(CommonStrata.definition);
     this.addDefinitionStratum(CommonStrata.override);
     this.addUserStratum(CommonStrata.user);
+    this.addUserStratum(CommonStrata.edit);
   }
 
   /**


### PR DESCRIPTION
### What this PR does

Some user made changes shouldn't be captured in share links, example form inputs for catalog functions. These changes should still supersede other strata. Another benefit is that the form changes can be cleared easily by resetting the `edit` stratum for a model.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
