### PR TITLE
Replace tini deb dependency with init.js

### DIFF
--- a/apps/terriamap/Dockerfile
+++ b/apps/terriamap/Dockerfile
@@ -35,15 +35,6 @@ RUN mkdir -p /tmp/terriamap-context \
 # deploy container
 FROM node:24-slim AS deploy
 
-# terriajs-server registers no SIGTERM/SIGINT handlers, and node:24-slim has no init
-# system, so without tini as PID 1, `docker stop` (and Kubernetes' pod termination,
-# which works the same way) has nothing to catch the signal - the container just sits
-# until the grace period expires and it gets SIGKILLed. tini forwards the signal to
-# node and reaps zombies, so shutdown is immediate. Installed as root, before USER
-# node, since apt-get needs root.
-RUN apt-get update && apt-get install -y --no-install-recommends tini \
-  && rm -rf /var/lib/apt/lists/*
-
 USER node
 
 WORKDIR /app
@@ -51,7 +42,10 @@ WORKDIR /app
 # Without the chown when copying directories, files are owned by root:root.
 COPY --from=build --chown=node:node /tmp/terriamap-context/component/ .
 
+# See init.js for why this is here instead of a plain CMD.
+COPY --chown=node:node apps/terriamap/deploy/docker/init.js init.js
+
 EXPOSE 3001
 ENV NODE_ENV=production
-ENTRYPOINT [ "/usr/bin/tini", "--" ]
+ENTRYPOINT [ "node", "init.js" ]
 CMD [ "node", "./node_modules/terriajs-server/lib/app.js", "--config-file", "serverconfig.json" ]

--- a/apps/terriamap/deploy/docker/init.js
+++ b/apps/terriamap/deploy/docker/init.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+// Minimal PID-1 init for the deploy container. node:24-slim has no init system, and
+// terriajs-server registers no SIGTERM/SIGINT handlers of its own, so without this,
+// `docker stop` (and Kubernetes' pod termination, which works the same way) has
+// nothing to catch the signal - the container just sits until the grace period
+// expires and gets SIGKILLed. This forwards the signal to the real process and exits
+// with its status, which is all that's needed here.
+//
+// It's not a full replacement for tini/dumb-init: it doesn't reap arbitrary orphaned
+// grandchild zombies (tini's waitpid-loop over every child, not just its direct one).
+// That's fine only because terriajs-server never spawns subprocesses of its own - if
+// that ever changes, revisit this.
+
+const { spawn } = require("child_process");
+
+const child = spawn(process.argv[2], process.argv.slice(3), {
+  stdio: "inherit"
+});
+
+for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+  process.on(sig, () => child.kill(sig));
+}
+
+child.on("exit", (code, signal) => {
+  process.exit(signal ? 128 + require("os").constants.signals[signal] : code);
+});


### PR DESCRIPTION
### What this PR does

Replaces the DEB package `tini` with a small script to handle SIGINT/SIGTERM.