### PR TITLE
Hide UI when MapInteractionMode message is empty.

### DIFF
--- a/packages/terriajs/lib/ReactViews/Notification/MapInteractionWindow.tsx
+++ b/packages/terriajs/lib/ReactViews/Notification/MapInteractionWindow.tsx
@@ -131,22 +131,30 @@ class MapInteractionWindow extends Component<{
     const isDiffTool =
       this.currentInteractionMode?.uiMode === UIMode.Difference;
 
+    const message = isDefined(this.currentInteractionMode)
+      ? parseCustomHtmlToReact(this.currentInteractionMode.message())
+      : undefined;
+    const messageAsNode = isDefined(this.currentInteractionMode)
+      ? this.currentInteractionMode.messageAsNode()
+      : undefined;
+
     return (
       <MapInteractionWindowWrapper
         className={windowClass}
         aria-hidden={!isActive}
         isDiffTool={isDiffTool}
       >
-        <div
-          className={classNames({
-            [Styles.content]: !isDiffTool
-          })}
-        >
-          {isDefined(this.currentInteractionMode) &&
-            parseCustomHtmlToReact(this.currentInteractionMode.message())}
-          {isDefined(this.currentInteractionMode) &&
-            this.currentInteractionMode.messageAsNode()}
-        </div>
+        {message ||
+          (messageAsNode && (
+            <div
+              className={classNames({
+                [Styles.content]: !isDiffTool
+              })}
+            >
+              {message}
+              {messageAsNode}
+            </div>
+          ))}
         {typeof this.currentInteractionMode?.customUi === "function" &&
           this.currentInteractionMode.customUi()}
         {this.currentInteractionMode?.onCancel && (

--- a/packages/terriajs/lib/ReactViews/Notification/map-interaction-window.scss
+++ b/packages/terriajs/lib/ReactViews/Notification/map-interaction-window.scss
@@ -13,6 +13,10 @@
   z-index: 999;
   color: #000;
   padding: variables.$padding;
+
+  &:empty {
+    padding: 0;
+  }
 }
 
 .isActive {


### PR DESCRIPTION
### What this PR does

Previously when MapInteractionMode `message` is empty, Terria shows a blank header with padding like below. 

This PR fixes is it so that nothing is shown when `message` is empty. This useful when rendering some other UI using `customUi`, example to show an `ActionBar` instead of the regular MapInteractionMode UI.

Before:
<img width="704" height="279" alt="image" src="https://github.com/user-attachments/assets/2ba33de3-e2ef-45d0-a9b8-6da7550e39e5" />

### Test me

Hard to provide a CI link as it requires a custom mode for testing.
Existing tools like Measurement tools that provide a `message` should still continue to work.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
