### PR TITLE
fix: drop trailing slash from CI trustedHosts

### DIFF
--- a/packages/terriajs/buildprocess/ci-values.yml
+++ b/packages/terriajs/buildprocess/ci-values.yml
@@ -42,7 +42,7 @@ terriamap:
     singlePageRouting:
       resolvePathRelativeToWwwroot: "/index.html"
       resolveUnmatchedPathsWithIndexHtml: true
-    trustedHosts: ["ci.terria.io/"]
+    trustedHosts: ["ci.terria.io"]
     securityHeaders:
       - cspReportOnly: false
   clientConfig:


### PR DESCRIPTION
### What this PR does

Share links (and feedback, and esri token auth) are broken on `ci.terria.io`. A `POST` to `http://ci.terria.io/<branch>/share` comes back `403 Forbidden` with the body `Cross-origin request blocked`.

That string comes from `makeOriginAllowlist` in `packages/terriajs-server/lib/controllers/origin-allowlist.js`, the CSRF guard wired in front of `/share`, `/feedback` and `/esri-token-auth` in `makeserver.js`. The guard parses the request's `Origin` (falling back to `Referer`) and does an **exact** `Set.has()` against the configured trusted hostnames — no normalisation.

`packages/terriajs/buildprocess/ci-values.yml` had:

```yaml
trustedHosts: ["ci.terria.io/"]
```

...with a trailing slash. `hostName` isn't set in the CI values, so it defaults to `localhost` (`options.js:139`), making the effective set `{"localhost", "ci.terria.io/"}`. A browser posting from `http://ci.terria.io/main/` sends `Origin: http://ci.terria.io`, whose hostname is `ci.terria.io` — which does not equal `ci.terria.io/`. Hence the 403 on every write.

This PR drops the slash. The documented config format is a bare hostname (`serverconfig.json.example:244` → `"trustedHosts": ["maps.example.com"]`).

**Why this surfaced now:** the trailing slash came in with #7913 (`eb23e06b4`, "start using csp headers on CI") but was latent — `apps/terriamap` still resolved `terriajs-server` to the published npm package, which has no origin allowlist. #7923 pointed both `apps/terriamap/package.json` and `packages/terriajs/package.json` at `"terriajs-server": "*"` (the in-repo workspace package), which is where the guard lives. That's the moment the malformed value started mattering.

Note the same set also constrains the http→https redirect target (`makeserver.js:89`), so that path was mis-configured too — it just isn't exercised on CI because `redirectToHttps` isn't enabled there.

### Test me

1. Wait for this branch to deploy, then open `http://ci.terria.io/fix-ci-trusted-host/`.
2. Add any layer, click **Share/Print**, and generate a share link.
3. It should produce a short link rather than an error. Before this change the request 403s.

For a direct check:

```
curl -i -X POST http://ci.terria.io/fix-ci-trusted-host/share \
  -H 'Origin: http://ci.terria.io' \
  -H 'Content-Type: application/json' -d '{}'
```

Should no longer return `403 Cross-origin request blocked`.

Also worth confirming `/feedback` still works from the CI map, since it sits behind the same guard.

### Follow-ups (not in this PR)

The guard turns a plausible-looking config typo into a blanket 403 with nothing in the server logs. Two cheap hardening options, deliberately left out to keep this fix minimal:

- Normalise `trustedHosts` entries where the set is built (`makeserver.js:56`) so `example.com`, `https://example.com` and `example.com/` all work.
- `console.warn` the rejected origin in the 403 branch, so this shows up in pod logs instead of only in the browser console.

Happy to fold either in if reviewers prefer.

### Checklist

- [x] There are unit tests to verify my changes are correct or unit tests aren't applicable — this is a one-line change to CI deployment values (`ci-values.yml`), not library code. The allowlist logic itself is already covered by `spec/controllers/origin-allowlist.spec.js` and `spec/csrf-origin-validation.e2e.spec.js`; those tests pass because they use correctly-formed hostnames. The bug was in config, not code.
- [x] I've updated relevant documentation in `doc/` — not applicable; the correct format is already documented in `serverconfig.json.example`.
- [x] I've updated CHANGES.md with what I changed — not applicable; this only affects the TerriaJS CI deployment, not anything a consumer of the library sees.
- [x] I've provided instructions in the PR description on how to test this PR.
