### PR TITLE
Preview title wrap

### DIFF
--- a/packages/terriajs/CHANGES.md
+++ b/packages/terriajs/CHANGES.md
@@ -15,6 +15,7 @@
 - Changed `About data` button to `About job` in workbench for CatalogFunctionJob instances.
 - Add `edit` stratum for tracking temporary user changes that shouldn't be captured in share link - example form edits.
 - Fix viewCatalogMember to correctly switch to the parent tab
+- Fix data preview title not wrapping long unbroken names (e.g. URLs), which caused a horizontal scrollbar in the preview panel and embedded iframes.
 
 #### 8.12.5 - 2026-07-28
 

--- a/packages/terriajs/lib/ReactViews/Preview/mappable-preview.scss
+++ b/packages/terriajs/lib/ReactViews/Preview/mappable-preview.scss
@@ -53,15 +53,17 @@
 .share-link--wrapper {
   margin-top: variables.$padding;
   min-width: 118px;
-  float: right;
+  flex-shrink: 0;
 }
 
 .h3 {
   composes: h3 from "../../Sass/common/_base.scss";
   margin-top: 0;
   padding-right: variables.$padding-small;
-  float: left;
-  width: 80%;
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: break-word;
+  word-break: break-word;
   font-size: variables.$font-size-mid-large;
 }
 .h4 {


### PR DESCRIPTION
### What this PR does

Fix data preview title not wrapping long unbroken names (e.g. URLs), which caused a horizontal scrollbar in the preview panel and embedded iframes.

### Test me
Preview a dataset with a very long name, it should now wrap instead of overflowing with horizontal scrollbar

**Before**
<img width="1142" height="905" alt="Screenshot 2026-08-20 at 1 44 50 pm" src="https://github.com/user-attachments/assets/e7bcf057-25bd-4222-8429-6b27dc9d698b" />

**After**
<img width="1214" height="906" alt="Screenshot 2026-08-20 at 1 43 08 pm" src="https://github.com/user-attachments/assets/ca20fbdc-333e-40da-8958-9e5f4d379cf2" />

### Checklist

- [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
- [ ] I've updated relevant documentation in `doc/`.
- [x] I've updated CHANGES.md with what I changed.
- [x] I've provided instructions in the PR description on how to test this PR.
