### PR TITLE
Add regexp for detecting I3S (Scene server) URLS

### DIFF
--- a/packages/terriajs/CHANGES.md
+++ b/packages/terriajs/CHANGES.md
@@ -2,6 +2,7 @@
 
 #### next release (8.x.x)
 
+- Automatically detect I3S layers by URL when adding web data, so ArcGIS `SceneServer` URLs resolve to an `I3SCatalogItem`.
 - Upgraded `terriajs-cesium` to `26.0.0` and `terriajs-cesium-widgets` to `16.0.0`. We are now using cesium 1.142.
 - Upgraded terriajs-server to v5.0.0-alpha.3
 - Upgraded to i18next v26 and migrated to i18next select pattern `(t($ => translation.key))` #7882

--- a/packages/terriajs/lib/Models/Catalog/registerCatalogMembers.ts
+++ b/packages/terriajs/lib/Models/Catalog/registerCatalogMembers.ts
@@ -318,6 +318,14 @@ export default function registerCatalogMembers() {
     WebMapTileServiceCatalogGroup.type,
     true
   );
+  // I3S SceneServer endpoints, eg
+  // .../arcgis/rest/services/<name>/SceneServer. Registered before the generic
+  // ArcGIS matchers below so that a SceneServer URL is not swallowed by the
+  // /arcgis/rest/ ArcGisCatalogGroup matcher.
+  UrlToCatalogMemberMapping.register(
+    matchesUrl(/\/SceneServer\b/i),
+    I3SCatalogItem.type
+  );
   UrlToCatalogMemberMapping.register(
     matchesUrl(/\/arcgis\/rest\/.*\/MapServer\/\d+\b/i),
     ArcGisMapServerCatalogItem.type,

--- a/packages/terriajs/lib/Traits/TraitsClasses/I3SCatalogItemTraits.ts
+++ b/packages/terriajs/lib/Traits/TraitsClasses/I3SCatalogItemTraits.ts
@@ -7,7 +7,8 @@ import primitiveTrait from "../Decorators/primitiveTrait";
 @traitClass({
   description: `Creates an I3S item in the catalog from an slpk.`,
   example: {
-    type: "I3S",
+    url: "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer",
+    type: "i3s",
     name: "CoM Melbourne 3D Photo Mesh",
     id: "some-unique-id"
   }

--- a/packages/terriajs/test/Models/Catalog/createUrlReferenceFromUrlSpec.ts
+++ b/packages/terriajs/test/Models/Catalog/createUrlReferenceFromUrlSpec.ts
@@ -4,6 +4,7 @@ import { USER_ADDED_CATEGORY_ID } from "../../../lib/Core/addedByUser";
 import isDefined from "../../../lib/Core/isDefined";
 import CsvCatalogItem from "../../../lib/Models/Catalog/CatalogItems/CsvCatalogItem";
 import GeoJsonCatalogItem from "../../../lib/Models/Catalog/CatalogItems/GeoJsonCatalogItem";
+import I3SCatalogItem from "../../../lib/Models/Catalog/CatalogItems/I3SCatalogItem";
 import createUrlReferenceFromUrl from "../../../lib/Models/Catalog/CatalogReferences/createUrlReferenceFromUrl";
 import UrlReference from "../../../lib/Models/Catalog/CatalogReferences/UrlReference";
 import createCatalogItemFromFileOrUrl from "../../../lib/Models/Catalog/createCatalogItemFromFileOrUrl";
@@ -71,6 +72,17 @@ describe("createUrlReferenceFromUrl", function () {
     expect(item).toBeDefined();
     if (item !== undefined) {
       expect(item instanceof CsvCatalogItem).toBe(true);
+    }
+  });
+
+  it("should create an I3SCatalogItem from an ArcGIS SceneServer URL", async function () {
+    const url =
+      "https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer";
+
+    const item = await createUrlReferenceFromUrl(url, terria, true);
+    expect(item).toBeDefined();
+    if (item instanceof UrlReference) {
+      expect(item.target instanceof I3SCatalogItem).toBe(true);
     }
   });
 


### PR DESCRIPTION
- update docs with example url and correct type string

### What this PR does
Correctly detect Esri scene server urls as I3S

### Test me

1. Click Add Data
2. Paste in a esri scene server url i.e. `https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_3DObjects_1_7/SceneServer`
3. layer should get added as I3S 

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [x] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
