### PR TITLE
Accept defaultProps for map tool component when registering the tool

### DIFF
--- a/packages/terriajs/lib/ViewModels/MapNavigation/MapToolbar.ts
+++ b/packages/terriajs/lib/ViewModels/MapNavigation/MapToolbar.ts
@@ -7,6 +7,7 @@ import ViewState from "../../ReactViewModels/ViewState";
 import { IconGlyph } from "../../Styled/Icon";
 import MapNavigationItemController from "./MapNavigationItemController";
 import { NavigationItemLocation } from "./MapNavigationModel";
+import { JsonObject } from "../../Core/Json";
 
 export interface ToolConfig {
   /**
@@ -33,6 +34,11 @@ export interface ToolConfig {
    * ```
    */
   toolComponentLoader: () => Promise<{ default: ComponentType<any> }>;
+
+  /**
+   * Default props to pass to the tool component in addition to any props passed to openTool().
+   */
+  defaultProps?: JsonObject;
 
   /**
    * The tool button configuration
@@ -223,6 +229,7 @@ export class ToolController extends MapNavigationItemController {
         getToolComponent: () =>
           toolConfig.toolComponentLoader().then((m) => m.default),
         params: {
+          ...toolConfig.defaultProps,
           ...props,
           // Pass toolId as an extra prop to the component.
           // TODO: Maybe we should use react contexts to do this instead of a magic prop?


### PR DESCRIPTION
### What this PR does

Small change to accept `defaultProps` when registering a map tool.
This is so that props can be optionally configured at the time of tool registration.

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've provided instructions in the PR description on how to test this PR.
